### PR TITLE
refactor(openagents.com): route provider account list through Effect service

### DIFF
--- a/apps/openagents.com/workers/api/src/provider-account-browser-routes.ts
+++ b/apps/openagents.com/workers/api/src/provider-account-browser-routes.ts
@@ -1,3 +1,5 @@
+import { Effect } from 'effect'
+
 import { methodNotAllowed, noStoreJsonResponse } from './http/responses'
 import {
   optionalBoolean,
@@ -5,31 +7,36 @@ import {
   readJsonObject,
 } from './json-boundary'
 import {
+  logWorkerRouteError,
+  observedEffect,
+  observedPromise,
+} from './observability'
+import {
   type ProviderApiKeyProbe,
   type StoreConnectedProviderApiKey,
   connectProviderApiKeyAccount,
   providerApiKeyConnectPolicyForRouteSegment,
 } from './provider-account-api-key'
 import {
+  providerAccountRouteErrorMessage,
+  providerAccountRouteErrorName,
+  providerAccountRouteErrorStatus,
+} from './provider-account-route-errors'
+import {
   type DeleteStartedCodexDeviceLogin,
+  ProviderAccountLifecycleService,
   type ReadStartedCodexDeviceLogin,
   type StoreConnectedCodexAuth,
   type StoreStartedCodexDeviceLogin,
   disconnectProviderAccountForUser,
   issueProviderAccountGrant,
-  listProviderAccountsForUser,
   makeD1ProviderAccountRepository,
+  makeProviderAccountLifecycleLayer,
   pollOpenAiCodexDeviceLogin,
   refreshChatGptCodexDeviceLoginForUser,
   startChatGptCodexDeviceLogin,
   startOpenAiCodexDeviceLogin,
 } from './provider-accounts'
-import {
-  providerAccountRouteErrorMessage,
-  providerAccountRouteErrorName,
-  providerAccountRouteErrorStatus,
-} from './provider-account-route-errors'
-import { logWorkerRouteError, observedPromise } from './observability'
 import { openAgentsDatabase } from './runtime'
 
 type ProviderAccountBrowserEnv = Readonly<{
@@ -71,6 +78,24 @@ type ProviderAccountBrowserDependencies<
   ) => StoreStartedCodexDeviceLogin
 }>
 
+export const handleProviderAccountsListEffect = <
+  Session extends ProviderAccountBrowserSession,
+>(
+  session: Session,
+  appendRefreshedSessionCookies: (
+    response: globalThis.Response,
+    session: Session,
+  ) => globalThis.Response,
+) =>
+  Effect.gen(function* () {
+    const lifecycle = yield* ProviderAccountLifecycleService
+    const response = noStoreJsonResponse(
+      yield* lifecycle.listForUser(session.user.userId),
+    )
+
+    return appendRefreshedSessionCookies(response, session)
+  })
+
 export const makeProviderAccountBrowserHandlers = <
   Session extends ProviderAccountBrowserSession,
   Env extends ProviderAccountBrowserEnv,
@@ -92,12 +117,45 @@ export const makeProviderAccountBrowserHandlers = <
       return noStoreJsonResponse({ error: 'unauthorized' }, { status: 401 })
     }
 
-    const repository = makeD1ProviderAccountRepository(openAgentsDatabase(env))
-    const response = noStoreJsonResponse(
-      await listProviderAccountsForUser(repository, session.user.userId),
-    )
+    try {
+      const lifecycleLayer = makeProviderAccountLifecycleLayer({
+        deleteStartedDeviceLogin: dependencies.deleteStartedCodexDeviceLogin(
+          env.AUTH_STORAGE,
+        ),
+        pollDeviceLogin: secret => pollOpenAiCodexDeviceLogin(secret),
+        readStartedDeviceLogin: dependencies.readStartedCodexDeviceLogin(
+          env.AUTH_STORAGE,
+        ),
+        repository: makeD1ProviderAccountRepository(openAgentsDatabase(env)),
+        startDeviceLogin: () => startOpenAiCodexDeviceLogin(),
+        storeConnectedAuth: dependencies.storeConnectedCodexAuth(
+          env.AUTH_STORAGE,
+        ),
+        storeStartedDeviceLogin: dependencies.storeStartedCodexDeviceLogin(
+          env.AUTH_STORAGE,
+        ),
+      })
 
-    return dependencies.appendRefreshedSessionCookies(response, session)
+      return await observedEffect(
+        'ProviderAccountBrowser.listProviderAccountsForUser',
+        handleProviderAccountsListEffect(
+          session,
+          dependencies.appendRefreshedSessionCookies,
+        ).pipe(Effect.provide(lifecycleLayer)),
+      )
+    } catch (error) {
+      logWorkerRouteError('provider_accounts_list_failed', error, {
+        errorName: providerAccountRouteErrorName(error),
+      })
+
+      return noStoreJsonResponse(
+        {
+          error: 'provider_accounts_list_failed',
+          message: providerAccountRouteErrorMessage(error),
+        },
+        { status: providerAccountRouteErrorStatus(error, 502) },
+      )
+    }
   },
 
   handleProviderAccountDisconnectApi: async (
@@ -324,9 +382,8 @@ export const makeProviderAccountBrowserHandlers = <
             },
             () => startOpenAiCodexDeviceLogin(),
             {
-              storeStartedDeviceLogin: dependencies.storeStartedCodexDeviceLogin(
-                env.AUTH_STORAGE,
-              ),
+              storeStartedDeviceLogin:
+                dependencies.storeStartedCodexDeviceLogin(env.AUTH_STORAGE),
             },
           ),
       )

--- a/apps/openagents.com/workers/api/src/provider-accounts.test.ts
+++ b/apps/openagents.com/workers/api/src/provider-accounts.test.ts
@@ -3,6 +3,7 @@ import { Effect } from 'effect'
 import { describe, expect, test } from 'vitest'
 
 import worker from './index'
+import { handleProviderAccountsListEffect } from './provider-account-browser-routes'
 import {
   CHATGPT_CODEX_PROVIDER,
   CHATGPT_CODEX_VERIFICATION_URL,
@@ -911,6 +912,42 @@ describe('provider account service', () => {
     expect(bundle.accounts.map(account => account.providerAccountRef)).toEqual([
       'provider-account_1',
       'provider-account_2',
+    ])
+  })
+
+  test('browser account list route composes through the lifecycle service layer', async () => {
+    const repository = new MemoryProviderAccountRepository()
+    repository.accounts.push(
+      makeAccount({
+        id: 'provider_account_1',
+        providerAccountRef: 'provider-account_1',
+      }),
+    )
+
+    const response = await Effect.runPromise(
+      handleProviderAccountsListEffect(
+        { user: { userId: 'github:1' } },
+        routeResponse => {
+          routeResponse.headers.set('x-session-refreshed', '1')
+
+          return routeResponse
+        },
+      ).pipe(
+        Effect.provide(
+          makeProviderAccountLifecycleTestLayer({
+            now: () => new Date('2026-06-02T19:05:00.000Z'),
+            repository,
+          }),
+        ),
+      ),
+    )
+    const body = (await response.json()) as Awaited<
+      ReturnType<typeof listProviderAccountsForUser>
+    >
+
+    expect(response.headers.get('x-session-refreshed')).toBe('1')
+    expect(body.accounts.map(account => account.providerAccountRef)).toEqual([
+      'provider-account_1',
     ])
   })
 


### PR DESCRIPTION
## Summary

- Move the browser provider-account list path into an internal Effect-returning route function backed by `ProviderAccountLifecycleService`.
- Run the Worker handler through the existing observed Effect bridge and map typed provider-account failures at the route boundary.
- Add focused coverage that provides a lifecycle test layer for the migrated list path.

Closes #7012

## Verification

- `bun run --cwd apps/openagents.com/workers/api test -- src/provider-accounts.test.ts`
- `bun run --cwd apps/openagents.com/workers/api typecheck`
- `bun run --cwd apps/openagents.com check:architecture`
- `bun run --cwd apps/openagents.com/workers/api test -- src/artanis-administrator-labor-tick.test.ts`

Note: the requested opaque verification ref `command.public.pylon_khala.verify.b5bea41b6c623f7c09f1bf24` was not resolvable to argv from this checkout or local assignment metadata. The last command above is the only local test fixture found with a `command.public.pylon_khala.verify.*` fixture ref; the issue-focused Worker checks are also listed above.
