### PR TITLE
fix(khala-desktop): honor loopback Apple FM sidecar port

### DIFF
--- a/clients/khala-desktop/src/bun/apple-fm-sidecar.ts
+++ b/clients/khala-desktop/src/bun/apple-fm-sidecar.ts
@@ -34,6 +34,7 @@ type AppleFmSidecarHostOptions = {
 }
 
 const APPLE_FM_BRIDGE_DEFAULT_PORT = 11435
+const LOOPBACK_HOSTS = new Set(["127.0.0.1", "localhost", "[::1]", "::1"])
 
 const trim = (value: string | undefined): string | null => {
   const trimmed = value?.trim() ?? ""
@@ -86,6 +87,23 @@ function controlBaseUrlFromEnv(env: Readonly<Record<string, string | undefined>>
   const host = trim(env.PYLON_CONTROL_HOST) ?? "127.0.0.1"
   const port = Number(trim(env.PYLON_CONTROL_PORT) ?? 4716)
   return `http://${host}:${Number.isFinite(port) ? port : 4716}`
+}
+
+function bridgePortFromEnv(env: Readonly<Record<string, string | undefined>>): number {
+  const rawBaseUrl =
+    trim(env.OPENAGENTS_APPLE_FM_BASE_URL) ?? trim(env.PROBE_APPLE_FM_BASE_URL)
+  if (rawBaseUrl === null) return APPLE_FM_BRIDGE_DEFAULT_PORT
+
+  try {
+    const parsed = new URL(rawBaseUrl)
+    if (!LOOPBACK_HOSTS.has(parsed.hostname)) return APPLE_FM_BRIDGE_DEFAULT_PORT
+    const port = Number(parsed.port)
+    return Number.isInteger(port) && port > 0 && port <= 65_535
+      ? port
+      : APPLE_FM_BRIDGE_DEFAULT_PORT
+  } catch {
+    return APPLE_FM_BRIDGE_DEFAULT_PORT
+  }
 }
 
 async function controlTokenFromEnv(
@@ -148,6 +166,7 @@ export function createAppleFmSidecarHost(
   const fetchFn = options.fetchFn ?? fetch
   const spawn = options.spawn ?? Bun.spawn
   const now = options.now ?? (() => new Date().toISOString())
+  const bridgePort = bridgePortFromEnv(env)
   const discoverOptions = {
     cwd: process.cwd(),
     env,
@@ -167,7 +186,7 @@ export function createAppleFmSidecarHost(
     }
     try {
       launchState = "launching"
-      child = spawn([helper.path, "--port", String(APPLE_FM_BRIDGE_DEFAULT_PORT)], {
+      child = spawn([helper.path, "--port", String(bridgePort)], {
         stdin: "ignore",
         stdout: "ignore",
         stderr: "ignore",

--- a/clients/khala-desktop/tests/apple-fm-sidecar.test.ts
+++ b/clients/khala-desktop/tests/apple-fm-sidecar.test.ts
@@ -98,4 +98,72 @@ describe("Khala Desktop Apple FM sidecar host", () => {
       rmSync(resourcesDir, { force: true, recursive: true })
     }
   })
+
+  test("uses explicit loopback Apple FM base URL port when launching helper", async () => {
+    const resourcesDir = mkdtempSync(join(tmpdir(), "khala-apple-fm-sidecar-port-"))
+    const helperPath = join(resourcesDir, APPLE_FM_BRIDGE_RESOURCES_SUBPATH)
+    mkdirSync(dirname(helperPath), { recursive: true })
+    writeFileSync(helperPath, "#!/usr/bin/env bash\n")
+    chmodSync(helperPath, 0o755)
+
+    const spawned: Array<ReadonlyArray<string>> = []
+    const host = createAppleFmSidecarHost({
+      arch: "arm64",
+      env: {
+        OPENAGENTS_APPLE_FM_BASE_URL: "http://127.0.0.1:12435",
+      },
+      now: () => fixedNow,
+      platform: "darwin",
+      resourcesDir,
+      spawn: ((command: ReadonlyArray<string>) => {
+        spawned.push([...command])
+        return {
+          exited: new Promise<number>(() => {}),
+          kill() {},
+        }
+      }) as unknown as typeof Bun.spawn,
+    })
+
+    try {
+      await host.readiness()
+      expect(spawned).toEqual([[helperPath, "--port", "12435"]])
+    } finally {
+      host.stop()
+      rmSync(resourcesDir, { force: true, recursive: true })
+    }
+  })
+
+  test("ignores non-loopback Apple FM base URL ports when launching helper", async () => {
+    const resourcesDir = mkdtempSync(join(tmpdir(), "khala-apple-fm-sidecar-port-"))
+    const helperPath = join(resourcesDir, APPLE_FM_BRIDGE_RESOURCES_SUBPATH)
+    mkdirSync(dirname(helperPath), { recursive: true })
+    writeFileSync(helperPath, "#!/usr/bin/env bash\n")
+    chmodSync(helperPath, 0o755)
+
+    const spawned: Array<ReadonlyArray<string>> = []
+    const host = createAppleFmSidecarHost({
+      arch: "arm64",
+      env: {
+        OPENAGENTS_APPLE_FM_BASE_URL: "http://example.com:12435",
+      },
+      now: () => fixedNow,
+      platform: "darwin",
+      resourcesDir,
+      spawn: ((command: ReadonlyArray<string>) => {
+        spawned.push([...command])
+        return {
+          exited: new Promise<number>(() => {}),
+          kill() {},
+        }
+      }) as unknown as typeof Bun.spawn,
+    })
+
+    try {
+      await host.readiness()
+      expect(spawned).toEqual([[helperPath, "--port", "11435"]])
+    } finally {
+      host.stop()
+      rmSync(resourcesDir, { force: true, recursive: true })
+    }
+  })
 })


### PR DESCRIPTION
## Summary

- Honor `OPENAGENTS_APPLE_FM_BASE_URL` / `PROBE_APPLE_FM_BASE_URL` loopback ports when launching the Khala Desktop packaged Apple FM bridge helper.
- Fail closed to the default bridge port for non-loopback, malformed, or portless base URLs.
- Add sidecar host tests for explicit loopback port launch and non-loopback rejection.

Closes #6973.

## Verification

- `bun run --cwd clients/khala-desktop verify`
- `bun run --cwd apps/openagents.com check:deploy`

Note: the task requested opaque ref `command.public.pylon_khala.verify.b5bea41b6c623f7c09f1bf24`; this checkout exposes one-way hashing for `command.public.pylon_khala.verify.*` refs but no reverse resolver from ref to argv. The issue-named deploy gate and focused Khala Desktop gate above both passed.