### PR TITLE
refactor(pylon): add Effect lease store diagnostics

### DIFF
--- a/apps/pylon/src/workspace-materializer.ts
+++ b/apps/pylon/src/workspace-materializer.ts
@@ -2,6 +2,7 @@ import { existsSync, realpathSync } from "node:fs"
 import { mkdir, readdir, readFile, rm, stat, utimes, writeFile } from "node:fs/promises"
 import { dirname, join, resolve } from "node:path"
 import { createHash } from "node:crypto"
+import { Context, Effect, Layer } from "effect"
 import { CLAUDE_AGENT_CAPABILITY_REF } from "./claude-agent.js"
 import { CODEX_AGENT_CAPABILITY_REF } from "./codex-agent.js"
 
@@ -755,6 +756,36 @@ export type WorkspaceLeaseRecord = {
   }
 }
 
+export type WorkspaceLeaseReadFailureKind = "not_found" | "malformed" | "storage_failed"
+
+export class WorkspaceLeaseReadError extends Error {
+  readonly operation = "workspace_lease.read"
+  readonly reasonRef: string
+  readonly causeRef: string
+
+  constructor(
+    readonly kind: WorkspaceLeaseReadFailureKind,
+    readonly workspaceRef: string,
+    cause: unknown,
+  ) {
+    const causeLabel = cause instanceof Error ? cause.name : typeof cause
+    super(`workspace lease read ${kind}: ${workspaceRef}`)
+    this.name = "WorkspaceLeaseReadError"
+    this.reasonRef = `reason.workspace_lease_read.${kind}`
+    this.causeRef = stableRef("cause.pylon.workspace_lease_read", `${kind}:${workspaceRef}:${causeLabel}`)
+  }
+}
+
+export class PylonWorkspaceLeaseStore extends Context.Service<
+  PylonWorkspaceLeaseStore,
+  {
+    readonly readLeaseRecord: (input: {
+      readonly workspaceStateRoot: string
+      readonly workspaceRef: string
+    }) => Effect.Effect<WorkspaceLeaseRecord, WorkspaceLeaseReadError>
+  }
+>()("PylonWorkspaceLeaseStore") {}
+
 /** Stable cache key for one public repository's shared bare clone. */
 export function repositoryCacheKeyFor(fullName: string): string {
   return createHash("sha256").update(fullName).digest("hex").slice(0, 24)
@@ -984,10 +1015,58 @@ function leaseRecordPath(workspaceStateRoot: string, workspaceRef: string) {
   return join(workspaceStateRoot, `${workspaceRef}.json`)
 }
 
-async function readLeaseRecord(path: string): Promise<WorkspaceLeaseRecord | null> {
+function workspaceLeaseReadErrorFromUnknown(
+  error: unknown,
+  workspaceRef: string,
+): WorkspaceLeaseReadError {
+  if (error instanceof WorkspaceLeaseReadError) return error
+  return new WorkspaceLeaseReadError("storage_failed", workspaceRef, error)
+}
+
+async function readLeaseRecordStrict(input: {
+  workspaceStateRoot: string
+  workspaceRef: string
+}): Promise<WorkspaceLeaseRecord> {
+  const path = leaseRecordPath(input.workspaceStateRoot, input.workspaceRef)
+  let raw: string
   try {
-    const record = JSON.parse(await readFile(path, "utf8")) as WorkspaceLeaseRecord
-    return record.schema === WORKSPACE_LEASE_SCHEMA ? record : null
+    raw = await readFile(path, "utf8")
+  } catch (error) {
+    if (isNodeErrorWithCode(error, "ENOENT")) {
+      throw new WorkspaceLeaseReadError("not_found", input.workspaceRef, error)
+    }
+    throw new WorkspaceLeaseReadError("storage_failed", input.workspaceRef, error)
+  }
+
+  try {
+    const record = JSON.parse(raw) as WorkspaceLeaseRecord
+    if (record?.schema !== WORKSPACE_LEASE_SCHEMA) {
+      throw new WorkspaceLeaseReadError("malformed", input.workspaceRef, "schema")
+    }
+    return record
+  } catch (error) {
+    throw workspaceLeaseReadErrorFromUnknown(
+      error instanceof WorkspaceLeaseReadError
+        ? error
+        : new WorkspaceLeaseReadError("malformed", input.workspaceRef, error),
+      input.workspaceRef,
+    )
+  }
+}
+
+export const PylonWorkspaceLeaseStoreLive = Layer.succeed(PylonWorkspaceLeaseStore, {
+  readLeaseRecord: (input) =>
+    Effect.tryPromise({
+      try: () => readLeaseRecordStrict(input),
+      catch: (error) => workspaceLeaseReadErrorFromUnknown(error, input.workspaceRef),
+    }),
+})
+
+async function readLeaseRecord(path: string): Promise<WorkspaceLeaseRecord | null> {
+  const workspaceRef = path.endsWith(".json") ? path.slice(path.lastIndexOf("/") + 1, -".json".length) : path
+  const workspaceStateRoot = path.slice(0, Math.max(0, path.length - `${workspaceRef}.json`.length - 1))
+  try {
+    return await readLeaseRecordStrict({ workspaceStateRoot, workspaceRef })
   } catch {
     return null
   }
@@ -1254,7 +1333,15 @@ export async function workspaceLeaseRecordFor(input: {
   workspaceStateRoot: string
   workspaceRef: string
 }): Promise<WorkspaceLeaseRecord | null> {
-  return readLeaseRecord(leaseRecordPath(input.workspaceStateRoot, input.workspaceRef))
+  return Effect.runPromise(
+    Effect.gen(function* () {
+      const store = yield* PylonWorkspaceLeaseStore
+      return yield* store.readLeaseRecord(input)
+    }).pipe(
+      Effect.catch(() => Effect.succeed(null)),
+      Effect.provide(PylonWorkspaceLeaseStoreLive),
+    ),
+  )
 }
 
 /**

--- a/apps/pylon/tests/workspace-worktree.test.ts
+++ b/apps/pylon/tests/workspace-worktree.test.ts
@@ -3,6 +3,7 @@ import { existsSync } from "node:fs"
 import { mkdir, mkdtemp, rm, utimes, writeFile } from "node:fs/promises"
 import { join } from "node:path"
 import { tmpdir } from "node:os"
+import { Effect } from "effect"
 import {
   captureWorkspaceChanges,
   cleanupExpiredWorkspaces,
@@ -12,6 +13,8 @@ import {
   detectWorkspaceChangeConflicts,
   materializeGitCheckoutWorkspaceWithLease,
   pruneWorkspaceCacheDirectories,
+  PylonWorkspaceLeaseStore,
+  PylonWorkspaceLeaseStoreLive,
   publicWorkspaceChangeCaptureProjection,
   publicWorkspaceLeaseProjection,
   releaseWorkspace,
@@ -101,6 +104,18 @@ function leaseInput(root: string, overrides: Record<string, unknown> = {}) {
     workspaceStateRoot: join(root, "workspace-leases"),
     ...overrides,
   }
+}
+
+function readLeaseRecordWithLiveStore(input: {
+  workspaceStateRoot: string
+  workspaceRef: string
+}) {
+  return Effect.runPromise(
+    Effect.gen(function* () {
+      const store = yield* PylonWorkspaceLeaseStore
+      return yield* store.readLeaseRecord(input)
+    }).pipe(Effect.provide(PylonWorkspaceLeaseStoreLive)),
+  )
 }
 
 describe("repositoryCacheKeyFor", () => {
@@ -551,6 +566,68 @@ describe("materializeGitCheckoutWorkspaceWithLease", () => {
       expect(record?.generatedAt).toBe(now.toISOString())
       expect(record?.cleanupRef).toBe(materialized.cleanupRef)
       expect(record?.local.workingDirectory).toBe(materialized.workingDirectory)
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
+  test("Effect lease store distinguishes missing lease records", async () => {
+    const root = await mkdtemp(join(tmpdir(), "pylon-worktree-lease-store-"))
+    try {
+      await expect(
+        readLeaseRecordWithLiveStore({
+          workspaceStateRoot: join(root, "workspace-leases"),
+          workspaceRef: "workspace.pylon.codex_agent_task.missing",
+        }),
+      ).rejects.toMatchObject({
+        kind: "not_found",
+        operation: "workspace_lease.read",
+        reasonRef: "reason.workspace_lease_read.not_found",
+        workspaceRef: "workspace.pylon.codex_agent_task.missing",
+      })
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
+  test("Effect lease store distinguishes malformed lease records", async () => {
+    const root = await mkdtemp(join(tmpdir(), "pylon-worktree-lease-store-"))
+    try {
+      const workspaceStateRoot = join(root, "workspace-leases")
+      const workspaceRef = "workspace.pylon.codex_agent_task.malformed"
+      await mkdir(workspaceStateRoot, { recursive: true })
+      await writeFile(join(workspaceStateRoot, `${workspaceRef}.json`), "{not-json}\n")
+
+      await expect(
+        readLeaseRecordWithLiveStore({ workspaceStateRoot, workspaceRef }),
+      ).rejects.toMatchObject({
+        kind: "malformed",
+        operation: "workspace_lease.read",
+        reasonRef: "reason.workspace_lease_read.malformed",
+        workspaceRef,
+      })
+      await expect(workspaceLeaseRecordFor({ workspaceStateRoot, workspaceRef })).resolves.toBeNull()
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
+  test("Effect lease store distinguishes storage failures", async () => {
+    const root = await mkdtemp(join(tmpdir(), "pylon-worktree-lease-store-"))
+    try {
+      const workspaceStateRoot = join(root, "workspace-leases")
+      await writeFile(workspaceStateRoot, "not a directory\n")
+      await expect(
+        readLeaseRecordWithLiveStore({
+          workspaceStateRoot,
+          workspaceRef: "workspace.pylon.codex_agent_task.storage_failed",
+        }),
+      ).rejects.toMatchObject({
+        kind: "storage_failed",
+        operation: "workspace_lease.read",
+        reasonRef: "reason.workspace_lease_read.storage_failed",
+        workspaceRef: "workspace.pylon.codex_agent_task.storage_failed",
+      })
     } finally {
       await rm(root, { recursive: true, force: true })
     }


### PR DESCRIPTION
## Summary
- Add a PylonWorkspaceLeaseStore Effect service facade for workspace lease reads.
- Surface typed lease-read diagnostics for not_found, malformed, and storage_failed states while preserving the existing Promise/null compatibility wrapper.
- Add focused workspace lease tests for the new typed diagnostics.

Closes #7011

## Verification
- bun test tests/workspace-worktree.test.ts (from apps/pylon)
- bun run typecheck (from apps/pylon)
- bun run test (from apps/pylon)

Note: the requested verifier ref command.public.pylon_khala.verify.b5bea41b6c623f7c09f1bf24 was not recoverable from local assignment metadata after the task workspace was cleaned and recreated; I ran the full Pylon package test suite as the broad package verifier.