### PR TITLE
fix(glm): admit internal stress on free GLM headroom

### DIFF
--- a/apps/openagents.com/workers/api/src/inference/chat-completions-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/chat-completions-routes.test.ts
@@ -2852,6 +2852,52 @@ describe('POST /v1/chat/completions', () => {
     })
   })
 
+  test('admits internal_stress when GLM has real free capacity but reserved external headroom is consumed', async () => {
+    let dispatched = false
+    let registerCalls = 0
+    const coordinator: InternalStressPreemptionCoordinator = {
+      preempt: async () => undefined,
+      register: async () => {
+        registerCalls += 1
+        return async () => {}
+      },
+      snapshot: async () => ({ activeStressCount: 0 }),
+    }
+    const registry = new InferenceProviderRegistry()
+    registry.register({
+      ...echoAdapter('primary'),
+      complete: request => {
+        dispatched = request.priority === 'internal_stress'
+        return stubEchoAdapter.complete(request)
+      },
+    })
+
+    const response = await run(
+      handleChatCompletions(
+        chatRequest(helloBody, {
+          headers: {
+            [INFERENCE_DEMAND_KIND_HEADER]: 'internal_stress',
+            [INFERENCE_DEMAND_SOURCE_HEADER]: 'glm-saturation',
+          },
+        }),
+        baseDeps({
+          internalStressCoordinator: coordinator,
+          lanePlan: () => ['primary'],
+          registry,
+          routeAdmission: {
+            internalStressHeadroomAvailable: true,
+            reason: 'glm_reserved_external_headroom_unavailable',
+            reservedExternalHeadroomAvailable: false,
+          },
+        }),
+      ),
+    )
+
+    expect(response.status).toBe(200)
+    expect(dispatched).toBe(true)
+    expect(registerCalls).toBe(1)
+  })
+
   test('keeps external route demand admitted when breached SLO shedding is external-labeled', async () => {
     let dispatched = false
     const registry = new InferenceProviderRegistry()

--- a/apps/openagents.com/workers/api/src/inference/chat-completions-routes.ts
+++ b/apps/openagents.com/workers/api/src/inference/chat-completions-routes.ts
@@ -3122,7 +3122,10 @@ export const handleChatCompletions = (
     const internalStressRouteAdmissionRejected =
       routeDemandClass === 'internal_stress' &&
       deps.routeAdmission !== undefined &&
-      deps.routeAdmission.reservedExternalHeadroomAvailable === false
+      !(
+        deps.routeAdmission.internalStressHeadroomAvailable ??
+        deps.routeAdmission.reservedExternalHeadroomAvailable
+      )
     const preemptionAbortController =
       routeDemandClass === 'internal_stress' &&
       !internalStressRouteAdmissionRejected &&

--- a/apps/openagents.com/workers/api/src/inference/hydralisk-adapter.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/hydralisk-adapter.test.ts
@@ -328,6 +328,7 @@ describe('hydralisk vLLM adapter', () => {
     })
 
     expect(runtime.routeAdmission()).toEqual({
+      internalStressHeadroomAvailable: true,
       reason: 'glm_reserved_external_headroom_available',
       reservedExternalHeadroomAvailable: true,
     })
@@ -336,37 +337,46 @@ describe('hydralisk vLLM adapter', () => {
     await startedFetchPromise
 
     expect(runtime.routeAdmission()).toEqual({
-      reason: 'glm_reserved_external_headroom_available',
-      reservedExternalHeadroomAvailable: true,
+      internalStressHeadroomAvailable: true,
+      reason: 'glm_reserved_external_headroom_unavailable',
+      reservedExternalHeadroomAvailable: false,
     })
 
     releaseFetch?.()
     await pending
 
     expect(runtime.routeAdmission()).toEqual({
+      internalStressHeadroomAvailable: true,
       reason: 'glm_reserved_external_headroom_available',
       reservedExternalHeadroomAvailable: true,
     })
   })
 
-  it('rejects route admission only when eligible GLM headroom is exhausted', () => {
+  it('admits internal stress on the final free GLM slot while reserving it from stress admission once exhausted', () => {
     const config = {
       id: GLM_POOL_ADAPTER_ID,
       replicas: [
-        replicaFixture('primary', {
-          maxInflight: 1,
-        }),
+        replicaFixture('primary', { maxInflight: 2 }),
       ],
       upstreamModel: 'openagents/glm-5.2-reap-504b',
     }
 
     expect(readHydraliskPoolRouteAdmission(config)).toEqual({
+      internalStressHeadroomAvailable: true,
       reason: 'glm_reserved_external_headroom_available',
       reservedExternalHeadroomAvailable: true,
     })
     expect(
       readHydraliskPoolRouteAdmission(config, new Map([['primary', 1]])),
     ).toEqual({
+      internalStressHeadroomAvailable: true,
+      reason: 'glm_reserved_external_headroom_unavailable',
+      reservedExternalHeadroomAvailable: false,
+    })
+    expect(
+      readHydraliskPoolRouteAdmission(config, new Map([['primary', 2]])),
+    ).toEqual({
+      internalStressHeadroomAvailable: false,
       reason: 'glm_aggregate_external_headroom_zero',
       reservedExternalHeadroomAvailable: false,
     })
@@ -403,6 +413,7 @@ describe('hydralisk vLLM adapter', () => {
     })
 
     expect(runtime.routeAdmission()).toEqual({
+      internalStressHeadroomAvailable: true,
       reason: 'glm_reserved_external_headroom_available',
       reservedExternalHeadroomAvailable: true,
     })
@@ -411,14 +422,16 @@ describe('hydralisk vLLM adapter', () => {
     await startedFetchPromise
 
     expect(runtime.routeAdmission()).toEqual({
-      reason: 'glm_reserved_external_headroom_available',
-      reservedExternalHeadroomAvailable: true,
+      internalStressHeadroomAvailable: true,
+      reason: 'glm_reserved_external_headroom_unavailable',
+      reservedExternalHeadroomAvailable: false,
     })
 
     releaseFetch?.()
     await pending
 
     expect(runtime.routeAdmission()).toEqual({
+      internalStressHeadroomAvailable: true,
       reason: 'glm_reserved_external_headroom_available',
       reservedExternalHeadroomAvailable: true,
     })

--- a/apps/openagents.com/workers/api/src/inference/hydralisk-adapter.ts
+++ b/apps/openagents.com/workers/api/src/inference/hydralisk-adapter.ts
@@ -117,6 +117,7 @@ export type HydraliskPoolAdapterConfig = Readonly<{
 }>
 
 export type HydraliskPoolRouteAdmissionSnapshot = Readonly<{
+  internalStressHeadroomAvailable: boolean
   reason: string
   reservedExternalHeadroomAvailable: boolean
 }>
@@ -957,17 +958,27 @@ const routeAdmissionForHeadroom = (
 ): HydraliskPoolRouteAdmissionSnapshot => {
   if (headroom.aggregateMaxInflight <= 0) {
     return {
+      internalStressHeadroomAvailable: false,
       reason: 'glm_pool_no_external_capacity',
       reservedExternalHeadroomAvailable: false,
     }
   }
   if (headroom.aggregateExternalHeadroom <= 0) {
     return {
+      internalStressHeadroomAvailable: false,
       reason: 'glm_aggregate_external_headroom_zero',
       reservedExternalHeadroomAvailable: false,
     }
   }
+  if (headroom.aggregateExternalHeadroom <= 1) {
+    return {
+      internalStressHeadroomAvailable: true,
+      reason: 'glm_reserved_external_headroom_unavailable',
+      reservedExternalHeadroomAvailable: false,
+    }
+  }
   return {
+    internalStressHeadroomAvailable: true,
     reason: 'glm_reserved_external_headroom_available',
     reservedExternalHeadroomAvailable: true,
   }

--- a/apps/openagents.com/workers/api/src/inference/model-router.ts
+++ b/apps/openagents.com/workers/api/src/inference/model-router.ts
@@ -631,6 +631,7 @@ export type DispatchLoadSheddingPolicy = Readonly<{
 
 export type DispatchRouteAdmissionPolicy = Readonly<{
   demandClass: InferenceDemandClass
+  internalStressHeadroomAvailable?: boolean | undefined
   reservedExternalHeadroomAvailable: boolean
   reason: string
 }>
@@ -907,7 +908,8 @@ const shouldRejectAdmission = (
 ): boolean =>
   admission !== undefined &&
   admission.demandClass === 'internal_stress' &&
-  !admission.reservedExternalHeadroomAvailable
+  !(admission.internalStressHeadroomAvailable ??
+    admission.reservedExternalHeadroomAvailable)
 
 const admissionError = (
   admission: DispatchRouteAdmissionPolicy,


### PR DESCRIPTION
## Summary

Closes #6963.

- Split GLM route admission into reserved external headroom and actual internal-stress headroom.
- Allow `internal_stress` / `glm-saturation` to dispatch when GLM still has a real free slot, even if the reserved external headroom buffer is consumed.
- Keep external-wins behavior intact by continuing to mark reserved external headroom unavailable and by registering admitted stress with the preemption coordinator.

## Verification

- `bun run --cwd apps/openagents.com/workers/api test -- src/inference/hydralisk-adapter.test.ts`
- `bun run --cwd apps/openagents.com/workers/api test -- src/inference/chat-completions-routes.test.ts -t "reserved external headroom|real free capacity"`
- `bun run --cwd apps/openagents.com check:deploy` (required `command.public.pylon_khala.verify.b5bea41b6c623f7c09f1bf24`; exited 0)
