### PR TITLE
fix(codex-supervisor): GC stale claims and fast-retry gate flakes

### DIFF
--- a/apps/pylon/scripts/codex-supervisor/backoff-policy.sh
+++ b/apps/pylon/scripts/codex-supervisor/backoff-policy.sh
@@ -121,8 +121,16 @@ sup_dispatch_failure_signature() {
     printf 'rate_limited'
     return 0
   fi
-  if grep -qiE '409|dispatch gate refused|target_pylon_unavailable|duplicate_active_assignment' "$out" 2>/dev/null; then
+  if grep -qiE 'duplicate_active_assignment' "$out" 2>/dev/null; then
     printf 'refused'
+    return 0
+  fi
+  if grep -qiE '409|pylon_api_conflict|dispatch gate refused|target_pylon_unavailable' "$out" 2>/dev/null; then
+    printf 'dispatch_gate_conflict'
+    return 0
+  fi
+  if grep -qiE '(^|[^0-9])(500|503)([^0-9]|$)|internal_server_error|could not read linked owner registration|linked Pylon capacity|d1 read' "$out" 2>/dev/null; then
+    printf 'dispatch_gate_transient'
     return 0
   fi
   printf 'other'
@@ -143,6 +151,12 @@ sup_should_escalate_failure_backoff() {
   local sig="$1"
   local repeated="$2"
   if [ "$sig" = "codex_agent_execution_refused" ]; then
+    return 1
+  fi
+  if [ "$sig" = "dispatch_gate_conflict" ]; then
+    return 1
+  fi
+  if [ "$sig" = "dispatch_gate_transient" ]; then
     return 1
   fi
   [ "$repeated" -ge "$SUP_FAILURE_BACKOFF_ESCALATE_THRESHOLD" ] 2>/dev/null

--- a/apps/pylon/scripts/codex-supervisor/backoff-policy.test.sh
+++ b/apps/pylon/scripts/codex-supervisor/backoff-policy.test.sh
@@ -43,6 +43,9 @@ fi
 
 printf '%s' '{"error":"codex_agent_execution_refused"}' > "$WORK/executor-refused.json"
 printf '%s' '{"error":"target_pylon_unavailable"}' > "$WORK/gate-refused.json"
+printf '%s' '{"error":"pylon_api_conflict"} HTTP 409' > "$WORK/gate-conflict.json"
+printf '%s' '{"blockerRefs":["blocker.public.pylon_dispatch.duplicate_active_assignment"]}' > "$WORK/duplicate-active.json"
+printf '%s' '503 could not read linked owner registration' > "$WORK/d1-flake.txt"
 printf '%s' 'HTTP 429 too many requests' > "$WORK/rate.txt"
 printf '%s' 'plain failure' > "$WORK/other.txt"
 
@@ -52,10 +55,28 @@ else
   bad "executor refusal classification failed"
 fi
 
-if [ "$(sup_dispatch_failure_signature "$WORK/gate-refused.json")" = "refused" ]; then
-  ok "gate refusal remains generic refused"
+if [ "$(sup_dispatch_failure_signature "$WORK/gate-refused.json")" = "dispatch_gate_conflict" ]; then
+  ok "target_pylon_unavailable is classified as fast dispatch gate conflict"
 else
   bad "gate refusal classification failed"
+fi
+
+if [ "$(sup_dispatch_failure_signature "$WORK/gate-conflict.json")" = "dispatch_gate_conflict" ]; then
+  ok "pylon_api_conflict/409 is classified as fast dispatch gate conflict"
+else
+  bad "pylon_api_conflict classification failed"
+fi
+
+if [ "$(sup_dispatch_failure_signature "$WORK/duplicate-active.json")" = "refused" ]; then
+  ok "duplicate_active_assignment stays parked as refused"
+else
+  bad "duplicate_active_assignment classification failed"
+fi
+
+if [ "$(sup_dispatch_failure_signature "$WORK/d1-flake.txt")" = "dispatch_gate_transient" ]; then
+  ok "500/503 D1 read flakes are classified as fast dispatch gate transient"
+else
+  bad "D1 flake classification failed"
 fi
 
 if [ "$(sup_dispatch_failure_signature "$WORK/rate.txt")" = "rate_limited" ]; then
@@ -119,6 +140,18 @@ if sup_should_escalate_failure_backoff codex_agent_execution_refused 9; then
   bad "executor refusal should not escalate general backoff"
 else
   ok "executor refusal never escalates general backoff"
+fi
+
+if sup_should_escalate_failure_backoff dispatch_gate_conflict 9; then
+  bad "dispatch gate conflict should not escalate general backoff"
+else
+  ok "dispatch gate conflict never escalates general backoff"
+fi
+
+if sup_should_escalate_failure_backoff dispatch_gate_transient 9; then
+  bad "dispatch gate transient should not escalate general backoff"
+else
+  ok "dispatch gate transient never escalates general backoff"
 fi
 
 printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"

--- a/apps/pylon/scripts/codex-supervisor/claim-dispatch.test.sh
+++ b/apps/pylon/scripts/codex-supervisor/claim-dispatch.test.sh
@@ -101,6 +101,14 @@ if sup_claim_is_active 701; then bad "stale #701 should be GC'd"; else ok "stale
 if sup_claim_is_active 702; then ok "fresh #702 survives GC"; else bad "fresh #702 should survive GC"; fi
 sup_release_claim 702
 
+# --- sup_gc_orphaned_claims -------------------------------------------------
+sup_try_claim_issue 704 999999 >/dev/null
+sup_try_claim_issue 705 "$$" >/dev/null
+sup_gc_orphaned_claims
+if sup_claim_is_active 704; then bad "orphaned #704 claim should be GC'd on startup"; else ok "orphaned #704 claim GC'd on startup"; fi
+if sup_claim_is_active 705; then ok "live-owner #705 claim survives startup GC"; else bad "live-owner #705 claim should survive startup GC"; fi
+sup_release_claim 705
+
 # --- sup_refresh_claim renews TTL ------------------------------------------
 sup_try_claim_issue 703 >/dev/null
 touch -t 200001010000 "$(sup_claims_dir)/claim.703" 2>/dev/null || true
@@ -132,6 +140,23 @@ sup_release_claim 710; sup_release_claim 711; sup_release_claim 712
 picked=$(pick_and_claim_unlocked_issue 0 799 713)
 if [ "$picked" = "713" ]; then ok "pick_and_claim skips CLOSED #799 -> #713"; else bad "expected 713, got '$picked'"; fi
 sup_release_claim 713
+
+# --- pick_and_claim skips standing-task / epic queue governors --------------
+sup_labels_for_issue() {
+  case "$1" in
+    714) printf 'standing-task,prio:4-backstop-burn' ;;
+    715) printf 'epic,prio:1-continual-learning' ;;
+    *) printf '' ;;
+  esac
+}
+picked=$(pick_and_claim_unlocked_issue 0 714 715 716)
+if [ "$picked" = "716" ]; then
+  ok "pick_and_claim skips standing-task/epic issues -> #716"
+else
+  bad "expected standing/epic skip to pick 716, got '$picked'"
+fi
+sup_release_claim 716
+sup_labels_for_issue() { printf ''; }
 
 # --- CONCURRENCY: N slots, same pool -> all DISTINCT, no duplicates ---------
 # This is the core regression assertion for the duplicate-dispatch bug.

--- a/apps/pylon/scripts/codex-supervisor/codex-supervisor.sh
+++ b/apps/pylon/scripts/codex-supervisor/codex-supervisor.sh
@@ -513,6 +513,12 @@ worker_loop() {
     if [ "$sig" = "codex_agent_execution_refused" ]; then
       failure_sleep="$SUP_CLAIMED_DEEP_BACKLOG_SLEEP_SECS"
       escalate_backoff=0
+    elif [ "$sig" = "dispatch_gate_conflict" ]; then
+      failure_sleep="$SUP_CLAIMED_DEEP_BACKLOG_SLEEP_SECS"
+      escalate_backoff=0
+    elif [ "$sig" = "dispatch_gate_transient" ]; then
+      failure_sleep="$SUP_CLAIMED_DEEP_BACKLOG_SLEEP_SECS"
+      escalate_backoff=0
     elif ! sup_should_escalate_failure_backoff "$sig" "$failure_repeat"; then
       escalate_backoff=0
     fi
@@ -543,6 +549,8 @@ echo $$ > "$SUP_STATE_DIR/supervisor.pid"
 # fresh process is not flagged wedged before its first dispatch (#6646).
 record_dispatch_attempt
 log "=== codex-supervisor START pid=$$ repo=$REPO_ROOT pylon=$SUP_PYLON_REF per_account=$SUP_PER_ACCOUNT max_slots=$SUP_MAX_SLOTS account_refs=${SUP_ACCOUNT_REFS:-all} ==="
+sup_gc_orphaned_claims
+log "startup claim GC swept orphaned in-flight claims"
 
 sup_run_timeout "$SUP_PYLON_TIMEOUT_SECS" "${PYLON[@]}" provider go-online >> "$SUP_LOG" 2>&1 || log "provider go-online nonzero (continuing)"
 

--- a/apps/pylon/scripts/codex-supervisor/lockout.sh
+++ b/apps/pylon/scripts/codex-supervisor/lockout.sh
@@ -273,6 +273,7 @@ pick_unlocked_issue() {
 # an issue another slot is actively working. Defaults to the dispatch timeout
 # when set, else 30m.
 : "${SUP_CLAIM_TTL_SECS:=${SUP_DISPATCH_TIMEOUT_SECS:-1800}}"
+: "${SUP_NON_DISPATCH_CLAIM_LABELS:=standing-task,epic}"
 
 sup_claims_dir() {
   local d="${SUP_LOCKOUT_CACHE_DIR:-$SUP_STATE_DIR}/claims"
@@ -298,6 +299,36 @@ sup_gc_stale_claims() {
   done
 }
 
+sup_claim_owner_pid() {
+  local claim="$1"
+  awk 'NR==1 {print $1}' "$claim/meta" 2>/dev/null
+}
+
+sup_claim_owner_is_live() {
+  local claim="$1"
+  local owner; owner="$(sup_claim_owner_pid "$claim")"
+  case "$owner" in
+    ''|*[!0-9]*) return 1 ;;
+  esac
+  kill -0 "$owner" 2>/dev/null
+}
+
+# sup_gc_orphaned_claims
+#   Startup/restart sweep for claims left behind by a killed supervisor. Active
+#   claims are tied to the worker shell's PID (BASHPID); if that process no
+#   longer exists, there is no live local owner refreshing the claim, so keeping
+#   it would wedge the next run until the full TTL expires.
+sup_gc_orphaned_claims() {
+  local dir; dir="$(sup_claims_dir)"
+  local claim
+  for claim in "$dir"/claim.*; do
+    [ -e "$claim" ] || continue
+    if ! sup_claim_owner_is_live "$claim"; then
+      rm -rf "$claim" 2>/dev/null || true
+    fi
+  done
+}
+
 # sup_claim_is_active <issue>
 #   rc 0 if a FRESH claim is held for the issue (reserved by some slot), rc 1
 #   otherwise. Does not mutate; GC of stale entries is sup_gc_stale_claims's job.
@@ -317,7 +348,7 @@ sup_claim_is_active() {
 #   rc 1 if another slot already holds a fresh claim. Relies on the caller (or a
 #   preceding sup_gc_stale_claims) to have cleared expired claims first.
 sup_try_claim_issue() {
-  local issue="$1"; local owner="${2:-$$}"
+  local issue="$1"; local owner="${2:-${BASHPID:-$$}}"
   [ -n "$issue" ] || return 1
   local dir; dir="$(sup_claims_dir)"
   local claim="$dir/claim.$issue"
@@ -340,7 +371,7 @@ sup_refresh_claim() {
   # sup_gc_stale_claims read); overwriting an existing inner file does not
   # reliably update the directory mtime on all filesystems.
   touch "$claim" 2>/dev/null || true
-  printf '%s %s\n' "${2:-$$}" "$(date +%s)" > "$claim/meta" 2>/dev/null || true
+  printf '%s %s\n' "${2:-${BASHPID:-$$}}" "$(date +%s)" > "$claim/meta" 2>/dev/null || true
 }
 
 # sup_release_claim <issue>
@@ -350,6 +381,38 @@ sup_refresh_claim() {
 sup_release_claim() {
   local issue="$1"; [ -n "$issue" ] || return 0
   rm -rf "$(sup_claims_dir)/claim.$issue" 2>/dev/null || true
+}
+
+sup_label_list_has_exact() {
+  local labels=",${1:-},"
+  local wanted="$2"
+  case "$labels" in
+    *",${wanted},"*) return 0 ;;
+  esac
+  return 1
+}
+
+# sup_issue_is_non_dispatch_claim_target <issue>
+#   Standing-task / epic issues are backlog governors, not unit work for Codex
+#   dispatch. They must never receive in-flight claims; claiming them parks the
+#   exact queue machinery that should be keeping the fleet moving. Label lookup
+#   is fail-open: if no label map/helper exists, normal dispatch guards decide.
+sup_issue_is_non_dispatch_claim_target() {
+  local issue="$1"
+  [ -n "$issue" ] || return 1
+  command -v sup_labels_for_issue >/dev/null 2>&1 || return 1
+  local labels; labels="$(sup_labels_for_issue "$issue")"
+  [ -n "$labels" ] || return 1
+  local oldifs="$IFS"; IFS=','
+  local blocked
+  for blocked in $SUP_NON_DISPATCH_CLAIM_LABELS; do
+    if [ -n "$blocked" ] && sup_label_list_has_exact "$labels" "$blocked"; then
+      IFS="$oldifs"
+      return 0
+    fi
+  done
+  IFS="$oldifs"
+  return 1
 }
 
 # pick_and_claim_unlocked_issue <start_index> <issue...>
@@ -370,6 +433,11 @@ pick_and_claim_unlocked_issue() {
   for (( k=0; k<n; k++ )); do
     i=$(( (start + k) % n ))
     issue="${arr[$i]}"
+    # Queue-governor issues should be recreated/managed, never claimed as unit
+    # dispatch work.
+    if sup_issue_is_non_dispatch_claim_target "$issue"; then
+      continue
+    fi
     # Already reserved by another slot this window -> spread to a distinct issue.
     if sup_claim_is_active "$issue"; then
       continue


### PR DESCRIPTION
## Summary
- GC orphaned codex-supervisor issue claims on startup using the live worker PID recorded in claim metadata.
- Skip in-flight claims for queue-governor issues labeled `standing-task` or `epic`.
- Split dispatch-gate conflicts/transient D1 read flakes from duplicate-active refusals so 409/500/503 gate flakes fast-retry instead of escalating normal backoff.

## Verification
- `while IFS= read -r t; do printf '%s\n' "$t"; bash "$t" || exit 1; done < <(find apps/pylon/scripts/codex-supervisor -maxdepth 1 -name '*.test.sh' -print | sort)`

Closes #6987
