### PR TITLE
refactor(world-client): scope browser socket cleanup

### DIFF
--- a/packages/world-client/src/index.test.ts
+++ b/packages/world-client/src/index.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, test } from "bun:test"
-import { Effect } from "effect"
+import { Effect, Fiber } from "effect"
 
 import {
+  WORLD_CONTRACT_SCHEMA_VERSION,
   WORLD_DELTA_SCHEMA_VERSION,
   decodeWorldCommandEnvelope,
   decodeWorldDelta,
@@ -17,6 +18,7 @@ import {
   applyDeltaToReadModel,
   applyDeltaToState,
   commandAckFromReceipt,
+  createBrowserWorldTransport,
   createStubWorldClientTransport,
   createWorldClient,
   makeEmptyClientWorld,
@@ -373,6 +375,75 @@ describe("world-client", () => {
     expect(calls).toContain("connect:cursor.region.run.1.1")
     expect(calls).toContain("connect:cursor.region.run.1.999")
     expect(calls).toContain("disconnect")
+  })
+
+  test("browser transport closes an opening socket when connect is interrupted", async () => {
+    class InterruptibleSocket {
+      static readonly instances: Array<InterruptibleSocket> = []
+
+      readonly listeners = new Map<string, Set<(event: unknown) => void>>()
+      readonly sent: Array<string> = []
+      readonly url: string
+      readyState = 0
+      closed = false
+
+      constructor(url: string) {
+        this.url = url
+        InterruptibleSocket.instances.push(this)
+      }
+
+      send(data: string): void {
+        this.sent.push(data)
+      }
+
+      close(): void {
+        this.closed = true
+        this.readyState = 3
+      }
+
+      addEventListener(type: string, listener: (event: unknown) => void): void {
+        const listeners = this.listeners.get(type) ?? new Set<(event: unknown) => void>()
+        listeners.add(listener)
+        this.listeners.set(type, listeners)
+      }
+
+      removeEventListener(type: string, listener: (event: unknown) => void): void {
+        this.listeners.get(type)?.delete(listener)
+      }
+    }
+
+    const fetchFn = (async () =>
+      new Response(JSON.stringify({
+        ok: true,
+        schemaVersion: WORLD_CONTRACT_SCHEMA_VERSION,
+        regionRef,
+        socketUrl: "wss://world.test/regions/region.run.1/socket",
+        subscriptionPlan: plan(),
+      }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      })) as unknown as typeof fetch
+
+    const transport = createBrowserWorldTransport({
+      worldUrl: "https://world.test",
+      actorRef: "actor.alice",
+      fetchFn,
+      webSocketCtor: InterruptibleSocket,
+    })
+
+    const fiber = Effect.runFork(transport.connect({}))
+    for (let attempt = 0; attempt < 10 && InterruptibleSocket.instances.length === 0; attempt += 1) {
+      await Effect.runPromise(Effect.yieldNow)
+    }
+
+    expect(InterruptibleSocket.instances).toHaveLength(1)
+    expect(InterruptibleSocket.instances[0]?.closed).toBe(false)
+
+    await Effect.runPromise(Fiber.interrupt(fiber))
+
+    expect(InterruptibleSocket.instances[0]?.closed).toBe(true)
+    expect(InterruptibleSocket.instances[0]?.listeners.get("open")?.size ?? 0).toBe(0)
+    expect(InterruptibleSocket.instances[0]?.listeners.get("error")?.size ?? 0).toBe(0)
   })
 
   test("callCommand exposes receipt sequence ack state", async () => {

--- a/packages/world-client/src/index.ts
+++ b/packages/world-client/src/index.ts
@@ -1,4 +1,4 @@
-import { Data, Effect } from "effect"
+import { Data, Effect, Exit, Scope } from "effect"
 
 import {
   WORLD_DELTA_SCHEMA_VERSION,
@@ -103,6 +103,11 @@ type BrowserWebSocketLike = Readonly<{
 
 type BrowserWebSocketCtor = new (url: string) => BrowserWebSocketLike
 
+type ScopedBrowserWebSocket = Readonly<{
+  socket: BrowserWebSocketLike
+  release: () => void
+}>
+
 export type BrowserWorldTransportInput = Readonly<{
   worldUrl: string
   actorRef: string
@@ -197,6 +202,7 @@ export const createBrowserWorldTransport = (
   const WebSocketCtor = input.webSocketCtor ??
     (globalThis as unknown as { WebSocket?: BrowserWebSocketCtor }).WebSocket
   let socket: BrowserWebSocketLike | null = null
+  let socketScope: Scope.Closeable | null = null
   const pendingCommands = new Map<
     string,
     {
@@ -215,52 +221,95 @@ export const createBrowserWorldTransport = (
     }
   }
 
+  const closeSocketScope = (): Effect.Effect<void> =>
+    Effect.gen(function* () {
+      const scope = socketScope
+      socketScope = null
+      socket = null
+      if (scope !== null) {
+        yield* Scope.close(scope, Exit.void)
+      }
+    })
+
+  const acquireSocket = (
+    socketUrl: string,
+  ): Effect.Effect<ScopedBrowserWebSocket, WorldClientError, Scope.Scope> =>
+    Effect.acquireRelease(
+      Effect.tryPromise({
+        try: signal =>
+          new Promise<ScopedBrowserWebSocket>((resolve, reject) => {
+            if (WebSocketCtor === undefined) {
+              reject(new Error("WebSocket is not available in this runtime."))
+              return
+            }
+            const next = new WebSocketCtor(socketUrl)
+            let settled = false
+            const cleanup = (): void => {
+              next.removeEventListener("open", onOpen)
+              next.removeEventListener("message", onMessage)
+              next.removeEventListener("error", onError)
+              signal.removeEventListener("abort", onAbort)
+            }
+            const onOpen = (): void => {
+              settled = true
+              cleanup()
+              next.addEventListener("message", onMessage)
+              next.send(JSON.stringify({ frameKind: "hydrate" }))
+              resolve({
+                socket: next,
+                release: () => {
+                  cleanup()
+                  next.close()
+                },
+              })
+            }
+            const onError = (): void => {
+              settled = true
+              cleanup()
+              reject(new Error("World WebSocket connection failed."))
+            }
+            const onAbort = (): void => {
+              cleanup()
+              next.close()
+              if (!settled) reject(new Error("World WebSocket connection interrupted."))
+            }
+            const onMessage = (event: unknown): void => {
+              const data = (event as { data?: unknown }).data
+              if (typeof data !== "string") return
+              try {
+                applyFrame(decodeWorldTransportFrame(JSON.parse(data)))
+              } catch {
+                // Bad frames are ignored locally; the Worker emits typed diagnostics
+                // for command/schema failures that pass the transport boundary.
+              }
+            }
+            next.addEventListener("open", onOpen, { once: true })
+            next.addEventListener("error", onError, { once: true })
+            signal.addEventListener("abort", onAbort, { once: true })
+          }),
+        catch: error => new WorldClientError({
+          phase: "connect",
+          reason: error instanceof Error ? error.message : "World socket connection failed.",
+          retryable: true,
+          sourceRefs: ["world-client.browser.socket"],
+        }),
+      }),
+      resource => Effect.sync(() => resource.release()),
+      { interruptible: true },
+    )
+
   const connectSocket = (
     socketUrl: string,
   ): Effect.Effect<void, WorldClientError> =>
-    Effect.tryPromise({
-      try: () =>
-        new Promise<void>((resolve, reject) => {
-          if (WebSocketCtor === undefined) {
-            reject(new Error("WebSocket is not available in this runtime."))
-            return
-          }
-          const next = new WebSocketCtor(socketUrl)
-          socket = next
-          const cleanup = (): void => {
-            next.removeEventListener("open", onOpen)
-            next.removeEventListener("message", onMessage)
-            next.removeEventListener("error", onError)
-          }
-          const onOpen = (): void => {
-            cleanup()
-            next.addEventListener("message", onMessage)
-            next.send(JSON.stringify({ frameKind: "hydrate" }))
-            resolve()
-          }
-          const onError = (): void => {
-            cleanup()
-            reject(new Error("World WebSocket connection failed."))
-          }
-          const onMessage = (event: unknown): void => {
-            const data = (event as { data?: unknown }).data
-            if (typeof data !== "string") return
-            try {
-              applyFrame(decodeWorldTransportFrame(JSON.parse(data)))
-            } catch {
-              // Bad frames are ignored locally; the Worker emits typed diagnostics
-              // for command/schema failures that pass the transport boundary.
-            }
-          }
-          next.addEventListener("open", onOpen, { once: true })
-          next.addEventListener("error", onError, { once: true })
-        }),
-      catch: error => new WorldClientError({
-        phase: "connect",
-        reason: error instanceof Error ? error.message : "World socket connection failed.",
-        retryable: true,
-        sourceRefs: ["world-client.browser.socket"],
-      }),
+    Effect.gen(function* () {
+      yield* closeSocketScope()
+      const scope = yield* Scope.make()
+      const resource = yield* acquireSocket(socketUrl).pipe(
+        Scope.provide(scope),
+        Effect.onInterrupt(() => Scope.close(scope, Exit.void)),
+      )
+      socketScope = scope
+      socket = resource.socket
     })
 
   const connect = (
@@ -348,9 +397,7 @@ export const createBrowserWorldTransport = (
             }),
       }),
     disconnect: () =>
-      Effect.sync(() => {
-        socket?.close()
-        socket = null
+      Effect.gen(function* () {
         for (const pending of pendingCommands.values()) {
           pending.reject(new WorldClientError({
             phase: "disconnect",
@@ -360,6 +407,7 @@ export const createBrowserWorldTransport = (
           }))
         }
         pendingCommands.clear()
+        yield* closeSocketScope()
       }),
   }
 }


### PR DESCRIPTION
## Summary
- migrate the browser world WebSocket connection path to an Effect Scope-backed acquire/release helper
- close the retained socket scope on disconnect and on interrupted connection attempts
- add interruption coverage that asserts an opening socket is closed and listeners are removed

Closes #7013

## Verification
- bun run --cwd packages/world-client test
- bun run --cwd packages/world-client typecheck