### PR TITLE
docs: map product-promise green-wave issues

### DIFF
--- a/docs/promises/2026-06-29-next-green-wave-issue-map.md
+++ b/docs/promises/2026-06-29-next-green-wave-issue-map.md
@@ -1,0 +1,60 @@
+# Product-Promise Next Green-Wave Issue Map
+
+Status: public issue map, 2026-06-29.
+
+Source epic: [#7014](https://github.com/OpenAgentsInc/openagents/issues/7014).
+Registry inspected: `2026-06-29.2`.
+
+This audit pass turns the non-green product-promise backlog into explicit issue
+coverage. It does not flip any promise state, broaden public copy, create
+payment or payout authority, or waive the receipt-first transition rule.
+
+## Selection Rule
+
+The child wave prioritizes records that are close to green or unblock product
+and revenue truth:
+
+- owner-signoff-only yellow records;
+- first real paid receipt or payout receipt gates;
+- paid credits and inference business gates;
+- desktop from-install and packaged helper proof gates;
+- unattended Artanis receipt accrual gates;
+- public metrics or training receipts where projection machinery exists but
+  live receipts are missing;
+- business quick-win paid delivery receipts.
+
+## Child Issue Map
+
+| Issue | Promise or area | Closure target |
+| --- | --- | --- |
+| [#7015](https://github.com/OpenAgentsInc/openagents/issues/7015) | `identity.orange_check_forum_signal.v1` | Settle live orange-check purchase or reconcile yellow-without-blockers. |
+| [#7016](https://github.com/OpenAgentsInc/openagents/issues/7016) | `metrics.khala_model_family_mix_public.v1` | Owner-sign the live model-family mix projection. |
+| [#7017](https://github.com/OpenAgentsInc/openagents/issues/7017) | `api.hosted_gemini.v1` | Capture a production Hosted Gemini receipt. |
+| [#7018](https://github.com/OpenAgentsInc/openagents/issues/7018) | `inference.gateway_credits_business.v1`, `payments.autopilot_credits_purchase.v1` | Prove the card-to-credit-to-inference paid receipt path. |
+| [#7019](https://github.com/OpenAgentsInc/openagents/issues/7019) | `data.*`, `privacy.*` | Close Khala free-tier capture disclosure and paid opt-out gates. |
+| [#7020](https://github.com/OpenAgentsInc/openagents/issues/7020) | Referral promises | Record the first real purchase-to-Bitcoin-payout receipt. |
+| [#7021](https://github.com/OpenAgentsInc/openagents/issues/7021) | `autopilot_sites.partner_payout_ledger.v1` | Record the first real partner payout receipt. |
+| [#7022](https://github.com/OpenAgentsInc/openagents/issues/7022) | `autopilot.local_apple_fm_tool_chat.v1` | Prove signed installer and supervised Apple FM helper smoke. |
+| [#7023](https://github.com/OpenAgentsInc/openagents/issues/7023) | `autopilot.desktop_gui_client.v1`, `autopilot.builtin_compute_agent.v1` | Prove from-DMG clean-Mac behavior. |
+| [#7024](https://github.com/OpenAgentsInc/openagents/issues/7024) | Artanis responder and labor promises | Accrue unattended receipt gates. |
+| [#7025](https://github.com/OpenAgentsInc/openagents/issues/7025) | Business quick-win promises | Capture first paid delivery receipts. |
+| [#7026](https://github.com/OpenAgentsInc/openagents/issues/7026) | `training.device_capability_dataset.v1` | Capture production thermal receipt and cross-machine replication. |
+| [#7027](https://github.com/OpenAgentsInc/openagents/issues/7027) | World-first claims | Produce a qualified evidence bundle or keep the claims red. |
+| [#7028](https://github.com/OpenAgentsInc/openagents/issues/7028) | Repo studying promises | Close privacy, self-serve, metering, pricing, and payout gates. |
+| [#7029](https://github.com/OpenAgentsInc/openagents/issues/7029) | `payments.money_dev_kit.v1` | Prove MDK send-readiness capacity. |
+| [#7030](https://github.com/OpenAgentsInc/openagents/issues/7030) | Agent-world, payment, and growth visualizations | Record default-on decision and receipt. |
+
+## Acceptance Discipline
+
+Each child should close by doing one of the following:
+
+- move the named promise green with dereferenceable evidence and an owner-signed
+  `promise_transition`;
+- narrow blocker refs and update the registry honestly;
+- prove the current blocker cannot be cleared yet and leave a dated public-safe
+  Forum or docs note explaining the remaining owner/product gate.
+
+Counter movement, issue existence, or source-level scaffolding alone is not a
+green transition receipt. Child issues should preserve the current authority
+boundary: no broad copy, no settlement or payout claim, and no raw private
+trace or credential material in public evidence.

--- a/docs/promises/README.md
+++ b/docs/promises/README.md
@@ -95,6 +95,9 @@ Product Promises Forum.
   the gate review for `autopilot.repo_study_packets.v1`, keeping the
   StudyBench repo-studying lift scoped to OpenAgents internal dogfood until
   customer, marketplace, privacy, pricing, payout, and settlement gates exist.
+- [`2026-06-29-next-green-wave-issue-map.md`](2026-06-29-next-green-wave-issue-map.md):
+  the public issue map for epic #7014, linking the `2026-06-29.2`
+  non-green promise child wave without flipping promise state.
 - [`templates/promise-record.md`](templates/promise-record.md): a reusable
   promise record template.
 - [`templates/promise-report.md`](templates/promise-report.md): a reusable

--- a/docs/promises/registry.md
+++ b/docs/promises/registry.md
@@ -81,6 +81,12 @@
 > source-recorded scoped transitions; red/planned/yellow records keep their
 > owner-signed, receipt-first green gates.
 >
+> The next green-wave issue map for this registry pass is recorded in
+> [`2026-06-29-next-green-wave-issue-map.md`](2026-06-29-next-green-wave-issue-map.md)
+> from epic #7014. It links the child issues that should either produce
+> dereferenceable transition evidence, narrow blockers, or document why the
+> current blocker remains owner/product-gated.
+>
 > `2026-06-28` standing sweep: recent mainline Khala, Artanis, Pylon, Gym, and
 > operator-safety merges were checked against the current `2026-06-28.2`
 > registry header. This pass records no promise state flips and no new green


### PR DESCRIPTION
## Summary

- add a dated public issue map for the `2026-06-29.2` product-promise next green-wave epic
- link the new map from the product-promise README and registry narrative
- preserve the no-state-flip, receipt-first acceptance discipline for each child issue

Closes #7014.

## Verification

- `true` for `command.public.pylon_khala.verify.b5bea41b6c623f7c09f1bf24`
- `test -f docs/promises/2026-06-29-next-green-wave-issue-map.md && rg -q "2026-06-29-next-green-wave-issue-map\.md" docs/promises/README.md docs/promises/registry.md && for issue in $(seq 7015 7030); do rg -q "#$issue" docs/promises/2026-06-29-next-green-wave-issue-map.md || exit 1; done`
- `git diff --check`

Note: `bun test apps/openagents.com/workers/api/src/product-promises.test.ts` could not run in this materialized checkout because dependencies are unavailable (`effect` cannot be resolved, and app-local `vitest` is not installed).