### PR TITLE
Fix Pylon growth scene refresh

### DIFF
--- a/apps/autopilot-desktop/src/ui/update.ts
+++ b/apps/autopilot-desktop/src/ui/update.ts
@@ -368,6 +368,13 @@ const chatWorldSceneMaterialKey = (
       state: node.state,
       color: node.color,
       online: node.online,
+      growth: {
+        tier: node.growth.tier,
+        scale: node.growth.scale,
+        facets: node.growth.facets,
+        brightness: node.growth.brightness,
+        settledSats: node.growth.settledSats,
+      },
       products: [...node.products].sort(),
     })),
   })

--- a/apps/autopilot-desktop/tests/verse-launch-checklist.test.ts
+++ b/apps/autopilot-desktop/tests/verse-launch-checklist.test.ts
@@ -102,6 +102,7 @@ const livePylonScene = (
       color: 0x4ade80,
       online: true,
       pulseSpeed: 0.4,
+      growth: pylonGrowthTier(2_100),
       products: ["labor"],
     },
   ],
@@ -525,6 +526,41 @@ describe("Verse packaged launch checklist (#5827)", () => {
     expect(verseSceneDiagnostics().map(entry => entry.event)).toContain(
       "chat-world-scene.noop",
     )
+  })
+
+  test("per-Pylon settled-sats growth changes refresh the live Verse scene", () => {
+    clearVerseEnv()
+    const [initial] = initialRuntimeState()
+    const [withScene] = update(
+      initial,
+      GotChatWorldScene({ scene: livePylonScene() }),
+    )
+    const grown = pylonGrowthTier(100_000)
+    const [afterGrowth] = update(
+      withScene,
+      GotChatWorldScene({
+        scene: livePylonScene({
+          growth: grown,
+          nodes: [
+            {
+              ...livePylonScene().nodes[0]!,
+              growth: grown,
+            },
+          ],
+        }),
+      }),
+    )
+
+    expect(afterGrowth).not.toBe(withScene)
+    expect(
+      verseSceneVisualization(afterGrowth).nodes?.find(
+        node => node.id === "pylon.alpha",
+      ),
+    ).toMatchObject({
+      detail: "working - tier 3 - 100000 sats - 12 facets",
+      role: "rung",
+      status: "active",
+    })
   })
 
   test("idle payment-particle ticks expire stale beams without a new payment", () => {


### PR DESCRIPTION
## Summary
- Include each live Pylon node's growth descriptor in the Verse scene material key so cumulative settled-sats tier changes are accepted instead of deduped away.
- Add a regression proving per-Pylon settled-sats growth refreshes the live Verse scene while heartbeat-only churn still no-ops.

Closes #6868.

## Verification
- `bun install --frozen-lockfile`
- `bun test tests/verse-launch-checklist.test.ts tests/chat-world-scene.test.ts tests/chat-world-visualization.test.ts` (from `apps/autopilot-desktop`)
- required verifier `command.public.pylon_khala.verify.b5bea41b6c623f7c09f1bf24` resolved to `true` and passed
