### PR TITLE
Close #6893: add fanout work-class idempotency

### DIFF
--- a/apps/openagents.com/workers/api/src/autopilot-work-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/autopilot-work-routes.test.ts
@@ -2927,6 +2927,7 @@ describe('Autopilot work routes', () => {
     )
     const body = (await response.json()) as {
       marketWorkRequestInput: {
+        idempotencyKey: string
         requiredCapabilityRefs: ReadonlyArray<string>
         verificationCommandRef: string
         workClass: string
@@ -2943,6 +2944,9 @@ describe('Autopilot work routes', () => {
     }
 
     expect(response.status).toBe(201)
+    expect(body.marketWorkRequestInput.idempotencyKey).toBe(
+      `self_serve_fanout.${workOrderRef}.dispatch.data_labeling`,
+    )
     expect(body.marketWorkRequestInput).toMatchObject({
       requiredCapabilityRefs: ['capability.market.data_labeling'],
       verificationCommandRef: 'command.public.market.data_labeling.audit',

--- a/apps/openagents.com/workers/api/src/autopilot-work-routes.ts
+++ b/apps/openagents.com/workers/api/src/autopilot-work-routes.ts
@@ -37,7 +37,10 @@ import {
   laneCFanoutObjectiveRef,
 } from './lane-c-fanout-bridge'
 import { isMarketplaceWorkClassId } from './marketplace-work-class-catalog'
-import { buildSelfServeFanoutPlan } from './self-serve-fanout'
+import {
+  buildSelfServeFanoutPlan,
+  selfServeFanoutDispatchIdempotencyKey,
+} from './self-serve-fanout'
 import {
   methodNotAllowed,
   noStoreJsonResponse,
@@ -3209,6 +3212,10 @@ const laneCFanoutWorkOrder = <Bindings extends AutopilotWorkRouteEnv>(
     // this branch (it gets a 409 above), so the floor cannot be bypassed.
     const objectiveRef = laneCFanoutObjectiveRef(workOrderRef)
     const marketWorkRequestInput = selfServePlan.marketWorkRequest ?? {
+      idempotencyKey: selfServeFanoutDispatchIdempotencyKey(
+        workOrderRef,
+        'code_task',
+      ),
       budgetSats: budgetCapSats,
       deadlineRef: 'deadline.public.lane_c_fanout.20261231',
       objectiveRef,

--- a/apps/openagents.com/workers/api/src/self-serve-fanout.test.ts
+++ b/apps/openagents.com/workers/api/src/self-serve-fanout.test.ts
@@ -12,6 +12,7 @@ import {
   dispatchSelfServeFanout,
   makeInMemorySelfServeFanoutStore,
   readSelfServeFanoutPlan,
+  selfServeFanoutDispatchIdempotencyKey,
   selfServeFanoutPlanId,
 } from './self-serve-fanout'
 import {
@@ -69,6 +70,9 @@ describe('buildSelfServeFanoutPlan', () => {
     expect(plan.gate.lane).toBe('public_market')
     expect(plan.gate.state).toBe('ready')
     expect(plan.marketWorkRequest).not.toBeNull()
+    expect(plan.marketWorkRequest?.idempotencyKey).toBe(
+      selfServeFanoutDispatchIdempotencyKey('wo-1', 'code_task'),
+    )
     expect(plan.marketWorkRequest?.workClass).toBe('code_task')
     expect(plan.marketWorkRequest?.budgetSats).toBe(5000)
     expect(plan.marketWorkRequest?.requiredCapabilityRefs).toEqual([
@@ -95,11 +99,35 @@ describe('buildSelfServeFanoutPlan', () => {
     expect(plan.workClass).toBe('data_labeling')
     expect(plan.readyForMarket).toBe(true)
     expect(plan.marketWorkRequest).toMatchObject({
+      idempotencyKey: selfServeFanoutDispatchIdempotencyKey(
+        'wo-1',
+        'data_labeling',
+      ),
       requiredCapabilityRefs: ['capability.market.data_labeling'],
       verificationCommandRef: 'command.public.market.data_labeling.audit',
       workClass: 'data_labeling',
     })
     expect(plan.unclearedBlockerRefs).toEqual([])
+  })
+
+  test('keeps downstream dispatch idempotent per work order and work class', () => {
+    const first = buildSelfServeFanoutPlan(optedInInput, readyFacts, 'now')
+    const repeat = buildSelfServeFanoutPlan(optedInInput, readyFacts, 'later')
+    const dataLabeling = buildSelfServeFanoutPlan(
+      { ...optedInInput, workClass: 'data_labeling' },
+      readyFacts,
+      'now',
+    )
+    if (!first.ok || !repeat.ok || !dataLabeling.ok) {
+      throw new Error('expected ready fanout plans')
+    }
+
+    expect(first.plan.marketWorkRequest?.idempotencyKey).toBe(
+      repeat.plan.marketWorkRequest?.idempotencyKey,
+    )
+    expect(first.plan.marketWorkRequest?.idempotencyKey).not.toBe(
+      dataLabeling.plan.marketWorkRequest?.idempotencyKey,
+    )
   })
 
   test('rejects an inert plugin work class before market authorization', () => {

--- a/apps/openagents.com/workers/api/src/self-serve-fanout.ts
+++ b/apps/openagents.com/workers/api/src/self-serve-fanout.ts
@@ -106,6 +106,8 @@ export type SelfServeFanoutInput = typeof SelfServeFanoutInput.Type
  * /api/forum/work-requests, assembled in the SAME self-serve step.
  */
 export const SelfServeFanoutMarketWorkRequest = S.Struct({
+  /** Stable key the market requester uses to avoid duplicate listings. */
+  idempotencyKey: S.String,
   /** Public-safe objective ref derived from the work order. */
   objectiveRef: S.String,
   /** Budget for the market job in whole sats. */
@@ -185,6 +187,13 @@ const isWholeNonNegative = (value: number): boolean =>
 /** Stable, public-safe plan id derived from a work order ref. */
 export const selfServeFanoutPlanId = (workOrderRef: string): string =>
   `self_serve_fanout.${workOrderRef.replace(/[^a-z0-9._-]+/giu, '_')}`
+
+/** Stable public-safe idempotency key for the downstream market listing. */
+export const selfServeFanoutDispatchIdempotencyKey = (
+  workOrderRef: string,
+  workClass: MarketplaceWorkClassId,
+): string =>
+  `${selfServeFanoutPlanId(workOrderRef)}.dispatch.${workClass}`
 
 /** Public-safe deadline ref for a self-serve fanout market job. */
 export const SELF_SERVE_FANOUT_DEADLINE_REF =
@@ -270,6 +279,10 @@ export const buildSelfServeFanoutPlan = (
   const marketWorkRequest: SelfServeFanoutMarketWorkRequest | null =
     fanout.readyForMarket
       ? {
+          idempotencyKey: selfServeFanoutDispatchIdempotencyKey(
+            input.workOrderRef,
+            workClass,
+          ),
           objectiveRef,
           budgetSats: input.budgetCapSats,
           title: input.title.slice(0, 160),


### PR DESCRIPTION
## Summary
- add a stable downstream market-listing idempotency key to self-serve fanout market work requests
- scope the key by work order and live work class so repeat dispatches do not duplicate assignments while distinct work classes remain distinct
- cover the idempotency contract in planner and lane-C route tests

Closes #6893.

## Verification
- `bun run --cwd apps/openagents.com/workers/api test -- src/self-serve-fanout.test.ts src/autopilot-work-routes.test.ts`
- `bun run --cwd apps/openagents.com/workers/api typecheck`
- `bun run --cwd apps/openagents.com check:deploy`
