### PR TITLE
fix(pylon): classify codex account execution refusals

### DIFF
--- a/apps/pylon/src/codex-agent-executor.ts
+++ b/apps/pylon/src/codex-agent-executor.ts
@@ -22,6 +22,8 @@ import {
   pylonAccountEnvironment,
   type ResolvedPylonAccountSelection,
 } from "./account-registry.js"
+import { classifyQuotaSignal } from "./account-quota.js"
+import { recordQuotaBlock } from "./account-quota-ledger.js"
 import {
   publishAssignmentPullRequest,
   type AssignmentPrTitleBody,
@@ -130,6 +132,7 @@ export type CodexAgentRunResult = {
   editedFileCount: number
   commandCount: number
   sessionRef: string | null
+  errorMessage?: string
 }
 
 export type CodexAgentRunner = (input: CodexAgentRunInput) => Promise<CodexAgentRunResult>
@@ -669,6 +672,56 @@ function totalTokensFromUsage(usage: CodexTurnUsage | undefined): number | undef
   return usage.inputTokens + usage.outputTokens + (usage.reasoningOutputTokens ?? 0)
 }
 
+type CodexExecutionFailureClass =
+  | "credentials_revoked"
+  | "usage_limited"
+  | "rate_limited"
+  | "network"
+  | "timeout"
+  | "other"
+
+type CodexExecutionFailure = {
+  blockerRef: string
+  digestRef: string
+  reason: CodexExecutionFailureClass
+  retryAtIso: string | null
+}
+
+function errorTextFrom(error: unknown): string {
+  if (error instanceof Error) return error.message
+  if (typeof error === "string") return error
+  try {
+    return JSON.stringify(error)
+  } catch {
+    return String(error)
+  }
+}
+
+export function classifyCodexExecutionFailure(error: unknown): CodexExecutionFailure {
+  const text = errorTextFrom(error)
+  const lower = text.toLowerCase()
+  const quota = classifyQuotaSignal(text, "codex")
+  const reason: CodexExecutionFailureClass =
+    /revok/.test(lower) ||
+    /could not be refreshed.*refresh token/.test(lower)
+      ? "credentials_revoked"
+      : /\b429\b|too many requests|rate limit/.test(lower)
+        ? "rate_limited"
+        : quota.exhausted
+          ? "usage_limited"
+          : /timed? ?out|timeout|deadline|aborted/.test(lower)
+            ? "timeout"
+            : /econn|enotfound|etimedout|network|websocket|wss:|fetch failed|socket|dns|tls/.test(lower)
+              ? "network"
+              : "other"
+  return {
+    blockerRef: `blocker.assignment.codex_agent_execution_${reason}`,
+    digestRef: stableRef("diagnostic.pylon.codex_agent_task.execution_error", text),
+    reason,
+    retryAtIso: quota.retryAtIso,
+  }
+}
+
 async function emitCodexProgress(
   reporter: CodexAgentRunInput["onProgress"],
   progress: CodexAgentRuntimeProgress,
@@ -861,6 +914,7 @@ export async function runWithCodexSdk(input: CodexAgentRunInput): Promise<CodexA
   let pendingRawEvents: Array<RawCodexThreadEvent> = []
   let pendingChunkItems: Array<CodexTurnReportItem> = []
   let pendingChunkRawEvents: Array<RawCodexThreadEvent> = []
+  let failureMessage: string | undefined
 
   const flushEventChunk = async (turnIndex: number) => {
     if (pendingChunkRawEvents.length === 0) return
@@ -949,7 +1003,12 @@ export async function runWithCodexSdk(input: CodexAgentRunInput): Promise<CodexA
         pendingChunkRawEvents = []
         activeTurnIndex = 0
       }
-      if (event.type === "turn.failed" || event.type === "error") failed = true
+      if (event.type === "turn.failed" || event.type === "error") {
+        failed = true
+        if (typeof event.error?.message === "string" && event.error.message.trim().length > 0) {
+          failureMessage = event.error.message
+        }
+      }
       if (event.type === "item.completed" && event.item?.type === "command_execution") {
         commandCount += 1
         await emitCodexProgress(input.onProgress, {
@@ -1001,7 +1060,14 @@ export async function runWithCodexSdk(input: CodexAgentRunInput): Promise<CodexA
     return { outcome: "budget_exceeded", turnCount, editedFileCount, commandCount, sessionRef }
   }
   if (failed) {
-    return { outcome: "refused", turnCount, editedFileCount, commandCount, sessionRef }
+    return {
+      outcome: "refused",
+      turnCount,
+      editedFileCount,
+      commandCount,
+      sessionRef,
+      ...(failureMessage === undefined ? {} : { errorMessage: failureMessage }),
+    }
   }
   return { outcome: "completed", turnCount, editedFileCount, commandCount, sessionRef }
 }
@@ -1162,6 +1228,42 @@ function refusalRecord(input: {
   }
 }
 
+async function recordCodexAccountExecutionHealth(input: {
+  account: ResolvedPylonAccountSelection | null | undefined
+  failure: CodexExecutionFailure
+  state: PylonLocalState
+  now: Date
+}) {
+  if (input.account?.provider !== "codex") return
+  if (input.failure.reason !== "usage_limited" && input.failure.reason !== "rate_limited") return
+  await recordQuotaBlock(input.state, {
+    accountRefHash: input.account.accountRefHash,
+    provider: "codex",
+    retryAtIso: input.failure.retryAtIso,
+    sourceDigestRef: input.failure.digestRef,
+    now: input.now,
+  }).catch(() => undefined)
+}
+
+function executionFailureRefusal(input: {
+  failure: CodexExecutionFailure
+  lease: CodexAgentLease
+  runRef: string
+}) {
+  return refusalRecord({
+    lease: input.lease,
+    runRef: input.runRef,
+    blockerRefs: [
+      "blocker.assignment.codex_agent_execution_refused",
+      input.failure.blockerRef,
+      input.failure.digestRef,
+    ],
+    resultRef: `result.public.pylon.codex_agent_task.execution_${input.failure.reason}`,
+    summaryRef: `summary.public.pylon.codex_agent_task.execution_${input.failure.reason}`,
+    message: `Local Codex thread refused with classified reason: ${input.failure.reason}.`,
+  })
+}
+
 /**
  * Executes a codex_sdk coding assignment. Returns null when the assignment
  * does not carry this work class, a typed refusal record when the lane is
@@ -1291,16 +1393,16 @@ export async function executeCodexAgentAssignment(
       ...(options.onProgress === undefined ? {} : { onProgress: options.onProgress }),
       workspaceRef: materialized.workspaceRef,
     })
-  } catch {
+  } catch (error) {
     await releaseCodexAgentWorkspace({ materialized, now })
-    return refusalRecord({
-      lease,
-      runRef,
-      blockerRefs: ["blocker.assignment.codex_agent_execution_refused"],
-      resultRef: "result.public.pylon.codex_agent_task.execution_refused",
-      summaryRef: "summary.public.pylon.codex_agent_task.execution_refused",
-      message: "Local Codex thread refused with a typed execution error.",
+    const failure = classifyCodexExecutionFailure(error)
+    await recordCodexAccountExecutionHealth({
+      account: options.account,
+      failure,
+      state,
+      now,
     })
+    return executionFailureRefusal({ failure, lease, runRef })
   }
 
   if (run.outcome === "workspace_escape_blocked") {
@@ -1326,14 +1428,14 @@ export async function executeCodexAgentAssignment(
   }
   if (run.outcome === "refused") {
     await releaseCodexAgentWorkspace({ materialized, now })
-    return refusalRecord({
-      lease,
-      runRef,
-      blockerRefs: ["blocker.assignment.codex_agent_execution_refused"],
-      resultRef: "result.public.pylon.codex_agent_task.execution_refused",
-      summaryRef: "summary.public.pylon.codex_agent_task.execution_refused",
-      message: "Local Codex thread ended with an execution error before completing the task.",
+    const failure = classifyCodexExecutionFailure(run.errorMessage ?? "codex turn failed")
+    await recordCodexAccountExecutionHealth({
+      account: options.account,
+      failure,
+      state,
+      now,
     })
+    return executionFailureRefusal({ failure, lease, runRef })
   }
 
   await Promise.resolve(options.onProgress?.({

--- a/apps/pylon/src/presence.ts
+++ b/apps/pylon/src/presence.ts
@@ -45,6 +45,7 @@ import {
   type PylonActiveCodingRunAccountCounts,
   type PylonActiveCodingRunCounts,
 } from "./active-assignment-runs.js"
+import { isAccountAvailable, loadQuotaRecord } from "./account-quota-ledger.js"
 
 // The fields of the local wallet probe the heartbeat needs to publish
 // receive-readiness (openagents #5151). A full WalletStatusProjection satisfies
@@ -295,6 +296,7 @@ export async function localCodingServiceReadyCounts(
 // carries a raw account ref, email, or home path.
 export type PylonCodexAccountReadiness = {
   accountRefHash: string
+  blockerRefs?: string[]
   ready: boolean
 }
 
@@ -326,14 +328,23 @@ export async function localCodexAccountReadiness(
   summary: Pick<BootstrapSummary, "paths">,
   env: NodeJS.ProcessEnv = process.env,
 ): Promise<PylonCodexAccountReadiness[]> {
-  const readiness = new Map<string, boolean>()
+  const now = new Date()
+  const readiness = new Map<string, PylonCodexAccountReadiness>()
   const registry = await loadPylonAccountRegistry(summary)
   const codexEntries = registry.filter(entry => entry.provider === "codex")
   for (const entry of codexEntries) {
-    readiness.set(
-      hashPylonAccountRef("codex", entry.ref),
-      await codexHomeHasAuth(entry.home),
-    )
+    const accountRefHash = hashPylonAccountRef("codex", entry.ref)
+    const quotaRecord = await loadQuotaRecord(summary, accountRefHash)
+    const hasAuth = await codexHomeHasAuth(entry.home)
+    const quotaAvailable = isAccountAvailable(quotaRecord, now)
+    readiness.set(accountRefHash, {
+      accountRefHash,
+      ready: hasAuth && quotaAvailable,
+      blockerRefs: [
+        ...(hasAuth ? [] : ["blocker.codex_agent.credentials_missing"]),
+        ...(quotaAvailable ? [] : ["blocker.codex_agent.usage_limited"]),
+      ],
+    })
   }
   if (codexEntries.length === 0) {
     const configuredCodexHome = env.CODEX_HOME?.trim()
@@ -341,15 +352,20 @@ export async function localCodexAccountReadiness(
       configuredCodexHome && configuredCodexHome.length > 0
         ? normalizeAccountHome(configuredCodexHome)
         : join(homedir(), ".codex")
-    readiness.set(
-      hashPylonAccountRef("codex", "default"),
-      await codexHomeHasAuth(defaultHome),
-    )
+    const accountRefHash = hashPylonAccountRef("codex", "default")
+    const quotaRecord = await loadQuotaRecord(summary, accountRefHash)
+    const hasAuth = await codexHomeHasAuth(defaultHome)
+    const quotaAvailable = isAccountAvailable(quotaRecord, now)
+    readiness.set(accountRefHash, {
+      accountRefHash,
+      ready: hasAuth && quotaAvailable,
+      blockerRefs: [
+        ...(hasAuth ? [] : ["blocker.codex_agent.credentials_missing"]),
+        ...(quotaAvailable ? [] : ["blocker.codex_agent.usage_limited"]),
+      ],
+    })
   }
-  return [...readiness.entries()].map(([accountRefHash, ready]) => ({
-    accountRefHash,
-    ready,
-  }))
+  return [...readiness.values()]
 }
 
 // Per-account Codex capacity: each ready account advertises `perAccountConcurrency`

--- a/apps/pylon/tests/codex-agent-executor.test.ts
+++ b/apps/pylon/tests/codex-agent-executor.test.ts
@@ -6,6 +6,7 @@ import { tmpdir } from "node:os"
 import {
   CODEX_AGENT_SUM_REPAIR_FIXTURE_REF,
   CODEX_AGENT_TASK_SCHEMA,
+  classifyCodexExecutionFailure,
   codexAgentTaskFrom,
   effectiveSandboxMode,
   executeCodexAgentAssignment,
@@ -15,6 +16,8 @@ import {
   type CodexAgentRunner,
 } from "../src/codex-agent-executor"
 import { CODEX_AGENT_SDK_PACKAGE } from "../src/codex-agent"
+import { hashPylonAccountRef, type ResolvedPylonAccountSelection } from "../src/account-registry"
+import { loadQuotaRecord } from "../src/account-quota-ledger"
 import type {
   CodexEventChunkReport,
   CodexTurnReport,
@@ -78,6 +81,9 @@ const idleRunner: CodexAgentRunner = async () => ({
   sessionRef: null,
 })
 
+const usageLimitMessage =
+  "Codex turn failed: You've hit your usage limit. Visit https://chatgpt.com/codex/settings/usage to purchase more credits or try again at Jun 14th, 2026 9:58 PM."
+
 async function withState<T>(fn: (state: Awaited<ReturnType<typeof ensurePylonLocalState>>) => Promise<T>) {
   const home = await mkdtemp(join(tmpdir(), "pylon-codex-exec-test-"))
   try {
@@ -90,6 +96,29 @@ async function withState<T>(fn: (state: Awaited<ReturnType<typeof ensurePylonLoc
 }
 
 describe("codex agent task recognition", () => {
+  test("classifies concrete Codex execution failures without retaining raw text", () => {
+    expect(
+      classifyCodexExecutionFailure(
+        new Error("Your access token could not be refreshed because your refresh token was revoked."),
+      ),
+    ).toMatchObject({
+      blockerRef: "blocker.assignment.codex_agent_execution_credentials_revoked",
+      reason: "credentials_revoked",
+    })
+    expect(classifyCodexExecutionFailure(new Error(usageLimitMessage))).toMatchObject({
+      blockerRef: "blocker.assignment.codex_agent_execution_usage_limited",
+      reason: "usage_limited",
+    })
+    expect(classifyCodexExecutionFailure(new Error("429 Too Many Requests"))).toMatchObject({
+      blockerRef: "blocker.assignment.codex_agent_execution_rate_limited",
+      reason: "rate_limited",
+    })
+    expect(classifyCodexExecutionFailure(new Error("WebSocket network failure"))).toMatchObject({
+      blockerRef: "blocker.assignment.codex_agent_execution_network",
+      reason: "network",
+    })
+  })
+
   test("recognizes the typed work class and passes everything else through", async () => {
     expect(codexAgentTaskFrom(codexAgentCodingAssignment)).not.toBeNull()
     expect(codexAgentTaskFrom({ kind: "job.public.tassadar_executor_trace", tassadar: {} })).toBeNull()
@@ -180,9 +209,13 @@ describe("codex agent task recognition", () => {
       const outcomes = [
         { outcome: "workspace_escape_blocked", blocker: "blocker.assignment.codex_agent_workspace_escape_blocked" },
         { outcome: "budget_exceeded", blocker: "blocker.assignment.codex_agent_budget_exceeded" },
-        { outcome: "refused", blocker: "blocker.assignment.codex_agent_execution_refused" },
+        {
+          outcome: "refused",
+          blocker: "blocker.assignment.codex_agent_execution_refused",
+          extraBlocker: "blocker.assignment.codex_agent_execution_other",
+        },
       ] as const
-      for (const { outcome, blocker } of outcomes) {
+      for (const { outcome, blocker, extraBlocker } of outcomes) {
         const runner: CodexAgentRunner = async () => ({
           outcome,
           turnCount: 1,
@@ -195,7 +228,9 @@ describe("codex agent task recognition", () => {
           codexAgentProbe: readyProbe,
         })
         expect(record?.status).toBe("rejected")
-        expect(record?.blockerRefs).toEqual([blocker])
+        expect(record?.blockerRefs).toContain(blocker)
+        if (extraBlocker !== undefined) expect(record?.blockerRefs).toContain(extraBlocker)
+        else expect(record?.blockerRefs).toEqual([blocker])
         assertPublicProjectionSafe(record)
       }
 
@@ -207,7 +242,46 @@ describe("codex agent task recognition", () => {
         codexAgentProbe: readyProbe,
       })
       expect(record?.status).toBe("rejected")
-      expect(record?.blockerRefs).toEqual(["blocker.assignment.codex_agent_execution_refused"])
+      expect(record?.blockerRefs).toContain("blocker.assignment.codex_agent_execution_refused")
+      expect(record?.blockerRefs).toContain("blocker.assignment.codex_agent_execution_other")
+    })
+  })
+
+  test("usage-limit refusals surface the reason and mark the account unavailable", async () => {
+    await withState(async (state) => {
+      const accountRef = "codex-usage-limited"
+      const accountRefHash = hashPylonAccountRef("codex", accountRef)
+      const account: ResolvedPylonAccountSelection = {
+        provider: "codex",
+        selector: "registry_ref",
+        accountRef,
+        accountRefHash,
+        home: join(state.paths.home, "accounts", "codex", accountRef),
+      }
+      const refusingRunner: CodexAgentRunner = async () => ({
+        outcome: "refused",
+        turnCount: 1,
+        editedFileCount: 0,
+        commandCount: 0,
+        sessionRef: null,
+        errorMessage: usageLimitMessage,
+      })
+
+      const record = await executeCodexAgentAssignment(state, lease, now, {
+        account,
+        codexAgentRunner: refusingRunner,
+        codexAgentProbe: readyProbe,
+      })
+
+      expect(record?.status).toBe("rejected")
+      expect(record?.blockerRefs).toContain("blocker.assignment.codex_agent_execution_usage_limited")
+      expect(record?.resultRefs).toContain("result.public.pylon.codex_agent_task.execution_usage_limited")
+      expect(JSON.stringify(record)).not.toContain(usageLimitMessage)
+      const quotaRecord = await loadQuotaRecord(state, accountRefHash)
+      expect(quotaRecord).not.toBeNull()
+      expect(quotaRecord?.provider).toBe("codex")
+      expect(quotaRecord?.sourceDigestRef).toStartWith("diagnostic.pylon.codex_agent_task.execution_error.")
+      assertPublicProjectionSafe(record)
     })
   })
 


### PR DESCRIPTION
Closes #6902.

## Changes
- classify Codex SDK execution failures into public-safe reason refs for revoked credentials, usage limits, rate limits, network errors, timeouts, and other failures
- thread SDK turn failure messages into rejected closeouts without exposing raw provider text
- record usage/rate-limit refusals in the existing account quota ledger and have per-account Codex heartbeat readiness omit quota-blocked accounts

## Verification
- bun test apps/pylon/tests/codex-agent-executor.test.ts apps/pylon/src/presence-codex-account-capacity.test.ts
- bun run --cwd apps/pylon typecheck

Note: I searched the checkout and local task cache for command.public.pylon_khala.verify.b5bea41b6c623f7c09f1bf24, but no command mapping was present. The focused Pylon tests and typecheck above were run as the relevant verification for this scoped change.