### PR TITLE
fix(codex-supervisor): keep lockout replenishment on short cadence

### DIFF
--- a/apps/pylon/scripts/codex-supervisor/backoff-policy.sh
+++ b/apps/pylon/scripts/codex-supervisor/backoff-policy.sh
@@ -17,6 +17,8 @@
 : "${SUP_CLAIMED_DEEP_BACKLOG_SLEEP_SECS:=1}"
 : "${SUP_FAILURE_BACKOFF_ESCALATE_THRESHOLD:=2}"
 : "${SUP_LOCKOUT_BACKOFF_MAX:=120}"
+: "${SUP_LOCKOUT_IDLE_SECS:=2}"
+: "${SUP_REPLENISHMENT_LOCKOUTS:=3}"
 
 sup_backoff_policy_dir() {
   local d="${SUP_BACKOFF_POLICY_DIR:-$SUP_STATE_DIR/backoff-policy}"
@@ -144,6 +146,11 @@ sup_lockout_pick_backoff_secs() {
   local open_count="$1"
   local desired_slots="$2"
   local current_backoff="$3"
+  local lockout_repeat="${4:-0}"
+  if [ "$lockout_repeat" -ge "$SUP_REPLENISHMENT_LOCKOUTS" ] 2>/dev/null; then
+    printf '%s' "$SUP_LOCKOUT_IDLE_SECS"
+    return 0
+  fi
   local selected
   selected="$(sup_claimed_pick_backoff_secs "$open_count" "$desired_slots" "$current_backoff")"
   if [ "$selected" -gt "$SUP_LOCKOUT_BACKOFF_MAX" ] 2>/dev/null; then

--- a/apps/pylon/scripts/codex-supervisor/backoff-policy.test.sh
+++ b/apps/pylon/scripts/codex-supervisor/backoff-policy.test.sh
@@ -22,6 +22,8 @@ export SUP_CODEX_REFUSAL_TUNE_THRESHOLD=3
 export SUP_CLAIMED_DEEP_BACKLOG_SLEEP_SECS=1
 export SUP_FAILURE_BACKOFF_ESCALATE_THRESHOLD=2
 export SUP_LOCKOUT_BACKOFF_MAX=120
+export SUP_LOCKOUT_IDLE_SECS=2
+export SUP_REPLENISHMENT_LOCKOUTS=3
 mkdir -p "$SUP_STATE_DIR" "$SUP_BACKOFF_POLICY_DIR"
 
 # shellcheck source=backoff-policy.sh
@@ -104,16 +106,28 @@ else
   bad "shallow backlog should keep normal backoff"
 fi
 
-if [ "$(sup_lockout_pick_backoff_secs 4 4 300)" = "120" ]; then
+if [ "$(sup_lockout_pick_backoff_secs 4 4 300 2)" = "120" ]; then
   ok "lockout pick backoff caps minute-scale idle waits"
 else
   bad "lockout pick backoff did not cap at SUP_LOCKOUT_BACKOFF_MAX"
 fi
 
-if [ "$(sup_lockout_pick_backoff_secs 12 4 300)" = "1" ]; then
+if [ "$(sup_lockout_pick_backoff_secs 12 4 300 2)" = "1" ]; then
   ok "deep backlog near-immediate retry still wins under lockout cap"
 else
   bad "lockout cap should preserve deep backlog immediate retry"
+fi
+
+if [ "$(sup_lockout_pick_backoff_secs 4 4 120 3)" = "2" ]; then
+  ok "sustained lockout stays on short replenishment cadence"
+else
+  bad "sustained lockout should not keep escalating backoff"
+fi
+
+if [ "$(sup_lockout_pick_backoff_secs 4 4 15 2)" = "15" ]; then
+  ok "pre-replenishment lockout keeps normal backoff policy"
+else
+  bad "pre-replenishment lockout should keep normal backoff policy"
 fi
 
 if sup_should_escalate_failure_backoff refused 1; then

--- a/apps/pylon/scripts/codex-supervisor/codex-supervisor.sh
+++ b/apps/pylon/scripts/codex-supervisor/codex-supervisor.sh
@@ -412,7 +412,7 @@ worker_loop() {
     fi
     if [ -z "$issue" ]; then
       local pick_sleep
-      pick_sleep="$(sup_lockout_pick_backoff_secs "${#issues[@]}" "$desired" "$backoff")"
+      pick_sleep="$(sup_lockout_pick_backoff_secs "${#issues[@]}" "$desired" "$backoff" "$lockout_repeat")"
       log "slot=$slot LOCKOUT all backlog issues are closed, already have open PRs, or are claimed by other slots; open_backlog=${#issues[@]} desired_slots=$desired repeated=$lockout_repeat backing off ${pick_sleep}s"
       sleep "$pick_sleep"
       if [ "$pick_sleep" = "$backoff" ]; then


### PR DESCRIPTION
Closes #6822.

## Summary
- keep sustained LOCKOUT/no-pick cycles on a short replenishment cadence after the replenishment threshold
- preserve the existing claimed-backlog and pre-replenishment backoff policy before that threshold
- add shell coverage for both sustained and pre-threshold LOCKOUT timing

## Verification
- `while IFS= read -r t; do printf '%s\\n' "$t"; bash "$t" || exit 1; done < <(find apps/pylon/scripts/codex-supervisor -maxdepth 1 -name '*.test.sh' -print | sort)`\n\nNote: `command.public.pylon_khala.verify.b5bea41b6c623f7c09f1bf24` was not recoverable as argv from local task metadata, so I ran the full codex-supervisor shell suite covering this change.