### PR TITLE
Fix operator fleet state progress visibility

### DIFF
--- a/apps/openagents.com/workers/api/src/operator-fleet-status-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/operator-fleet-status-routes.test.ts
@@ -104,6 +104,33 @@ const rowsForSql = (sql: string): ReadonlyArray<Record<string, unknown>> => {
     ]
   }
 
+  if (sql.includes('FROM pylon_api_events')) {
+    return [
+      {
+        assignment_ref: 'lease.public.issue_6427',
+        created_at: '2026-06-27T18:39:45.000Z',
+        event_body_json: JSON.stringify({
+          assignmentRef: 'assignment.public.issue_6427',
+          lastProgressEvent: 'verification.started',
+          message: 'Running focused verification.',
+          phase: 'testing',
+          status: 'running',
+        }),
+        event_kind: 'assignment_progress',
+        status: 'running',
+      },
+    ]
+  }
+
+  if (sql.includes('tokens_so_far')) {
+    return [
+      {
+        task_ref: 'assignment.public.issue_6427',
+        tokens_so_far: 321,
+      },
+    ]
+  }
+
   if (sql.includes('tokens_today')) {
     return [{ tokens_today: 1200 }]
   }
@@ -191,7 +218,7 @@ describe('operator fleet status route', () => {
     expect(first.headers.get('x-openagents-cache')).toBe('miss')
     expect(second.headers.get('x-openagents-cache')).toBe('hit')
     expect(log.length).toBeGreaterThan(0)
-    expect(log.length).toBe(9)
+    expect(log.length).toBe(11)
     expect(cachedBody).toEqual(body)
     expect(body).toMatchObject({
       authority: {
@@ -209,9 +236,10 @@ describe('operator fleet status route', () => {
           {
             assignmentRef: 'assignment.public.issue_6427',
             elapsedMs: 660000,
-            lastProgressEvent: null,
-            phase: 'running',
-            tokensSoFar: null,
+            lastLog: 'Running focused verification.',
+            lastProgressEvent: 'verification.started',
+            phase: 'testing',
+            tokensSoFar: 321,
           },
         ],
         activeSlots: 3,
@@ -269,6 +297,7 @@ describe('operator fleet status route', () => {
     expect(JSON.stringify(body)).not.toContain('/Users/')
     expect(JSON.stringify(body)).not.toContain('auth.json')
     expect(JSON.stringify(body)).not.toContain('Fan out bounded')
+    expect(JSON.stringify(body)).not.toContain('raw prompt')
   })
 
   test('accepts a registered agent token through the owner-scoped state path', async () => {

--- a/apps/openagents.com/workers/api/src/operator-fleet-status-routes.ts
+++ b/apps/openagents.com/workers/api/src/operator-fleet-status-routes.ts
@@ -1,7 +1,10 @@
 import { jsonResponse } from '@openagentsinc/sync-worker'
 
 import { methodNotAllowed, noStoreJsonResponse } from './http/responses'
-import { parseJsonStringArray } from './json-boundary'
+import {
+  parseJsonRecord as parseJsonBoundaryRecord,
+  parseJsonStringArray,
+} from './json-boundary'
 import { openAgentsDatabase } from './runtime'
 import { currentIsoTimestamp } from './runtime-primitives'
 
@@ -80,6 +83,19 @@ type GlmHeartbeatRow = Readonly<{
   health_status: string | null
 }>
 
+type AssignmentProgressRow = Readonly<{
+  assignment_ref: string | null
+  created_at: string
+  event_body_json: string
+  event_kind: string
+  status: string
+}>
+
+type AssignmentTokenRow = Readonly<{
+  task_ref: string
+  tokens_so_far: number | null
+}>
+
 type CacheEntry = Readonly<{
   expiresAt: number
   generatedAt: string
@@ -108,6 +124,68 @@ const millisBetween = (startIso: string, endIso: string): number => {
   return Number.isFinite(start) && Number.isFinite(end)
     ? Math.max(0, end - start)
     : 0
+}
+
+const boundedString = (
+  value: unknown,
+  maxLength = 180,
+): string | null => {
+  if (typeof value !== 'string') {
+    return null
+  }
+  const trimmed = value.trim()
+  if (trimmed.length === 0) {
+    return null
+  }
+  return trimmed.length <= maxLength ? trimmed : `${trimmed.slice(0, maxLength)}...`
+}
+
+const phaseFromProgress = (
+  row: AssignmentProgressRow | undefined,
+  fallbackState: string,
+): string => {
+  if (row === undefined) {
+    return fallbackState === 'proof_submitted'
+      ? 'proof'
+      : fallbackState === 'running' || fallbackState === 'accepted'
+        ? 'running'
+        : 'queued'
+  }
+
+  const body = parseJsonBoundaryRecord(row.event_body_json) ?? {}
+  const bodyPhase = boundedString(body.phase, 64)
+  if (bodyPhase !== null) {
+    return bodyPhase
+  }
+
+  const status = boundedString(body.status, 64) ?? row.status
+  return status === 'artifact-ready'
+    ? 'diff'
+    : status === 'proof-ready' || status === 'submitted'
+      ? 'proof'
+      : status === 'accepted'
+        ? 'running'
+        : status
+}
+
+const progressEventLabel = (
+  row: AssignmentProgressRow | undefined,
+): string | null => {
+  if (row === undefined) {
+    return null
+  }
+  const body = parseJsonBoundaryRecord(row.event_body_json) ?? {}
+  return boundedString(body.lastProgressEvent, 100) ?? row.event_kind
+}
+
+const progressLogLine = (
+  row: AssignmentProgressRow | undefined,
+): string | null => {
+  if (row === undefined) {
+    return null
+  }
+  const body = parseJsonBoundaryRecord(row.event_body_json) ?? {}
+  return boundedString(body.message)
 }
 
 const safeAll = async <T>(
@@ -254,6 +332,62 @@ const buildFleetStatusSnapshot = async (
     ),
   ])
 
+  const progressOwnerClause = scope.kind === 'agent' ? 'AND owner_agent_user_id = ?' : ''
+  const tokenOwnerClause = scope.kind === 'agent' ? 'AND actor_user_id = ?' : ''
+  const [
+    progressRows,
+    assignmentTokenRows,
+  ] = await Promise.all([
+    safeAll<AssignmentProgressRow>(
+      db,
+      `SELECT assignment_ref, event_kind, status, event_body_json, created_at
+         FROM pylon_api_events
+        WHERE archived_at IS NULL
+          AND event_kind IN ('assignment_acceptance', 'assignment_progress', 'artifact_proof_metadata', 'worker_closeout')
+          ${progressOwnerClause}
+        ORDER BY created_at DESC
+        LIMIT 200`,
+      ...ownerBindings,
+    ),
+    safeAll<AssignmentTokenRow>(
+      db,
+      `SELECT task_ref, COALESCE(SUM(total_tokens), 0) AS tokens_so_far
+         FROM token_usage_events
+        WHERE task_ref IS NOT NULL
+          AND provider = 'pylon-codex-own-capacity'
+          AND model = 'openagents/pylon-codex'
+          AND usage_truth = 'exact'
+          AND demand_kind = 'own_capacity'
+          AND demand_source = 'khala_coding_delegation'
+          ${tokenOwnerClause}
+        GROUP BY task_ref
+        ORDER BY MAX(observed_at) DESC
+        LIMIT 200`,
+      ...ownerBindings,
+    ),
+  ])
+
+  const latestProgressByAssignmentRef = new Map<string, AssignmentProgressRow>()
+  for (const row of progressRows) {
+    const body = parseJsonBoundaryRecord(row.event_body_json) ?? {}
+    const refs = [
+      row.assignment_ref,
+      boundedString(body.assignmentRef, 160),
+      boundedString(body.leaseRef, 160),
+    ].filter((ref): ref is string => ref !== null)
+    for (const ref of refs) {
+      if (!latestProgressByAssignmentRef.has(ref)) {
+        latestProgressByAssignmentRef.set(ref, row)
+      }
+    }
+  }
+  const tokensByAssignmentRef = new Map(
+    assignmentTokenRows.map(row => [
+      row.task_ref,
+      Math.max(0, Math.trunc(row.tokens_so_far ?? 0)),
+    ]),
+  )
+
   const nowMs = Date.parse(nowIso)
   const activeFreshCutoffMs = nowMs - 90_000
   const fleetAccounts = registrations.map(row => {
@@ -375,15 +509,17 @@ const buildFleetStatusSnapshot = async (
         jobKind: row.job_kind,
         state: row.state,
         elapsedMs: millisBetween(row.created_at, nowIso),
-        phase:
-          row.state === 'proof_submitted'
-            ? 'proof'
-            : row.state === 'running' || row.state === 'accepted'
-              ? 'running'
-              : 'queued',
-        tokensSoFar: null,
-        lastProgressEvent: null,
-        lastLog: null,
+        phase: phaseFromProgress(
+          latestProgressByAssignmentRef.get(row.assignment_ref),
+          row.state,
+        ),
+        tokensSoFar: tokensByAssignmentRef.get(row.assignment_ref) ?? null,
+        lastProgressEvent: progressEventLabel(
+          latestProgressByAssignmentRef.get(row.assignment_ref),
+        ),
+        lastLog: progressLogLine(
+          latestProgressByAssignmentRef.get(row.assignment_ref),
+        ),
         updatedAt: row.updated_at,
         leaseExpiresAt: row.lease_expires_at,
       })),
@@ -397,7 +533,12 @@ const buildFleetStatusSnapshot = async (
         leaseExpiresAt: row.lease_expires_at,
       })),
       activeAssignmentCount: activeAssignments.length,
-      sourceRefs: ['d1:pylon_api_registrations', 'd1:pylon_api_assignments'],
+      sourceRefs: [
+        'd1:pylon_api_registrations',
+        'd1:pylon_api_assignments',
+        'd1:pylon_api_events',
+        'd1:token_usage_events',
+      ],
     },
     accounts: {
       status: accountLedger,


### PR DESCRIPTION
## Summary
- Fill `/api/operator/fleet/state` active assignment progress fields from persisted Pylon assignment events.
- Add exact downstream Pylon/Codex token totals from `token_usage_events` for each active assignment.
- Keep the join tolerant of lease-keyed progress rows by also matching the public-safe `assignmentRef` in the event body.

Closes #6958

## Verification
- `bun run --cwd apps/openagents.com/workers/api test src/operator-fleet-status-routes.test.ts`
- `bun run --cwd apps/openagents.com/workers/api typecheck`
- `bun run check:deploy`

Note: the task-provided opaque verifier ref was `command.public.pylon_khala.verify.b5bea41b6c623f7c09f1bf24`; no local command-ref metadata mapping was present in this bounded checkout, so I ran the focused Worker route test, Worker typecheck, and full deploy check relevant to this issue slice.