### PR TITLE
Parse Pylon provider quota reset hints

### DIFF
--- a/apps/pylon/src/account-quota.ts
+++ b/apps/pylon/src/account-quota.ts
@@ -8,13 +8,32 @@ export type QuotaSignal = {
 }
 
 const quotaPattern =
-  /usage limit|hit your usage limit|purchase more credits|rate limit|try again at/
+  /usage limit|hit your usage limit|purchase more credits|rate limit|retry-after|try again (?:at|after|in)/
 
-function retryAtIsoFromRaw(retryAtRaw: string | null): string | null {
+type RetryAtParseOptions = {
+  now?: Date
+}
+
+function retryAtIsoFromRaw(retryAtRaw: string | null, options: RetryAtParseOptions = {}): string | null {
   if (retryAtRaw === null) return null
 
   try {
-    const normalized = retryAtRaw.replace(/\b(\d{1,2})(st|nd|rd|th)\b/gi, "$1")
+    const normalized = retryAtRaw.trim().replace(/\b(\d{1,2})(st|nd|rd|th)\b/gi, "$1")
+    const retryAfterSeconds = normalized.match(/^(?:retry-after:\s*)?(\d{1,8})$/i)?.[1]
+    if (retryAfterSeconds !== undefined) {
+      return new Date((options.now ?? new Date()).getTime() + Number(retryAfterSeconds) * 1000).toISOString()
+    }
+    const relative = normalized.match(/^(\d{1,5})\s*(second|seconds|sec|secs|s|minute|minutes|min|mins|m|hour|hours|hr|hrs|h)\b/i)
+    if (relative) {
+      const amount = Number(relative[1])
+      const unit = relative[2]?.toLowerCase() ?? ""
+      const multiplier = unit.startsWith("s")
+        ? 1000
+        : unit.startsWith("m")
+          ? 60_000
+          : 3600_000
+      return new Date((options.now ?? new Date()).getTime() + amount * multiplier).toISOString()
+    }
     const parsed = new Date(normalized)
     if (Number.isNaN(parsed.getTime())) return null
 
@@ -27,18 +46,22 @@ function retryAtIsoFromRaw(retryAtRaw: string | null): string | null {
 export function classifyQuotaSignal(
   output: string,
   provider: "codex" | "claude_agent",
+  options: RetryAtParseOptions = {},
 ): QuotaSignal {
   void provider
 
   try {
     const normalizedOutput = String(output ?? "")
     const lowerOutput = normalizedOutput.toLowerCase()
-    const retryAtRaw = normalizedOutput.match(/try again at\s+(.+?)(?:\.|$)/i)?.[1]?.trim() ?? null
+    const retryAtRaw =
+      normalizedOutput.match(/\bretry-after:\s*([^\r\n]+)/i)?.[1]?.trim() ??
+      normalizedOutput.match(/try again (?:at|after|in)\s+(.+?)(?:\.|$)/i)?.[1]?.trim() ??
+      null
 
     return {
       exhausted: quotaPattern.test(lowerOutput),
       retryAtRaw,
-      retryAtIso: retryAtIsoFromRaw(retryAtRaw),
+      retryAtIso: retryAtIsoFromRaw(retryAtRaw, options),
       sourceDigestRef: `digest.pylon.account_quota.${createHash("sha256")
         .update(normalizedOutput)
         .digest("hex")

--- a/apps/pylon/tests/account-quota.test.ts
+++ b/apps/pylon/tests/account-quota.test.ts
@@ -14,6 +14,30 @@ describe("classifyQuotaSignal", () => {
     expect(signal.retryAtIso).toEqual(expect.any(String))
   })
 
+  test("parses provider retry-after seconds into a concrete reset time", () => {
+    const signal = classifyQuotaSignal(
+      "HTTP 429 rate limit exceeded\nretry-after: 120",
+      "codex",
+      { now: new Date("2026-06-28T21:41:00.000Z") },
+    )
+
+    expect(signal.exhausted).toBe(true)
+    expect(signal.retryAtRaw).toBe("120")
+    expect(signal.retryAtIso).toBe("2026-06-28T21:43:00.000Z")
+  })
+
+  test("parses relative provider cooldown prose into a concrete reset time", () => {
+    const signal = classifyQuotaSignal(
+      "rate limit exceeded, try again in 17 minutes.",
+      "claude_agent",
+      { now: new Date("2026-06-28T21:41:00.000Z") },
+    )
+
+    expect(signal.exhausted).toBe(true)
+    expect(signal.retryAtRaw).toBe("17 minutes")
+    expect(signal.retryAtIso).toBe("2026-06-28T21:58:00.000Z")
+  })
+
   test("classifies Claude-style rate limits without reset timestamps", () => {
     const signal = classifyQuotaSignal(
       "rate limit exceeded, try again later",


### PR DESCRIPTION
## Summary
- extend Pylon quota classification to parse provider `Retry-After` seconds and relative cooldown prose into concrete reset timestamps
- keep quota projections sanitized while preserving the existing digest-only source reference
- add focused tests for provider reset hints

Closes #6637

## Verification
- `bun test apps/pylon/tests/account-quota.test.ts`
- `git diff --check -- apps/pylon/src/account-quota.ts apps/pylon/tests/account-quota.test.ts`

## Notes
- Attempted broader focused run: `bun test apps/pylon/tests/account-quota.test.ts apps/pylon/tests/account-quota-ledger.test.ts apps/pylon/src/account-status.test.ts`; it is blocked in this checkout because Bun cannot resolve workspace package `@openagentsinc/tassadar-executor` from `apps/pylon/src/bootstrap.ts`.
- Required opaque verification ref `command.public.pylon_khala.verify.b5bea41b6c623f7c09f1bf24` was not resolvable to a command body from files or environment in this bounded checkout; no command with that ref is stored locally.