### PR TITLE
Hard-stop AgentCL Vertex runs at the spend cap

### DIFF
--- a/apps/openagents.com/workers/api/src/inference/gym/agentcl.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/gym/agentcl.test.ts
@@ -354,7 +354,7 @@ describe('AgentCL repo-reuse gym environment', () => {
     })
     expect(
       assessAgentClVertexRunnerCircuitBreaker({
-        estimatedSpendUsdCents: 5001,
+        estimatedSpendUsdCents: 5000,
         consecutiveBillingOrQuotaErrors: 0,
       }),
     ).toEqual({ tripped: true, reason: 'spend_cap_exceeded' })
@@ -444,6 +444,35 @@ describe('AgentCL repo-reuse gym environment', () => {
     expect(result.report.budgetGuard.estimatedSpendUsdCents).toBeGreaterThan(
       5000,
     )
+  })
+
+  test('halts AgentCL live execution at the $50 cap before another paid call', async () => {
+    let calls = 0
+    const result = await Effect.runPromise(
+      runAgentClVertexRunnerLoop({
+        adapter: fakeVertexAdapter(() => {
+          calls += 1
+          return Effect.succeed(
+            vertexResult({
+              completionTokens: 166_666_667,
+              promptTokens: 0,
+              totalTokens: 166_666_667,
+            }),
+          )
+        }),
+        ownerApprovalRef: 'owner.approval.agentcl.vertex_stress.20260628',
+        runMode: 'owner_armed_real',
+      }),
+    )
+
+    expect(calls).toBe(1)
+    expect(result.status).toBe('aborted_circuit_breaker')
+    expect(result.report.budgetGuard.circuitBreakerReason).toBe(
+      'spend_cap_exceeded',
+    )
+    expect(
+      result.report.budgetGuard.estimatedSpendUsdCents,
+    ).toBeGreaterThanOrEqual(5000)
   })
 
   test('aborts AgentCL live execution after three consecutive billing or quota errors', async () => {

--- a/apps/openagents.com/workers/api/src/inference/gym/agentcl.ts
+++ b/apps/openagents.com/workers/api/src/inference/gym/agentcl.ts
@@ -1026,7 +1026,7 @@ export const assessAgentClVertexRunnerCircuitBreaker = (
     'owner.approval.agentcl.vertex_stress.required',
   )
   const reason =
-    input.estimatedSpendUsdCents > runnerPlan.budgetGuard.spendCapUsdCents
+    input.estimatedSpendUsdCents >= runnerPlan.budgetGuard.spendCapUsdCents
       ? 'spend_cap_exceeded'
       : input.consecutiveBillingOrQuotaErrors >=
           runnerPlan.budgetGuard.abortOnConsecutiveBillingOrQuotaErrors


### PR DESCRIPTION
## Summary

- Hard-stop the AgentCL Vertex circuit breaker when measured spend reaches the $50 cap, not only after it exceeds the cap.
- Add regression coverage proving an owner-armed AgentCL Vertex loop does not make another paid call once the cap is reached.

Closes #6762.

## Verification

- `bun run --cwd apps/openagents.com/workers/api test -- src/inference/gym/agentcl.test.ts src/inference/gym/agentcl-vertex-runner.test.ts`

Note: the assignment requested verification ref `command.public.pylon_khala.verify.b5bea41b6c623f7c09f1bf24`, but this bounded checkout did not include the argv metadata needed to reverse that opaque hash. The focused AgentCL verification above is the directly relevant local command for this patch.
