### PR TITLE
fix(ops): hydrate issue triage candidates

### DIFF
--- a/scripts/github-issue-triage.test.ts
+++ b/scripts/github-issue-triage.test.ts
@@ -2,8 +2,10 @@ import { describe, expect, test } from "bun:test"
 import {
   buildTechnicalPlan,
   buildCandidateIssueSearch,
+  buildIssueViewArgs,
   classifyIssuePriority,
   findDuplicateCandidates,
+  hydrateCandidateIssues,
   inferRelevantFiles,
   issueHasAnyLabel,
   issueHasPriorityLabel,
@@ -124,6 +126,45 @@ describe("github issue triage output", () => {
   test("builds the default candidate query from newly opened unlabeled issues", () => {
     expect(buildCandidateIssueSearch(false)).toBe("is:issue is:open no:label sort:created-desc")
     expect(buildCandidateIssueSearch(true)).toBe("is:issue is:open sort:created-desc")
+  })
+
+  test("builds bounded issue view args for full candidate descriptions", () => {
+    expect(buildIssueViewArgs("OpenAgentsInc/openagents", 6708)).toEqual([
+      "issue",
+      "view",
+      "6708",
+      "--repo",
+      "OpenAgentsInc/openagents",
+      "--json",
+      "number,title,body,labels,url",
+    ])
+  })
+
+  test("hydrates candidate issues before classification", () => {
+    const listed = issue({
+      body: "",
+      labels: [],
+      number: 6708,
+      title: "task(ops): standing backlog triage",
+    })
+    const hydrated = hydrateCandidateIssues([listed], issueNumber =>
+      issue({
+        body: "Full description mentions docs/promises/registry.md and duplicate checks.",
+        labels: [{ name: "standing-task" }],
+        number: issueNumber,
+        title: "task(ops): standing backlog triage + scoping + dedup loop",
+        url: "https://github.com/OpenAgentsInc/openagents/issues/6708",
+      }),
+    )
+
+    expect(hydrated).toEqual([
+      expect.objectContaining({
+        body: "Full description mentions docs/promises/registry.md and duplicate checks.",
+        labels: [{ name: "standing-task" }],
+        number: 6708,
+        title: "task(ops): standing backlog triage + scoping + dedup loop",
+      }),
+    ])
   })
 
   test("builds a scoped execution plan and rendered comment", () => {

--- a/scripts/github-issue-triage.ts
+++ b/scripts/github-issue-triage.ts
@@ -313,13 +313,32 @@ export const listRepositoryFiles = (cwd: string): ReadonlyArray<string> => {
 export const buildCandidateIssueSearch = (includeLabeled: boolean): string =>
   includeLabeled ? "is:issue is:open sort:created-desc" : "is:issue is:open no:label sort:created-desc"
 
+export const buildIssueViewArgs = (repo: string, issueNumber: number): ReadonlyArray<string> => [
+  "issue",
+  "view",
+  String(issueNumber),
+  "--repo",
+  repo,
+  "--json",
+  "number,title,body,labels,url",
+]
+
+export const hydrateCandidateIssues = (
+  issues: ReadonlyArray<GitHubIssue>,
+  readIssue: (issueNumber: number) => GitHubIssue,
+): ReadonlyArray<GitHubIssue> =>
+  issues.map(issue => ({
+    ...issue,
+    ...readIssue(issue.number),
+  }))
+
 const listCandidateIssues = (
   repo: string,
   limit: number,
   includeLabeled: boolean,
 ): ReadonlyArray<GitHubIssue> => {
   const search = buildCandidateIssueSearch(includeLabeled)
-  return runGhJson([
+  const issues = runGhJson([
     "issue",
     "list",
     "--repo",
@@ -333,6 +352,8 @@ const listCandidateIssues = (
     "--json",
     "number,title,body,labels,url",
   ]) as ReadonlyArray<GitHubIssue>
+
+  return hydrateCandidateIssues(issues, issueNumber => runGhJson(buildIssueViewArgs(repo, issueNumber)) as GitHubIssue)
 }
 
 const listOpenIssues = (repo: string, limit: number): ReadonlyArray<GitHubIssue> =>


### PR DESCRIPTION
Closes #6708.

### Changes
- Hydrates candidate issues with `gh issue view` after the initial list query so triage classification/comment output uses the full issue description and current labels.
- Adds focused coverage for the bounded `gh issue view` argv and hydration behavior.

### Verification
- `bun test scripts/github-issue-triage.test.ts` passed (12 tests).
- `bun run test:github-issue-triage` passed (12 tests).
- `command.public.pylon_khala.verify.b5bea41b6c623f7c09f1bf24` resolved to `true` and passed.
- `git diff --check` passed.