### PR TITLE
Gate Forge promotions on verification receipts

### DIFF
--- a/apps/openagents.com/workers/api/src/forge-coordination-store.test.ts
+++ b/apps/openagents.com/workers/api/src/forge-coordination-store.test.ts
@@ -273,4 +273,110 @@ describe('forge coordination D1 store', () => {
       store.listPromotionDecisionReceipts('tenant.openagents', 10, 'change.forge.6770'),
     ).resolves.toEqual([promotionDecision])
   })
+
+  test('fails approved promotions closed without a matching passed verification receipt', async () => {
+    const store = makeStore()
+    const baseVerificationReceipt = {
+      schema: 'openagents.forge.verification.receipt.v0.1' as const,
+      tenant_ref: 'tenant.openagents',
+      verification_ref: 'verification.forge.6795',
+      change_ref: 'change.forge.6795',
+      repository_ref: 'repo:OpenAgentsInc/openagents',
+      base_ref: 'refs/heads/main',
+      base_head: '8e0c9b2eaf84c821caf555cae233a0d27e94d4ab',
+      head_ref: 'refs/heads/forge-6795',
+      head_head: '9e0c9b2eaf84c821caf555cae233a0d27e94d4ac',
+      packfile_ref: 'packfile.forge.6795',
+      packfile_sha256: 'sha256:verification',
+      executor_identity_ref: 'agent.public.forge',
+      command_ref: 'cmd.test',
+      command_args: ['bun', 'test'],
+      exit_code: 0,
+      verdict: 'passed' as const,
+      started_at: now,
+      completed_at: '2026-06-28T16:02:00.000Z',
+      artifact_refs: ['artifact:test-log'],
+      log_sha256: 'sha256:log',
+      source_refs: ['github:OpenAgentsInc/openagents#6795'],
+      redacted: true as const,
+    }
+    const basePromotionDecision = {
+      schema: 'openagents.forge.promotion.decision.v0.1' as const,
+      tenant_ref: 'tenant.openagents',
+      promotion_ref: 'promotion.forge.6795',
+      queue_ref: 'queue.forge.main',
+      change_ref: 'change.forge.6795',
+      decision: 'approved' as const,
+      base_head: baseVerificationReceipt.base_head,
+      candidate_head: baseVerificationReceipt.head_head,
+      promoted_head: baseVerificationReceipt.head_head,
+      verification_ref: baseVerificationReceipt.verification_ref,
+      gate_refs: ['gate.tests'],
+      blocker_refs: [],
+      decided_by_ref: 'agent.public.forge',
+      decided_at: '2026-06-28T16:03:00.000Z',
+      source_refs: ['github:OpenAgentsInc/openagents#6795'],
+      redacted: true as const,
+    }
+
+    await expect(
+      store.recordPromotionDecisionReceipt(
+        { ...basePromotionDecision, verification_ref: null },
+        now,
+      ),
+    ).rejects.toThrow('requires a verification receipt ref')
+    await expect(
+      store.recordPromotionDecisionReceipt(basePromotionDecision, now),
+    ).rejects.toThrow('verification receipt is missing')
+
+    await store.recordVerificationReceipt(
+      {
+        ...baseVerificationReceipt,
+        verification_ref: 'verification.forge.6795.failed',
+        exit_code: 1,
+        verdict: 'failed',
+      },
+      now,
+    )
+    await expect(
+      store.recordPromotionDecisionReceipt(
+        {
+          ...basePromotionDecision,
+          promotion_ref: 'promotion.forge.6795.failed',
+          verification_ref: 'verification.forge.6795.failed',
+        },
+        now,
+      ),
+    ).rejects.toThrow('does not match the promoted change')
+
+    await store.recordVerificationReceipt(baseVerificationReceipt, now)
+    await expect(
+      store.recordPromotionDecisionReceipt(
+        {
+          ...basePromotionDecision,
+          promotion_ref: 'promotion.forge.6795.stale',
+          base_head: '7e0c9b2eaf84c821caf555cae233a0d27e94d4ab',
+        },
+        now,
+      ),
+    ).rejects.toThrow('does not match the promoted change')
+    await expect(
+      store.recordPromotionDecisionReceipt(
+        {
+          ...basePromotionDecision,
+          promotion_ref: 'promotion.forge.6795.wrong-head',
+          candidate_head: 'ae0c9b2eaf84c821caf555cae233a0d27e94d4ac',
+          promoted_head: 'ae0c9b2eaf84c821caf555cae233a0d27e94d4ac',
+        },
+        now,
+      ),
+    ).rejects.toThrow('does not match the promoted change')
+
+    await expect(
+      store.recordPromotionDecisionReceipt(basePromotionDecision, now),
+    ).resolves.toMatchObject({
+      decision: 'approved',
+      verification_ref: baseVerificationReceipt.verification_ref,
+    })
+  })
 })

--- a/apps/openagents.com/workers/api/src/forge-coordination-store.ts
+++ b/apps/openagents.com/workers/api/src/forge-coordination-store.ts
@@ -257,6 +257,51 @@ const rowOrFail = <T>(row: T | null, label: string): T => {
   return row
 }
 
+const assertApprovedPromotionHasPassingVerification = async (
+  db: D1Database,
+  receipt: ForgePromotionDecisionReceipt,
+): Promise<void> => {
+  if (receipt.decision !== 'approved') {
+    return
+  }
+
+  if (receipt.verification_ref === null) {
+    throw new ForgeCoordinationStoreInvariantError(
+      'approved Forge promotion requires a verification receipt ref',
+    )
+  }
+
+  const verificationRow = await db
+    .prepare(
+      `
+        SELECT *
+        FROM forge_verification_receipts
+        WHERE tenant_ref = ? AND verification_ref = ?
+      `,
+    )
+    .bind(receipt.tenant_ref, receipt.verification_ref)
+    .first<ForgeVerificationReceiptRow>()
+
+  if (verificationRow === null) {
+    throw new ForgeCoordinationStoreInvariantError(
+      'approved Forge promotion verification receipt is missing',
+    )
+  }
+
+  const verification = verificationReceiptFromRow(verificationRow)
+  if (
+    verification.change_ref !== receipt.change_ref ||
+    verification.base_head !== receipt.base_head ||
+    verification.head_head !== receipt.candidate_head ||
+    verification.verdict !== 'passed' ||
+    verification.exit_code !== 0
+  ) {
+    throw new ForgeCoordinationStoreInvariantError(
+      'approved Forge promotion verification receipt does not match the promoted change',
+    )
+  }
+}
+
 const firstIssue = async (
   db: D1Database,
   tenantRef: string,
@@ -858,6 +903,7 @@ export const makeD1ForgeCoordinationStore = (
 
   async recordPromotionDecisionReceipt(receipt, createdAt) {
     const decoded = decodeForgePromotionDecisionReceipt(receipt)
+    await assertApprovedPromotionHasPassingVerification(db, decoded)
     await db
       .prepare(
         `


### PR DESCRIPTION
## Summary

- Require approved Forge promotion decisions to reference an existing verification receipt.
- Fail approved promotions closed unless the receipt passed with exit code 0 and matches the same change, base head, and candidate head.
- Add regression coverage for missing, failing, stale-base, wrong-head, and matching receipt cases.

Closes #6795

## Verification

- `bun run --cwd apps/openagents.com/workers/api test -- src/forge-coordination-store.test.ts`
- `bun run --cwd apps/openagents.com/workers/api typecheck`
- `bun run --cwd apps/openagents.com check:deploy`
- `true` (`command.public.pylon_khala.verify.b5bea41b6c623f7c09f1bf24`)
