### PR TITLE
fix: constrain MirrorCode smoke launches

### DIFF
--- a/apps/openagents.com/workers/api/src/inference/gym/mirrorcode-contract.ts
+++ b/apps/openagents.com/workers/api/src/inference/gym/mirrorcode-contract.ts
@@ -61,6 +61,26 @@ export const MIRRORCODE_PUBLIC_TARGETS_BY_BUCKET = {
   L: ['ruff', 'pkl', 'cprepro'],
 } as const
 
+export const MIRRORCODE_SMOKE_LAUNCH_BUCKETS: ReadonlyArray<MirrorCodeBucket> = [
+  'S',
+]
+
+export const MIRRORCODE_SMOKE_LAUNCH_POLICY = {
+  mode: 'owner_gated_smoke',
+  allowedBuckets: MIRRORCODE_SMOKE_LAUNCH_BUCKETS,
+  publicTargetsByBucket: {
+    S: MIRRORCODE_PUBLIC_TARGETS_BY_BUCKET.S,
+  },
+  maxTokensPerRun: 50_000_000,
+  maxWallClockSeconds: 6 * 60 * 60,
+  defaultLanguagePolicy: '1l',
+  caveatRefs: [
+    'caveat.public.gym.mirrorcode.launch_smoke_only',
+    'caveat.public.gym.mirrorcode.launch_s_bucket_only',
+    'caveat.public.gym.mirrorcode.scored_results_require_exact_token_rows',
+  ],
+} as const
+
 // Run lifecycle status. `queued`/`running` are in-progress; `passed`/`failed`
 // are scored terminal states; `error` is an execution/harness failure.
 export const MirrorCodeRunStatus = S.Literals([
@@ -306,6 +326,14 @@ export const isMirrorCodePublicTargetForBucket = (
     taskId,
   )
 
+const assertSmokeLaunchBucket = (bucket: MirrorCodeBucket): void => {
+  if (!MIRRORCODE_SMOKE_LAUNCH_BUCKETS.includes(bucket)) {
+    throw new MirrorCodeRunError(
+      'MirrorCode launch intents are smoke-only and currently allow S-bucket public targets only.',
+    )
+  }
+}
+
 const assertPublicTarget = (input: {
   readonly bucket: MirrorCodeBucket
   readonly taskId: string
@@ -426,6 +454,7 @@ export const buildMirrorCodeLaunchRun = (
   if (taskPart.length < 1) {
     throw new MirrorCodeRunError('taskId must contain a public-safe id.')
   }
+  assertSmokeLaunchBucket(launch.bucket)
   assertPublicTarget(launch)
   if (launch.grade === 'decision_grade') {
     throw new MirrorCodeRunError(

--- a/apps/openagents.com/workers/api/src/inference/gym/mirrorcode-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/gym/mirrorcode-routes.test.ts
@@ -116,6 +116,20 @@ describe('buildMirrorCodeRun', () => {
     expect(built.summary).toContain('Owner-gated MirrorCode launch queued')
   })
 
+  test('rejects owner-gated launch intents outside the smoke S bucket', () => {
+    expect(() =>
+      buildMirrorCodeLaunchRun(
+        {
+          kind: 'launch',
+          taskId: 'ruff',
+          bucket: 'L',
+          language: 'python',
+        },
+        '2026-06-27T02:03:04.000Z',
+      ),
+    ).toThrow(MirrorCodeRunError)
+  })
+
   test('rejects an owner-gated launch for an unknown public target', () => {
     expect(() =>
       buildMirrorCodeLaunchRun(
@@ -222,12 +236,24 @@ describe('handleMirrorCodeRunsApi GET', () => {
     const body = (await response.json()) as {
       schemaVersion: string
       model: string
+      launchPolicy: {
+        mode: string
+        allowedBuckets: ReadonlyArray<string>
+        publicTargetsByBucket: { S: ReadonlyArray<string> }
+        maxTokensPerRun: number
+        maxWallClockSeconds: number
+      }
       runs: ReadonlyArray<{ runId: string }>
       comparators: ReadonlyArray<{ source: string }>
       staleness: { composition: string }
     }
     expect(body.schemaVersion).toBe('openagents.gym.mirrorcode_runs.v1')
     expect(body.model).toBe('openagents/khala')
+    expect(body.launchPolicy.mode).toBe('owner_gated_smoke')
+    expect(body.launchPolicy.allowedBuckets).toEqual(['S'])
+    expect(body.launchPolicy.publicTargetsByBucket.S).toContain('qsv_select')
+    expect(body.launchPolicy.maxTokensPerRun).toBe(50_000_000)
+    expect(body.launchPolicy.maxWallClockSeconds).toBe(21_600)
     expect(body.runs[0]?.runId).toBe('mc-phase0-cal-py-0001')
     expect(body.comparators.length).toBeGreaterThan(0)
     expect(
@@ -404,6 +430,35 @@ describe('handleMirrorCodeRunsApi POST', () => {
     expect(stored).toBe(0)
     const body = (await response.json()) as { reason: string }
     expect(body.reason).toContain('launch intents are smoke-only')
+  })
+
+  test('authorized POST rejects non-S launch intents without storing', async () => {
+    let stored = 0
+    const response = await run(
+      handleMirrorCodeRunsApi(
+        postRequest({
+          kind: 'launch',
+          taskId: 'ruff',
+          bucket: 'L',
+          language: 'python',
+        }),
+        {
+          requireAdminApiToken: async () => true,
+          nowIso: () => '2026-06-27T02:03:04.000Z',
+          store: {
+            listRuns: () => Effect.succeed([]),
+            getRun: () => Effect.sync(() => undefined),
+            upsertRun: () => Effect.sync(() => {
+              stored += 1
+            }),
+          },
+        },
+      ),
+    )
+    expect(response.status).toBe(400)
+    expect(stored).toBe(0)
+    const body = (await response.json()) as { reason: string }
+    expect(body.reason).toContain('S-bucket public targets only')
   })
 
   test('authorized POST with task contents is rejected 400', async () => {

--- a/apps/openagents.com/workers/api/src/inference/gym/mirrorcode-routes.ts
+++ b/apps/openagents.com/workers/api/src/inference/gym/mirrorcode-routes.ts
@@ -32,6 +32,7 @@ import {
   KHALA_MODEL_ID,
   MIRRORCODE_BENCHMARK_LABEL,
   MIRRORCODE_PAPER_REFERENCE_COMPARATORS,
+  MIRRORCODE_SMOKE_LAUNCH_POLICY,
   MirrorCodeTokenBurnReportSchemaVersion,
   MirrorCodeRunError,
   MirrorCodeRunsSchemaVersion,
@@ -154,6 +155,7 @@ const publicEnvelope = (
   staleness: mirrorCodeStaleness(),
   model: KHALA_MODEL_ID,
   benchmark: MIRRORCODE_BENCHMARK_LABEL,
+  launchPolicy: MIRRORCODE_SMOKE_LAUNCH_POLICY,
   runs,
   comparators: MIRRORCODE_PAPER_REFERENCE_COMPARATORS,
 })


### PR DESCRIPTION
## Summary
- Publish the MirrorCode owner-gated launch policy on the public runs endpoint so clients see the smoke-only scope, S-bucket target catalog, and token/wall-clock caps.
- Reject owner-gated MirrorCode launch intents outside the S bucket before storage while keeping scored result ingest available for future owner-run measurements.
- Add focused coverage for the public launch policy and non-S launch rejection.

Closes #6376

## Verification
- true (required verifier ref command.public.pylon_khala.verify.b5bea41b6c623f7c09f1bf24)
- bunx vitest@4.1.8 run apps/openagents.com/workers/api/src/inference/gym/mirrorcode-routes.test.ts

## Notes
- bun run --cwd apps/openagents.com/workers/api typecheck currently fails outside this patch in wasm-plugin-marketplace.ts plus existing Effect lint diagnostics.