### PR TITLE
fix(api): require trace and eval evidence for GEPA standing loop

### DIFF
--- a/apps/openagents.com/workers/api/src/probe-gepa-standing-optimization-loop.test.ts
+++ b/apps/openagents.com/workers/api/src/probe-gepa-standing-optimization-loop.test.ts
@@ -64,7 +64,7 @@ describe('Probe GEPA standing optimization loop projection (#6707)', () => {
     ])
   })
 
-  test('blocks the standing loop without trace or eval evidence and low-quality selection', () => {
+  test('blocks the standing loop without trace evidence, eval evidence, or low-quality selection', () => {
     const projection = projectProbeGepaStandingOptimizationLoop(
       input({
         evalResultRefs: [],
@@ -76,11 +76,32 @@ describe('Probe GEPA standing optimization loop projection (#6707)', () => {
 
     expect(projection.decision).toBe('blocked')
     expect(projection.blockerRefs).toContain(
-      'blocker.probe_gepa_standing_loop.trace_or_eval_refs_missing',
+      'blocker.probe_gepa_standing_loop.source_trace_refs_missing',
+    )
+    expect(projection.blockerRefs).toContain(
+      'blocker.probe_gepa_standing_loop.eval_result_refs_missing',
     )
     expect(projection.blockerRefs).toContain(
       'blocker.probe_gepa_standing_loop.low_quality_selection_missing',
     )
+  })
+
+  test('requires both source trace refs and eval result refs before candidate emission', () => {
+    expect(
+      projectProbeGepaStandingOptimizationLoop(
+        input({
+          evalResultRefs: [],
+        }),
+      ).blockerRefs,
+    ).toContain('blocker.probe_gepa_standing_loop.eval_result_refs_missing')
+
+    expect(
+      projectProbeGepaStandingOptimizationLoop(
+        input({
+          sourceTraceRefs: [],
+        }),
+      ).blockerRefs,
+    ).toContain('blocker.probe_gepa_standing_loop.source_trace_refs_missing')
   })
 
   test('requires the DSPy/RLM audit, Mutalisk optimizer runs, candidate manifests, and authority gates before emission', () => {

--- a/apps/openagents.com/workers/api/src/probe-gepa-standing-optimization-loop.ts
+++ b/apps/openagents.com/workers/api/src/probe-gepa-standing-optimization-loop.ts
@@ -121,8 +121,6 @@ const normalizeInput = (
 const blockerRefsFor = (
   input: ProbeGepaStandingOptimizationLoopInput,
 ): ReadonlyArray<string> => {
-  const hasTraceOrEvalEvidence =
-    input.sourceTraceRefs.length > 0 || input.evalResultRefs.length > 0
   const hasLowQualitySelection =
     input.lowQualityTurnRefs.length > 0 || input.failureFamilyRefs.length > 0
   const candidateRequested = input.requestedAction === 'emit_candidates'
@@ -131,8 +129,11 @@ const blockerRefsFor = (
     input.candidateManifestRefs.length > 0
 
   return uniqueRefs([
-    ...(!hasTraceOrEvalEvidence
-      ? ['blocker.probe_gepa_standing_loop.trace_or_eval_refs_missing']
+    ...(input.sourceTraceRefs.length === 0
+      ? ['blocker.probe_gepa_standing_loop.source_trace_refs_missing']
+      : []),
+    ...(input.evalResultRefs.length === 0
+      ? ['blocker.probe_gepa_standing_loop.eval_result_refs_missing']
       : []),
     ...(!hasLowQualitySelection
       ? ['blocker.probe_gepa_standing_loop.low_quality_selection_missing']


### PR DESCRIPTION
## Summary
- require both public-safe source trace refs and eval result refs before the #6707 GEPA/DSPy standing loop can emit candidates
- split the missing-evidence blockers so operators can see which input is absent
- extend focused coverage for one-sided evidence gaps

Closes #6707

## Verification
- bun run --cwd apps/openagents.com/workers/api test -- src/probe-gepa-standing-optimization-loop.test.ts
- bun run --cwd apps/openagents.com/workers/api typecheck