### PR TITLE
fix(pylon): verify fetched VMQ PR head

### DIFF
--- a/apps/pylon/src/blueprint-gates/virtual-merge-queue.test.ts
+++ b/apps/pylon/src/blueprint-gates/virtual-merge-queue.test.ts
@@ -335,6 +335,11 @@ describe("virtual merge queue", () => {
     expect(result.nextVirtualHeadAfter).toBe(C)
     expect(result.commands).toEqual([
       { kind: "git_fetch_pr_head", args: ["git", "fetch", "origin", "pull/123/head"] },
+      {
+        kind: "git_verify_fetched_pr_head",
+        args: ["git", "rev-parse", "--verify", "FETCH_HEAD^{commit}"],
+        expectedStdout: B,
+      },
       { kind: "git_checkout_branch", args: ["git", "checkout", "main"] },
       { kind: "git_reset_actual_head", args: ["git", "reset", "--hard", A] },
       { kind: "git_merge_ff_only", args: ["git", "merge", "--ff-only", B] },

--- a/apps/pylon/src/blueprint-gates/virtual-merge-queue.ts
+++ b/apps/pylon/src/blueprint-gates/virtual-merge-queue.ts
@@ -82,6 +82,11 @@ export type VirtualMergeQueuePrFastForwardCommand =
       readonly args: readonly ["git", "fetch", "origin", string]
     }
   | {
+      readonly kind: "git_verify_fetched_pr_head"
+      readonly args: readonly ["git", "rev-parse", "--verify", "FETCH_HEAD^{commit}"]
+      readonly expectedStdout: string
+    }
+  | {
       readonly kind: "git_checkout_branch"
       readonly args: readonly ["git", "checkout", string]
     }
@@ -442,6 +447,11 @@ export function planVirtualMergeQueuePrFastForward(input: {
       {
         kind: "git_fetch_pr_head",
         args: ["git", "fetch", "origin", `pull/${request.prNumber}/head`] as const,
+      },
+      {
+        kind: "git_verify_fetched_pr_head",
+        args: ["git", "rev-parse", "--verify", "FETCH_HEAD^{commit}"] as const,
+        expectedStdout: request.prHeadCommit,
       },
       {
         kind: "git_checkout_branch",

--- a/apps/pylon/tests/control-protocol.test.ts
+++ b/apps/pylon/tests/control-protocol.test.ts
@@ -317,6 +317,7 @@ describe("control protocol", () => {
           })
           expect((result as { commands: Array<{ kind: string }> }).commands.map((command) => command.kind)).toEqual([
             "git_fetch_pr_head",
+            "git_verify_fetched_pr_head",
             "git_checkout_branch",
             "git_reset_actual_head",
             "git_merge_ff_only",


### PR DESCRIPTION
## Summary
- add an explicit `git_verify_fetched_pr_head` step to the VMQ PR fast-forward plan
- require supervisors to compare `FETCH_HEAD^{commit}` with the pinned PR head before checkout/reset/merge/push
- cover the new command in the pure VMQ planner and node control protocol tests

Closes #6695

## Verification
- `bun run --cwd apps/pylon test -- src/blueprint-gates/virtual-merge-queue.test.ts tests/control-protocol.test.ts`
- `bun run --cwd apps/pylon typecheck`