### PR TITLE
Add Forge promotion gate receipt fields

### DIFF
--- a/apps/openagents.com/workers/api/migrations/0259_forge_promotion_decision_gate_results.sql
+++ b/apps/openagents.com/workers/api/migrations/0259_forge_promotion_decision_gate_results.sql
@@ -1,0 +1,8 @@
+ALTER TABLE forge_promotion_decisions
+  ADD COLUMN target_ref TEXT NOT NULL DEFAULT '';
+
+ALTER TABLE forge_promotion_decisions
+  ADD COLUMN queue_position INTEGER NOT NULL DEFAULT 0;
+
+ALTER TABLE forge_promotion_decisions
+  ADD COLUMN gate_results_json TEXT NOT NULL DEFAULT '[]';

--- a/apps/openagents.com/workers/api/src/forge-control-plane-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/forge-control-plane-routes.test.ts
@@ -63,6 +63,13 @@ const controlPlaneReceiptsMigration = readFileSync(
   new URL('../migrations/0254_forge_control_plane_receipts.sql', import.meta.url),
   'utf8',
 )
+const promotionDecisionGateResultsMigration = readFileSync(
+  new URL(
+    '../migrations/0259_forge_promotion_decision_gate_results.sql',
+    import.meta.url,
+  ),
+  'utf8',
+)
 const canonicalGitMigration = readFileSync(
   new URL('../migrations/0255_forge_git_canonical_store.sql', import.meta.url),
   'utf8',
@@ -76,6 +83,7 @@ const makeStores = (): Readonly<{
   db.exec('PRAGMA foreign_keys = ON')
   db.exec(coordinationMigration)
   db.exec(controlPlaneReceiptsMigration)
+  db.exec(promotionDecisionGateResultsMigration)
   db.exec(canonicalGitMigration)
   const d1 = new SqliteD1(db) as unknown as D1Database
   return {
@@ -349,13 +357,24 @@ describe('Forge control-plane routes', () => {
           tenant_ref: 'tenant.openagents',
           promotion_ref: 'promotion.forge.6770',
           queue_ref: 'queue.forge.main',
+          queue_position: 0,
           change_ref: 'change.forge.6770',
           decision: 'approved',
+          target_ref: 'refs/heads/main',
           base_head: '8e0c9b2eaf84c821caf555cae233a0d27e94d4ab',
           candidate_head: '9e0c9b2eaf84c821caf555cae233a0d27e94d4ac',
           promoted_head: '9e0c9b2eaf84c821caf555cae233a0d27e94d4ac',
           verification_ref: 'verification.forge.6770',
           gate_refs: ['gate.tests'],
+          gate_results: [
+            {
+              gate_ref: 'gate.tests',
+              verdict: 'passed',
+              evidence_refs: ['verification.forge.6770'],
+              blocker_refs: [],
+              decided_at: '2026-06-28T17:03:00.000Z',
+            },
+          ],
           blocker_refs: [],
           decided_by_ref: 'agent.public.forge',
           decided_at: '2026-06-28T17:03:00.000Z',

--- a/apps/openagents.com/workers/api/src/forge-coordination-store.test.ts
+++ b/apps/openagents.com/workers/api/src/forge-coordination-store.test.ts
@@ -70,12 +70,20 @@ const controlPlaneReceiptsMigration = readFileSync(
   new URL('../migrations/0254_forge_control_plane_receipts.sql', import.meta.url),
   'utf8',
 )
+const promotionDecisionGateResultsMigration = readFileSync(
+  new URL(
+    '../migrations/0259_forge_promotion_decision_gate_results.sql',
+    import.meta.url,
+  ),
+  'utf8',
+)
 
 const makeStore = (): ForgeCoordinationStore => {
   const db = new DatabaseSync(':memory:')
   db.exec('PRAGMA foreign_keys = ON')
   db.exec(coordinationMigration)
   db.exec(controlPlaneReceiptsMigration)
+  db.exec(promotionDecisionGateResultsMigration)
   return makeD1ForgeCoordinationStore(new SqliteD1(db) as unknown as D1Database)
 }
 
@@ -253,13 +261,24 @@ describe('forge coordination D1 store', () => {
         tenant_ref: 'tenant.openagents',
         promotion_ref: 'promotion.forge.6770',
         queue_ref: 'queue.forge.main',
+        queue_position: 0,
         change_ref: 'change.forge.6770',
         decision: 'approved',
+        target_ref: 'refs/heads/main',
         base_head: '8e0c9b2eaf84c821caf555cae233a0d27e94d4ab',
         candidate_head: '9e0c9b2eaf84c821caf555cae233a0d27e94d4ac',
         promoted_head: '9e0c9b2eaf84c821caf555cae233a0d27e94d4ac',
         verification_ref: verificationReceipt.verification_ref,
         gate_refs: ['gate.tests'],
+        gate_results: [
+          {
+            gate_ref: 'gate.tests',
+            verdict: 'passed',
+            evidence_refs: [verificationReceipt.verification_ref],
+            blocker_refs: [],
+            decided_at: '2026-06-28T16:03:00.000Z',
+          },
+        ],
         blocker_refs: [],
         decided_by_ref: 'agent.public.forge',
         decided_at: '2026-06-28T16:03:00.000Z',
@@ -269,6 +288,8 @@ describe('forge coordination D1 store', () => {
       now,
     )
     expect(promotionDecision.decision).toBe('approved')
+    expect(promotionDecision.target_ref).toBe('refs/heads/main')
+    expect(promotionDecision.gate_results[0]?.verdict).toBe('passed')
     await expect(
       store.listPromotionDecisionReceipts('tenant.openagents', 10, 'change.forge.6770'),
     ).resolves.toEqual([promotionDecision])

--- a/apps/openagents.com/workers/api/src/forge-coordination-store.ts
+++ b/apps/openagents.com/workers/api/src/forge-coordination-store.ts
@@ -4,6 +4,7 @@ import {
   decodeForgeCoordinationStatusRow,
   decodeForgeDispatchLeaseRow,
   decodeForgeMergeQueueLedgerRow,
+  ForgePromotionGateResult,
   decodeForgePromotionDecisionReceipt,
   decodeForgeVerificationReceipt,
   forgeNip34StatusKindForState,
@@ -141,6 +142,7 @@ export type ForgeCoordinationStore = Readonly<{
 }>
 
 const StringArray = S.Array(S.String)
+const PromotionGateResultArray = S.Array(ForgePromotionGateResult)
 
 const jsonArray = (values: ReadonlyArray<string>): string =>
   JSON.stringify([...values])
@@ -176,13 +178,16 @@ type ForgePromotionDecisionReceiptRow = Readonly<{
   tenant_ref: string
   promotion_ref: string
   queue_ref: string
+  queue_position: number
   change_ref: string
   decision: string
+  target_ref: string
   base_head: string
   candidate_head: string
   promoted_head: string | null
   verification_ref: string | null
   gate_refs_json: string
+  gate_results_json: string
   blocker_refs_json: string
   decided_by_ref: string
   decided_at: string
@@ -192,6 +197,11 @@ type ForgePromotionDecisionReceiptRow = Readonly<{
 
 const stringArrayFromJson = (value: string): ReadonlyArray<string> =>
   parseJsonWithSchema(StringArray, value)
+
+const promotionGateResultsFromJson = (
+  value: string,
+): ReadonlyArray<typeof ForgePromotionGateResult.Type> =>
+  parseJsonWithSchema(PromotionGateResultArray, value)
 
 const verificationReceiptFromRow = (
   row: ForgeVerificationReceiptRow,
@@ -229,13 +239,16 @@ const promotionDecisionReceiptFromRow = (
     tenant_ref: row.tenant_ref,
     promotion_ref: row.promotion_ref,
     queue_ref: row.queue_ref,
+    queue_position: row.queue_position,
     change_ref: row.change_ref,
     decision: row.decision,
+    target_ref: row.target_ref,
     base_head: row.base_head,
     candidate_head: row.candidate_head,
     promoted_head: row.promoted_head,
     verification_ref: row.verification_ref,
     gate_refs: stringArrayFromJson(row.gate_refs_json),
+    gate_results: promotionGateResultsFromJson(row.gate_results_json),
     blocker_refs: stringArrayFromJson(row.blocker_refs_json),
     decided_by_ref: row.decided_by_ref,
     decided_at: row.decided_at,
@@ -865,29 +878,35 @@ export const makeD1ForgeCoordinationStore = (
             tenant_ref,
             promotion_ref,
             queue_ref,
+            queue_position,
             change_ref,
             decision,
+            target_ref,
             base_head,
             candidate_head,
             promoted_head,
             verification_ref,
             gate_refs_json,
+            gate_results_json,
             blocker_refs_json,
             decided_by_ref,
             decided_at,
             source_refs_json,
             redacted,
             created_at
-          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1, ?)
+          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1, ?)
           ON CONFLICT (tenant_ref, promotion_ref) DO UPDATE SET
             queue_ref = excluded.queue_ref,
+            queue_position = excluded.queue_position,
             change_ref = excluded.change_ref,
             decision = excluded.decision,
+            target_ref = excluded.target_ref,
             base_head = excluded.base_head,
             candidate_head = excluded.candidate_head,
             promoted_head = excluded.promoted_head,
             verification_ref = excluded.verification_ref,
             gate_refs_json = excluded.gate_refs_json,
+            gate_results_json = excluded.gate_results_json,
             blocker_refs_json = excluded.blocker_refs_json,
             decided_by_ref = excluded.decided_by_ref,
             decided_at = excluded.decided_at,
@@ -898,13 +917,16 @@ export const makeD1ForgeCoordinationStore = (
         decoded.tenant_ref,
         decoded.promotion_ref,
         decoded.queue_ref,
+        decoded.queue_position,
         decoded.change_ref,
         decoded.decision,
+        decoded.target_ref,
         decoded.base_head,
         decoded.candidate_head,
         decoded.promoted_head,
         decoded.verification_ref,
         jsonArray(decoded.gate_refs),
+        JSON.stringify(decoded.gate_results),
         jsonArray(decoded.blocker_refs),
         decoded.decided_by_ref,
         decoded.decided_at,

--- a/docs/forge/2026-06-28-forge-boundary-contract.md
+++ b/docs/forge/2026-06-28-forge-boundary-contract.md
@@ -132,21 +132,26 @@ promotable or blocked it. The required fields are:
 
 - `promotion_ref`
 - `queue_ref`
+- `queue_position`
 - `change_ref`
 - `decision`
+- `target_ref`
 - `base_head`
 - `candidate_head`
 - `promoted_head`
 - `verification_ref`
 - `gate_refs`
+- `gate_results`
 - `blocker_refs`
 - `decided_by_ref`
 - `decided_at`
 - `source_refs`
 - `redacted: true`
 
-`approved` decisions identify the fast-forward target in `promoted_head`.
-`blocked` decisions keep `promoted_head` null and name the blockers.
+`target_ref` names the canonical ref being promoted. `approved` decisions
+identify the fast-forward target in `promoted_head`. `blocked` decisions keep
+`promoted_head` null and name the blockers. `gate_results` records one bounded
+public-safe result per Blueprint gate, with evidence refs and blocker refs only.
 
 ## UI Boundary
 

--- a/packages/forge-protocol/README.md
+++ b/packages/forge-protocol/README.md
@@ -29,9 +29,9 @@ verification ref, artifact/proof/result refs, and settlement status.
 
 Verification and promotion receipts are modeled as
 `ForgeVerificationReceipt` and `ForgePromotionDecisionReceipt`. They carry refs,
-hashes, command metadata, exit/verdict state, timestamps, artifact refs, and log
-digests, but not raw logs, raw source, private provider payloads, git tokens, or
-wallet material.
+hashes, command metadata, exit/verdict state, queue position, canonical target
+ref, bounded gate results, timestamps, artifact refs, and log digests, but not
+raw logs, raw source, private provider payloads, git tokens, or wallet material.
 
 The package is public-safe by default: records carry refs, bounded state,
 timestamps, and JSON-encoded ref arrays. They do not carry raw prompts, raw

--- a/packages/forge-protocol/src/index.test.ts
+++ b/packages/forge-protocol/src/index.test.ts
@@ -317,13 +317,31 @@ describe("@openagentsinc/forge-protocol", () => {
       tenant_ref: "tenant.openagents",
       promotion_ref: "promotion.forge.6768",
       queue_ref: "queue.forge.main",
+      queue_position: 0,
       change_ref: verification.change_ref,
       decision: "approved",
+      target_ref: "refs/heads/main",
       base_head: verification.base_head,
       candidate_head: verification.head_head,
       promoted_head: verification.head_head,
       verification_ref: verification.verification_ref,
       gate_refs: ["gate.merge-deploy", "gate.issue-close-safe"],
+      gate_results: [
+        {
+          gate_ref: "gate.merge-deploy",
+          verdict: "passed",
+          evidence_refs: [verification.verification_ref],
+          blocker_refs: [],
+          decided_at: "2026-06-28T16:02:00.000Z",
+        },
+        {
+          gate_ref: "gate.issue-close-safe",
+          verdict: "passed",
+          evidence_refs: ["github:OpenAgentsInc/openagents#6768"],
+          blocker_refs: [],
+          decided_at: "2026-06-28T16:02:00.000Z",
+        },
+      ],
       blocker_refs: [],
       decided_by_ref: "forge.service.promotion",
       decided_at: "2026-06-28T16:02:00.000Z",
@@ -332,5 +350,10 @@ describe("@openagentsinc/forge-protocol", () => {
     });
     expect(promotion.decision).toBe("approved");
     expect(promotion.promoted_head).toBe(verification.head_head);
+    expect(promotion.queue_position).toBe(0);
+    expect(promotion.gate_results.map(result => result.gate_ref)).toEqual([
+      "gate.merge-deploy",
+      "gate.issue-close-safe",
+    ]);
   });
 });

--- a/packages/forge-protocol/src/index.ts
+++ b/packages/forge-protocol/src/index.ts
@@ -167,6 +167,22 @@ export const ForgePromotionDecisionState = S.Literals([
 export type ForgePromotionDecisionState =
   typeof ForgePromotionDecisionState.Type;
 
+export const ForgePromotionGateVerdict = S.Literals([
+  "passed",
+  "blocked",
+  "not_applicable",
+]);
+export type ForgePromotionGateVerdict = typeof ForgePromotionGateVerdict.Type;
+
+export const ForgePromotionGateResult = S.Struct({
+  gate_ref: S.String,
+  verdict: ForgePromotionGateVerdict,
+  evidence_refs: S.Array(S.String),
+  blocker_refs: S.Array(S.String),
+  decided_at: S.String,
+});
+export type ForgePromotionGateResult = typeof ForgePromotionGateResult.Type;
+
 export const ForgeDispatchGitAccessDelivery = S.Literals([
   "out_of_band",
   "same_response_ephemeral",
@@ -448,13 +464,16 @@ export const ForgePromotionDecisionReceipt = S.Struct({
   tenant_ref: S.String,
   promotion_ref: S.String,
   queue_ref: S.String,
+  queue_position: S.Number,
   change_ref: S.String,
   decision: ForgePromotionDecisionState,
+  target_ref: S.String,
   base_head: S.String,
   candidate_head: S.String,
   promoted_head: S.NullOr(S.String),
   verification_ref: S.NullOr(S.String),
   gate_refs: S.Array(S.String),
+  gate_results: S.Array(ForgePromotionGateResult),
   blocker_refs: S.Array(S.String),
   decided_by_ref: S.String,
   decided_at: S.String,


### PR DESCRIPTION
## Summary

- Extends `ForgePromotionDecisionReceipt` with canonical `target_ref`, deterministic `queue_position`, and typed `gate_results` entries.
- Persists and reads those fields through the Forge coordination D1 store with a migration.
- Updates Forge protocol, store, route tests, and the boundary docs so promotion receipts can carry the SU-4 gate evidence required for owned merge authority.

This is a small structural step toward the SU-4 owned merge authority path; it does not add the final canonical-ref fast-forward executor.

Refs #6794

## Verification

- `bun test packages/forge-protocol/src/index.test.ts`
- `bun run typecheck:forge-protocol`
- `bun run --cwd apps/openagents.com/workers/api test -- src/forge-coordination-store.test.ts src/forge-control-plane-routes.test.ts`
- `bun run --cwd apps/openagents.com/workers/api typecheck`
- `bun run --cwd apps/openagents.com check:architecture`
- `bun run --cwd apps/openagents.com check:deploy`

Note: the task supplied opaque verification ref `command.public.pylon_khala.verify.b5bea41b6c623f7c09f1bf24`; this checkout did not include a local argv lookup for that ref. The issue acceptance command `bun run --cwd apps/openagents.com check:deploy` was run and passed.