### PR TITLE
Tag MirrorCode backstop burn ledger refs

### DIFF
--- a/apps/openagents.com/scripts/mirrorcode/README.md
+++ b/apps/openagents.com/scripts/mirrorcode/README.md
@@ -47,7 +47,8 @@ the batch; `MC_BACKSTOP_SMOKE=1` runs that preflight standalone.
 Problem source: the built-in **public-domain fixture set** (classic toy
 functions — sum, reverse, palindrome, factorial, gcd, FizzBuzz, …). These are
 **NOT MirrorCode tasks**, so there is no benchmark contamination, and the load is
-tagged `demand_kind=internal` / `demand_source=gym_backstop`. The read-only
+tagged `demand_kind=internal` / `demand_source=gym_mirrorcode` with the standing
+#6923 task/workflow/ledger refs. The read-only
 MirrorCode clone is detected and surfaced (`mirrorcodeClonePresent`,
 `mirrorcodeSTargets`) in the result when present, but its tasks are **not** run
 here.

--- a/apps/openagents.com/scripts/mirrorcode/backstop_eval.py
+++ b/apps/openagents.com/scripts/mirrorcode/backstop_eval.py
@@ -28,7 +28,7 @@ spend. The live CLI path (`--live`) uses the Khala model_fn.
 Honesty: this is a real measurement of our own model against public-domain toy
 problems; it is NOT the MirrorCode paper benchmark and must never be published
 as a MirrorCode score. Results are tagged `demand_kind=internal`,
-`demand_source=gym_backstop`.
+`demand_source=gym_mirrorcode`.
 
 Python 3.9 compatible (system python3); no third-party deps.
 """
@@ -46,7 +46,12 @@ import tempfile
 import uuid
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
-DEMAND = {"kind": "internal", "source": "gym_backstop", "client": "mirrorcode-backstop"}
+ISSUE_NUMBER = 6923
+TASK_REF = "issue.public.openagents.6923.mirrorcode_backstop_burn"
+WORKFLOW_REF = "workflow.public.gym.mirrorcode.backstop_burn.6923"
+LEDGER_REF = "ledger.public.gym.mirrorcode.backstop_burn.6923"
+
+DEMAND = {"kind": "internal", "source": "gym_mirrorcode", "client": "mirrorcode-backstop"}
 
 # --- Built-in public-domain fixture problem set --------------------------------
 # Small, classic, public-domain coding problems (NOT MirrorCode tasks, so no
@@ -276,6 +281,10 @@ def evaluate_batch(
             "solutionChars": len(code),
             "solution": code,  # public-safe: fixtures are public-domain toy problems
             "demand": DEMAND,
+            "issueNumber": ISSUE_NUMBER,
+            "taskRef": TASK_REF,
+            "workflowRef": WORKFLOW_REF,
+            "ledgerRef": LEDGER_REF,
             "recordedAt": _now_iso(),
         }
         per_problem.append(trace)
@@ -301,6 +310,10 @@ def evaluate_batch(
         "mirrorcodeClonePresent": mirrorcode_clone_present(),
         "mirrorcodeSTargets": MIRRORCODE_S_TARGETS if mirrorcode_clone_present() else [],
         "demand": DEMAND,
+        "issueNumber": ISSUE_NUMBER,
+        "taskRef": TASK_REF,
+        "workflowRef": WORKFLOW_REF,
+        "ledgerRef": LEDGER_REF,
         "grade": "backstop",
         "decisionGrade": False,
         "modelErrorCount": model_error_count,

--- a/apps/openagents.com/scripts/mirrorcode/backstop_eval_test.py
+++ b/apps/openagents.com/scripts/mirrorcode/backstop_eval_test.py
@@ -98,6 +98,11 @@ class EvaluateBatchTests(unittest.TestCase):
             self.assertEqual(summary["fullySolved"], 3)
             self.assertEqual(summary["passRate"], 1.0)
             self.assertEqual(summary["status"], "passed")
+            self.assertEqual(summary["demand"]["source"], "gym_mirrorcode")
+            self.assertEqual(summary["issueNumber"], 6923)
+            self.assertEqual(summary["taskRef"], be.TASK_REF)
+            self.assertEqual(summary["workflowRef"], be.WORKFLOW_REF)
+            self.assertEqual(summary["ledgerRef"], be.LEDGER_REF)
             # summary + per-problem trace files written
             self.assertTrue(os.path.isfile(os.path.join(d, "t-all.json")))
             for pid in solutions:
@@ -106,7 +111,11 @@ class EvaluateBatchTests(unittest.TestCase):
                 with open(tpath) as fh:
                     tr = json.load(fh)
                 self.assertEqual(tr["status"], "passed")
-                self.assertEqual(tr["demand"]["source"], "gym_backstop")
+                self.assertEqual(tr["demand"]["source"], "gym_mirrorcode")
+                self.assertEqual(tr["issueNumber"], 6923)
+                self.assertEqual(tr["taskRef"], be.TASK_REF)
+                self.assertEqual(tr["workflowRef"], be.WORKFLOW_REF)
+                self.assertEqual(tr["ledgerRef"], be.LEDGER_REF)
 
     def test_mixed_pass_rate(self):
         # 2 problems: one correct (3/3), one all-wrong (0/3) -> aggregate 3/6.


### PR DESCRIPTION
## Summary
- Align the MirrorCode backstop runner's demand attribution with the existing `gym_mirrorcode` standing-task lane.
- Add issue #6923 task/workflow/ledger refs to both summary and per-problem trace output.
- Update the focused runner test and adjacent operator docs for the new public evidence fields.

Closes #6923

## Verification
- `python3 apps/openagents.com/scripts/mirrorcode/backstop_eval_test.py`
- `bun test apps/openagents.com/workers/api/src/inference/gym/mirrorcode-backstop-burn.test.ts`
- `bun run --cwd apps/openagents.com/workers/api typecheck`

Note: the task-provided opaque verifier ref was `command.public.pylon_khala.verify.b5bea41b6c623f7c09f1bf24`. No argv mapping for that ref was present in this bounded checkout or local assignment metadata, so I ran the focused MirrorCode runner/contract tests plus Worker API typecheck for the touched surface.