### PR TITLE
fix(artanis): run RLM composition on operator path

### DIFF
--- a/apps/openagents.com/workers/api/src/artanis-operator.test.ts
+++ b/apps/openagents.com/workers/api/src/artanis-operator.test.ts
@@ -636,6 +636,53 @@ describe('#6654 Artanis RLM composition', () => {
       requests.every(request => request.model === ARTANIS_OPERATOR_KHALA_MODEL),
     ).toBe(true)
   })
+
+  test('uses RLM composition on the real tool-enabled operator path', async () => {
+    const { calls, tool } = makeFakeReadTool('tool result should not be needed')
+    const { client, requests } = makeScriptedKhalaClient([
+      textResult(
+        JSON.stringify({
+          compositionInstruction:
+            'Compose from the typed evidence packets only.',
+          subqueries: [
+            {
+              evidenceRefs: ['evidence.artanis.operator.rlm.tool_enabled'],
+              id: 'tool-enabled',
+              question: 'What should the operator compose?',
+              signatureRef: ARTANIS_OPERATOR_RLM_SIGNATURE_REF,
+            },
+          ],
+        }),
+      ),
+      textResult('Evidence packet from a separate RLM subquery.'),
+      textResult('I composed this through the RLM path.'),
+    ])
+
+    const result = await Effect.runPromise(
+      artanisOperatorTurn({
+        awareness: exampleAwareness,
+        khalaClient: client,
+        memory: exampleMemory,
+        messages: [
+          {
+            content: 'write a detailed architecture report',
+            role: 'user',
+          },
+        ],
+        ownerId: 'owner:github:14167547',
+        tools: [tool],
+      }),
+    )
+
+    expect('error' in result).toBe(false)
+    if ('error' in result) return
+    expect(result.reply).toBe('I composed this through the RLM path.')
+    expect(result.rlmTrace.used).toBe(true)
+    expect(result.toolInvocations).toEqual([])
+    expect(calls).toHaveLength(0)
+    expect(requests).toHaveLength(3)
+    expect(requests.every(request => !('tools' in request))).toBe(true)
+  })
 })
 
 describe('#6364 artanis operator bounded tool-calling loop', () => {

--- a/apps/openagents.com/workers/api/src/artanis-operator.ts
+++ b/apps/openagents.com/workers/api/src/artanis-operator.ts
@@ -667,7 +667,6 @@ const LONG_FORM_OWNER_CUES: ReadonlyArray<string> = [
   'long',
   'plan',
   'report',
-  'roadmap',
   'strategy',
   'write-up',
 ]
@@ -1335,7 +1334,7 @@ export const artanisOperatorTurn = (input: {
       messages: input.messages,
     })
 
-    if (tools.length === 0 && shouldUseArtanisRlmComposition(input.messages)) {
+    if (shouldUseArtanisRlmComposition(input.messages)) {
       const composed = yield* runArtanisRlmComposition({
         baseMessages,
         khalaClient: input.khalaClient,


### PR DESCRIPTION
## Summary

- enables Artanis RLM composition for long-form owner asks on the real tool-enabled operator path
- narrows `roadmap` so direct repo-read requests like `read docs/roadmap.md` still use grounding tools
- adds regression coverage for tool-enabled RLM composition without advertising tools to planner/subquery/composer calls

Closes #6654.

## Verification

- `bun run --cwd apps/openagents.com/workers/api test -- src/artanis-operator.test.ts`
- `bun run --cwd apps/openagents.com/workers/api typecheck`

Note: I could not resolve `command.public.pylon_khala.verify.b5bea41b6c623f7c09f1bf24` to a stored argv in the local workspace lease or active Pylon assignment records, so I ran the focused Worker verification for the touched files directly.
