### PR TITLE
Add Forge GitHub mirror receipts

### DIFF
--- a/apps/openagents.com/workers/api/migrations/0257_forge_github_mirror_receipts.sql
+++ b/apps/openagents.com/workers/api/migrations/0257_forge_github_mirror_receipts.sql
@@ -1,0 +1,39 @@
+-- FORGE SU-6 (#6796): GitHub mirror receipts for Forge-promoted commits.
+--
+-- GitHub is downstream visibility only. These rows record attempts to move a
+-- GitHub ref after Forge has already accepted a promotion decision.
+
+CREATE TABLE IF NOT EXISTS forge_github_mirror_receipts (
+  tenant_ref TEXT NOT NULL,
+  mirror_ref TEXT NOT NULL,
+  promotion_ref TEXT NOT NULL,
+  source_canonical_ref TEXT NOT NULL,
+  destination_repository TEXT NOT NULL,
+  destination_ref TEXT NOT NULL,
+  commit_id TEXT NOT NULL,
+  status TEXT NOT NULL CHECK (status IN ('mirrored', 'already_mirrored', 'failed', 'refused')),
+  attempted_at TEXT NOT NULL,
+  mirrored_at TEXT,
+  refusal_reason TEXT,
+  error_reason TEXT,
+  source_refs_json TEXT NOT NULL DEFAULT '[]',
+  redacted INTEGER NOT NULL DEFAULT 1 CHECK (redacted = 1),
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  PRIMARY KEY (tenant_ref, mirror_ref)
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_forge_github_mirror_receipts_idempotent
+  ON forge_github_mirror_receipts (
+    tenant_ref,
+    promotion_ref,
+    destination_repository,
+    destination_ref,
+    commit_id
+  );
+
+CREATE INDEX IF NOT EXISTS idx_forge_github_mirror_receipts_promotion
+  ON forge_github_mirror_receipts (tenant_ref, promotion_ref, attempted_at);
+
+CREATE INDEX IF NOT EXISTS idx_forge_github_mirror_receipts_status
+  ON forge_github_mirror_receipts (tenant_ref, status, attempted_at);

--- a/apps/openagents.com/workers/api/src/config.ts
+++ b/apps/openagents.com/workers/api/src/config.ts
@@ -430,6 +430,7 @@ export type OpenAgentsWorkerConfigEnv = Readonly<{
   OPENAGENTS_SPARK_API_KEY?: string | undefined
   OPENAGENTS_ADMIN_API_TOKEN?: string | undefined
   OPENAGENTS_FORGE_CONTROL_PLANE_TOKEN?: string | undefined
+  OPENAGENTS_FORGE_GITHUB_MIRROR_TOKEN?: string | undefined
   OPENAGENTS_APP_URL?: string | undefined
   OPENAUTH_CLIENT_ID?: string | undefined
   OPENAUTH_ISSUER_URL?: string | undefined

--- a/apps/openagents.com/workers/api/src/forge-control-plane-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/forge-control-plane-routes.test.ts
@@ -67,6 +67,10 @@ const canonicalGitMigration = readFileSync(
   new URL('../migrations/0255_forge_git_canonical_store.sql', import.meta.url),
   'utf8',
 )
+const gitHubMirrorReceiptsMigration = readFileSync(
+  new URL('../migrations/0257_forge_github_mirror_receipts.sql', import.meta.url),
+  'utf8',
+)
 
 const makeStores = (): Readonly<{
   canonicalStore: ForgeGitCanonicalStore
@@ -77,6 +81,7 @@ const makeStores = (): Readonly<{
   db.exec(coordinationMigration)
   db.exec(controlPlaneReceiptsMigration)
   db.exec(canonicalGitMigration)
+  db.exec(gitHubMirrorReceiptsMigration)
   const d1 = new SqliteD1(db) as unknown as D1Database
   return {
     canonicalStore: makeD1ForgeGitCanonicalStore(d1),
@@ -123,14 +128,25 @@ const requestJson = (
 
 const makeHarness = () => {
   const { canonicalStore, coordinationStore } = makeStores()
+  const githubMirrorUpdates: Array<{
+    commitId: string
+    destinationRef: string
+    destinationRepository: string
+    token: string
+  }> = []
   const routes = makeForgeControlPlaneRoutes({
     authorizeControlPlaneBearer: (request, _env, scope) =>
       authorizeForgeControlPlaneBearer(request, controlPlaneToken, scope),
     fetch: makeGitHubFetch(),
+    githubMirrorRefUpdater: async update => {
+      githubMirrorUpdates.push(update)
+      return { status: 'mirrored' }
+    },
     makeCanonicalStore: () => canonicalStore,
     makeStore: () => coordinationStore,
     nowIso: () => now,
     requireAdminApiToken: () => Promise.resolve(false),
+    resolveGitHubMirrorToken: () => 'github-mirror-token',
   })
   const run = (request: Request): Promise<Response> => {
     const effect = routes.routeForgeControlPlaneRequest(request, {})
@@ -142,7 +158,7 @@ const makeHarness = () => {
     return Effect.runPromise(effect)
   }
 
-  return { canonicalStore, run, store: coordinationStore }
+  return { canonicalStore, githubMirrorUpdates, run, store: coordinationStore }
 }
 
 describe('Forge control-plane routes', () => {
@@ -389,6 +405,144 @@ describe('Forge control-plane routes', () => {
       promotionDecisions: ReadonlyArray<unknown>
     }
     expect(decisionsBody.promotionDecisions).toHaveLength(1)
+  })
+
+  test('mirrors only approved Forge promotion decisions to GitHub', async () => {
+    const { githubMirrorUpdates, run } = makeHarness()
+    const scopes = [
+      'forge:promotion:decide',
+      'forge:mirror:read',
+      'forge:mirror:write',
+    ].join(' ')
+
+    await run(
+      requestJson('/api/forge/promotion-decisions', {
+        json: {
+          schema: 'openagents.forge.promotion.decision.v0.1',
+          tenant_ref: 'tenant.openagents',
+          promotion_ref: 'promotion.forge.blocked',
+          queue_ref: 'queue.forge.main',
+          change_ref: 'change.forge.blocked',
+          decision: 'blocked',
+          base_head: '8e0c9b2eaf84c821caf555cae233a0d27e94d4ab',
+          candidate_head: '9e0c9b2eaf84c821caf555cae233a0d27e94d4ac',
+          promoted_head: null,
+          verification_ref: null,
+          gate_refs: [],
+          blocker_refs: ['gate.tests.failed'],
+          decided_by_ref: 'agent.public.forge',
+          decided_at: '2026-06-28T17:03:00.000Z',
+          source_refs: ['github:OpenAgentsInc/openagents#6796'],
+          redacted: true,
+        },
+        headers: authHeaders(scopes),
+        method: 'POST',
+      }),
+    )
+
+    const refusedMirrorResponse = await run(
+      requestJson('/api/forge/github-mirrors', {
+        json: {
+          tenantRef: 'tenant.openagents',
+          mirrorRef: 'mirror.github.openagents.main.blocked',
+          promotionRef: 'promotion.forge.blocked',
+          sourceCanonicalRef: 'refs/heads/main',
+          destinationRepository: 'OpenAgentsInc/openagents',
+          destinationRef: 'refs/heads/main',
+          sourceRefs: ['github:OpenAgentsInc/openagents#6796'],
+        },
+        headers: authHeaders(scopes),
+        method: 'POST',
+      }),
+    )
+    const refusedMirrorBody = (await refusedMirrorResponse.json()) as {
+      githubMirrorReceipt: { status: string; refusal_reason: string }
+    }
+    expect(refusedMirrorResponse.status).toBe(201)
+    expect(refusedMirrorBody.githubMirrorReceipt).toMatchObject({
+      refusal_reason: 'promotion_blocked',
+      status: 'refused',
+    })
+    expect(githubMirrorUpdates).toHaveLength(0)
+
+    const promotedCommit = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+    await run(
+      requestJson('/api/forge/promotion-decisions', {
+        json: {
+          schema: 'openagents.forge.promotion.decision.v0.1',
+          tenant_ref: 'tenant.openagents',
+          promotion_ref: 'promotion.forge.approved',
+          queue_ref: 'queue.forge.main',
+          change_ref: 'change.forge.approved',
+          decision: 'approved',
+          base_head: '8e0c9b2eaf84c821caf555cae233a0d27e94d4ab',
+          candidate_head: promotedCommit,
+          promoted_head: promotedCommit,
+          verification_ref: 'verification.forge.approved',
+          gate_refs: ['gate.tests'],
+          blocker_refs: [],
+          decided_by_ref: 'agent.public.forge',
+          decided_at: '2026-06-28T17:04:00.000Z',
+          source_refs: ['github:OpenAgentsInc/openagents#6796'],
+          redacted: true,
+        },
+        headers: authHeaders(scopes),
+        method: 'POST',
+      }),
+    )
+
+    const mirrorRequest: JsonRequestInit = {
+      json: {
+        tenantRef: 'tenant.openagents',
+        mirrorRef: 'mirror.github.openagents.main.approved',
+        promotionRef: 'promotion.forge.approved',
+        sourceCanonicalRef: 'refs/heads/main',
+        destinationRepository: 'OpenAgentsInc/openagents',
+        destinationRef: 'refs/heads/main',
+        sourceRefs: ['github:OpenAgentsInc/openagents#6796'],
+      },
+      headers: authHeaders(scopes),
+      method: 'POST',
+    }
+    const mirrorResponse = await run(
+      requestJson('/api/forge/github-mirrors', mirrorRequest),
+    )
+    const mirrorBody = (await mirrorResponse.json()) as {
+      githubMirrorReceipt: { commit_id: string; status: string }
+    }
+    expect(mirrorResponse.status).toBe(201)
+    expect(mirrorBody.githubMirrorReceipt).toMatchObject({
+      commit_id: promotedCommit,
+      status: 'mirrored',
+    })
+    expect(githubMirrorUpdates).toEqual([
+      {
+        commitId: promotedCommit,
+        destinationRef: 'refs/heads/main',
+        destinationRepository: 'OpenAgentsInc/openagents',
+        token: 'github-mirror-token',
+      },
+    ])
+
+    const retryResponse = await run(
+      requestJson('/api/forge/github-mirrors', mirrorRequest),
+    )
+    const retryBody = (await retryResponse.json()) as { idempotent: boolean }
+    expect(retryResponse.status).toBe(200)
+    expect(retryBody.idempotent).toBe(true)
+    expect(githubMirrorUpdates).toHaveLength(1)
+
+    const listResponse = await run(
+      new Request(
+        'https://openagents.com/api/forge/github-mirrors?tenantRef=tenant.openagents&promotionRef=promotion.forge.approved',
+        { headers: authHeaders(scopes) },
+      ),
+    )
+    const listBody = (await listResponse.json()) as {
+      githubMirrorReceipts: ReadonlyArray<unknown>
+    }
+    expect(listResponse.status).toBe(200)
+    expect(listBody.githubMirrorReceipts).toHaveLength(1)
   })
 
   test('imports the public OpenAgents main ref into canonical refs idempotently', async () => {

--- a/apps/openagents.com/workers/api/src/forge-control-plane-routes.ts
+++ b/apps/openagents.com/workers/api/src/forge-control-plane-routes.ts
@@ -2,11 +2,13 @@ import {
   ForgeCoordinationChangeState,
   ForgeCoordinationIssueState,
   ForgeCoordinationStatusState,
+  ForgeGitHubMirrorReceipt,
   ForgeMergeQueueLedgerState,
   ForgePromotionDecisionReceipt,
   ForgeVerificationReceipt,
   decodeForgeControlPlaneScope,
   type ForgeControlPlaneScope,
+  type ForgeGitHubMirrorStatus,
 } from '@openagentsinc/forge-protocol'
 import { Effect, Schema as S } from 'effect'
 
@@ -44,11 +46,29 @@ export type ForgeControlPlaneAuthorize<Bindings> = (
 type ForgeControlPlaneRouteDependencies<Bindings> = Readonly<{
   authorizeControlPlaneBearer?: ForgeControlPlaneAuthorize<Bindings> | undefined
   fetch?: typeof fetch
+  githubMirrorRefUpdater?: ForgeGitHubMirrorRefUpdater | undefined
   makeCanonicalStore: (env: Bindings) => ForgeGitCanonicalStore
   makeStore: (env: Bindings) => ForgeCoordinationStore
   nowIso?: () => string
   requireAdminApiToken?: (request: Request, env: Bindings) => Promise<boolean>
+  resolveGitHubMirrorToken?: (env: Bindings) => string | undefined
 }>
+
+type ForgeGitHubMirrorRefUpdate = Readonly<{
+  commitId: string
+  destinationRef: string
+  destinationRepository: string
+  token: string
+}>
+
+type ForgeGitHubMirrorRefUpdateResult = Readonly<{
+  status: 'mirrored' | 'already_mirrored' | 'failed'
+  errorReason?: string | undefined
+}>
+
+type ForgeGitHubMirrorRefUpdater = (
+  update: ForgeGitHubMirrorRefUpdate,
+) => Promise<ForgeGitHubMirrorRefUpdateResult>
 
 class ForgeControlPlaneHttpError extends Error {
   constructor(
@@ -120,6 +140,16 @@ const ForgeMergeQueueSnapshotRequest = S.Struct({
 const ForgeOpenAgentsImportRequest = S.Struct({
   tenantRef: S.String,
   repositoryRef: S.String,
+})
+
+const ForgeGitHubMirrorRequest = S.Struct({
+  tenantRef: S.String,
+  mirrorRef: S.String,
+  promotionRef: S.String,
+  sourceCanonicalRef: S.String,
+  destinationRepository: S.String,
+  destinationRef: S.String,
+  sourceRefs: S.optionalKey(S.Array(S.String)),
 })
 
 const readBearerToken = (request: Request): string | undefined => {
@@ -655,6 +685,196 @@ const routePromotionDecisions = async <Bindings>(
   return noStoreJsonResponse({ promotionDecision }, { status: 201 })
 }
 
+const mirrorReceipt = (
+  body: typeof ForgeGitHubMirrorRequest.Type,
+  fields: Readonly<{
+    attemptedAt: string
+    commitId: string
+    errorReason?: string | null
+    mirroredAt?: string | null
+    refusalReason?: string | null
+    status: ForgeGitHubMirrorStatus
+  }>,
+): typeof ForgeGitHubMirrorReceipt.Type => ({
+  schema: 'openagents.forge.github.mirror.receipt.v0.1',
+  tenant_ref: body.tenantRef,
+  mirror_ref: body.mirrorRef,
+  promotion_ref: body.promotionRef,
+  source_canonical_ref: body.sourceCanonicalRef,
+  destination_repository: body.destinationRepository,
+  destination_ref: body.destinationRef,
+  commit_id: fields.commitId,
+  status: fields.status,
+  attempted_at: fields.attemptedAt,
+  mirrored_at: fields.mirroredAt ?? null,
+  refusal_reason: fields.refusalReason ?? null,
+  error_reason: fields.errorReason ?? null,
+  source_refs: body.sourceRefs ?? [],
+  redacted: true,
+})
+
+const githubBranchNameFromRef = (destinationRef: string): string | undefined => {
+  const trimmed = destinationRef.trim()
+  if (!trimmed.startsWith('refs/heads/')) {
+    return undefined
+  }
+  const branch = trimmed.slice('refs/heads/'.length)
+  return branch === '' || branch.includes('..') ? undefined : branch
+}
+
+const defaultGitHubMirrorRefUpdater =
+  (fetchImpl: typeof fetch = fetch): ForgeGitHubMirrorRefUpdater =>
+  async update => {
+    const branch = githubBranchNameFromRef(update.destinationRef)
+    if (branch === undefined) {
+      return {
+        errorReason: 'destination_ref_must_be_branch_ref',
+        status: 'failed',
+      }
+    }
+
+    const refUrl = `https://api.github.com/repos/${update.destinationRepository}/git/ref/heads/${encodeURIComponent(branch)}`
+    const headers = {
+      accept: 'application/vnd.github+json',
+      authorization: `Bearer ${update.token}`,
+      'content-type': 'application/json',
+      'user-agent': 'openagents-forge-github-mirror',
+    }
+    const currentResponse = await fetchImpl(refUrl, { headers })
+    if (currentResponse.ok) {
+      const current = (await currentResponse.json()) as {
+        object?: { sha?: unknown }
+      }
+      if (
+        typeof current.object?.sha === 'string' &&
+        current.object.sha.toLowerCase() === update.commitId.toLowerCase()
+      ) {
+        return { status: 'already_mirrored' }
+      }
+    }
+
+    const response = await fetchImpl(refUrl, {
+      body: JSON.stringify({ force: false, sha: update.commitId }),
+      headers,
+      method: 'PATCH',
+    })
+
+    return response.ok
+      ? { status: 'mirrored' }
+      : {
+          errorReason: `github_ref_update_http_${response.status}`,
+          status: 'failed',
+        }
+  }
+
+const routeGitHubMirrors = async <Bindings>(
+  dependencies: ForgeControlPlaneRouteDependencies<Bindings>,
+  request: Request,
+  env: Bindings,
+  url: URL,
+) => {
+  const store = dependencies.makeStore(env)
+
+  if (request.method === 'GET') {
+    const tenantRef = tenantRefFromQuery(url)
+    await requireScope(dependencies, request, env, 'forge:mirror:read', tenantRef)
+    const limit = limitFromQuery(url)
+    return noStoreJsonResponse({
+      githubMirrorReceipts: await store.listGitHubMirrorReceipts(
+        tenantRef,
+        limit,
+        optionalQuery(url, 'promotionRef'),
+      ),
+      limit,
+      tenantRef,
+    })
+  }
+
+  if (request.method !== 'POST') {
+    return methodNotAllowed(['GET', 'POST'])
+  }
+
+  const body = await decodeBody(request, ForgeGitHubMirrorRequest)
+  await requireScope(dependencies, request, env, 'forge:mirror:write', body.tenantRef)
+  const now = routeNowIso(dependencies)
+  const existing = await store.readGitHubMirrorReceipt(body.tenantRef, body.mirrorRef)
+  if (
+    existing?.status === 'mirrored' ||
+    existing?.status === 'already_mirrored'
+  ) {
+    return noStoreJsonResponse(
+      { githubMirrorReceipt: existing, idempotent: true },
+      { status: 200 },
+    )
+  }
+
+  const promotion = await store.readPromotionDecisionReceipt(
+    body.tenantRef,
+    body.promotionRef,
+  )
+  if (promotion === undefined) {
+    const githubMirrorReceipt = await store.recordGitHubMirrorReceipt(
+      mirrorReceipt(body, {
+        attemptedAt: now,
+        commitId: 'unknown',
+        refusalReason: 'promotion_receipt_missing',
+        status: 'refused',
+      }),
+      now,
+    )
+    return noStoreJsonResponse({ githubMirrorReceipt }, { status: 201 })
+  }
+
+  if (promotion.decision !== 'approved' || promotion.promoted_head === null) {
+    const githubMirrorReceipt = await store.recordGitHubMirrorReceipt(
+      mirrorReceipt(body, {
+        attemptedAt: now,
+        commitId: promotion.promoted_head ?? promotion.candidate_head,
+        refusalReason: `promotion_${promotion.decision}`,
+        status: 'refused',
+      }),
+      now,
+    )
+    return noStoreJsonResponse({ githubMirrorReceipt }, { status: 201 })
+  }
+
+  const token = dependencies.resolveGitHubMirrorToken?.(env)?.trim()
+  if (token === undefined || token === '') {
+    const githubMirrorReceipt = await store.recordGitHubMirrorReceipt(
+      mirrorReceipt(body, {
+        attemptedAt: now,
+        commitId: promotion.promoted_head,
+        errorReason: 'github_mirror_token_unconfigured',
+        status: 'failed',
+      }),
+      now,
+    )
+    return noStoreJsonResponse({ githubMirrorReceipt }, { status: 201 })
+  }
+
+  const result = await (
+    dependencies.githubMirrorRefUpdater ??
+    defaultGitHubMirrorRefUpdater(dependencies.fetch)
+  )({
+    commitId: promotion.promoted_head,
+    destinationRef: body.destinationRef,
+    destinationRepository: body.destinationRepository,
+    token,
+  })
+  const githubMirrorReceipt = await store.recordGitHubMirrorReceipt(
+    mirrorReceipt(body, {
+      attemptedAt: now,
+      commitId: promotion.promoted_head,
+      errorReason: result.errorReason ?? null,
+      mirroredAt: result.status === 'failed' ? null : now,
+      status: result.status,
+    }),
+    now,
+  )
+
+  return noStoreJsonResponse({ githubMirrorReceipt }, { status: 201 })
+}
+
 const sha256Hex = async (value: string): Promise<string> => {
   const bytes = await crypto.subtle.digest(
     'SHA-256',
@@ -873,6 +1093,12 @@ export const makeForgeControlPlaneRoutes = <Bindings>(
     if (route.length === 1 && route[0] === 'promotion-decisions') {
       return routeEffect(() =>
         routePromotionDecisions(dependencies, request, env, url),
+      )
+    }
+
+    if (route.length === 1 && route[0] === 'github-mirrors') {
+      return routeEffect(() =>
+        routeGitHubMirrors(dependencies, request, env, url),
       )
     }
 

--- a/apps/openagents.com/workers/api/src/forge-coordination-store.test.ts
+++ b/apps/openagents.com/workers/api/src/forge-coordination-store.test.ts
@@ -70,12 +70,17 @@ const controlPlaneReceiptsMigration = readFileSync(
   new URL('../migrations/0254_forge_control_plane_receipts.sql', import.meta.url),
   'utf8',
 )
+const gitHubMirrorReceiptsMigration = readFileSync(
+  new URL('../migrations/0257_forge_github_mirror_receipts.sql', import.meta.url),
+  'utf8',
+)
 
 const makeStore = (): ForgeCoordinationStore => {
   const db = new DatabaseSync(':memory:')
   db.exec('PRAGMA foreign_keys = ON')
   db.exec(coordinationMigration)
   db.exec(controlPlaneReceiptsMigration)
+  db.exec(gitHubMirrorReceiptsMigration)
   return makeD1ForgeCoordinationStore(new SqliteD1(db) as unknown as D1Database)
 }
 
@@ -272,5 +277,43 @@ describe('forge coordination D1 store', () => {
     await expect(
       store.listPromotionDecisionReceipts('tenant.openagents', 10, 'change.forge.6770'),
     ).resolves.toEqual([promotionDecision])
+  })
+
+  test('records GitHub mirror receipts for promoted commits', async () => {
+    const store = makeStore()
+    const receipt = await store.recordGitHubMirrorReceipt(
+      {
+        schema: 'openagents.forge.github.mirror.receipt.v0.1',
+        tenant_ref: 'tenant.openagents',
+        mirror_ref: 'mirror.github.openagents.main.6770',
+        promotion_ref: 'promotion.forge.6770',
+        source_canonical_ref: 'refs/heads/main',
+        destination_repository: 'OpenAgentsInc/openagents',
+        destination_ref: 'refs/heads/main',
+        commit_id: '9e0c9b2eaf84c821caf555cae233a0d27e94d4ac',
+        status: 'mirrored',
+        attempted_at: '2026-06-28T16:04:00.000Z',
+        mirrored_at: '2026-06-28T16:04:00.000Z',
+        refusal_reason: null,
+        error_reason: null,
+        source_refs: ['github:OpenAgentsInc/openagents#6796'],
+        redacted: true,
+      },
+      now,
+    )
+
+    await expect(
+      store.readGitHubMirrorReceipt(
+        'tenant.openagents',
+        'mirror.github.openagents.main.6770',
+      ),
+    ).resolves.toEqual(receipt)
+    await expect(
+      store.listGitHubMirrorReceipts(
+        'tenant.openagents',
+        10,
+        'promotion.forge.6770',
+      ),
+    ).resolves.toEqual([receipt])
   })
 })

--- a/apps/openagents.com/workers/api/src/forge-coordination-store.ts
+++ b/apps/openagents.com/workers/api/src/forge-coordination-store.ts
@@ -3,6 +3,7 @@ import {
   decodeForgeCoordinationPrRow,
   decodeForgeCoordinationStatusRow,
   decodeForgeDispatchLeaseRow,
+  decodeForgeGitHubMirrorReceipt,
   decodeForgeMergeQueueLedgerRow,
   decodeForgePromotionDecisionReceipt,
   decodeForgeVerificationReceipt,
@@ -14,6 +15,7 @@ import {
   type ForgeCoordinationStatusRow,
   type ForgeCoordinationStatusState,
   type ForgeDispatchLeaseRow,
+  type ForgeGitHubMirrorReceipt,
   type ForgeMergeQueueLedgerRow,
   type ForgeMergeQueueLedgerState,
   type ForgePromotionDecisionReceipt,
@@ -138,6 +140,23 @@ export type ForgeCoordinationStore = Readonly<{
     limit: number,
     changeRef?: string,
   ) => Promise<ReadonlyArray<ForgePromotionDecisionReceipt>>
+  readPromotionDecisionReceipt: (
+    tenantRef: string,
+    promotionRef: string,
+  ) => Promise<ForgePromotionDecisionReceipt | undefined>
+  recordGitHubMirrorReceipt: (
+    receipt: ForgeGitHubMirrorReceipt,
+    createdAt: string,
+  ) => Promise<ForgeGitHubMirrorReceipt>
+  listGitHubMirrorReceipts: (
+    tenantRef: string,
+    limit: number,
+    promotionRef?: string,
+  ) => Promise<ReadonlyArray<ForgeGitHubMirrorReceipt>>
+  readGitHubMirrorReceipt: (
+    tenantRef: string,
+    mirrorRef: string,
+  ) => Promise<ForgeGitHubMirrorReceipt | undefined>
 }>
 
 const StringArray = S.Array(S.String)
@@ -186,6 +205,23 @@ type ForgePromotionDecisionReceiptRow = Readonly<{
   blocker_refs_json: string
   decided_by_ref: string
   decided_at: string
+  source_refs_json: string
+  redacted: number | boolean
+}>
+
+type ForgeGitHubMirrorReceiptRow = Readonly<{
+  tenant_ref: string
+  mirror_ref: string
+  promotion_ref: string
+  source_canonical_ref: string
+  destination_repository: string
+  destination_ref: string
+  commit_id: string
+  status: string
+  attempted_at: string
+  mirrored_at: string | null
+  refusal_reason: string | null
+  error_reason: string | null
   source_refs_json: string
   redacted: number | boolean
 }>
@@ -239,6 +275,27 @@ const promotionDecisionReceiptFromRow = (
     blocker_refs: stringArrayFromJson(row.blocker_refs_json),
     decided_by_ref: row.decided_by_ref,
     decided_at: row.decided_at,
+    source_refs: stringArrayFromJson(row.source_refs_json),
+    redacted: row.redacted === true || row.redacted === 1,
+  })
+
+const gitHubMirrorReceiptFromRow = (
+  row: ForgeGitHubMirrorReceiptRow,
+): ForgeGitHubMirrorReceipt =>
+  decodeForgeGitHubMirrorReceipt({
+    schema: 'openagents.forge.github.mirror.receipt.v0.1',
+    tenant_ref: row.tenant_ref,
+    mirror_ref: row.mirror_ref,
+    promotion_ref: row.promotion_ref,
+    source_canonical_ref: row.source_canonical_ref,
+    destination_repository: row.destination_repository,
+    destination_ref: row.destination_ref,
+    commit_id: row.commit_id,
+    status: row.status,
+    attempted_at: row.attempted_at,
+    mirrored_at: row.mirrored_at,
+    refusal_reason: row.refusal_reason,
+    error_reason: row.error_reason,
     source_refs: stringArrayFromJson(row.source_refs_json),
     redacted: row.redacted === true || row.redacted === 1,
   })
@@ -958,5 +1015,127 @@ export const makeD1ForgeCoordinationStore = (
             .all<ForgePromotionDecisionReceiptRow>()
 
     return rows.results.map(promotionDecisionReceiptFromRow)
+  },
+
+  async readPromotionDecisionReceipt(tenantRef, promotionRef) {
+    const row = await db
+      .prepare(
+        `
+          SELECT *
+          FROM forge_promotion_decisions
+          WHERE tenant_ref = ? AND promotion_ref = ?
+        `,
+      )
+      .bind(tenantRef, promotionRef)
+      .first<ForgePromotionDecisionReceiptRow>()
+
+    return row === null ? undefined : promotionDecisionReceiptFromRow(row)
+  },
+
+  async recordGitHubMirrorReceipt(receipt, createdAt) {
+    const decoded = decodeForgeGitHubMirrorReceipt(receipt)
+    await db
+      .prepare(
+        `
+          INSERT INTO forge_github_mirror_receipts (
+            tenant_ref, mirror_ref, promotion_ref, source_canonical_ref,
+            destination_repository, destination_ref, commit_id, status,
+            attempted_at, mirrored_at, refusal_reason, error_reason,
+            source_refs_json, redacted, created_at, updated_at
+          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1, ?, ?)
+          ON CONFLICT (tenant_ref, mirror_ref) DO UPDATE SET
+            promotion_ref = excluded.promotion_ref,
+            source_canonical_ref = excluded.source_canonical_ref,
+            destination_repository = excluded.destination_repository,
+            destination_ref = excluded.destination_ref,
+            commit_id = excluded.commit_id,
+            status = excluded.status,
+            attempted_at = excluded.attempted_at,
+            mirrored_at = excluded.mirrored_at,
+            refusal_reason = excluded.refusal_reason,
+            error_reason = excluded.error_reason,
+            source_refs_json = excluded.source_refs_json,
+            updated_at = excluded.updated_at
+        `,
+      )
+      .bind(
+        decoded.tenant_ref,
+        decoded.mirror_ref,
+        decoded.promotion_ref,
+        decoded.source_canonical_ref,
+        decoded.destination_repository,
+        decoded.destination_ref,
+        decoded.commit_id,
+        decoded.status,
+        decoded.attempted_at,
+        decoded.mirrored_at,
+        decoded.refusal_reason,
+        decoded.error_reason,
+        jsonArray(decoded.source_refs),
+        createdAt,
+        createdAt,
+      )
+      .run()
+
+    const row = await db
+      .prepare(
+        `
+          SELECT *
+          FROM forge_github_mirror_receipts
+          WHERE tenant_ref = ? AND mirror_ref = ?
+        `,
+      )
+      .bind(decoded.tenant_ref, decoded.mirror_ref)
+      .first<ForgeGitHubMirrorReceiptRow>()
+
+    return gitHubMirrorReceiptFromRow(
+      rowOrFail(row, 'forge GitHub mirror receipt'),
+    )
+  },
+
+  async listGitHubMirrorReceipts(tenantRef, limit, promotionRef) {
+    const rows =
+      promotionRef === undefined
+        ? await db
+            .prepare(
+              `
+                SELECT *
+                FROM forge_github_mirror_receipts
+                WHERE tenant_ref = ?
+                ORDER BY attempted_at DESC, mirror_ref DESC
+                LIMIT ?
+              `,
+            )
+            .bind(tenantRef, limitRows(limit))
+            .all<ForgeGitHubMirrorReceiptRow>()
+        : await db
+            .prepare(
+              `
+                SELECT *
+                FROM forge_github_mirror_receipts
+                WHERE tenant_ref = ? AND promotion_ref = ?
+                ORDER BY attempted_at DESC, mirror_ref DESC
+                LIMIT ?
+              `,
+            )
+            .bind(tenantRef, promotionRef, limitRows(limit))
+            .all<ForgeGitHubMirrorReceiptRow>()
+
+    return rows.results.map(gitHubMirrorReceiptFromRow)
+  },
+
+  async readGitHubMirrorReceipt(tenantRef, mirrorRef) {
+    const row = await db
+      .prepare(
+        `
+          SELECT *
+          FROM forge_github_mirror_receipts
+          WHERE tenant_ref = ? AND mirror_ref = ?
+        `,
+      )
+      .bind(tenantRef, mirrorRef)
+      .first<ForgeGitHubMirrorReceiptRow>()
+
+    return row === null ? undefined : gitHubMirrorReceiptFromRow(row)
   },
 })

--- a/apps/openagents.com/workers/api/src/index.ts
+++ b/apps/openagents.com/workers/api/src/index.ts
@@ -13485,6 +13485,8 @@ const routeRequest = makeWorkerRouteRequest({
       nowIso: currentIsoTimestamp,
       requireAdminApiToken: (authRequest, authEnv) =>
         requireAdminApiToken(authRequest, authEnv),
+      resolveGitHubMirrorToken: mirrorEnv =>
+        mirrorEnv.OPENAGENTS_FORGE_GITHUB_MIRROR_TOKEN,
     }).routeForgeControlPlaneRequest(request, env),
   routeSiteCommerceRequest: (request, _env, _ctx) =>
     siteCommerceRoutesForEnv(_env).routeSiteCommerceRequest(request),

--- a/packages/forge-protocol/src/index.ts
+++ b/packages/forge-protocol/src/index.ts
@@ -100,6 +100,8 @@ export const ForgeControlPlaneScope = S.Literals([
   "forge:queue:write",
   "forge:receipt:write",
   "forge:promotion:decide",
+  "forge:mirror:read",
+  "forge:mirror:write",
   "forge:admin",
 ]);
 export type ForgeControlPlaneScope = typeof ForgeControlPlaneScope.Type;
@@ -115,6 +117,8 @@ export const forgeControlPlaneScopes: ReadonlyArray<ForgeControlPlaneScope> = [
   "forge:queue:write",
   "forge:receipt:write",
   "forge:promotion:decide",
+  "forge:mirror:read",
+  "forge:mirror:write",
   "forge:admin",
 ];
 
@@ -166,6 +170,14 @@ export const ForgePromotionDecisionState = S.Literals([
 ]);
 export type ForgePromotionDecisionState =
   typeof ForgePromotionDecisionState.Type;
+
+export const ForgeGitHubMirrorStatus = S.Literals([
+  "mirrored",
+  "already_mirrored",
+  "failed",
+  "refused",
+]);
+export type ForgeGitHubMirrorStatus = typeof ForgeGitHubMirrorStatus.Type;
 
 export const ForgeDispatchGitAccessDelivery = S.Literals([
   "out_of_band",
@@ -464,6 +476,25 @@ export const ForgePromotionDecisionReceipt = S.Struct({
 export type ForgePromotionDecisionReceipt =
   typeof ForgePromotionDecisionReceipt.Type;
 
+export const ForgeGitHubMirrorReceipt = S.Struct({
+  schema: S.Literal("openagents.forge.github.mirror.receipt.v0.1"),
+  tenant_ref: S.String,
+  mirror_ref: S.String,
+  promotion_ref: S.String,
+  source_canonical_ref: S.String,
+  destination_repository: S.String,
+  destination_ref: S.String,
+  commit_id: S.String,
+  status: ForgeGitHubMirrorStatus,
+  attempted_at: S.String,
+  mirrored_at: S.NullOr(S.String),
+  refusal_reason: S.NullOr(S.String),
+  error_reason: S.NullOr(S.String),
+  source_refs: S.Array(S.String),
+  redacted: S.Literal(true),
+});
+export type ForgeGitHubMirrorReceipt = typeof ForgeGitHubMirrorReceipt.Type;
+
 export const ForgeDispatchMessage = S.Union([
   ForgeDispatchWorkItem,
   ForgeDispatchDecision,
@@ -528,6 +559,9 @@ export const decodeForgeVerificationReceipt = S.decodeUnknownSync(
 );
 export const decodeForgePromotionDecisionReceipt = S.decodeUnknownSync(
   ForgePromotionDecisionReceipt,
+);
+export const decodeForgeGitHubMirrorReceipt = S.decodeUnknownSync(
+  ForgeGitHubMirrorReceipt,
 );
 
 export const forgeCoordinationStatusStateForNip34Kind = (


### PR DESCRIPTION
## Summary

- Add Forge GitHub mirror receipt schema/scope and D1 storage for promoted-commit mirror attempts.
- Add `/api/forge/github-mirrors` control-plane read/write route that only calls the GitHub ref updater for approved promotion receipts with a promoted commit.
- Record refused/failed mirror receipts for missing or blocked promotions, missing mirror token, and updater failures; make successful mirror retries idempotent by `mirrorRef`.

Closes #6796.

## Verification

- `bun run --cwd packages/forge-protocol test`
- `bun run --cwd apps/openagents.com/workers/api test -- src/forge-coordination-store.test.ts src/forge-control-plane-routes.test.ts`
- `bun run --cwd apps/openagents.com/workers/api typecheck`
- `bun run --cwd apps/openagents.com check:deploy` (verification for `command.public.pylon_khala.verify.b5bea41b6c623f7c09f1bf24`)