### PR TITLE
Add repo study marketplace economic gates

### DIFF
--- a/apps/openagents.com/workers/api/src/product-promises.test.ts
+++ b/apps/openagents.com/workers/api/src/product-promises.test.ts
@@ -1027,14 +1027,15 @@ describe('public product promises document', () => {
           audience: expect.arrayContaining(['agent', 'operator', 'developer']),
           blockerRefs: expect.arrayContaining([
             'blocker.product_promises.repo_studying_privacy_review_missing',
-            'blocker.product_promises.repo_studying_marketplace_metering_missing',
-            'blocker.product_promises.repo_studying_payout_settlement_gates_missing',
+            'blocker.product_promises.repo_studying_armed_marketplace_closeout_receipt_missing',
+            'blocker.product_promises.repo_studying_owner_signed_marketplace_green_transition_missing',
           ]),
           evidenceRefs: expect.arrayContaining([
             'docs/research/machine-studying/openagents-studybench/runs/2026-06-17-mvp-14-baseline-packet-gepa-comparison.md',
             'packages/probe/docs/benchmarks/2026-06-17-openagents-studybench-mvp-14-comparison.json',
             'docs/promises/2026-06-17-repo-studying-product-promise-gate-review.md',
             'packages/probe/packages/runtime/src/benchmark/openagents-customer-private-validation.ts',
+            'packages/probe/packages/runtime/src/benchmark/external-repo-studying-marketplace-gates.ts',
             'promise:repo.open_source_code_map.v1',
           ]),
           promiseId: 'autopilot.repo_study_packets.v1',
@@ -1270,6 +1271,22 @@ describe('public product promises document', () => {
     expect(repoStudyPacketPromise?.authorityBoundary).toContain(
       'not paid work',
     )
+    expect(repoStudyPacketPromise?.evidenceRefs).toContain(
+      'packages/probe/packages/runtime/tests/external-repo-studying-marketplace-gates.test.ts',
+    )
+    expect(repoStudyPacketPromise?.blockerRefs).not.toEqual(
+      expect.arrayContaining([
+        'blocker.product_promises.repo_studying_marketplace_metering_missing',
+        'blocker.product_promises.repo_studying_pricing_package_policy_missing',
+        'blocker.product_promises.repo_studying_payout_settlement_gates_missing',
+      ]),
+    )
+    expect(repoStudyPacketPromise?.blockerRefs).toEqual(
+      expect.arrayContaining([
+        'blocker.product_promises.repo_studying_armed_marketplace_closeout_receipt_missing',
+        'blocker.product_promises.repo_studying_owner_signed_marketplace_green_transition_missing',
+      ]),
+    )
     const externalRepoStudyPromise = decoded.promises.find(
       promise => promise.promiseId === 'autopilot.external_repo_studying_pilot.v1',
     )
@@ -1292,6 +1309,22 @@ describe('public product promises document', () => {
     )
     expect(externalRepoStudyPromise?.authorityBoundary).toContain(
       'no private repo ingestion authority',
+    )
+    expect(externalRepoStudyPromise?.evidenceRefs).toContain(
+      'packages/probe/packages/runtime/src/benchmark/external-repo-studying-marketplace-gates.ts',
+    )
+    expect(externalRepoStudyPromise?.blockerRefs).not.toEqual(
+      expect.arrayContaining([
+        'blocker.product_promises.external_repo_studying_marketplace_metering_missing',
+        'blocker.product_promises.external_repo_studying_pricing_package_policy_missing',
+        'blocker.product_promises.external_repo_studying_payout_settlement_gates_missing',
+      ]),
+    )
+    expect(externalRepoStudyPromise?.blockerRefs).toEqual(
+      expect.arrayContaining([
+        'blocker.product_promises.external_repo_studying_armed_marketplace_closeout_receipt_missing',
+        'blocker.product_promises.external_repo_studying_owner_signed_marketplace_green_transition_missing',
+      ]),
     )
   })
 

--- a/apps/openagents.com/workers/api/src/product-promises.ts
+++ b/apps/openagents.com/workers/api/src/product-promises.ts
@@ -261,6 +261,7 @@ export const publicProductPromisesDocument = () => {
         'Registry 2026-06-28.3 implements #6891 for models.tassadar_percepta_executor.v1 and flips NO promise state. Pylon v1.0 now has a deterministic bounded CPU computation-transform fixture in apps/pylon/src/tassadar-cpu-transform-training.ts that runs one CPU-only optimization step, self-verifies loss improvement, emits receipt.models.tassadar_percepta_executor.cpu_transform_training.cpu_transform_fixture_v1, and keeps realBitcoinMoved:false / settlementState:not_settled. GET /api/public/models/tassadar-percepta-executor/cpu-transform-training-receipts now projects that public-safe receipt alongside the architecture and Artanis distillation dataset inputs, so the old pylon_v03_cpu_transform_training_receipts_missing blocker is replaced by blocker.product_promises.tassadar_cpu_transform_real_settlement_missing and blocker.product_promises.tassadar_cpu_transform_owner_green_signoff_missing. The promise STAYS planned: this is one fixture-scale receipt, not a trained model, not a paid earning path, not model promotion, and not a green transition; any future green flip remains receipt-first and owner-signed per proof.claim_upgrade_receipts.v1.',
         'Registry 2026-06-29.1 implements #6848 for payments.accepted_outcome_economics.v1 and flips NO promise state. The accepted-outcome economics spine now has a dereferenceable contributor accrual bundle at GET /api/public/payments/contributor-accrual-bundle?economicsId=... plus the settlement bundle at GET /api/public/accepted-outcome/settlement/{economicsId}; together they compose a gross-margin receipt, contributor accrual ledger entries, and an eight-state settlement machine from one stored accepted-outcome economics row. Tests prove the ledger and receipt share the same economicsId, reconcile gross margin exactly, reconcile pending_payout to the distributable ledger pool, keep public projections free of internal cents/raw payment material, and surface missing contributor provenance honestly. The old source-level blockers contributor_ledger_missing and gross_margin_receipts_missing are replaced by real_accepted_outcome_receipt_missing and owner_signed_green_transition_missing. The promise STAYS red because source/fixture receipt machinery is not a real accepted outcome carried through a money-moving settlement path, and any future green flip remains receipt-first and owner-signed per proof.claim_upgrade_receipts.v1.',
         'Registry 2026-06-29.2 is a current-main refresh after #6997/#6999/#7001/#7002/#7006 and flips NO promise state. The terminal-agent current-state audit and Codex tool-layer study are now cited as evidence for the Codex/Probe/Pylon runtime direction: current production coding delegation is still Pylon plus external agent SDK lanes and OpenAgents-native terminal tools remain a consolidation task, not a new green claim. The codex-supervisor LOCKOUT replenishment helper can create or reuse three bounded standing issues so owner-capacity supervisors do not idle indefinitely, but it creates no paid labor, payout, settlement, or broad availability claim. The inference router now has GLM own-capacity failover alerting and public-safe fallback telemetry for repeated no-headroom saturation, but the paid gateway still stays red until a dereferenceable paid receipt exists. Khala Desktop now carries source-level Electrobun Apple FM sidecar packaging/readiness plus redaction tests, but Apple FM local mode remains yellow until a signed/notarized from-install smoke with helper supervision exists. The Khala model-mix promise remains live-at-read with maxStalenessSeconds:0; the stale 2-second cache wording is not applied.',
+        'Registry 2026-06-29.3 implements #7028 economic-gate narrowing for repo studying and flips NO promise state. packages/probe/packages/runtime/src/benchmark/external-repo-studying-marketplace-gates.ts now provides a refs-only inert marketplace gate that requires package policy, usage-metering unit, pricing policy, payout policy, settlement policy, terms, flag arming, and owner sign-off before a future marketplace package could be allowed. The gate always keeps customerPublicClaimAllowed:false, marketplacePackageAllowed:false, packageListed:false, payoutEligible:false, and effectsApplied:false, so it lists no package, bills nothing, pays nothing, settles nothing, and exposes no raw private repo material. The broad economic-policy blockers on autopilot.repo_study_packets.v1 and autopilot.external_repo_studying_pilot.v1 are narrowed to receipt-first armed-marketplace blockers; privacy, self-serve upload, product-copy, and real armed customer-private closeout blockers remain.',
       ],
     },
     promises: [
@@ -314,17 +315,18 @@ export const publicProductPromisesDocument = () => {
           'docs/promises/2026-06-17-repo-studying-product-promise-gate-review.md',
           'packages/probe/packages/runtime/src/benchmark/openagents-customer-private-validation.ts',
           'packages/probe/packages/runtime/tests/openagents-customer-private-validation.test.ts',
+          'packages/probe/packages/runtime/src/benchmark/external-repo-studying-marketplace-gates.ts',
+          'packages/probe/packages/runtime/tests/external-repo-studying-marketplace-gates.test.ts',
           'promise:repo.open_source_code_map.v1',
         ],
         blockerRefs: [
           'blocker.product_promises.repo_studying_privacy_review_missing',
-          'blocker.product_promises.repo_studying_marketplace_metering_missing',
-          'blocker.product_promises.repo_studying_pricing_package_policy_missing',
-          'blocker.product_promises.repo_studying_payout_settlement_gates_missing',
+          'blocker.product_promises.repo_studying_armed_marketplace_closeout_receipt_missing',
+          'blocker.product_promises.repo_studying_owner_signed_marketplace_green_transition_missing',
           'blocker.product_promises.repo_studying_product_copy_review_missing',
         ],
         verification:
-          'Yellow is limited to the recorded MVP-14 OpenAgents public-safe comparison plus docs review. Green or external copy requires customer-data privacy review, private validation/holdout discipline, marketplace package policy, usage metering, pricing, payout eligibility, settlement receipts, and product-promise preflight. Public score summaries must keep productPromiseBoundary.publicProductClaimAllowed false until those gates pass.',
+          'Yellow is limited to the recorded MVP-14 OpenAgents public-safe comparison plus docs review. Green or external copy requires customer-data privacy review, private validation/holdout discipline, the refs-only marketplace economic gate, an armed customer-private marketplace closeout receipt, owner-signed transition, and product-promise preflight. Public score summaries must keep productPromiseBoundary.publicProductClaimAllowed false until those gates pass.',
         authorityBoundary:
           'A StudyBench row or study packet is evidence and repository-memory input only. It grants no runtime mutation, customer repository ingestion, marketplace listing, billing, payout eligibility, settlement, training promotion, or public green-claim authority, and it is not paid work.',
       },
@@ -346,6 +348,8 @@ export const publicProductPromisesDocument = () => {
           'packages/probe/packages/runtime/src/benchmark/external-repo-studying-pilot-admission.ts',
           'packages/probe/packages/runtime/tests/external-repo-studying-pilot-admission.test.ts',
           'packages/probe/packages/runtime/src/benchmark/openagents-customer-private-validation.ts',
+          'packages/probe/packages/runtime/src/benchmark/external-repo-studying-marketplace-gates.ts',
+          'packages/probe/packages/runtime/tests/external-repo-studying-marketplace-gates.test.ts',
           'docs/research/machine-studying/openagents-studybench/private-boundary.md',
           'docs/research/machine-studying/2026-06-17-tassadar-openagents-repo-studying-roadmap.md#phase-6',
           'promise:autopilot.repo_study_packets.v1',
@@ -353,12 +357,11 @@ export const publicProductPromisesDocument = () => {
         blockerRefs: [
           'blocker.product_promises.external_repo_studying_privacy_policy_missing',
           'blocker.product_promises.external_repo_studying_self_serve_upload_missing',
-          'blocker.product_promises.external_repo_studying_marketplace_metering_missing',
-          'blocker.product_promises.external_repo_studying_pricing_package_policy_missing',
-          'blocker.product_promises.external_repo_studying_payout_settlement_gates_missing',
+          'blocker.product_promises.external_repo_studying_armed_marketplace_closeout_receipt_missing',
+          'blocker.product_promises.external_repo_studying_owner_signed_marketplace_green_transition_missing',
         ],
         verification:
-          'Yellow is limited to the S7 non-OpenAgents fixture pipeline: corpus manifest, study packet, graph, S3 verdict, S4-style eval lift, and coder context. Any real customer-private repo product requires admission policy, privacy review, customer review, self-serve controls, usage metering, pricing, payout eligibility, settlement evidence, and product-promise copy preflight.',
+          'Yellow is limited to the S7 non-OpenAgents fixture pipeline: corpus manifest, study packet, graph, S3 verdict, S4-style eval lift, coder context, and refs-only inert marketplace economic gates. Any real customer-private repo product requires admission policy, privacy review, customer review, self-serve controls, an armed marketplace closeout receipt, owner-signed transition, and product-promise copy preflight.',
         authorityBoundary:
           'The external-repo studying pilot is repository-memory evidence only. It grants no private repo ingestion authority, write authority, runtime mutation, marketplace listing, billing, payout eligibility, settlement, training promotion, or green public customer claim.',
       },

--- a/packages/probe/packages/runtime/src/benchmark/external-repo-studying-marketplace-gates.ts
+++ b/packages/probe/packages/runtime/src/benchmark/external-repo-studying-marketplace-gates.ts
@@ -1,0 +1,437 @@
+import { Effect, Schema as S } from "effect";
+import {
+  ProbeBenchmarkContractError,
+  validateProbeBenchmarkPublicProjection,
+} from "../contracts/benchmark";
+import { type ProbePublicProjectionUnsafe } from "../contracts/provider-account";
+import { sha256Ref, shortHash, stableJson } from "./stable-hash";
+
+/**
+ * Refs-only economic gate for repo-studying marketplace claims.
+ *
+ * This is source-level policy machinery only. It can prove that package
+ * metering, pricing, payout, and settlement-policy refs are present and
+ * mutually bound before a future armed marketplace listing. It never lists,
+ * bills, settles, pays, or marks a study packet claimable.
+ */
+export const OPENAGENTS_EXTERNAL_REPO_STUDY_MARKETPLACE_GATES_SCHEMA_REF =
+  "openagents.external_repo_study_marketplace_gates.v0" as const;
+
+export const ExternalRepoStudyMarketplaceGateFlagName =
+  "EXTERNAL_REPO_STUDY_MARKETPLACE_GATES_ENABLED" as const;
+
+export const OpenAgentsExternalRepoStudyMarketplaceGateState = S.Literals([
+  "inert_disabled",
+  "armed_blocked",
+  "armed_ready",
+]);
+export type OpenAgentsExternalRepoStudyMarketplaceGateState =
+  typeof OpenAgentsExternalRepoStudyMarketplaceGateState.Type;
+
+export const OpenAgentsExternalRepoStudyMarketplaceDecisionState = S.Literals([
+  "economic_gates_ready_held",
+  "blocked",
+]);
+export type OpenAgentsExternalRepoStudyMarketplaceDecisionState =
+  typeof OpenAgentsExternalRepoStudyMarketplaceDecisionState.Type;
+
+export interface ExternalRepoStudyMarketplaceGateRequest {
+  readonly contributorRef: string;
+  readonly customerRef: string;
+  readonly meteringPolicyRef?: string;
+  readonly packagePolicyRef?: string;
+  readonly packetRef: string;
+  readonly payoutPolicyRef?: string;
+  readonly pricingPolicyRef?: string;
+  readonly repo: string;
+  readonly settlementPolicyRef?: string;
+  readonly termsAccepted?: boolean;
+  readonly usageUnitRef?: string;
+}
+
+export const OpenAgentsExternalRepoStudyMarketplaceGate = S.Struct({
+  blockedReasonRefs: S.Array(S.String),
+  effectsApplied: S.Literal(false),
+  flagName: S.Literal(ExternalRepoStudyMarketplaceGateFlagName),
+  ownerSignoffPresent: S.Boolean,
+  state: OpenAgentsExternalRepoStudyMarketplaceGateState,
+});
+export type OpenAgentsExternalRepoStudyMarketplaceGate =
+  typeof OpenAgentsExternalRepoStudyMarketplaceGate.Type;
+
+export const OpenAgentsExternalRepoStudyMarketplaceGates = S.Struct({
+  blockerRefs: S.Array(S.String),
+  contributorRef: S.String,
+  customerPublicClaimAllowed: S.Literal(false),
+  customerRef: S.String,
+  effectsApplied: S.Literal(false),
+  evidenceRefs: S.Array(S.String),
+  generatedAt: S.String,
+  gate: OpenAgentsExternalRepoStudyMarketplaceGate,
+  marketplaceGatesHash: S.String,
+  marketplaceGatesRef: S.String,
+  marketplacePackageAllowed: S.Literal(false),
+  meteringPolicyPresent: S.Boolean,
+  packageListed: S.Literal(false),
+  packagePolicyPresent: S.Boolean,
+  packetRef: S.String,
+  payoutEligible: S.Literal(false),
+  payoutPolicyPresent: S.Boolean,
+  pricingPolicyPresent: S.Boolean,
+  repo: S.String,
+  safeCopy: S.String,
+  schemaRef: S.Literal(
+    OPENAGENTS_EXTERNAL_REPO_STUDY_MARKETPLACE_GATES_SCHEMA_REF,
+  ),
+  settlementPolicyPresent: S.Boolean,
+  sourceBoundary: S.Literal("customer_refs_withheld"),
+  state: OpenAgentsExternalRepoStudyMarketplaceDecisionState,
+  termsAccepted: S.Boolean,
+  unsafeCopyRefs: S.Array(S.String),
+  usageUnitPresent: S.Boolean,
+  wouldAllowMarketplaceWhenArmed: S.Boolean,
+});
+export type OpenAgentsExternalRepoStudyMarketplaceGates =
+  typeof OpenAgentsExternalRepoStudyMarketplaceGates.Type;
+
+export interface BuildOpenAgentsExternalRepoStudyMarketplaceGatesInput {
+  readonly generatedAt?: string;
+  readonly marketplaceFlagArmed?: boolean;
+  readonly ownerSignoffPresent?: boolean;
+  readonly request: ExternalRepoStudyMarketplaceGateRequest;
+}
+
+export function buildOpenAgentsExternalRepoStudyMarketplaceGates(
+  input: BuildOpenAgentsExternalRepoStudyMarketplaceGatesInput,
+): Effect.Effect<
+  OpenAgentsExternalRepoStudyMarketplaceGates,
+  ProbeBenchmarkContractError | ProbePublicProjectionUnsafe
+> {
+  return Effect.gen(function* () {
+    const request = input.request;
+    yield* requireNonEmpty(request.repo, "externalRepoStudyMarketplace.repo");
+    yield* requireNonEmpty(
+      request.customerRef,
+      "externalRepoStudyMarketplace.customerRef",
+    );
+    yield* requireNonEmpty(
+      request.contributorRef,
+      "externalRepoStudyMarketplace.contributorRef",
+    );
+    yield* requireNonEmpty(
+      request.packetRef,
+      "externalRepoStudyMarketplace.packetRef",
+    );
+
+    const meteringPolicyPresent = hasRef(request.meteringPolicyRef);
+    const packagePolicyPresent = hasRef(request.packagePolicyRef);
+    const payoutPolicyPresent = hasRef(request.payoutPolicyRef);
+    const pricingPolicyPresent = hasRef(request.pricingPolicyRef);
+    const settlementPolicyPresent = hasRef(request.settlementPolicyRef);
+    const usageUnitPresent = hasRef(request.usageUnitRef);
+    const termsAccepted = request.termsAccepted ?? false;
+
+    const economicGatePassed =
+      meteringPolicyPresent &&
+      packagePolicyPresent &&
+      payoutPolicyPresent &&
+      pricingPolicyPresent &&
+      settlementPolicyPresent &&
+      usageUnitPresent &&
+      termsAccepted;
+
+    const blockerRefs = buildMarketplaceBlockerRefs({
+      meteringPolicyPresent,
+      packagePolicyPresent,
+      payoutPolicyPresent,
+      pricingPolicyPresent,
+      settlementPolicyPresent,
+      termsAccepted,
+      usageUnitPresent,
+    });
+
+    const gate = buildMarketplaceGate({
+      economicGatePassed,
+      marketplaceFlagArmed: input.marketplaceFlagArmed ?? false,
+      ownerSignoffPresent: input.ownerSignoffPresent ?? false,
+    });
+
+    const generatedAt =
+      input.generatedAt ??
+      "generated_at.withheld_for_stable_external_repo_study_marketplace_gates_hash";
+
+    const evidenceRefs = [
+      request.customerRef,
+      request.contributorRef,
+      request.packetRef,
+      ...(request.meteringPolicyRef ? [request.meteringPolicyRef] : []),
+      ...(request.packagePolicyRef ? [request.packagePolicyRef] : []),
+      ...(request.pricingPolicyRef ? [request.pricingPolicyRef] : []),
+      ...(request.payoutPolicyRef ? [request.payoutPolicyRef] : []),
+      ...(request.settlementPolicyRef ? [request.settlementPolicyRef] : []),
+      ...(request.usageUnitRef ? [request.usageUnitRef] : []),
+      "docs/launch/vertex-fleet/autopilot.external_repo_studying_pilot.v1.md",
+    ];
+
+    const base: OpenAgentsExternalRepoStudyMarketplaceGates = {
+      blockerRefs,
+      contributorRef: request.contributorRef,
+      customerPublicClaimAllowed: false,
+      customerRef: request.customerRef,
+      effectsApplied: false,
+      evidenceRefs,
+      generatedAt,
+      gate,
+      marketplaceGatesHash: "sha256:pending",
+      marketplaceGatesRef: "external_repo_study_marketplace_gates.pending",
+      marketplacePackageAllowed: false,
+      meteringPolicyPresent,
+      packageListed: false,
+      packagePolicyPresent,
+      packetRef: request.packetRef,
+      payoutEligible: false,
+      payoutPolicyPresent,
+      pricingPolicyPresent,
+      repo: request.repo,
+      safeCopy:
+        "Repo-studying marketplace gates checked package policy, metering unit, pricing, payout, and settlement refs without listing a package, billing, paying, settling, or allowing a public customer claim.",
+      schemaRef: OPENAGENTS_EXTERNAL_REPO_STUDY_MARKETPLACE_GATES_SCHEMA_REF,
+      settlementPolicyPresent,
+      sourceBoundary: "customer_refs_withheld",
+      state: economicGatePassed ? "economic_gates_ready_held" : "blocked",
+      termsAccepted,
+      unsafeCopyRefs: [
+        "blocked_claim.repo_study_marketplace_package_live",
+        "blocked_claim.repo_study_usage_billing_live",
+        "blocked_claim.repo_study_payout_eligible",
+        "blocked_claim.repo_study_settlement_live",
+      ],
+      usageUnitPresent,
+      wouldAllowMarketplaceWhenArmed:
+        economicGatePassed && gate.state === "armed_ready",
+    };
+
+    const marketplaceGatesHash =
+      openAgentsExternalRepoStudyMarketplaceGatesHash(base);
+
+    return yield* decodeOpenAgentsExternalRepoStudyMarketplaceGates({
+      ...base,
+      marketplaceGatesHash,
+      marketplaceGatesRef: `external_repo_study_marketplace_gates.${slugRepo(request.repo)}.${shortHash(marketplaceGatesHash)}`,
+    });
+  });
+}
+
+export function decodeOpenAgentsExternalRepoStudyMarketplaceGates(
+  value: unknown,
+): Effect.Effect<
+  OpenAgentsExternalRepoStudyMarketplaceGates,
+  ProbeBenchmarkContractError | ProbePublicProjectionUnsafe
+> {
+  return Effect.gen(function* () {
+    yield* validateProbeBenchmarkPublicProjection(
+      value,
+      "externalRepoStudyMarketplace",
+    );
+    const gates = yield* S.decodeUnknownEffect(
+      OpenAgentsExternalRepoStudyMarketplaceGates,
+    )(value).pipe(
+      Effect.mapError(
+        (error) =>
+          new ProbeBenchmarkContractError({
+            path: "externalRepoStudyMarketplace",
+            reason: String(error),
+          }),
+      ),
+    );
+    yield* validateExternalRepoStudyMarketplaceGates(gates);
+    return gates;
+  });
+}
+
+export function openAgentsExternalRepoStudyMarketplaceGatesHash(
+  gates: OpenAgentsExternalRepoStudyMarketplaceGates,
+): string {
+  const {
+    generatedAt: _generatedAt,
+    marketplaceGatesHash: _marketplaceGatesHash,
+    marketplaceGatesRef: _marketplaceGatesRef,
+    ...stable
+  } = gates;
+  return sha256Ref(stableJson(stable));
+}
+
+function buildMarketplaceGate(input: {
+  readonly economicGatePassed: boolean;
+  readonly marketplaceFlagArmed: boolean;
+  readonly ownerSignoffPresent: boolean;
+}): OpenAgentsExternalRepoStudyMarketplaceGate {
+  if (!input.marketplaceFlagArmed) {
+    return {
+      blockedReasonRefs: [],
+      effectsApplied: false,
+      flagName: ExternalRepoStudyMarketplaceGateFlagName,
+      ownerSignoffPresent: input.ownerSignoffPresent,
+      state: "inert_disabled",
+    };
+  }
+
+  const blockedReasonRefs: string[] = [];
+  if (!input.economicGatePassed) {
+    blockedReasonRefs.push("marketplace.blocked.economic_gate_not_passed");
+  }
+  if (!input.ownerSignoffPresent) {
+    blockedReasonRefs.push("marketplace.blocked.owner_signoff_missing");
+  }
+
+  return {
+    blockedReasonRefs,
+    effectsApplied: false,
+    flagName: ExternalRepoStudyMarketplaceGateFlagName,
+    ownerSignoffPresent: input.ownerSignoffPresent,
+    state: blockedReasonRefs.length === 0 ? "armed_ready" : "armed_blocked",
+  };
+}
+
+function buildMarketplaceBlockerRefs(input: {
+  readonly meteringPolicyPresent: boolean;
+  readonly packagePolicyPresent: boolean;
+  readonly payoutPolicyPresent: boolean;
+  readonly pricingPolicyPresent: boolean;
+  readonly settlementPolicyPresent: boolean;
+  readonly termsAccepted: boolean;
+  readonly usageUnitPresent: boolean;
+}): ReadonlyArray<string> {
+  const blockers: string[] = [];
+  if (!input.packagePolicyPresent) {
+    blockers.push("blocker.external_repo_study_marketplace.package_policy_missing");
+  }
+  if (!input.meteringPolicyPresent || !input.usageUnitPresent) {
+    blockers.push("blocker.external_repo_study_marketplace.metering_missing");
+  }
+  if (!input.pricingPolicyPresent) {
+    blockers.push("blocker.external_repo_study_marketplace.pricing_missing");
+  }
+  if (!input.payoutPolicyPresent) {
+    blockers.push("blocker.external_repo_study_marketplace.payout_policy_missing");
+  }
+  if (!input.settlementPolicyPresent) {
+    blockers.push("blocker.external_repo_study_marketplace.settlement_policy_missing");
+  }
+  if (!input.termsAccepted) {
+    blockers.push("blocker.external_repo_study_marketplace.terms_not_accepted");
+  }
+  return blockers;
+}
+
+function validateExternalRepoStudyMarketplaceGates(
+  gates: OpenAgentsExternalRepoStudyMarketplaceGates,
+): Effect.Effect<void, ProbeBenchmarkContractError> {
+  return Effect.gen(function* () {
+    yield* requireNonEmpty(gates.repo, "externalRepoStudyMarketplace.repo");
+    yield* requireNonEmpty(
+      gates.customerRef,
+      "externalRepoStudyMarketplace.customerRef",
+    );
+    yield* requireNonEmpty(
+      gates.contributorRef,
+      "externalRepoStudyMarketplace.contributorRef",
+    );
+    yield* requireNonEmpty(
+      gates.packetRef,
+      "externalRepoStudyMarketplace.packetRef",
+    );
+    yield* requireSha256(
+      gates.marketplaceGatesHash,
+      "externalRepoStudyMarketplace.marketplaceGatesHash",
+    );
+
+    if (
+      gates.customerPublicClaimAllowed !== false ||
+      gates.marketplacePackageAllowed !== false ||
+      gates.payoutEligible !== false ||
+      gates.packageListed !== false ||
+      gates.effectsApplied !== false ||
+      gates.gate.effectsApplied !== false
+    ) {
+      return yield* marketplaceError(
+        "externalRepoStudyMarketplace.claimGates",
+        "marketplace gate must not grant package, billing, payout, settlement, or customer claims",
+      );
+    }
+
+    if (gates.state === "economic_gates_ready_held") {
+      if (
+        !gates.packagePolicyPresent ||
+        !gates.meteringPolicyPresent ||
+        !gates.usageUnitPresent ||
+        !gates.pricingPolicyPresent ||
+        !gates.payoutPolicyPresent ||
+        !gates.settlementPolicyPresent ||
+        !gates.termsAccepted
+      ) {
+        return yield* marketplaceError(
+          "externalRepoStudyMarketplace.state",
+          "economic_gates_ready_held requires package, metering, usage, pricing, payout, settlement, and terms refs",
+        );
+      }
+    }
+
+    if (
+      gates.wouldAllowMarketplaceWhenArmed &&
+      gates.gate.state !== "armed_ready"
+    ) {
+      return yield* marketplaceError(
+        "externalRepoStudyMarketplace.wouldAllowMarketplaceWhenArmed",
+        "marketplace can only be marked would-allow once the armed gate is ready",
+      );
+    }
+
+    if (
+      gates.marketplaceGatesHash !==
+      openAgentsExternalRepoStudyMarketplaceGatesHash(gates)
+    ) {
+      return yield* marketplaceError(
+        "externalRepoStudyMarketplace.marketplaceGatesHash",
+        "must match the deterministic marketplace gates hash",
+      );
+    }
+  });
+}
+
+function hasRef(value: string | undefined): boolean {
+  return (value ?? "").trim().length > 0;
+}
+
+function requireNonEmpty(
+  value: string,
+  path: string,
+): Effect.Effect<void, ProbeBenchmarkContractError> {
+  return value.trim().length === 0
+    ? marketplaceError(path, "must be non-empty")
+    : Effect.void;
+}
+
+function requireSha256(
+  value: string,
+  path: string,
+): Effect.Effect<void, ProbeBenchmarkContractError> {
+  return value.startsWith("sha256:")
+    ? Effect.void
+    : marketplaceError(path, "must be a sha256 ref");
+}
+
+function slugRepo(repo: string): string {
+  return repo
+    .replace(/[^a-zA-Z0-9]+/g, "_")
+    .replace(/^_+|_+$/g, "")
+    .toLowerCase()
+    .slice(0, 80);
+}
+
+function marketplaceError(
+  path: string,
+  reason: string,
+): Effect.Effect<never, ProbeBenchmarkContractError> {
+  return Effect.fail(new ProbeBenchmarkContractError({ path, reason }));
+}

--- a/packages/probe/packages/runtime/src/index.ts
+++ b/packages/probe/packages/runtime/src/index.ts
@@ -20,6 +20,7 @@ export * from "./benchmark/fixtures";
 export * from "./benchmark/external-repo-studying-product";
 export * from "./benchmark/external-repo-studying-pilot-admission";
 export * from "./benchmark/external-repo-studying-self-serve-upload";
+export * from "./benchmark/external-repo-studying-marketplace-gates";
 export * from "./benchmark/external-repo-studying-privacy-review";
 export * from "./benchmark/external-repo-studying-privacy-policy-registry";
 export * from "./benchmark/external-repo-studying-scan-attestation-registry";

--- a/packages/probe/packages/runtime/tests/external-repo-studying-marketplace-gates.test.ts
+++ b/packages/probe/packages/runtime/tests/external-repo-studying-marketplace-gates.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, test } from "bun:test";
+import { Effect } from "effect";
+import {
+  buildOpenAgentsExternalRepoStudyMarketplaceGates,
+  decodeOpenAgentsExternalRepoStudyMarketplaceGates,
+  openAgentsExternalRepoStudyMarketplaceGatesHash,
+  type ExternalRepoStudyMarketplaceGateRequest,
+} from "../src";
+
+const generatedAt = "2026-06-29T00:00:00.000Z" as const;
+
+const request: ExternalRepoStudyMarketplaceGateRequest = {
+  contributorRef: "contributor.pylon.448ba824.v0",
+  customerRef: "customer.examplecorp.v0",
+  meteringPolicyRef: "policy.external_repo_study.metering.usage_unit.v0",
+  packagePolicyRef: "policy.external_repo_study.package.refs_only.v0",
+  packetRef: "external_repo_study_packet.examplecorp_widget.sha256abcdef",
+  payoutPolicyRef: "policy.external_repo_study.payout.receipt_first.v0",
+  pricingPolicyRef: "policy.external_repo_study.pricing.package_v0",
+  repo: "ExampleCorp/widget-service",
+  settlementPolicyRef: "policy.external_repo_study.settlement.no_spend_until_receipt.v0",
+  termsAccepted: true,
+  usageUnitRef: "usage_unit.external_repo_study.packet_access.v0",
+};
+
+describe("external repo studying marketplace gates", () => {
+  test("passes complete economic refs while holding package, billing, payout, and settlement inert", async () => {
+    const gates = await Effect.runPromise(
+      buildOpenAgentsExternalRepoStudyMarketplaceGates({
+        generatedAt,
+        request,
+      }),
+    );
+
+    expect(gates.schemaRef).toBe(
+      "openagents.external_repo_study_marketplace_gates.v0",
+    );
+    expect(gates.state).toBe("economic_gates_ready_held");
+    expect(gates.gate.state).toBe("inert_disabled");
+    expect(gates.meteringPolicyPresent).toBe(true);
+    expect(gates.usageUnitPresent).toBe(true);
+    expect(gates.packagePolicyPresent).toBe(true);
+    expect(gates.pricingPolicyPresent).toBe(true);
+    expect(gates.payoutPolicyPresent).toBe(true);
+    expect(gates.settlementPolicyPresent).toBe(true);
+    expect(gates.termsAccepted).toBe(true);
+
+    expect(gates.customerPublicClaimAllowed).toBe(false);
+    expect(gates.marketplacePackageAllowed).toBe(false);
+    expect(gates.packageListed).toBe(false);
+    expect(gates.payoutEligible).toBe(false);
+    expect(gates.effectsApplied).toBe(false);
+    expect(gates.gate.effectsApplied).toBe(false);
+    expect(gates.wouldAllowMarketplaceWhenArmed).toBe(false);
+    expect(gates.sourceBoundary).toBe("customer_refs_withheld");
+    expect(gates.marketplaceGatesHash).toBe(
+      openAgentsExternalRepoStudyMarketplaceGatesHash(gates),
+    );
+    expect(gates.evidenceRefs).toEqual(
+      expect.arrayContaining([
+        request.packetRef,
+        request.meteringPolicyRef,
+        request.pricingPolicyRef,
+        request.payoutPolicyRef,
+        request.settlementPolicyRef,
+        request.usageUnitRef,
+      ]),
+    );
+    expect(`${gates.safeCopy} ${gates.unsafeCopyRefs.join(" ")}`).not.toMatch(
+      /marketplace package live|payout eligible|settlement live/i,
+    );
+  });
+
+  test("would allow marketplace only when flag and owner signoff are present, still inert", async () => {
+    const gates = await Effect.runPromise(
+      buildOpenAgentsExternalRepoStudyMarketplaceGates({
+        generatedAt,
+        marketplaceFlagArmed: true,
+        ownerSignoffPresent: true,
+        request,
+      }),
+    );
+
+    expect(gates.gate.state).toBe("armed_ready");
+    expect(gates.wouldAllowMarketplaceWhenArmed).toBe(true);
+    expect(gates.marketplacePackageAllowed).toBe(false);
+    expect(gates.packageListed).toBe(false);
+    expect(gates.payoutEligible).toBe(false);
+    expect(gates.effectsApplied).toBe(false);
+  });
+
+  test("armed marketplace blocks without owner signoff", async () => {
+    const gates = await Effect.runPromise(
+      buildOpenAgentsExternalRepoStudyMarketplaceGates({
+        generatedAt,
+        marketplaceFlagArmed: true,
+        request,
+      }),
+    );
+
+    expect(gates.gate.state).toBe("armed_blocked");
+    expect(gates.gate.blockedReasonRefs).toContain(
+      "marketplace.blocked.owner_signoff_missing",
+    );
+    expect(gates.wouldAllowMarketplaceWhenArmed).toBe(false);
+  });
+
+  test("blocks missing metering, pricing, payout, settlement, and terms refs", async () => {
+    const gates = await Effect.runPromise(
+      buildOpenAgentsExternalRepoStudyMarketplaceGates({
+        generatedAt,
+        request: {
+          ...request,
+          meteringPolicyRef: undefined,
+          payoutPolicyRef: undefined,
+          pricingPolicyRef: undefined,
+          settlementPolicyRef: undefined,
+          termsAccepted: false,
+          usageUnitRef: undefined,
+        },
+      }),
+    );
+
+    expect(gates.state).toBe("blocked");
+    expect(gates.blockerRefs).toEqual(
+      expect.arrayContaining([
+        "blocker.external_repo_study_marketplace.metering_missing",
+        "blocker.external_repo_study_marketplace.pricing_missing",
+        "blocker.external_repo_study_marketplace.payout_policy_missing",
+        "blocker.external_repo_study_marketplace.settlement_policy_missing",
+        "blocker.external_repo_study_marketplace.terms_not_accepted",
+      ]),
+    );
+    expect(gates.marketplacePackageAllowed).toBe(false);
+    expect(gates.payoutEligible).toBe(false);
+  });
+
+  test("rejects unsafe decoded projections that claim payout eligibility", async () => {
+    const gates = await Effect.runPromise(
+      buildOpenAgentsExternalRepoStudyMarketplaceGates({
+        generatedAt,
+        request,
+      }),
+    );
+
+    await expect(
+      Effect.runPromise(
+        decodeOpenAgentsExternalRepoStudyMarketplaceGates({
+          ...gates,
+          payoutEligible: true,
+        }),
+      ),
+    ).rejects.toMatchObject({
+      path: "externalRepoStudyMarketplace",
+    });
+  });
+});


### PR DESCRIPTION
Closes #7028.

## Summary
- Adds a refs-only inert Probe marketplace economic gate for repo studying.
- Requires package policy, usage-metering unit, pricing, payout, settlement, terms, flag arming, and owner sign-off before a future marketplace package could be allowed.
- Keeps customer claims, package listing, payout eligibility, settlement, and effects disabled by construction.
- Updates the product-promise registry to narrow the broad economic blockers to receipt-first armed-marketplace blockers while leaving privacy/self-serve/copy gates yellow.

## Verification
- `bun test packages/probe/packages/runtime/tests/external-repo-studying-marketplace-gates.test.ts`
- `bun test apps/openagents.com/workers/api/src/product-promises.test.ts`
- `command.public.pylon_khala.verify.b5bea41b6c623f7c09f1bf24` (`true`)
