### PR TITLE
fix(khala): keep fleet lockout replenishment moving

### DIFF
--- a/clients/khala-cli/src/fleet-run.test.ts
+++ b/clients/khala-cli/src/fleet-run.test.ts
@@ -75,8 +75,39 @@ describe("fleet run planning", () => {
     expect(first[1]?.objective).toContain("apps/pylon")
 
     const second = plannedReplenishmentRounds(plan, new Set(first.map(round => round.dedupeKey ?? "")))
-    expect(second).toHaveLength(1)
+    expect(second).toHaveLength(2)
     expect(second[0]?.dedupeKey).toBe("test-lint-typecheck-sweep")
+    expect(second[1]?.dedupeKey).toBe("lockout-recovery-sweep-2")
+  })
+
+  test("keeps producing bounded replenishment work after fixed recovery tasks are exhausted", () => {
+    const plan = buildFleetRunPlan({
+      commit,
+      issues: [6820, 6707],
+      maxSlots: 2,
+      mode: "supervise",
+      perAccount: 1,
+      pylonRef: "pylon.local",
+      readyAccounts: ["codex", "codex-2"],
+      repo: "OpenAgentsInc/openagents",
+      verify: "bun test",
+    })
+    const dispatched = new Set([
+      "gepa-dspy-6707",
+      "bounded-codebase-audit",
+      "test-lint-typecheck-sweep",
+    ])
+
+    const generated = plannedReplenishmentRounds(plan, dispatched)
+
+    expect(generated).toHaveLength(2)
+    expect(generated.map(round => round.workKind)).toEqual(["replenishment", "replenishment"])
+    expect(generated.map(round => round.dedupeKey)).toEqual([
+      "lockout-recovery-sweep-3",
+      "lockout-recovery-sweep-4",
+    ])
+    expect(generated.map(round => round.issue)).toEqual([6707, 6820])
+    expect(generated[0]?.objective).toContain("Re-audit public issue #6707")
   })
 
   test("keeps lockout recovery in the short supervisor cadence", () => {

--- a/clients/khala-cli/src/fleet-run.ts
+++ b/clients/khala-cli/src/fleet-run.ts
@@ -233,14 +233,36 @@ export function plannedReplenishmentRounds(
   alreadyDispatchedKeys: ReadonlySet<string> = new Set(),
 ): ReadonlyArray<FleetRunSlot> {
   const available = REPLENISHMENT_OBJECTIVES.filter(task => !alreadyDispatchedKeys.has(task.dedupeKey))
-  return available.slice(0, plan.targetSlots).map((task, slot) => ({
+  const staticRounds = available.slice(0, plan.targetSlots).map((task, slot) => ({
     accountRef: plan.readyAccounts[slot % plan.readyAccounts.length] ?? "codex",
     dedupeKey: task.dedupeKey,
     issue: task.issue,
     objective: task.objective,
     slot,
-    workKind: "replenishment",
+    workKind: "replenishment" as const,
   }))
+  if (staticRounds.length >= plan.targetSlots) return staticRounds
+
+  const generatedStart = alreadyDispatchedKeys.size
+  const generatedCount = plan.targetSlots - staticRounds.length
+  const generatedRounds = Array.from({ length: generatedCount }, (_, index) => {
+    const slot = staticRounds.length + index
+    const issue = plan.issues[(generatedStart + index) % plan.issues.length] ?? null
+    const dedupeKey = `lockout-recovery-sweep-${generatedStart + index}`
+    return {
+      accountRef: plan.readyAccounts[slot % plan.readyAccounts.length] ?? "codex",
+      dedupeKey,
+      issue,
+      objective:
+        issue === null
+          ? "Run a bounded public-safe lockout recovery audit over the checkout. Fix one concrete issue if found, avoid duplicate open PRs, and run the named verification."
+          : `Re-audit public issue #${issue} after fleet lockout. Implement the smallest safe non-duplicate change that moves it toward closure and run the named verification.`,
+      slot,
+      workKind: "replenishment" as const,
+    }
+  })
+
+  return [...staticRounds, ...generatedRounds]
 }
 
 export function nextFleetSupervisorDelay(input: {


### PR DESCRIPTION
Closes #6820.

## Summary
- keeps `khala fleet run` replenishment planning full after the fixed recovery task list is exhausted
- generates bounded public-safe lockout recovery slots tied back to the issue list instead of returning an empty recovery plan
- adds regression coverage for exhausted recovery tasks

## Verification
- `bun test clients/khala-cli/src/fleet-run.test.ts`
- `bun run --cwd clients/khala-cli typecheck`
- `bun run test:khala-cli`
- `command.public.pylon_khala.verify.b5bea41b6c623f7c09f1bf24`: `bun run --cwd apps/openagents.com check:deploy`
