### PR TITLE
Gate MDK wallet readiness on send capacity

### DIFF
--- a/apps/openagents.com/workers/api/src/forum/tip-smoke.test.ts
+++ b/apps/openagents.com/workers/api/src/forum/tip-smoke.test.ts
@@ -94,6 +94,7 @@ describe('Forum tip smoke fixture', () => {
       baseInput({
         mode: 'signet',
         operatorApprovedPayment: true,
+        sendReadinessCapacity: 'sufficient',
         walletHomeMode: 'original_funded_wallet_home',
       }),
     )
@@ -117,6 +118,23 @@ describe('Forum tip smoke fixture', () => {
       'send',
       'paid_retry',
     ])
+  })
+
+  test('blocks signet wallet payment when agent-wallet send capacity is not sufficient', () => {
+    const projection = planForumTipSmoke(
+      baseInput({
+        mode: 'signet',
+        operatorApprovedPayment: true,
+        sendReadinessCapacity: 'insufficient',
+        walletHomeMode: 'original_funded_wallet_home',
+      }),
+    )
+
+    expect(projection.status).toBe('blocked_by_agent_wallet_send_capacity')
+    expect(projection.steps.some(step => step.maySpendBitcoin)).toBe(false)
+    expect(projection.agentWalletSmoke.status).toBe(
+      'blocked_by_insufficient_capacity',
+    )
   })
 
   test('blocks mnemonic-restore payer wallet before Forum wallet payment', () => {

--- a/apps/openagents.com/workers/api/src/forum/tip-smoke.ts
+++ b/apps/openagents.com/workers/api/src/forum/tip-smoke.ts
@@ -10,6 +10,7 @@ import {
 import { openAgentsRunnerGatewayPayloadHasPrivateMaterial } from '../runner-gateway'
 
 export const ForumTipSmokeStatus = S.Literals([
+  'blocked_by_agent_wallet_send_capacity',
   'blocked_by_payer_wallet',
   'blocked_by_recipient_readiness',
   'blocked_by_spend_cap',
@@ -53,6 +54,9 @@ export const ForumTipSmokeInput = S.Struct({
   recipientReadinessRef: S.String,
   redactedEvidenceRef: S.String,
   routeStateRef: S.String,
+  sendReadinessCapacity: S.optionalKey(
+    S.Literals(['insufficient', 'sufficient', 'unknown']),
+  ),
   spendCapBitcoinSatoshis: S.Number,
   tokenCacheRef: S.String,
   walletHomeMode: S.optionalKey(
@@ -173,6 +177,7 @@ const safeRef = (value: string, fallback: string): string =>
 const statusForInput = (
   input: ForumTipSmokeInput,
   agentWalletStatus:
+    | 'blocked_by_insufficient_capacity'
     | 'blocked_by_spend_cap'
     | 'blocked_by_wallet_restore_mode'
     | 'blocked_until_operator_authority'
@@ -193,6 +198,10 @@ const statusForInput = (
 
   if (agentWalletStatus === 'ready_for_signet') {
     return 'ready_for_signet'
+  }
+
+  if (agentWalletStatus === 'blocked_by_insufficient_capacity') {
+    return 'blocked_by_agent_wallet_send_capacity'
   }
 
   return input.mode === 'fake_sandbox'
@@ -406,6 +415,7 @@ export const planForumTipSmoke = (
     operatorApprovedPayment:
       input.operatorApprovedPayment && higherLevelPrerequisitesReady,
     routeStateRef: input.routeStateRef,
+    sendReadinessCapacity: input.sendReadinessCapacity ?? 'unknown',
     spendCapBitcoinSatoshis,
     tokenCacheRef: input.tokenCacheRef,
     walletHomeMode: input.walletHomeMode ?? 'unknown',

--- a/apps/openagents.com/workers/api/src/mdk-agent-wallet-smoke-fixture.test.ts
+++ b/apps/openagents.com/workers/api/src/mdk-agent-wallet-smoke-fixture.test.ts
@@ -18,6 +18,7 @@ const baseInput = (
   operatorApprovedPayment: false,
   routeStateRef: 'route_state.fake_sandbox.l402_available',
   spendCapBitcoinSatoshis: 10_000,
+  sendReadinessCapacity: 'unknown',
   tokenCacheRef: 'token_cache.local.redacted',
   walletHomeMode: 'unknown',
   walletHomeRef: 'wallet_home.local.mdk_wallet',
@@ -56,6 +57,7 @@ describe('OpenAgents MDK agent-wallet smoke fixture', () => {
       baseInput({
         mode: 'signet',
         operatorApprovedPayment: true,
+        sendReadinessCapacity: 'sufficient',
         walletHomeMode: 'original_funded_wallet_home',
       }),
     )
@@ -92,6 +94,7 @@ describe('OpenAgents MDK agent-wallet smoke fixture', () => {
         amountBitcoinSatoshis: 20_000,
         mode: 'signet',
         operatorApprovedPayment: true,
+        sendReadinessCapacity: 'sufficient',
         spendCapBitcoinSatoshis: 10_000,
         walletHomeMode: 'original_funded_wallet_home',
       }),
@@ -107,6 +110,28 @@ describe('OpenAgents MDK agent-wallet smoke fixture', () => {
     expect(overCap.steps.some(step => step.maySpendBitcoin)).toBe(false)
     expect(liveBlocked.status).toBe('blocked_until_operator_authority')
     expect(liveBlocked.steps.some(step => step.kind === 'send')).toBe(false)
+  })
+
+  test('blocks original funded homes until send capacity is public-safe sufficient', () => {
+    const projection = planOpenAgentsMdkAgentWalletSmoke(
+      baseInput({
+        mode: 'signet',
+        operatorApprovedPayment: true,
+        sendReadinessCapacity: 'insufficient',
+        walletHomeMode: 'original_funded_wallet_home',
+      }),
+    )
+
+    expect(projection.status).toBe('blocked_by_insufficient_capacity')
+    expect(projection.sendReadinessCapacity).toBe('insufficient')
+    expect(projection.payoutModeGate.blockerRefs).toContain(
+      'blocker.mdk_agent_wallet.send_readiness_missing',
+    )
+    expect(projection.steps.some(step => step.kind === 'send')).toBe(false)
+    expect(
+      projection.steps.find(step => step.kind === 'send_readiness_preflight')
+        ?.noteRefs,
+    ).toContain('note.agent_wallet.send_capacity_required_for_amount')
   })
 
   test('blocks mnemonic-restore mode before any send step', () => {

--- a/apps/openagents.com/workers/api/src/mdk-agent-wallet-smoke-fixture.ts
+++ b/apps/openagents.com/workers/api/src/mdk-agent-wallet-smoke-fixture.ts
@@ -16,6 +16,7 @@ export type OpenAgentsMdkAgentWalletSmokeMode =
   typeof OpenAgentsMdkAgentWalletSmokeMode.Type
 
 export const OpenAgentsMdkAgentWalletSmokeStatus = S.Literals([
+  'blocked_by_insufficient_capacity',
   'blocked_by_spend_cap',
   'blocked_by_wallet_restore_mode',
   'blocked_until_operator_authority',
@@ -45,6 +46,9 @@ export const OpenAgentsMdkAgentWalletSmokeInput = S.Struct({
   operatorApprovedPayment: S.Boolean,
   routeStateRef: S.String,
   spendCapBitcoinSatoshis: S.Number,
+  sendReadinessCapacity: S.optionalKey(
+    S.Literals(['insufficient', 'sufficient', 'unknown']),
+  ),
   tokenCacheRef: S.String,
   walletHomeMode: S.optionalKey(
     S.Literals(['mnemonic_restore', 'original_funded_wallet_home', 'unknown']),
@@ -72,6 +76,11 @@ export const OpenAgentsMdkAgentWalletSmokeProjection = S.Struct({
   reasonRefs: S.Array(S.String),
   routeStateRef: S.String,
   spendCapBitcoinSatoshis: S.Number,
+  sendReadinessCapacity: S.Literals([
+    'insufficient',
+    'sufficient',
+    'unknown',
+  ]),
   status: OpenAgentsMdkAgentWalletSmokeStatus,
   steps: S.Array(OpenAgentsMdkAgentWalletSmokeStep),
   tokenCacheRef: S.String,
@@ -98,6 +107,7 @@ const publicLiteralValues = new Set([
   '<payment_preimage_from_wallet_output>',
   'Authorization: L402 <l402_token_from_402_response>:<payment_preimage_from_wallet_output>',
   'balance',
+  'blocked_by_insufficient_capacity',
   'blocked_by_spend_cap',
   'blocked_by_wallet_restore_mode',
   'blocked_until_operator_authority',
@@ -139,6 +149,8 @@ const publicLiteralValues = new Set([
   'note.agent_wallet.operator_approved_signet_only',
   'note.agent_wallet.original_funded_home_required_for_send',
   'note.agent_wallet.receive_for_funding_test_only',
+  'note.agent_wallet.send_capacity_required_for_amount',
+  'note.agent_wallet.send_capacity_sufficient_public_signal',
   'note.agent_wallet.send_readiness_preflight_shared',
   'paid_retry',
   'receive',
@@ -226,7 +238,9 @@ const statusForInput = (
     ? 'blocked_by_spend_cap'
     : input.operatorApprovedPayment && input.mode === 'signet'
       ? (input.walletHomeMode ?? 'unknown') === 'original_funded_wallet_home'
-        ? 'ready_for_signet'
+        ? (input.sendReadinessCapacity ?? 'unknown') === 'sufficient'
+          ? 'ready_for_signet'
+          : 'blocked_by_insufficient_capacity'
         : 'blocked_by_wallet_restore_mode'
       : input.mode === 'fake_sandbox'
         ? 'documentation_only'
@@ -261,6 +275,10 @@ const baseSteps = (
       `wallet_home.mdk_agent_wallet.${input.walletHomeMode ?? 'unknown'}`,
       'note.agent_wallet.original_funded_home_required_for_send',
       'note.agent_wallet.send_readiness_preflight_shared',
+      'note.agent_wallet.send_capacity_required_for_amount',
+      ...((input.sendReadinessCapacity ?? 'unknown') === 'sufficient'
+        ? ['note.agent_wallet.send_capacity_sufficient_public_signal']
+        : []),
       ...((input.walletHomeMode ?? 'unknown') === 'mnemonic_restore'
         ? ['note.agent_wallet.mnemonic_restore_not_send_ready']
         : []),
@@ -356,6 +374,7 @@ export const planOpenAgentsMdkAgentWalletSmoke = (
     payoutModeGate,
     reasonRefs: safeRefs([`reason.agent_wallet_smoke.${status}`]),
     routeStateRef: safeRef(input.routeStateRef) ?? 'route_state.redacted',
+    sendReadinessCapacity: input.sendReadinessCapacity ?? 'unknown',
     spendCapBitcoinSatoshis: Math.max(
       0,
       Math.trunc(input.spendCapBitcoinSatoshis),

--- a/apps/openagents.com/workers/api/src/product-promises.test.ts
+++ b/apps/openagents.com/workers/api/src/product-promises.test.ts
@@ -1080,6 +1080,10 @@ describe('public product promises document', () => {
           ]),
           promiseId: 'payments.money_dev_kit.v1',
           state: 'yellow',
+          unsafeCopy: expect.stringContaining('positive balance'),
+          verification: expect.stringContaining(
+            'sufficient capacity for the attempted amount',
+          ),
         }),
         expect.objectContaining({
           blockerRefs: [],

--- a/apps/openagents.com/workers/api/src/product-promises.ts
+++ b/apps/openagents.com/workers/api/src/product-promises.ts
@@ -1257,7 +1257,7 @@ export const publicProductPromisesDocument = () => {
         safeCopy:
           'OpenAgents uses MDK hosted checkout and agent-wallet flows for scoped small-sats/L402 paths, and Forum tips can project confirmed live direct BOLT 12 MDK/provider payments as ordinary content tips. Broader payout, withdrawal, and accepted-work settlement claims remain scoped by their own route authority and wallet readiness.',
         unsafeCopy:
-          'Do not claim MDK mnemonic restore or hosted MDK payout proves full send readiness or provider settlement.',
+          'Do not claim MDK mnemonic restore, positive balance, or hosted MDK payout proves sufficient agent-wallet send readiness or provider settlement.',
         evidenceRefs: [
           'apps/openagents.com/docs/mdk',
           'apps/pylon/docs/mdk-wallet-readiness-ledger.md',
@@ -1274,7 +1274,7 @@ export const publicProductPromisesDocument = () => {
           'blocker.product_promises.mdk_agent_wallet_send_readiness_insufficient_capacity',
         ],
         verification:
-          'Run smoke:forum:mdk-readiness with a ready-recipient post, user-specified sats amount, explicit live-spend approval, public receipt lookup, and `tip-post-smoke --strict-smooth` from a funded production payer wallet. Separate wallet configured, receive-ready, positive balance, send-ready, direct payment sent, webhook-confirmed payment, timeout recovery, refund/reversal, accepted work, payout, and accepted-work settlement states.',
+          'Run smoke:forum:mdk-readiness with a ready-recipient post, user-specified sats amount, explicit live-spend approval, public receipt lookup, and `tip-post-smoke --strict-smooth` from an original funded production payer wallet whose public-safe send-readiness preflight shows sufficient capacity for the attempted amount. Separate wallet configured, receive-ready, positive balance, sufficient send capacity, direct payment sent, webhook-confirmed payment, timeout recovery, refund/reversal, accepted work, payout, and accepted-work settlement states.',
         authorityBoundary:
           'Payment proof does not bypass route auth, owner scope, moderation, deployment, payout, or settlement gates.',
       },


### PR DESCRIPTION
## Summary

- Require an explicit public-safe sufficient send-capacity signal before the MDK agent-wallet smoke can become `ready_for_signet`.
- Propagate the new blocked capacity state through the Forum tip smoke wrapper.
- Tighten `payments.money_dev_kit.v1` promise copy/tests so positive balance or mnemonic restore cannot be treated as send readiness.

Closes #7029

## Verification

- `bun run --cwd apps/openagents.com/workers/api test -- src/mdk-agent-wallet-smoke-fixture.test.ts src/forum/tip-smoke.test.ts src/product-promises.test.ts`
- `bun run --cwd apps/openagents.com/workers/api typecheck` (passes; emits existing Effect advisory messages)
- Required verifier `command.public.pylon_khala.verify.b5bea41b6c623f7c09f1bf24`: `true`
