### PR TITLE
Align free-tier capture disclosure gate

### DIFF
--- a/apps/openagents.com/apps/web/public/AGENTS.md
+++ b/apps/openagents.com/apps/web/public/AGENTS.md
@@ -69,12 +69,13 @@ your key. Streaming via `"stream": true` (SSE). Over the free quota → `402`; a
 or wait for the UTC reset. Full quickstart (curl + Python + JS, limits, errors):
 `docs/faq/khala-inference-quickstart.md`.
 
-**Free-tier data sharing (read this).** When you use the free Khala API without
-paying for privacy, your traffic is **captured by default** as a **redacted,
-private-by-default (`owner_only`)** trace and **may be used to improve and train**
-OpenAgents models. **Pay for privacy** (or run confidential compute) to opt out of
-capture entirely. A captured trace is shared **publicly only if its owner opts it
-in**. Capture grants **no payout or settlement** (the data-market reward marker is
+**Free-tier data sharing (read this).** The free Khala API is designed to be
+**captured by default when owner-armed**; until then, the owner-gated blocker
+remains explicit. Captured traffic is a **redacted, private-by-default
+(`owner_only`)** trace and **may be used to improve and train** OpenAgents
+models. **Pay for privacy** (or run confidential compute) to opt out of capture
+entirely. A captured trace is shared **publicly only if its owner opts it in**.
+Capture grants **no payout or settlement** (the data-market reward marker is
 inert and owner-gated). The full canonical terms are agent-readable at
 `GET https://openagents.com/api/public/free-tier-data-sharing` (also embedded in
 the `POST /api/keys/free` mint response as `dataSharing`), and tracked as the

--- a/apps/openagents.com/workers/api/src/free-key-mint-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/free-key-mint-routes.test.ts
@@ -155,7 +155,11 @@ describe('POST /api/keys/free (issue #6228)', () => {
       dataSharing: {
         promiseId: string
         terms: ReadonlyArray<string>
-        policy: { capturedByDefault: boolean; paidPrivacyOptOut: boolean }
+        policy: {
+          capturedByDefault: boolean
+          captureDefaultOwnerGated: boolean
+          paidPrivacyOptOut: boolean
+        }
       }
     }
     expect(body.tier).toBe('free')
@@ -169,6 +173,7 @@ describe('POST /api/keys/free (issue #6228)', () => {
     )
     expect(body.dataSharing.terms.length).toBeGreaterThan(0)
     expect(body.dataSharing.policy.capturedByDefault).toBe(true)
+    expect(body.dataSharing.policy.captureDefaultOwnerGated).toBe(true)
     expect(body.dataSharing.policy.paidPrivacyOptOut).toBe(true)
     // The minted account is now marked free-tier in D1.
     const row = await db

--- a/apps/openagents.com/workers/api/src/inference/free-tier-data-sharing-disclosure.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/free-tier-data-sharing-disclosure.test.ts
@@ -17,12 +17,18 @@ describe('free-tier data-sharing disclosure (#6296)', () => {
     // The bounded policy facts mirror the runtime capture seams.
     expect(disclosure.policy).toEqual({
       capturedByDefault: true,
+      captureDefaultOwnerGated: true,
+      captureDefaultGate: 'KHALA_FREE_TIER_TRACE_CAPTURE_DEFAULT',
       redacted: true,
       defaultVisibility: 'owner_only',
       mayTrain: true,
       paidPrivacyOptOut: true,
       publicSharingOptIn: true,
       rewardInert: true,
+      blockerRefs: [
+        'blocker.product_promises.free_tier_capture_default_owner_gated',
+        'blocker.product_promises.disclosure_copy_owner_signoff_pending',
+      ],
     })
     expect(disclosure.reportPath).toContain('forum/f/product-promises')
   })
@@ -33,6 +39,7 @@ describe('free-tier data-sharing disclosure (#6296)', () => {
       .toLowerCase()
     // captured by default, redacted, private
     expect(text).toContain('captured by default')
+    expect(text).toContain('owner-gated blocker')
     expect(text).toContain('redacted')
     expect(text).toContain('owner_only')
     // may improve/train

--- a/apps/openagents.com/workers/api/src/inference/free-tier-data-sharing-disclosure.ts
+++ b/apps/openagents.com/workers/api/src/inference/free-tier-data-sharing-disclosure.ts
@@ -36,20 +36,20 @@ export const FREE_TIER_DATA_SHARING_PROMISE_ID =
 
 // Disclosure version. Bump when the TERMS text changes (not on unrelated copy
 // edits). Surfaces echo this so a caller/agent can pin which terms they saw.
-export const FREE_TIER_DATA_SHARING_DISCLOSURE_VERSION = '2026-06-25.1' as const
+export const FREE_TIER_DATA_SHARING_DISCLOSURE_VERSION = '2026-06-29.1' as const
 
 // Public, human-readable summary line. Intentionally short and quotable; the
 // full clause list carries the precise terms.
 export const FREE_TIER_DATA_SHARING_SUMMARY: string =
-  'Free API usage is captured by default as redacted, private-by-default traces ' +
-  'that may be used to improve and train OpenAgents models. Pay for privacy ' +
-  '(or use confidential compute) to opt out of capture. Public sharing of a ' +
-  'captured trace is opt-in only.'
+  'Free API usage is designed to be captured by default, when owner-armed, as ' +
+  'redacted, private-by-default traces that may be used to improve and train ' +
+  'OpenAgents models. Pay for privacy (or use confidential compute) to opt out ' +
+  'of capture. Public sharing of a captured trace is opt-in only.'
 
 // The precise, code-accurate terms, one bounded clause each. Public-safe: no
 // secrets, no account material, no prompts.
 export const FREE_TIER_DATA_SHARING_TERMS: ReadonlyArray<string> = [
-  'Free tier: when you use the free Khala API (openagents/khala) without paying for privacy, your request/response traffic is captured by default.',
+  'Free tier: when the deployment owner arms default capture for the free Khala API (openagents/khala), free usage without paid privacy is captured by default; until then, the owner-gated blocker remains explicit.',
   'Redacted: captured traffic is scrubbed for secrets, credentials, wallet/payment material, and personal data before storage, with a public-safety backstop that drops anything residual.',
   'Private by default: an auto-captured trace is stored owner_only — it is not in any public feed and is not reachable by link until you explicitly choose to share it.',
   'May be used to improve/train: captured free-tier data may be used to improve and train the next generation of OpenAgents models.',
@@ -64,6 +64,10 @@ export type FreeTierDataSharingPolicy = Readonly<{
   // Free-tier traffic is captured by default (subject to the deployment's
   // capture flag being armed; the POLICY default is capture-on for free tier).
   capturedByDefault: true
+  // Default capture is still owner-gated until the deployment flag is armed.
+  captureDefaultOwnerGated: true
+  // Public-safe name of the deployment flag that arms default capture.
+  captureDefaultGate: 'KHALA_FREE_TIER_TRACE_CAPTURE_DEFAULT'
   // Captured traffic is redacted before storage.
   redacted: true
   // Default stored visibility of an auto-captured trace.
@@ -76,16 +80,24 @@ export type FreeTierDataSharingPolicy = Readonly<{
   publicSharingOptIn: true
   // Capture grants no payout/settlement (reward marker inert, owner-gated).
   rewardInert: true
+  // Public-safe blocker refs that explain why this disclosure is yellow.
+  blockerRefs: ReadonlyArray<string>
 }>
 
 export const FREE_TIER_DATA_SHARING_POLICY: FreeTierDataSharingPolicy = {
   capturedByDefault: true,
+  captureDefaultOwnerGated: true,
+  captureDefaultGate: 'KHALA_FREE_TIER_TRACE_CAPTURE_DEFAULT',
   redacted: true,
   defaultVisibility: 'owner_only',
   mayTrain: true,
   paidPrivacyOptOut: true,
   publicSharingOptIn: true,
   rewardInert: true,
+  blockerRefs: [
+    'blocker.product_promises.free_tier_capture_default_owner_gated',
+    'blocker.product_promises.disclosure_copy_owner_signoff_pending',
+  ],
 }
 
 // The canonical disclosure object surfaced to humans and agents. Stable shape:

--- a/apps/openagents.com/workers/api/src/openagents-openapi.ts
+++ b/apps/openagents.com/workers/api/src/openagents-openapi.ts
@@ -4153,7 +4153,7 @@ const requestSchemas = (): JsonSchema => ({
     additionalProperties: false,
     required: ['tier', 'model', 'credential', 'quota', 'usage', 'dataSharing'],
     description:
-      'Khala FREE API mode mint result. The raw bearer token is returned ONCE here and is not redisplayed. No wallet, payment, or owner-private material is included. The dataSharing field carries the honest free-tier data-sharing terms (#6296): free usage is captured by default as redacted, private traces that may improve/train models; pay for privacy to opt out; public sharing is opt-in only.',
+      'Khala FREE API mode mint result. The raw bearer token is returned ONCE here and is not redisplayed. No wallet, payment, or owner-private material is included. The dataSharing field carries the honest free-tier data-sharing terms (#6296): free usage is designed to be captured by default when owner-armed as redacted, private traces that may improve/train models; pay for privacy to opt out; public sharing is opt-in only.',
     properties: {
       tier: { type: 'string', enum: ['free'] },
       model: { type: 'string', enum: ['openagents/khala'] },
@@ -5606,7 +5606,7 @@ const paths = (): JsonSchema => ({
       operationId: 'getFreeTierDataSharingDisclosure',
       summary: 'Read free-API data-sharing terms',
       description:
-        'Returns the canonical, code-accurate data-sharing terms for the free Khala API so agents and users can discover them over the API surface, not only in human UI. The honest terms: free API usage is captured by default as REDACTED, PRIVATE (owner_only) traces that may be used to improve and train OpenAgents models; paying for privacy (or running confidential compute) opts you OUT of capture (fail-closed to not-captured); public sharing of a captured trace is owner opt-in only; and being captured grants NO payout or settlement (the data-market reward marker is inert and owner-gated). The same disclosure object is embedded in the POST /api/keys/free mint response. Read-only, no auth, no secrets.',
+        'Returns the canonical, code-accurate data-sharing terms for the free Khala API so agents and users can discover them over the API surface, not only in human UI. The honest terms: free API usage is designed to be captured by default when owner-armed as REDACTED, PRIVATE (owner_only) traces that may be used to improve and train OpenAgents models; until then the owner-gated blocker remains explicit; paying for privacy (or running confidential compute) opts you OUT of capture (fail-closed to not-captured); public sharing of a captured trace is owner opt-in only; and being captured grants NO payout or settlement (the data-market reward marker is inert and owner-gated). The same disclosure object is embedded in the POST /api/keys/free mint response. Read-only, no auth, no secrets.',
       tags: ['Public Proof', 'Agents'],
       security: publicRead,
       responses: {

--- a/apps/openagents.com/workers/api/src/product-promises.ts
+++ b/apps/openagents.com/workers/api/src/product-promises.ts
@@ -1026,9 +1026,9 @@ export const publicProductPromisesDocument = () => {
         audience: ['user', 'agent', 'contributor', 'public'],
         state: 'yellow',
         claim:
-          'Free Khala API usage is captured by default as redacted, private traces that may be used to improve and train models; pay for privacy to opt out; public sharing is opt-in only.',
+          'Free Khala API usage is designed to be captured by default when owner-armed as redacted, private traces that may be used to improve and train models; pay for privacy to opt out; public sharing is opt-in only.',
         safeCopy:
-          'Free tier: when you use the free Khala API without paying for privacy, your traffic is captured by default as a redacted, private-by-default (owner_only) trace and may be used to improve and train OpenAgents models. Pay for privacy, or run confidential compute, to opt out of capture (fail-closed to not-captured). A captured trace is shared publicly only if its owner explicitly opts it into public visibility. Capture grants no payout or settlement — the data-market reward marker is inert and owner-gated. The canonical terms are served at GET /api/public/free-tier-data-sharing and embedded in the POST /api/keys/free mint response.',
+          'Free tier: the free Khala API disclosure describes default capture when the deployment owner arms KHALA_FREE_TIER_TRACE_CAPTURE_DEFAULT; until then, blocker.product_promises.free_tier_capture_default_owner_gated remains explicit. When armed, free usage without paid privacy is captured as a redacted, private-by-default (owner_only) trace and may be used to improve and train OpenAgents models. Pay for privacy, or run confidential compute, to opt out of capture (fail-closed to not-captured). A captured trace is shared publicly only if its owner explicitly opts it into public visibility. Capture grants no payout or settlement — the data-market reward marker is inert and owner-gated. The canonical terms are served at GET /api/public/free-tier-data-sharing and embedded in the POST /api/keys/free mint response.',
         unsafeCopy:
           'Do not claim free traffic is never captured, do not claim captured traces are public by default, do not claim paid-privacy callers are captured, and do not claim capture earns the user a payout, reward, or settlement.',
         evidenceRefs: [


### PR DESCRIPTION
## Summary

- Make the canonical free-tier data-sharing disclosure explicitly say default capture is owner-armed and still blocked until `KHALA_FREE_TIER_TRACE_CAPTURE_DEFAULT` is armed.
- Add public-safe policy facts for the owner gate and blocker refs, and assert them in the disclosure and free-key mint tests.
- Align public AGENTS.md, OpenAPI descriptions, and product-promise copy with the same capture/opt-out/payout boundary.

Closes #7019.

## Verification

- `bun run --cwd apps/openagents.com/workers/api test -- src/free-key-mint-routes.test.ts src/inference/free-tier-data-sharing-disclosure.test.ts src/inference/inference-privacy-entitlement.test.ts src/product-promises.test.ts`
  - 4 files passed, 26 tests passed
