### PR TITLE
Align partner payout public blockers

### DIFF
--- a/apps/openagents.com/workers/api/src/partner-payout-public-projection.test.ts
+++ b/apps/openagents.com/workers/api/src/partner-payout-public-projection.test.ts
@@ -41,9 +41,13 @@ describe('aggregatePartnerPayoutPublicProjection', () => {
       )?.percentBps,
     ).toBe(PARTNER_PAYOUT_ROLE_POLICY.referral.percentBps)
     expect(projection.blockerRefs).toEqual([
-      'blocker.product_promises.partner_payout_settlement_not_wired',
       'blocker.product_promises.partner_first_real_payout_pending',
     ])
+    expect(
+      projection.blockerRefs.includes(
+        'blocker.product_promises.partner_payout_settlement_not_wired',
+      ),
+    ).toBe(false)
     expect(
       projection.blockerRefs.includes(
         'blocker.product_promises.partner_projection_api_missing',

--- a/apps/openagents.com/workers/api/src/partner-payout-public-projection.ts
+++ b/apps/openagents.com/workers/api/src/partner-payout-public-projection.ts
@@ -36,7 +36,6 @@ const PARTNER_PAYOUT_PUBLIC_CAVEAT_REFS = [
 ] as const
 
 const PARTNER_PAYOUT_PUBLIC_BLOCKER_REFS = [
-  'blocker.product_promises.partner_payout_settlement_not_wired',
   'blocker.product_promises.partner_first_real_payout_pending',
 ] as const
 


### PR DESCRIPTION
## Summary

- Drop the stale `partner_payout_settlement_not_wired` blocker from the public partner-payout projection.
- Keep `partner_first_real_payout_pending` as the only public blocker, matching the current product-promise registry and issue audit state.
- Add focused regression coverage that the stale settlement-wiring blocker does not reappear.

## Safety

This does not arm live partner payouts, record a settled partner payout, broaden partner earning/withdrawal copy, or flip the promise green. Production payout dispatch remains owner-gated and fail-closed; the public projection now accurately reports the remaining blocker.

Closes #7021

## Verification

- `bun run --cwd apps/openagents.com/workers/api test -- src/partner-payout-public-projection.test.ts`
- `true` (`command.public.pylon_khala.verify.b5bea41b6c623f7c09f1bf24`)
