### PR TITLE
Guard world-first promise blockers

### DIFF
--- a/apps/openagents.com/workers/api/src/product-promises.ts
+++ b/apps/openagents.com/workers/api/src/product-promises.ts
@@ -697,6 +697,7 @@ export const publicProductPromisesDocument = () => {
           'docs/transcripts/238.md',
           'docs/launch/2026-06-18-pylon-v1-launch-readiness-audit.md',
           'docs/launch/2026-06-18-world-firsts-verification.md',
+          'docs/promises/2026-06-29-world-first-claims-blocker-audit.md',
           'promise:training.decentralized_training_launch.v1',
           'promise:promises.registry.v1',
           'promise:proof.claim_upgrade_receipts.v1',
@@ -706,7 +707,7 @@ export const publicProductPromisesDocument = () => {
           'blocker.product_promises.world_first_owner_signed_upgrade_missing',
         ],
         verification:
-          'An independent prior-art/competing-claim search now exists (docs/launch/2026-06-18-world-firsts-verification.md; prior art checked includes Spirit of Satoshi, Bittensor/Templar, Gensyn, Prime Intellect, Nous/Psyche, Salad, Percepta, Tracr) with a defensible narrowed wording. Green still requires (1) a dereferenceable evidence pack tying the qualified world-first to the live run receipts and (2) an owner-signed receipt-first upgrade per proof.claim_upgrade_receipts.v1. Until then this stays red and any public use must carry the full qualifiers.',
+          'An independent prior-art/competing-claim search now exists (docs/launch/2026-06-18-world-firsts-verification.md; prior art checked includes Spirit of Satoshi, Bittensor/Templar, Gensyn, Prime Intellect, Nous/Psyche, Salad, Percepta, Tracr) with a defensible narrowed wording. The dated #7027 blocker audit (docs/promises/2026-06-29-world-first-claims-blocker-audit.md) keeps this red because green still requires (1) a dereferenceable evidence pack tying the qualified world-first to the live run receipts and (2) an owner-signed receipt-first upgrade per proof.claim_upgrade_receipts.v1. Until then this stays red and any public use must carry the full qualifiers.',
         authorityBoundary:
           'A launch transcript does not establish a world-first. The bounded real settlements prove payment to two contributors, not a first-in-the-world claim, and grant no network-scale or comparison authority.',
       },
@@ -728,6 +729,7 @@ export const publicProductPromisesDocument = () => {
           'docs/launch/2026-06-18-world-firsts-verification.md',
           'docs/launch/2026-06-20-llm-computer-training-run-definition.md',
           'docs/launch/2026-06-20-world-first-llm-computer-evidence-pack.md',
+          'docs/promises/2026-06-29-world-first-claims-blocker-audit.md',
           'apps/openagents.com/workers/api/src/world-first-llm-computer-evidence-pack.test.ts',
           'promise:compute.tassadar_executor_poc.v1',
           'promise:models.tassadar_percepta_executor.v1',
@@ -738,7 +740,7 @@ export const publicProductPromisesDocument = () => {
           'blocker.product_promises.world_first_owner_signed_upgrade_missing',
         ],
         verification:
-          'An independent prior-art/competing-claim search now exists (docs/launch/2026-06-18-world-firsts-verification.md) with a defensible narrowed wording crediting Percepta as the paradigm originator. A precise definition of "LLM-computer training run" now exists (docs/launch/2026-06-20-llm-computer-training-run-definition.md): it pins the phrase to the executor-construction / exact-trace sense (sense B), distinguishes it from gradient-descent model training (sense A), credits Percepta, and enumerates the refuse-list so the phrase cannot overclaim against the no-gradient-descent executor PoC. A focused, dereferenceable evidence pack now exists (docs/launch/2026-06-20-world-first-llm-computer-evidence-pack.md): it ties the qualified Claim-2 world-first to the live-run receipts qualifier-by-qualifier (public/open-contributor paid loop -> run summary + two contributor settlement receipts; Percepta paradigm credit -> Percepta blog/transformer-vm + prior-art search; executor/exact-trace/replay-verified -> verified+rejected replay pairs and a Verified challenge), with a skeptic-runnable verification recipe and a refuse-list. A regression guard (apps/openagents.com/workers/api/src/world-first-llm-computer-evidence-pack.test.ts) now machine-enforces that the pack and definition stay dereferenceable: every repo-relative doc they cite resolves on disk, every promise: evidence ref resolves to a real registry promiseId, the cleared definition/evidence-pack blockers stay cleared without flipping state, and the refuse-list plus Percepta credit stay in the copy. Green still requires an owner-signed receipt-first upgrade per proof.claim_upgrade_receipts.v1, and the underlying public paid loop remains bounded (two contributors, not at scale).',
+          'An independent prior-art/competing-claim search now exists (docs/launch/2026-06-18-world-firsts-verification.md) with a defensible narrowed wording crediting Percepta as the paradigm originator. A precise definition of "LLM-computer training run" now exists (docs/launch/2026-06-20-llm-computer-training-run-definition.md): it pins the phrase to the executor-construction / exact-trace sense (sense B), distinguishes it from gradient-descent model training (sense A), credits Percepta, and enumerates the refuse-list so the phrase cannot overclaim against the no-gradient-descent executor PoC. A focused, dereferenceable evidence pack now exists (docs/launch/2026-06-20-world-first-llm-computer-evidence-pack.md): it ties the qualified Claim-2 world-first to the live-run receipts qualifier-by-qualifier (public/open-contributor paid loop -> run summary + two contributor settlement receipts; Percepta paradigm credit -> Percepta blog/transformer-vm + prior-art search; executor/exact-trace/replay-verified -> verified+rejected replay pairs and a Verified challenge), with a skeptic-runnable verification recipe and a refuse-list. The dated #7027 blocker audit (docs/promises/2026-06-29-world-first-claims-blocker-audit.md) keeps this red until an owner-signed receipt-first transition exists. A regression guard (apps/openagents.com/workers/api/src/world-first-llm-computer-evidence-pack.test.ts) now machine-enforces that the pack and definition stay dereferenceable: every repo-relative doc they cite resolves on disk, every promise: evidence ref resolves to a real registry promiseId, the cleared definition/evidence-pack blockers stay cleared without flipping state, and the refuse-list plus Percepta credit stay in the copy. Green still requires an owner-signed receipt-first upgrade per proof.claim_upgrade_receipts.v1, and the underlying public paid loop remains bounded (two contributors, not at scale).',
         authorityBoundary:
           'A bounded exact-trace executor proof of concept grants no general LLM-computer capability claim and no world-first claim. The Tassadar research publication gates stay closed for everything beyond the scoped compute.tassadar_executor_poc.v1 promise.',
       },
@@ -3870,6 +3872,7 @@ export const publicProductPromisesDocument = () => {
         evidenceRefs: [
           'docs/transcripts/239.md',
           'docs/promises/2026-06-19-episode-239-lets-make-money-registry-reconciliation.md',
+          'docs/promises/2026-06-29-world-first-claims-blocker-audit.md',
           'promise:referral.refer_once_earn_forever.v1',
           'promise:claims.world_first_ai_training_paid_bitcoin.v1',
         ],
@@ -3879,7 +3882,7 @@ export const publicProductPromisesDocument = () => {
           'blocker.product_promises.world_first_owner_signed_upgrade_missing',
         ],
         verification:
-          'This record is intentionally never green from aspiration. Any future non-aspirational claim would require a real, sized, independently-countable agentic sales force, an independent prior-art / record review, a dereferenceable evidence pack, and an owner-signed receipt-first upgrade per proof.claim_upgrade_receipts.v1. Until then it stays a labeled pursuit.',
+          'This record is intentionally never green from aspiration. The dated #7027 blocker audit (docs/promises/2026-06-29-world-first-claims-blocker-audit.md) keeps it planned because no sized, independently-countable agentic sales force exists and no owner-signed receipt-first transition exists. Any future non-aspirational claim would require a real, sized, independently-countable agentic sales force, an independent prior-art / record review, a dereferenceable evidence pack, and an owner-signed receipt-first upgrade per proof.claim_upgrade_receipts.v1. Until then it stays a labeled pursuit.',
         authorityBoundary:
           'A pursued world first grants no record-holder status, no marketing-claim authority, and no sales, payout, or settlement authority. Aspiration is not achievement.',
       },
@@ -3898,6 +3901,7 @@ export const publicProductPromisesDocument = () => {
         evidenceRefs: [
           'docs/transcripts/239.md',
           'docs/promises/2026-06-19-episode-239-lets-make-money-registry-reconciliation.md',
+          'docs/promises/2026-06-29-world-first-claims-blocker-audit.md',
           'promise:claims.pursued_world_first_largest_agentic_sales_force.v1',
           'promise:claims.world_first_public_llm_computer_training_run.v1',
         ],
@@ -3907,7 +3911,7 @@ export const publicProductPromisesDocument = () => {
           'blocker.product_promises.world_first_owner_signed_upgrade_missing',
         ],
         verification:
-          'This record is intentionally never green from aspiration. Any future non-aspirational claim would require independently verified counts crossing the stated bar, an independent prior-art / record review (with the comparison figure independently sourced, not ChatGPT-attributed), a dereferenceable evidence pack, and an owner-signed receipt-first upgrade per proof.claim_upgrade_receipts.v1.',
+          'This record is intentionally never green from aspiration. The dated #7027 blocker audit (docs/promises/2026-06-29-world-first-claims-blocker-audit.md) keeps it planned because the roughly seven-million selling-or-sell-equipped-agent bar is unmet, the comparison figure is not OpenAgents-verified evidence, and no owner-signed receipt-first transition exists. Any future non-aspirational claim would require independently verified counts crossing the stated bar, an independent prior-art / record review (with the comparison figure independently sourced, not ChatGPT-attributed), a dereferenceable evidence pack, and an owner-signed receipt-first upgrade per proof.claim_upgrade_receipts.v1.',
         authorityBoundary:
           'A pursued world first grants no record-holder status, no marketing-claim authority, and no sales, payout, or settlement authority. Aspiration is not achievement.',
       },

--- a/apps/openagents.com/workers/api/src/world-first-claims-copy-gate.test.ts
+++ b/apps/openagents.com/workers/api/src/world-first-claims-copy-gate.test.ts
@@ -1,0 +1,142 @@
+import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs'
+
+import { describe, expect, test } from 'vitest'
+
+import { publicProductPromisesDocument } from './product-promises'
+
+const AUDIT_DOC =
+  'docs/promises/2026-06-29-world-first-claims-blocker-audit.md'
+
+const WORLD_FIRST_PROMISE_IDS = [
+  'claims.world_first_ai_training_paid_bitcoin.v1',
+  'claims.world_first_public_llm_computer_training_run.v1',
+  'claims.pursued_world_first_largest_agentic_sales_force.v1',
+  'claims.pursued_world_first_largest_sales_force.v1',
+] as const
+
+const repoFile = (relPath: string): URL =>
+  new URL(`../../../../../${relPath}`, import.meta.url)
+
+const readRepoFile = (relPath: string): string =>
+  readFileSync(repoFile(relPath), 'utf8')
+
+const productCopyRoots = [
+  'apps/openagents.com/apps/web/src',
+  'apps/openagents.com/workers/api/src',
+] as const
+
+const skippedRuntimeCopyFiles = new Set([
+  'apps/openagents.com/workers/api/src/product-promises.ts',
+  'apps/openagents.com/workers/api/src/world-first-claims-copy-gate.test.ts',
+  'apps/openagents.com/workers/api/src/world-first-llm-computer-evidence-pack.test.ts',
+])
+
+const runtimeSourceFiles = (relDir: string): ReadonlyArray<string> => {
+  const entries = readdirSync(repoFile(relDir), { withFileTypes: true })
+  return entries.flatMap(entry => {
+    const relPath = `${relDir}/${entry.name}`
+    if (entry.name === 'node_modules' || entry.name === 'dist') {
+      return []
+    }
+    if (entry.isDirectory()) {
+      return runtimeSourceFiles(relPath)
+    }
+    if (!entry.isFile() || !/\.(ts|tsx|js|jsx|html)$/.test(entry.name)) {
+      return []
+    }
+    if (entry.name.endsWith('.test.ts') || skippedRuntimeCopyFiles.has(relPath)) {
+      return []
+    }
+    return [relPath]
+  })
+}
+
+describe('world-first public-claim copy gate', () => {
+  test('the dated #7027 audit exists and carries the refuse list', () => {
+    expect(existsSync(repoFile(AUDIT_DOC))).toBe(true)
+
+    const audit = readRepoFile(AUDIT_DOC)
+    expect(audit).toContain('Date: 2026-06-29')
+    expect(audit).toContain('## Refuse List')
+    expect(audit).toContain('Bare "world first" without the full qualifiers')
+    expect(audit).toContain('OpenAgents has the largest agentic sales force')
+    expect(audit).toContain('OpenAgents has the largest sales force')
+  })
+
+  test('each world-first promise cites the audit and stays blocked', () => {
+    const document = publicProductPromisesDocument()
+
+    for (const promiseId of WORLD_FIRST_PROMISE_IDS) {
+      const promise = document.promises.find(
+        candidate => candidate.promiseId === promiseId,
+      )
+      expect(promise, promiseId).toBeDefined()
+      expect(promise?.evidenceRefs).toContain(AUDIT_DOC)
+      expect(promise?.blockerRefs).toContain(
+        'blocker.product_promises.world_first_owner_signed_upgrade_missing',
+      )
+      expect(promise?.verification).toContain('2026-06-29')
+      expect(promise?.verification).toContain('#7027')
+    }
+
+    expect(
+      document.promises.find(
+        promise =>
+          promise.promiseId ===
+          'claims.world_first_ai_training_paid_bitcoin.v1',
+      )?.state,
+    ).toBe('red')
+    expect(
+      document.promises.find(
+        promise =>
+          promise.promiseId ===
+          'claims.world_first_public_llm_computer_training_run.v1',
+      )?.state,
+    ).toBe('red')
+    expect(
+      document.promises.find(
+        promise =>
+          promise.promiseId ===
+          'claims.pursued_world_first_largest_agentic_sales_force.v1',
+      )?.state,
+    ).toBe('planned')
+    expect(
+      document.promises.find(
+        promise =>
+          promise.promiseId ===
+          'claims.pursued_world_first_largest_sales_force.v1',
+      )?.state,
+    ).toBe('planned')
+  })
+
+  test('runtime product copy does not carry unqualified world-first claims', () => {
+    const forbiddenPatterns = [
+      /\bworld first\b/i,
+      /\blargest agentic sales force\b/i,
+      /\blargest sales force\b/i,
+      /\bseven million agents\b/i,
+      /\bworld record\b/i,
+    ]
+
+    const files = productCopyRoots.flatMap(runtimeSourceFiles)
+    expect(files.length).toBeGreaterThan(0)
+
+    for (const file of files) {
+      const stat = statSync(repoFile(file))
+      expect(stat.isFile()).toBe(true)
+
+      const text = readRepoFile(file)
+      for (const pattern of forbiddenPatterns) {
+        expect({
+          file,
+          pattern: String(pattern),
+          matched: pattern.test(text),
+        }).toEqual({
+          file,
+          pattern: String(pattern),
+          matched: false,
+        })
+      }
+    }
+  })
+})

--- a/docs/promises/2026-06-29-world-first-claims-blocker-audit.md
+++ b/docs/promises/2026-06-29-world-first-claims-blocker-audit.md
@@ -1,0 +1,81 @@
+# World-First Claims Blocker Audit
+
+Date: 2026-06-29
+
+Issue: #7027
+
+## Scope
+
+This audit covers the four world-first / largest-force promise records named in
+`#7027`:
+
+- `claims.world_first_ai_training_paid_bitcoin.v1`
+- `claims.world_first_public_llm_computer_training_run.v1`
+- `claims.pursued_world_first_largest_agentic_sales_force.v1`
+- `claims.pursued_world_first_largest_sales_force.v1`
+
+No owner-signed transition receipt exists for these records as of this audit.
+Therefore none of the four records may move green from this note.
+
+## Qualified Copy Gate
+
+Public copy may use only the qualified forms already recorded in the registry:
+
+- Bitcoin-paid AI training: only with the combined qualifiers
+  "Bitcoin + replay-verified training compute + own consumer devices", tied to
+  bounded live-run receipts.
+- Public LLM-computer training run: only as a public/open-contributor
+  LLM-computer executor-construction run, with Percepta credited as paradigm
+  originator and with no gradient-descent model-training implication.
+- Largest agentic sales force: only as a clearly labeled pursuit/aspiration,
+  not as achieved, verified, held, or at scale.
+- Largest sales force of any kind: only as a clearly labeled pursuit/aspiration,
+  with the roughly seven-million-agent bar unmet and the Avon comparison not
+  treated as independently verified OpenAgents evidence.
+
+## Refuse List
+
+Do not publish product or marketing copy that says or implies any of the
+following until a dereferenceable evidence bundle and owner-signed receipt-first
+transition exist for the exact wording:
+
+- Bare "world first" without the full qualifiers.
+- "First AI training run paid in Bitcoin to consumer compute" without the
+  Bitcoin, replay-verified training compute, own-consumer-device, bounded-receipt
+  qualifiers.
+- "First public LLM-computer training run" without Percepta credit and the
+  executor-construction / exact-trace / no-gradient-descent boundary.
+- "OpenAgents has the largest agentic sales force."
+- "OpenAgents has the largest sales force."
+- "OpenAgents holds the world record" for either sales-force claim.
+- The seven-million-agent sales-force bar has been met.
+- The cited Avon comparison is an OpenAgents-verified statistic.
+
+## Blocker Notes
+
+`claims.world_first_ai_training_paid_bitcoin.v1` stays `red` because the prior
+art review exists, but the dedicated evidence pack tying the qualified wording
+to dereferenceable live-run receipts is still missing, and no owner-signed
+receipt-first transition exists.
+
+`claims.world_first_public_llm_computer_training_run.v1` stays `red` because a
+definition and focused evidence pack exist, but the owner-signed receipt-first
+transition is still missing. The claim remains limited to the qualified
+LLM-computer executor-construction sense with Percepta credit.
+
+`claims.pursued_world_first_largest_agentic_sales_force.v1` stays `planned`
+because it is an aspiration, not an achieved record. No sized, independently
+countable agentic sales force exists, and no owner-signed transition exists.
+
+`claims.pursued_world_first_largest_sales_force.v1` stays `planned` because it
+is an aspiration, not an achieved record. The roughly seven-million
+selling-or-sell-equipped-agent bar is unmet, the comparison figure is not an
+OpenAgents-verified statistic, and no owner-signed transition exists.
+
+## Existing Evidence Inputs
+
+- `docs/launch/2026-06-18-world-firsts-verification.md`
+- `docs/launch/2026-06-20-llm-computer-training-run-definition.md`
+- `docs/launch/2026-06-20-world-first-llm-computer-evidence-pack.md`
+- `docs/promises/2026-06-19-episode-239-lets-make-money-registry-reconciliation.md`
+- `apps/openagents.com/workers/api/src/world-first-llm-computer-evidence-pack.test.ts`


### PR DESCRIPTION
## Summary

- Add a dated #7027 blocker audit for the four world-first / largest-force promise records.
- Wire the audit into the product-promise registry records while keeping the two world-first claims red and the two sales-force pursuit claims planned.
- Add a focused copy-gate test for the audit refuse list, blocker/evidence refs, and runtime product-copy scans for unqualified world-first/largest-force wording.

Closes #7027

## Verification

- `bun run --cwd apps/openagents.com/workers/api test -- src/world-first-claims-copy-gate.test.ts src/world-first-llm-computer-evidence-pack.test.ts src/product-promises.test.ts`
- `bun run --cwd apps/openagents.com/workers/api typecheck`