### PR TITLE
Expose pending card-credit receipt evidence refs

### DIFF
--- a/apps/openagents.com/workers/api/src/inference/card-credit-spend-receipt-store.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/card-credit-spend-receipt-store.test.ts
@@ -1,13 +1,15 @@
-import { DatabaseSync } from 'node:sqlite'
-
 import { Effect } from 'effect'
+import { DatabaseSync } from 'node:sqlite'
 import { describe, expect, test } from 'vitest'
 
 import { readAgentBalance } from '../payments-ledger'
-import { makeD1CardCreditSpendReceiptStore } from './card-credit-spend-receipt-store'
 import { cardCreditSpendReceiptRef } from './card-credit-spend-receipt'
-import { fundInferenceFromCredit, usdCreditGrantReceiptRef } from './usd-credit-bridge'
+import { makeD1CardCreditSpendReceiptStore } from './card-credit-spend-receipt-store'
 import { makeLedgerMeteringHook } from './metering-hook'
+import {
+  fundInferenceFromCredit,
+  usdCreditGrantReceiptRef,
+} from './usd-credit-bridge'
 
 type Row = Record<string, unknown>
 
@@ -174,6 +176,72 @@ const run = <A, E>(effect: Effect.Effect<A, E>): Promise<A> =>
   Effect.runPromise(effect)
 
 describe('D1 card-credit-spend receipt store', () => {
+  test('pending projection names the purchase ledger key when checkout is missing', async () => {
+    const db = makeDb()
+
+    const projection = await makeD1CardCreditSpendReceiptStore(
+      db,
+    ).readCardCreditSpendReceipt(
+      cardCreditSpendReceiptRef(SESSION),
+      '2026-06-28T12:01:00.000Z',
+    )
+
+    expect(projection?.resolution).toEqual({
+      missing: 'purchase',
+      nextEvidenceRef: `billing:stripe-checkout:${SESSION}`,
+      status: 'pending',
+    })
+  })
+
+  test('pending projection names the card-origin grant context when checkout exists', async () => {
+    const db = makeDb()
+    await seedStripeCheckoutCredit(db)
+
+    const projection = await makeD1CardCreditSpendReceiptStore(
+      db,
+    ).readCardCreditSpendReceipt(
+      cardCreditSpendReceiptRef(SESSION),
+      '2026-06-28T12:01:00.000Z',
+    )
+
+    expect(projection?.resolution).toEqual({
+      missing: 'grant',
+      nextEvidenceRef: `inference:usd-credit:card:${SESSION}`,
+      status: 'pending',
+    })
+  })
+
+  test('pending projection names the inference charge context when grant exists', async () => {
+    const db = makeDb()
+    await seedStripeCheckoutCredit(db)
+
+    const grant = await run(
+      fundInferenceFromCredit(
+        {
+          amountCents: 500,
+          grantRef: 'grant-card-credit-spend',
+          sourceCheckoutSessionId: SESSION,
+          userId: USER,
+        },
+        { db, nowIso: () => NOW },
+      ),
+    )
+    expect(grant.ok).toBe(true)
+
+    const projection = await makeD1CardCreditSpendReceiptStore(
+      db,
+    ).readCardCreditSpendReceipt(
+      cardCreditSpendReceiptRef(SESSION),
+      '2026-06-28T12:01:00.000Z',
+    )
+
+    expect(projection?.resolution).toEqual({
+      missing: 'spend',
+      nextEvidenceRef: 'ledger.pay_ins.inference_charge.context_ref',
+      status: 'pending',
+    })
+  })
+
   test('resolves ok after card credit is bridged and spent by real metering', async () => {
     const db = makeDb()
     await seedStripeCheckoutCredit(db)
@@ -248,9 +316,9 @@ describe('D1 card-credit-spend receipt store', () => {
         step: 'msat_to_inference',
       },
     ])
-    expect(projection.resolution.receipt.conservation.spentMsat).toBeGreaterThan(
-      0,
-    )
+    expect(
+      projection.resolution.receipt.conservation.spentMsat,
+    ).toBeGreaterThan(0)
     expect(JSON.stringify(projection)).not.toMatch(
       /invoice|lnbc|payment_hash|preimage|wallet|secret|api[_-]?key|bearer/i,
     )

--- a/apps/openagents.com/workers/api/src/inference/card-credit-spend-receipt-store.ts
+++ b/apps/openagents.com/workers/api/src/inference/card-credit-spend-receipt-store.ts
@@ -8,6 +8,7 @@ import {
   type CardCreditSpendReceipt,
   type CreditToMsatGrantLeg,
   type InferenceSpendLeg,
+  cardCreditPurchaseLedgerKey,
   cardCreditSpendReceiptRef,
 } from './card-credit-spend-receipt'
 import {
@@ -23,7 +24,11 @@ export type PublicCardCreditSpendReceiptProjection = Readonly<{
   receiptRef: string
   resolution:
     | Readonly<{ status: 'ok'; receipt: CardCreditSpendReceipt }>
-    | Readonly<{ status: 'pending'; missing: 'purchase' | 'grant' | 'spend' }>
+    | Readonly<{
+        status: 'pending'
+        missing: 'purchase' | 'grant' | 'spend'
+        nextEvidenceRef: string
+      }>
     | Readonly<{ status: 'invalid'; reason: string; message: string }>
   schemaVersion: 'openagents.inference.card_credit_spend_receipt.v1'
   sourceRefs: ReadonlyArray<string>
@@ -54,8 +59,27 @@ const sessionIdFromReceiptRef = (receiptRef: string): string | null =>
     ? receiptRef.slice(prefix.length)
     : null
 
+const pendingNextEvidenceRef = (
+  sessionId: string,
+  missing: 'purchase' | 'grant' | 'spend',
+): string => {
+  if (missing === 'purchase') {
+    return cardCreditPurchaseLedgerKey(sessionId)
+  }
+
+  if (missing === 'grant') {
+    return (
+      cardCreditGrantContextRef(sessionId) ??
+      'ledger.pay_ins.usd_credit_grant.context_ref'
+    )
+  }
+
+  return 'ledger.pay_ins.inference_charge.context_ref'
+}
+
 const publicProjectionFromResolution = (
   receiptRef: string,
+  sessionId: string,
   generatedAt: string,
   resolution: CardCreditSpendReceiptResolution,
 ): PublicCardCreditSpendReceiptProjection | null => {
@@ -76,7 +100,14 @@ const publicProjectionFromResolution = (
     resolution: resolution.ok
       ? { receipt: resolution.receipt, status: 'ok' }
       : resolution.status === 'pending'
-        ? { missing: resolution.missing, status: 'pending' }
+        ? {
+            missing: resolution.missing,
+            nextEvidenceRef: pendingNextEvidenceRef(
+              sessionId,
+              resolution.missing,
+            ),
+            status: 'pending',
+          }
         : {
             message: resolution.message,
             reason: resolution.reason,
@@ -279,6 +310,11 @@ export const makeD1CardCreditSpendReceiptStore = (
       },
     })
 
-    return publicProjectionFromResolution(receiptRef, generatedAt, resolution)
+    return publicProjectionFromResolution(
+      receiptRef,
+      sessionId,
+      generatedAt,
+      resolution,
+    )
   },
 })

--- a/apps/openagents.com/workers/api/src/public-card-credit-spend-receipt-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/public-card-credit-spend-receipt-routes.test.ts
@@ -15,7 +15,11 @@ const projection = (
   caveatRefs: ['caveat.public.pending_is_not_paid_loop_completion'],
   generatedAt: '2026-06-20T00:01:00.000Z',
   receiptRef,
-  resolution: { missing: 'spend', status: 'pending' },
+  resolution: {
+    missing: 'spend',
+    nextEvidenceRef: 'ledger.pay_ins.inference_charge.context_ref',
+    status: 'pending',
+  },
   schemaVersion: 'openagents.inference.card_credit_spend_receipt.v1',
   sourceRefs: [
     `route:/api/public/inference/card-credit-spend-receipts/${receiptRef}`,
@@ -73,7 +77,11 @@ describe('public card-credit-spend receipt routes', () => {
     expect(body.receipt).toMatchObject({
       generatedAt: '2026-06-20T00:01:00.000Z',
       receiptRef,
-      resolution: { missing: 'spend', status: 'pending' },
+      resolution: {
+        missing: 'spend',
+        nextEvidenceRef: 'ledger.pay_ins.inference_charge.context_ref',
+        status: 'pending',
+      },
       schemaVersion: 'openagents.inference.card_credit_spend_receipt.v1',
       staleness: {
         composition: 'live_at_read',


### PR DESCRIPTION
## Summary

Closes #7018.

- Adds `nextEvidenceRef` to pending public card-credit-spend receipt projections so an incomplete card -> credit -> inference chain names the next public-safe ledger evidence to resolve.
- Covers purchase-missing, grant-missing, and spend-missing pending states in the D1-backed receipt store tests, and updates the public route fixture.

This does not green the paid inference promises or assert a live paid receipt exists; it tightens the dereferenceable audit path for the receipt resolver while the production payment path remains owner/receipt gated.

## Verification

- `bun run test -- src/inference/card-credit-spend-receipt-store.test.ts src/public-card-credit-spend-receipt-routes.test.ts` from `apps/openagents.com/workers/api` (7 passed)
- `bun run typecheck` from `apps/openagents.com/workers/api` (exit 0; existing Effect advisory messages printed)

Note: I could not resolve opaque verification ref `command.public.pylon_khala.verify.b5bea41b6c623f7c09f1bf24` to argv from the checkout or local task metadata; I ran the relevant focused verification directly.