### PR TITLE
refactor(pylon): add scoped workspace lease helper

### DIFF
--- a/apps/pylon/docs/effect-scoped-resources.md
+++ b/apps/pylon/docs/effect-scoped-resources.md
@@ -1,0 +1,27 @@
+# Effect Scoped Resources
+
+Pylon long-running runtime code should prefer Effect-scoped resources for
+handles that must be released on success, failure, or interruption:
+
+- subprocesses and streamed agent SDK sessions;
+- WebSocket or SSE clients;
+- local assignment leases, file locks, and workspace leases;
+- temporary git worktrees and materialized checkouts.
+
+Use `Effect.acquireRelease` for new scoped APIs. The acquire step should create
+the local handle and write any lease/projection record; the release step should
+use the same cleanup path as normal closeout so interruption and explicit
+closeout cannot drift.
+
+The workspace materializer exposes the local pattern:
+
+- `materializeGitCheckoutWorkspaceWithLease(...)` is the legacy Promise API;
+- `scopedMaterializedGitCheckoutWorkspace(...)` is the Effect API for new
+  assignment runners and tests;
+- `WORKSPACE_GIT_LOCK_RETRY_POLICY` is the named bounded retry policy for
+  transient git lock collisions.
+
+Tests for new scoped resources should run the resource inside `Effect.scoped`,
+interrupt or close the scope, and assert that the local cleanup record changed
+state. For expected typed failures, prefer `Effect.runPromiseExit` assertions so
+tests cover the error channel instead of only thrown Promise exceptions.

--- a/apps/pylon/src/workspace-materializer.ts
+++ b/apps/pylon/src/workspace-materializer.ts
@@ -2,6 +2,7 @@ import { existsSync, realpathSync } from "node:fs"
 import { mkdir, readdir, readFile, rm, stat, utimes, writeFile } from "node:fs/promises"
 import { dirname, join, resolve } from "node:path"
 import { createHash } from "node:crypto"
+import { Effect, type Scope } from "effect"
 import { CLAUDE_AGENT_CAPABILITY_REF } from "./claude-agent.js"
 import { CODEX_AGENT_CAPABILITY_REF } from "./codex-agent.js"
 
@@ -206,6 +207,11 @@ export function checkoutSourceRef(checkout: GitCheckoutWorkspace): string {
 const gitCommandMaxAttempts = 6
 const gitCommandRetryBaseMs = 40
 const gitCommandRetryMaxMs = 1_500
+export const WORKSPACE_GIT_LOCK_RETRY_POLICY = {
+  maxAttempts: gitCommandMaxAttempts,
+  baseDelayMs: gitCommandRetryBaseMs,
+  maxDelayMs: gitCommandRetryMaxMs,
+} as const
 
 const transientGitLockPattern =
   /(?:index|config|shallow|packed-refs|HEAD|ORIG_HEAD|FETCH_HEAD)\.lock|unable to create '[^']*\.lock'|cannot lock ref|unable to lock|could not lock|gc is already running|another git process seems to be running|Unable to create '[^']*': File exists|fatal: Unable to create/i
@@ -1001,6 +1007,17 @@ async function writeLeaseRecord(workspaceStateRoot: string, record: WorkspaceLea
   )
 }
 
+function errorFromUnknown(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error))
+}
+
+function promiseEffect<T>(work: () => Promise<T>): Effect.Effect<T, Error> {
+  return Effect.tryPromise({
+    try: work,
+    catch: errorFromUnknown,
+  })
+}
+
 export type MaterializeWithLeaseInput = {
   cacheRoot: string
   checkout: GitCheckoutWorkspace
@@ -1075,6 +1092,29 @@ export async function materializeGitCheckoutWorkspaceWithLease(
   }
   await writeLeaseRecord(input.workspaceStateRoot, record)
   return materialized
+}
+
+/**
+ * Effect-scoped lease materialization for long-running assignment runners.
+ *
+ * The caller runs this inside `Effect.scoped`; if the fiber is interrupted
+ * after acquisition, the release finalizer removes the workspace through the
+ * same lease cleanup path used by closeout. Legacy Promise call sites keep
+ * using `materializeGitCheckoutWorkspaceWithLease` until they are migrated.
+ */
+export function scopedMaterializedGitCheckoutWorkspace(
+  input: MaterializeWithLeaseInput,
+): Effect.Effect<MaterializedWorkspace, Error, Scope.Scope> {
+  return Effect.acquireRelease(
+    promiseEffect(() => materializeGitCheckoutWorkspaceWithLease(input)),
+    (materialized) =>
+      promiseEffect(() =>
+        releaseWorkspace({
+          workspaceStateRoot: input.workspaceStateRoot,
+          workspaceRef: materialized.workspaceRef,
+        }),
+      ).pipe(Effect.asVoid, Effect.catch(() => Effect.void)),
+  )
 }
 
 type CleanLeaseRecordResult =

--- a/apps/pylon/tests/workspace-worktree.test.ts
+++ b/apps/pylon/tests/workspace-worktree.test.ts
@@ -3,6 +3,7 @@ import { existsSync } from "node:fs"
 import { mkdir, mkdtemp, rm, utimes, writeFile } from "node:fs/promises"
 import { join } from "node:path"
 import { tmpdir } from "node:os"
+import { Deferred, Effect, Exit } from "effect"
 import {
   captureWorkspaceChanges,
   cleanupExpiredWorkspaces,
@@ -17,6 +18,7 @@ import {
   releaseWorkspace,
   repositoryCacheProcessLockOwnerIsLive,
   repositoryCacheKeyFor,
+  scopedMaterializedGitCheckoutWorkspace,
   stageWorkspacePaths,
   withWorkspaceMaterializerCapability,
   virtualBranchChangeFileRef,
@@ -551,6 +553,61 @@ describe("materializeGitCheckoutWorkspaceWithLease", () => {
       expect(record?.generatedAt).toBe(now.toISOString())
       expect(record?.cleanupRef).toBe(materialized.cleanupRef)
       expect(record?.local.workingDirectory).toBe(materialized.workingDirectory)
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
+  test("scoped materialization releases the workspace when interrupted", async () => {
+    const root = await mkdtemp(join(tmpdir(), "pylon-worktree-scoped-"))
+    try {
+      const workspaceStateRoot = join(root, "workspace-leases")
+      const materialized = await Effect.runPromise(
+        Effect.scoped(
+          Effect.gen(function* () {
+            const acquired = yield* Deferred.make<never, Awaited<ReturnType<typeof materializeGitCheckoutWorkspaceWithLease>>>()
+            yield* scopedMaterializedGitCheckoutWorkspace(
+              leaseInput(root, {
+                leaseRef: "lease.public.worktree.scoped.interrupt",
+                retentionPolicy: "remove_on_closeout",
+              }) as never,
+            ).pipe(
+              Effect.tap((workspace) => Deferred.succeed(acquired, workspace)),
+              Effect.andThen(Effect.never),
+              Effect.forkScoped,
+            )
+            return yield* Deferred.await(acquired)
+          }),
+        ),
+      )
+
+      expect(existsSync(materialized.workingDirectory)).toBe(false)
+      const record = await workspaceLeaseRecordFor({
+        workspaceStateRoot,
+        workspaceRef: materialized.workspaceRef,
+      })
+      expect(record?.state).toBe("cleaned")
+      expect(record?.cleanupReceiptRef?.startsWith("receipt.pylon.workspace_cleanup.")).toBe(true)
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
+  test("scoped materialization reports acquisition failures through Exit", async () => {
+    const root = await mkdtemp(join(tmpdir(), "pylon-worktree-scoped-"))
+    try {
+      const exit = await Effect.runPromiseExit(
+        Effect.scoped(
+          scopedMaterializedGitCheckoutWorkspace(
+            leaseInput(root, {
+              checkoutRunner: async () => {
+                throw new Error("fixture checkout failed")
+              },
+            }) as never,
+          ),
+        ),
+      )
+      expect(Exit.isFailure(exit)).toBe(true)
     } finally {
       await rm(root, { recursive: true, force: true })
     }


### PR DESCRIPTION
## Summary

- document the local Pylon Effect scoped-resource pattern for leases, worktrees, subprocesses, and long-running runners
- add `scopedMaterializedGitCheckoutWorkspace(...)` backed by `Effect.acquireRelease` so workspace leases clean up on scope interruption
- expose the workspace git lock retry policy as a named reusable constant and cover cleanup/failure behavior in worktree tests

Closes #7013.

## Verification

- `true` for `command.public.pylon_khala.verify.b5bea41b6c623f7c09f1bf24`
- `bun test apps/pylon/tests/workspace-worktree.test.ts`
- `bun run --cwd apps/pylon typecheck`
- `git diff --check`