### PR TITLE
Expose referral payout receipt proof chain

### DIFF
--- a/apps/openagents.com/workers/api/src/public-site-referral-payout-receipt-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/public-site-referral-payout-receipt-routes.test.ts
@@ -21,6 +21,24 @@ const projection = (
   ],
   generatedAt: '2026-06-20T00:01:00.000Z',
   policyRefs: ['policy.site_referral_payout.v1'],
+  proofChain: {
+    attribution: {
+      linked: true,
+      source: 'consume_once_referral_attribution',
+    },
+    eligibility: {
+      source: 'site_referral_payout_ledger_entries',
+      state: 'recorded',
+    },
+    paidEvent: {
+      kind: 'inference_paid_request',
+      source: 'qualifying_event_kind',
+    },
+    settlement: {
+      receiptRef,
+      state: 'settled',
+    },
+  },
   qualifyingEventKind: 'inference_paid_request',
   receiptRef,
   resolution: {
@@ -89,6 +107,24 @@ describe('public Site referral payout receipt routes', () => {
     expect(body.receipt).toMatchObject({
       attributionLinked: true,
       generatedAt: '2026-06-20T00:01:00.000Z',
+      proofChain: {
+        attribution: {
+          linked: true,
+          source: 'consume_once_referral_attribution',
+        },
+        eligibility: {
+          source: 'site_referral_payout_ledger_entries',
+          state: 'recorded',
+        },
+        paidEvent: {
+          kind: 'inference_paid_request',
+          source: 'qualifying_event_kind',
+        },
+        settlement: {
+          receiptRef,
+          state: 'settled',
+        },
+      },
       qualifyingEventKind: 'inference_paid_request',
       receiptRef,
       resolution: {

--- a/apps/openagents.com/workers/api/src/site-referral-payout-receipt-loop.test.ts
+++ b/apps/openagents.com/workers/api/src/site-referral-payout-receipt-loop.test.ts
@@ -355,6 +355,24 @@ describe('RL-1 staging-test settlement-receipt closed loop (#5524)', () => {
     expect(receipt).toMatchObject({
       amountSats: fed.entry.amountSats,
       attributionLinked: true,
+      proofChain: {
+        attribution: {
+          linked: true,
+          source: 'consume_once_referral_attribution',
+        },
+        eligibility: {
+          source: 'site_referral_payout_ledger_entries',
+          state: 'recorded',
+        },
+        paidEvent: {
+          kind: 'forum_tip_paid',
+          source: 'qualifying_event_kind',
+        },
+        settlement: {
+          receiptRef: outcome.receiptRef,
+          state: 'settled',
+        },
+      },
       qualifyingEventKind: 'forum_tip_paid',
       receiptRef: outcome.receiptRef,
       resolution: {

--- a/apps/openagents.com/workers/api/src/site-referral-payout-receipts.ts
+++ b/apps/openagents.com/workers/api/src/site-referral-payout-receipts.ts
@@ -21,6 +21,24 @@ export type PublicSiteReferralPayoutReceiptProjection = Readonly<{
   evidenceRefs: ReadonlyArray<string>
   generatedAt: string
   policyRefs: ReadonlyArray<string>
+  proofChain: Readonly<{
+    attribution: Readonly<{
+      linked: true
+      source: 'consume_once_referral_attribution'
+    }>
+    eligibility: Readonly<{
+      source: 'site_referral_payout_ledger_entries'
+      state: 'recorded'
+    }>
+    paidEvent: Readonly<{
+      kind: string
+      source: 'qualifying_event_kind'
+    }>
+    settlement: Readonly<{
+      receiptRef: string
+      state: 'settled'
+    }>
+  }>
   qualifyingEventKind: string
   receiptRef: string
   resolution: Readonly<{
@@ -84,6 +102,24 @@ const publicProjection = (
     evidenceRefs,
     generatedAt,
     policyRefs: parseJsonStringArray(row.policy_refs_json),
+    proofChain: {
+      attribution: {
+        linked: true,
+        source: 'consume_once_referral_attribution',
+      },
+      eligibility: {
+        source: 'site_referral_payout_ledger_entries',
+        state: 'recorded',
+      },
+      paidEvent: {
+        kind: row.qualifying_event_kind,
+        source: 'qualifying_event_kind',
+      },
+      settlement: {
+        receiptRef,
+        state: 'settled',
+      },
+    },
     qualifyingEventKind: row.qualifying_event_kind,
     receiptRef,
     resolution: {


### PR DESCRIPTION
## Summary

- Adds a public-safe `proofChain` to settled Site referral payout receipt projections.
- The chain records the paid-event kind, consume-once attribution linkage, eligibility ledger source, and settled receipt ref without exposing payout refs, user ids, attribution ids, destinations, hashes, preimages, provider payloads, or wallet material.
- Extends the public route test and closed-loop D1 receipt test to assert the chain.

Closes #7020

## Verification

- `bunx vitest run src/public-site-referral-payout-receipt-routes.test.ts src/site-referral-payout-receipt-loop.test.ts src/site-referral-payout-wire.test.ts src/site-referral-payout-adapter.test.ts src/product-promises.test.ts` from `apps/openagents.com/workers/api` passed: 5 files, 36 tests.
- `bun run --cwd apps/openagents.com/workers/api typecheck` passed with existing Effect advisory messages in unrelated files (`artanis-activity-routes.ts`, `artanis-operator-tools.ts`, `artanis-public-report-routes.ts`, `pylon-api-routes.ts`).