### PR TITLE
Harden site referral payout receipt projection

### DIFF
--- a/apps/openagents.com/workers/api/src/site-referral-payout-receipt-loop.test.ts
+++ b/apps/openagents.com/workers/api/src/site-referral-payout-receipt-loop.test.ts
@@ -428,6 +428,50 @@ describe('RL-1 staging-test settlement-receipt closed loop (#5524)', () => {
     expect(receipt?.receiptRef).toBe(expectedReceiptRef)
   })
 
+  test('public receipt dereference refuses contaminated row metadata', async () => {
+    const store = new LoopStore()
+    store.rows.push({
+      amount_sats: 125,
+      archived_at: null,
+      caveat_refs_json: JSON.stringify([
+        'caveat.site_referral_payout.settlement_evidence_required',
+      ]),
+      created_at: '2026-06-22T12:05:00.000Z',
+      evidence_refs_json: JSON.stringify([
+        'receipt.site_referral_payout.hosted_mdk.safe123',
+      ]),
+      id: 'site_referral_payout_entry_contaminated',
+      idempotency_key: 'site_referral_payout.contaminated',
+      payout_ref: 'site_referral_payout_contaminated',
+      period_key: '2026-06',
+      policy_refs_json: JSON.stringify([
+        'policy.site_referral_payout.v1',
+        'provider_payload.raw_payment_hash',
+      ]),
+      previous_entry_id: null,
+      qualifying_amount_sats: 2500,
+      qualifying_event_kind: 'raw_payment_hash',
+      qualifying_event_ref: 'evidence.btc_paid.contaminated',
+      referred_user_id: 'github:buyer',
+      referral_attribution_id: 'referral_attribution_contaminated',
+      referral_invite_id: null,
+      referral_source_id: 'site_referral_source_contaminated',
+      referrer_user_id: 'github:referrer',
+      reversal_of_entry_id: null,
+      state: 'settled',
+      state_reason_ref: null,
+    })
+
+    const receipt = await makeD1SiteReferralPayoutReceiptStore(
+      loopDb(store),
+    ).readSiteReferralPayoutReceipt(
+      'receipt.site_referral_payout.hosted_mdk.safe123',
+      '2026-06-22T12:06:00.000Z',
+    )
+
+    expect(receipt).toBeNull()
+  })
+
   test('fail-safe: a DISABLED staging adapter never settles and records no settled state (no receipt to dereference)', async () => {
     const store = new LoopStore()
     seedAttribution(store, 'github:loop-buyer')

--- a/apps/openagents.com/workers/api/src/site-referral-payout-receipts.ts
+++ b/apps/openagents.com/workers/api/src/site-referral-payout-receipts.ts
@@ -52,10 +52,14 @@ const receiptPrefix = 'receipt.site_referral_payout.'
 
 const safeReceiptPattern = /^[A-Za-z0-9][A-Za-z0-9_.:/-]{0,300}$/
 const prohibitedRefPattern =
-  /\b(lnbc|lntb|lnbcrt|lno1|mnemonic|xprv|payment_preimage|payment_secret|payment_hash|wallet_secret|private_key|webhook_secret|mdk_access_token|access_token|refresh_token|device_auth_id|code_verifier|gho_[a-z0-9_]+)/i
+  /\b(authorization|bearer|customer|email|invoice|lnbc|lntb|lnbcrt|lno1|mdk_payload|mnemonic|payment_hash|payment_id|payment_preimage|payment_secret|payout_address|payout_destination|payout_target|preimage|provider_payload|raw_payment|raw_payout|secret|wallet|xprv|private_key|webhook_secret|mdk_access_token|access_token|refresh_token|device_auth_id|code_verifier|gho_[a-z0-9_]+)/i
+const safeEventKindPattern = /^[a-z][a-z0-9_]{0,80}$/
 
 const isPublicSafeRef = (value: string): boolean =>
   safeReceiptPattern.test(value) && !prohibitedRefPattern.test(value)
+
+const isPublicSafeEventKind = (value: string): boolean =>
+  safeEventKindPattern.test(value) && !prohibitedRefPattern.test(value)
 
 const settlementRailForReceipt = (
   receiptRef: string,
@@ -70,7 +74,20 @@ const publicProjection = (
   row: SettledReceiptRow,
   receiptRef: string,
   generatedAt: string,
-): PublicSiteReferralPayoutReceiptProjection => {
+): PublicSiteReferralPayoutReceiptProjection | null => {
+  if (!isPublicSafeEventKind(row.qualifying_event_kind)) {
+    return null
+  }
+
+  const caveatRefs = parseJsonStringArray(row.caveat_refs_json)
+  const policyRefs = parseJsonStringArray(row.policy_refs_json)
+  if (
+    caveatRefs.some(ref => !isPublicSafeRef(ref)) ||
+    policyRefs.some(ref => !isPublicSafeRef(ref))
+  ) {
+    return null
+  }
+
   const evidenceRefs = parseJsonStringArray(row.evidence_refs_json).filter(ref =>
     isPublicSafeRef(ref),
   )
@@ -80,10 +97,10 @@ const publicProjection = (
     attributionLinked: true,
     authorityBoundary:
       'Public proof only. This referral payout receipt read grants no attribution, invite, checkout, spend, refund, payout, settlement, wallet, provider, or registry authority.',
-    caveatRefs: parseJsonStringArray(row.caveat_refs_json),
+    caveatRefs,
     evidenceRefs,
     generatedAt,
-    policyRefs: parseJsonStringArray(row.policy_refs_json),
+    policyRefs,
     qualifyingEventKind: row.qualifying_event_kind,
     receiptRef,
     resolution: {


### PR DESCRIPTION
## Summary

- harden the public Site referral payout receipt projection so contaminated settled-row metadata does not dereference
- require receipt event kinds, caveat refs, and policy refs to pass the public-safety boundary before projection
- add a regression covering private/provider/payment material in receipt metadata

Closes #7020

## Verification

- `bun run --cwd apps/openagents.com/workers/api test -- src/site-referral-payout-receipt-loop.test.ts src/public-site-referral-payout-receipt-routes.test.ts src/site-referral-payout-adapter.test.ts src/site-referral-payout-wire.test.ts src/product-promises.test.ts`
- `true` (`command.public.pylon_khala.verify.b5bea41b6c623f7c09f1bf24`)
- `git diff --check`
