### PR TITLE
Guard world-first promise claims

### DIFF
--- a/apps/openagents.com/workers/api/src/product-promises.test.ts
+++ b/apps/openagents.com/workers/api/src/product-promises.test.ts
@@ -157,6 +157,9 @@ describe('public product promises document', () => {
     expect(decoded.sourceRefs).toContain(
       'docs/tassadar/2026-06-21-tassadar-cpu-transform-training-receipt-surface.md',
     )
+    expect(decoded.sourceRefs).toContain(
+      'docs/promises/2026-06-29-world-first-claims-7027-audit.md',
+    )
     expect(decoded.promises.length).toBeGreaterThan(0)
     expect(decoded.verificationSummary.promiseCount).toBe(
       decoded.promises.length,
@@ -440,9 +443,10 @@ describe('public product promises document', () => {
       /latest stays 0\.2\.5|only published, installable Pylon|release candidate, not stable 0\.3\.0|Pylon v1\.0 is present in the monorepo as a release candidate/i,
     )
     expect(currentCopy).toContain('Pylon v1.0 has a stable source cut')
-    expect(currentCopy).toContain('Registry 2026-06-29.2')
+    expect(currentCopy).toContain('Registry 2026-06-29.3')
     expect(currentCopy).toContain('flips NO promise state')
     expect(currentCopy).toContain('Khala Desktop now carries source-level')
+    expect(currentCopy).toContain('implements #7027')
     expect(currentCopy).toContain('maxStalenessSeconds:0')
     const codexSuccessorPromise = decoded.promises.find(
       promise => promise.promiseId === 'autopilot.codex_probe_pylon_successor.v1',
@@ -797,6 +801,7 @@ describe('public product promises document', () => {
           evidenceRefs: expect.arrayContaining([
             'docs/transcripts/238.md',
             'docs/launch/2026-06-18-world-firsts-verification.md',
+            'docs/promises/2026-06-29-world-first-claims-7027-audit.md',
           ]),
         }),
         expect.objectContaining({
@@ -814,6 +819,7 @@ describe('public product promises document', () => {
             'promise:compute.tassadar_executor_poc.v1',
             'docs/launch/2026-06-20-llm-computer-training-run-definition.md',
             'docs/launch/2026-06-20-world-first-llm-computer-evidence-pack.md',
+            'docs/promises/2026-06-29-world-first-claims-7027-audit.md',
             'apps/openagents.com/workers/api/src/world-first-llm-computer-evidence-pack.test.ts',
           ]),
         }),
@@ -936,12 +942,18 @@ describe('public product promises document', () => {
           blockerRefs: expect.arrayContaining([
             'blocker.product_promises.world_first_agentic_sales_force_not_achieved',
           ]),
+          evidenceRefs: expect.arrayContaining([
+            'docs/promises/2026-06-29-world-first-claims-7027-audit.md',
+          ]),
         }),
         expect.objectContaining({
           promiseId: 'claims.pursued_world_first_largest_sales_force.v1',
           state: 'planned',
           blockerRefs: expect.arrayContaining([
             'blocker.product_promises.world_first_largest_sales_force_not_achieved',
+          ]),
+          evidenceRefs: expect.arrayContaining([
+            'docs/promises/2026-06-29-world-first-claims-7027-audit.md',
           ]),
         }),
         expect.objectContaining({
@@ -1292,6 +1304,81 @@ describe('public product promises document', () => {
     )
     expect(externalRepoStudyPromise?.authorityBoundary).toContain(
       'no private repo ingestion authority',
+    )
+  })
+
+  test('keeps world-first and largest-force claims non-green with dated copy gates', () => {
+    const decoded = S.decodeUnknownSync(ProductPromisesDocument)(
+      publicProductPromisesDocument(),
+    )
+    const byId = new Map(
+      decoded.promises.map(promise => [promise.promiseId, promise]),
+    )
+    const auditRef =
+      'docs/promises/2026-06-29-world-first-claims-7027-audit.md'
+
+    const bitcoinPaidTraining = byId.get(
+      'claims.world_first_ai_training_paid_bitcoin.v1',
+    )
+    expect(bitcoinPaidTraining?.state).toBe('red')
+    expect(bitcoinPaidTraining?.evidenceRefs).toContain(auditRef)
+    expect(bitcoinPaidTraining?.blockerRefs).toEqual(
+      expect.arrayContaining([
+        'blocker.product_promises.world_first_evidence_pack_missing',
+        'blocker.product_promises.world_first_owner_signed_upgrade_missing',
+      ]),
+    )
+    expect(bitcoinPaidTraining?.safeCopy).toContain('full qualifiers')
+    expect(bitcoinPaidTraining?.unsafeCopy).toContain('bare "world first"')
+    expect(bitcoinPaidTraining?.verification).toContain('dated #7027 audit')
+
+    const llmComputer = byId.get(
+      'claims.world_first_public_llm_computer_training_run.v1',
+    )
+    expect(llmComputer?.state).toBe('red')
+    expect(llmComputer?.evidenceRefs).toContain(auditRef)
+    expect(llmComputer?.blockerRefs).toEqual([
+      'blocker.product_promises.world_first_owner_signed_upgrade_missing',
+    ])
+    expect(llmComputer?.safeCopy).toContain('Percepta')
+    expect(llmComputer?.unsafeCopy).toContain('without the qualifiers')
+    expect(llmComputer?.verification).toContain('refuse-list')
+
+    const largestAgenticSalesForce = byId.get(
+      'claims.pursued_world_first_largest_agentic_sales_force.v1',
+    )
+    expect(largestAgenticSalesForce?.state).toBe('planned')
+    expect(largestAgenticSalesForce?.evidenceRefs).toContain(auditRef)
+    expect(largestAgenticSalesForce?.blockerRefs).toEqual(
+      expect.arrayContaining([
+        'blocker.product_promises.world_first_agentic_sales_force_not_achieved',
+        'blocker.product_promises.world_first_agentic_sales_force_no_sized_verifiable_force',
+        'blocker.product_promises.world_first_owner_signed_upgrade_missing',
+      ]),
+    )
+    expect(largestAgenticSalesForce?.safeCopy).toContain('PURSUED')
+    expect(largestAgenticSalesForce?.unsafeCopy).toContain(
+      'Do not state OpenAgents HAS the largest agentic sales force',
+    )
+
+    const largestSalesForce = byId.get(
+      'claims.pursued_world_first_largest_sales_force.v1',
+    )
+    expect(largestSalesForce?.state).toBe('planned')
+    expect(largestSalesForce?.evidenceRefs).toContain(auditRef)
+    expect(largestSalesForce?.blockerRefs).toEqual(
+      expect.arrayContaining([
+        'blocker.product_promises.world_first_largest_sales_force_not_achieved',
+        'blocker.product_promises.world_first_largest_sales_force_seven_million_bar_unmet',
+        'blocker.product_promises.world_first_owner_signed_upgrade_missing',
+      ]),
+    )
+    expect(largestSalesForce?.safeCopy).toContain('NOT achieved')
+    expect(largestSalesForce?.unsafeCopy).toContain(
+      'Do not state OpenAgents HAS the largest sales force',
+    )
+    expect(largestSalesForce?.verification).toContain(
+      'roughly seven-million-agent bar is unmet',
     )
   })
 

--- a/apps/openagents.com/workers/api/src/product-promises.ts
+++ b/apps/openagents.com/workers/api/src/product-promises.ts
@@ -4,7 +4,7 @@ import { currentIsoTimestamp } from './runtime-primitives'
 export const PublicProductPromisesEndpoint = '/api/public/product-promises'
 export const PublicProductPromisesSchemaVersion =
   'openagents.product_promises.v1'
-export const PublicProductPromisesVersion = '2026-06-29.2'
+export const PublicProductPromisesVersion = '2026-06-29.3'
 
 const reportPath = 'https://openagents.com/forum/f/product-promises'
 
@@ -110,6 +110,7 @@ const sourceRefs = [
   'apps/openagents.com/docs/labor/2026-06-19-agentic-labor-product-flow-scaffold.md',
   'docs/business/2026-06-20-openagents-business-intake-spec.md',
   'docs/business/2026-06-20-business-offering-promise-coverage.md',
+  'docs/promises/2026-06-29-world-first-claims-7027-audit.md',
 ]
 
 const basePromiseFields = {
@@ -261,6 +262,7 @@ export const publicProductPromisesDocument = () => {
         'Registry 2026-06-28.3 implements #6891 for models.tassadar_percepta_executor.v1 and flips NO promise state. Pylon v1.0 now has a deterministic bounded CPU computation-transform fixture in apps/pylon/src/tassadar-cpu-transform-training.ts that runs one CPU-only optimization step, self-verifies loss improvement, emits receipt.models.tassadar_percepta_executor.cpu_transform_training.cpu_transform_fixture_v1, and keeps realBitcoinMoved:false / settlementState:not_settled. GET /api/public/models/tassadar-percepta-executor/cpu-transform-training-receipts now projects that public-safe receipt alongside the architecture and Artanis distillation dataset inputs, so the old pylon_v03_cpu_transform_training_receipts_missing blocker is replaced by blocker.product_promises.tassadar_cpu_transform_real_settlement_missing and blocker.product_promises.tassadar_cpu_transform_owner_green_signoff_missing. The promise STAYS planned: this is one fixture-scale receipt, not a trained model, not a paid earning path, not model promotion, and not a green transition; any future green flip remains receipt-first and owner-signed per proof.claim_upgrade_receipts.v1.',
         'Registry 2026-06-29.1 implements #6848 for payments.accepted_outcome_economics.v1 and flips NO promise state. The accepted-outcome economics spine now has a dereferenceable contributor accrual bundle at GET /api/public/payments/contributor-accrual-bundle?economicsId=... plus the settlement bundle at GET /api/public/accepted-outcome/settlement/{economicsId}; together they compose a gross-margin receipt, contributor accrual ledger entries, and an eight-state settlement machine from one stored accepted-outcome economics row. Tests prove the ledger and receipt share the same economicsId, reconcile gross margin exactly, reconcile pending_payout to the distributable ledger pool, keep public projections free of internal cents/raw payment material, and surface missing contributor provenance honestly. The old source-level blockers contributor_ledger_missing and gross_margin_receipts_missing are replaced by real_accepted_outcome_receipt_missing and owner_signed_green_transition_missing. The promise STAYS red because source/fixture receipt machinery is not a real accepted outcome carried through a money-moving settlement path, and any future green flip remains receipt-first and owner-signed per proof.claim_upgrade_receipts.v1.',
         'Registry 2026-06-29.2 is a current-main refresh after #6997/#6999/#7001/#7002/#7006 and flips NO promise state. The terminal-agent current-state audit and Codex tool-layer study are now cited as evidence for the Codex/Probe/Pylon runtime direction: current production coding delegation is still Pylon plus external agent SDK lanes and OpenAgents-native terminal tools remain a consolidation task, not a new green claim. The codex-supervisor LOCKOUT replenishment helper can create or reuse three bounded standing issues so owner-capacity supervisors do not idle indefinitely, but it creates no paid labor, payout, settlement, or broad availability claim. The inference router now has GLM own-capacity failover alerting and public-safe fallback telemetry for repeated no-headroom saturation, but the paid gateway still stays red until a dereferenceable paid receipt exists. Khala Desktop now carries source-level Electrobun Apple FM sidecar packaging/readiness plus redaction tests, but Apple FM local mode remains yellow until a signed/notarized from-install smoke with helper supervision exists. The Khala model-mix promise remains live-at-read with maxStalenessSeconds:0; the stale 2-second cache wording is not applied.',
+        'Registry 2026-06-29.3 implements #7027 as a world-first/largest-force claim audit and flips NO promise state. The four records claims.world_first_ai_training_paid_bitcoin.v1, claims.world_first_public_llm_computer_training_run.v1, claims.pursued_world_first_largest_agentic_sales_force.v1, and claims.pursued_world_first_largest_sales_force.v1 now cite docs/promises/2026-06-29-world-first-claims-7027-audit.md as the dated blocker/copy-gate note. The Bitcoin-paid-training claim stays red on world_first_evidence_pack_missing plus owner-signed upgrade; the LLM-computer claim stays red on owner-signed upgrade even though its focused evidence pack exists; the largest-force claims stay planned as explicit pursuits with no achieved sized force. Tests guard that these records keep exact blockers, qualified safe/unsafe copy, and owner-signed/refuse-list language so public copy cannot accidentally overclaim.',
       ],
     },
     promises: [
@@ -697,6 +699,7 @@ export const publicProductPromisesDocument = () => {
           'docs/transcripts/238.md',
           'docs/launch/2026-06-18-pylon-v1-launch-readiness-audit.md',
           'docs/launch/2026-06-18-world-firsts-verification.md',
+          'docs/promises/2026-06-29-world-first-claims-7027-audit.md',
           'promise:training.decentralized_training_launch.v1',
           'promise:promises.registry.v1',
           'promise:proof.claim_upgrade_receipts.v1',
@@ -706,7 +709,7 @@ export const publicProductPromisesDocument = () => {
           'blocker.product_promises.world_first_owner_signed_upgrade_missing',
         ],
         verification:
-          'An independent prior-art/competing-claim search now exists (docs/launch/2026-06-18-world-firsts-verification.md; prior art checked includes Spirit of Satoshi, Bittensor/Templar, Gensyn, Prime Intellect, Nous/Psyche, Salad, Percepta, Tracr) with a defensible narrowed wording. Green still requires (1) a dereferenceable evidence pack tying the qualified world-first to the live run receipts and (2) an owner-signed receipt-first upgrade per proof.claim_upgrade_receipts.v1. Until then this stays red and any public use must carry the full qualifiers.',
+          'An independent prior-art/competing-claim search now exists (docs/launch/2026-06-18-world-firsts-verification.md; prior art checked includes Spirit of Satoshi, Bittensor/Templar, Gensyn, Prime Intellect, Nous/Psyche, Salad, Percepta, Tracr) with a defensible narrowed wording. The dated #7027 audit (docs/promises/2026-06-29-world-first-claims-7027-audit.md) keeps this red because green still requires (1) a dereferenceable evidence pack tying the qualified world-first to the live run receipts and (2) an owner-signed receipt-first upgrade per proof.claim_upgrade_receipts.v1. Until then this stays red and any public use must carry the full qualifiers.',
         authorityBoundary:
           'A launch transcript does not establish a world-first. The bounded real settlements prove payment to two contributors, not a first-in-the-world claim, and grant no network-scale or comparison authority.',
       },
@@ -728,6 +731,7 @@ export const publicProductPromisesDocument = () => {
           'docs/launch/2026-06-18-world-firsts-verification.md',
           'docs/launch/2026-06-20-llm-computer-training-run-definition.md',
           'docs/launch/2026-06-20-world-first-llm-computer-evidence-pack.md',
+          'docs/promises/2026-06-29-world-first-claims-7027-audit.md',
           'apps/openagents.com/workers/api/src/world-first-llm-computer-evidence-pack.test.ts',
           'promise:compute.tassadar_executor_poc.v1',
           'promise:models.tassadar_percepta_executor.v1',
@@ -738,7 +742,7 @@ export const publicProductPromisesDocument = () => {
           'blocker.product_promises.world_first_owner_signed_upgrade_missing',
         ],
         verification:
-          'An independent prior-art/competing-claim search now exists (docs/launch/2026-06-18-world-firsts-verification.md) with a defensible narrowed wording crediting Percepta as the paradigm originator. A precise definition of "LLM-computer training run" now exists (docs/launch/2026-06-20-llm-computer-training-run-definition.md): it pins the phrase to the executor-construction / exact-trace sense (sense B), distinguishes it from gradient-descent model training (sense A), credits Percepta, and enumerates the refuse-list so the phrase cannot overclaim against the no-gradient-descent executor PoC. A focused, dereferenceable evidence pack now exists (docs/launch/2026-06-20-world-first-llm-computer-evidence-pack.md): it ties the qualified Claim-2 world-first to the live-run receipts qualifier-by-qualifier (public/open-contributor paid loop -> run summary + two contributor settlement receipts; Percepta paradigm credit -> Percepta blog/transformer-vm + prior-art search; executor/exact-trace/replay-verified -> verified+rejected replay pairs and a Verified challenge), with a skeptic-runnable verification recipe and a refuse-list. A regression guard (apps/openagents.com/workers/api/src/world-first-llm-computer-evidence-pack.test.ts) now machine-enforces that the pack and definition stay dereferenceable: every repo-relative doc they cite resolves on disk, every promise: evidence ref resolves to a real registry promiseId, the cleared definition/evidence-pack blockers stay cleared without flipping state, and the refuse-list plus Percepta credit stay in the copy. Green still requires an owner-signed receipt-first upgrade per proof.claim_upgrade_receipts.v1, and the underlying public paid loop remains bounded (two contributors, not at scale).',
+          'An independent prior-art/competing-claim search now exists (docs/launch/2026-06-18-world-firsts-verification.md) with a defensible narrowed wording crediting Percepta as the paradigm originator. A precise definition of "LLM-computer training run" now exists (docs/launch/2026-06-20-llm-computer-training-run-definition.md): it pins the phrase to the executor-construction / exact-trace sense (sense B), distinguishes it from gradient-descent model training (sense A), credits Percepta, and enumerates the refuse-list so the phrase cannot overclaim against the no-gradient-descent executor PoC. A focused, dereferenceable evidence pack now exists (docs/launch/2026-06-20-world-first-llm-computer-evidence-pack.md): it ties the qualified Claim-2 world-first to the live-run receipts qualifier-by-qualifier (public/open-contributor paid loop -> run summary + two contributor settlement receipts; Percepta paradigm credit -> Percepta blog/transformer-vm + prior-art search; executor/exact-trace/replay-verified -> verified+rejected replay pairs and a Verified challenge), with a skeptic-runnable verification recipe and a refuse-list. A regression guard (apps/openagents.com/workers/api/src/world-first-llm-computer-evidence-pack.test.ts) now machine-enforces that the pack and definition stay dereferenceable: every repo-relative doc they cite resolves on disk, every promise: evidence ref resolves to a real registry promiseId, the cleared definition/evidence-pack blockers stay cleared without flipping state, and the refuse-list plus Percepta credit stay in the copy. The dated #7027 audit (docs/promises/2026-06-29-world-first-claims-7027-audit.md) keeps this red because green still requires an owner-signed receipt-first upgrade per proof.claim_upgrade_receipts.v1, and the underlying public paid loop remains bounded (two contributors, not at scale).',
         authorityBoundary:
           'A bounded exact-trace executor proof of concept grants no general LLM-computer capability claim and no world-first claim. The Tassadar research publication gates stay closed for everything beyond the scoped compute.tassadar_executor_poc.v1 promise.',
       },
@@ -3870,6 +3874,7 @@ export const publicProductPromisesDocument = () => {
         evidenceRefs: [
           'docs/transcripts/239.md',
           'docs/promises/2026-06-19-episode-239-lets-make-money-registry-reconciliation.md',
+          'docs/promises/2026-06-29-world-first-claims-7027-audit.md',
           'promise:referral.refer_once_earn_forever.v1',
           'promise:claims.world_first_ai_training_paid_bitcoin.v1',
         ],
@@ -3879,7 +3884,7 @@ export const publicProductPromisesDocument = () => {
           'blocker.product_promises.world_first_owner_signed_upgrade_missing',
         ],
         verification:
-          'This record is intentionally never green from aspiration. Any future non-aspirational claim would require a real, sized, independently-countable agentic sales force, an independent prior-art / record review, a dereferenceable evidence pack, and an owner-signed receipt-first upgrade per proof.claim_upgrade_receipts.v1. Until then it stays a labeled pursuit.',
+          'This record is intentionally never green from aspiration. The dated #7027 audit (docs/promises/2026-06-29-world-first-claims-7027-audit.md) keeps the blockers explicit: no real, sized, independently-countable agentic sales force exists. Any future non-aspirational claim would require that force, an independent prior-art / record review, a dereferenceable evidence pack, and an owner-signed receipt-first upgrade per proof.claim_upgrade_receipts.v1. Until then it stays a labeled pursuit.',
         authorityBoundary:
           'A pursued world first grants no record-holder status, no marketing-claim authority, and no sales, payout, or settlement authority. Aspiration is not achievement.',
       },
@@ -3898,6 +3903,7 @@ export const publicProductPromisesDocument = () => {
         evidenceRefs: [
           'docs/transcripts/239.md',
           'docs/promises/2026-06-19-episode-239-lets-make-money-registry-reconciliation.md',
+          'docs/promises/2026-06-29-world-first-claims-7027-audit.md',
           'promise:claims.pursued_world_first_largest_agentic_sales_force.v1',
           'promise:claims.world_first_public_llm_computer_training_run.v1',
         ],
@@ -3907,7 +3913,7 @@ export const publicProductPromisesDocument = () => {
           'blocker.product_promises.world_first_owner_signed_upgrade_missing',
         ],
         verification:
-          'This record is intentionally never green from aspiration. Any future non-aspirational claim would require independently verified counts crossing the stated bar, an independent prior-art / record review (with the comparison figure independently sourced, not ChatGPT-attributed), a dereferenceable evidence pack, and an owner-signed receipt-first upgrade per proof.claim_upgrade_receipts.v1.',
+          'This record is intentionally never green from aspiration. The dated #7027 audit (docs/promises/2026-06-29-world-first-claims-7027-audit.md) keeps the blockers explicit: the named roughly seven-million-agent bar is unmet, and the comparison figure is not OpenAgents-verified. Any future non-aspirational claim would require independently verified counts crossing the stated bar, an independent prior-art / record review (with the comparison figure independently sourced, not ChatGPT-attributed), a dereferenceable evidence pack, and an owner-signed receipt-first upgrade per proof.claim_upgrade_receipts.v1.',
         authorityBoundary:
           'A pursued world first grants no record-holder status, no marketing-claim authority, and no sales, payout, or settlement authority. Aspiration is not achievement.',
       },

--- a/docs/promises/2026-06-29-world-first-claims-7027-audit.md
+++ b/docs/promises/2026-06-29-world-first-claims-7027-audit.md
@@ -1,0 +1,58 @@
+# World-First Claims Audit for #7027
+
+Date: 2026-06-29
+
+Issue: [#7027](https://github.com/OpenAgentsInc/openagents/issues/7027)
+
+## Scope
+
+This audit covers the four active world-first / largest-force promise records:
+
+- `claims.world_first_ai_training_paid_bitcoin.v1`
+- `claims.world_first_public_llm_computer_training_run.v1`
+- `claims.pursued_world_first_largest_agentic_sales_force.v1`
+- `claims.pursued_world_first_largest_sales_force.v1`
+
+## Decision
+
+No promise is ready to turn green.
+
+The LLM-computer claim has a focused evidence pack and definition, but it still
+needs an owner-signed receipt-first transition before public copy can present it
+as achieved. The Bitcoin-paid-training claim still needs its own
+dereferenceable qualified evidence bundle and the same owner-signed transition.
+The two largest-force claims remain explicit pursuits, not achieved records.
+
+## Blockers Kept Explicit
+
+| Promise | State | Why it stays non-green |
+| --- | --- | --- |
+| `claims.world_first_ai_training_paid_bitcoin.v1` | red | Missing a qualified evidence pack tying the narrowed wording to receipts; missing owner-signed upgrade. |
+| `claims.world_first_public_llm_computer_training_run.v1` | red | Evidence pack exists, but owner-signed upgrade is still missing. Public copy must keep Percepta credit, executor-construction wording, and no-gradient-descent caveats. |
+| `claims.pursued_world_first_largest_agentic_sales_force.v1` | planned | No real, sized, independently countable agentic sales force exists. |
+| `claims.pursued_world_first_largest_sales_force.v1` | planned | The named roughly seven-million-agent bar is unmet, and the comparison figure is not OpenAgents-verified. |
+
+## Copy Gate
+
+Public copy must not use bare "world first", "has the largest sales force",
+"largest sales force in the world", "world record achieved", or equivalent
+unqualified achievement language for these records.
+
+Allowed copy is limited to the registry's qualified wording:
+
+- Claim 1 may be discussed only with the full Bitcoin + replay-verified training
+  compute + own consumer devices qualifiers, and only as red pending receipt
+  upgrade.
+- Claim 2 may be discussed only as a public/open-contributor LLM-computer
+  training-run claim with Percepta credit, executor-construction semantics, and
+  no gradient-descent model-training overclaim.
+- The largest-force records may be discussed only as clearly labeled pursuits or
+  aspirations.
+
+## Follow-Up Required
+
+To close the remaining gates, prepare one owner-signed transition request per
+claim that is actually ready. Each request must cite dereferenceable receipt
+refs, the prior-art review, exact qualifier language, and the relevant refuse
+list. Until those receipts exist, the machine-readable registry must keep the
+records red/planned and keep the blockers listed.

--- a/docs/promises/registry.md
+++ b/docs/promises/registry.md
@@ -1,5 +1,18 @@
 # Promise Registry
 
+> Registry `2026-06-29.3` implements #7027 as a world-first/largest-force
+> claim audit and flips NO promise state. The four records
+> `claims.world_first_ai_training_paid_bitcoin.v1`,
+> `claims.world_first_public_llm_computer_training_run.v1`,
+> `claims.pursued_world_first_largest_agentic_sales_force.v1`, and
+> `claims.pursued_world_first_largest_sales_force.v1` now cite
+> [`docs/promises/2026-06-29-world-first-claims-7027-audit.md`](2026-06-29-world-first-claims-7027-audit.md)
+> as the dated blocker/copy-gate note. The Bitcoin-paid-training claim stays red
+> on evidence-pack plus owner-signed-upgrade blockers; the LLM-computer claim
+> stays red on owner-signed upgrade; and the largest-force claims stay planned
+> as explicit pursuits with no achieved sized force. Tests guard the qualified
+> copy and blocker language so public surfaces cannot accidentally overclaim.
+>
 > Registry `2026-06-29.2` is a current-main refresh after #6997, #6999,
 > #7001, #7002, and #7006 and flips NO promise state. It records the
 > terminal-agent current-state audit and Codex tool-layer study as evidence for
@@ -66,9 +79,9 @@
 > Current machine-readable source of truth: `/api/public/product-promises` is
 > generated from
 > [`product-promises.ts`](../../apps/openagents.com/workers/api/src/product-promises.ts),
-> which currently advertises registry `2026-06-29.2` with
+> which currently advertises registry `2026-06-29.3` with
 > `lastUpdated: "2026-06-29"`. This narrative document records the same
-> top-line 2026-06-29.2 promise decisions above, plus historical reconciliation
+> top-line 2026-06-29.3 promise decisions above, plus historical reconciliation
 > context below; when in doubt, agents and reviewers should defer to the
 > machine-readable registry and include its version in mismatch reports.
 >
@@ -76,7 +89,7 @@
 > Tassadar CPU-transform, referral, small-model proxy, WASM plugin, Verse scene,
 > native email, marketplace, metrics, terminal-agent audit, supervisor
 > replenishment, GLM failover, Apple FM sidecar, and operator-safety merges were
-> checked against the current `2026-06-29.2` registry header. This pass records
+> checked against the current `2026-06-29.3` registry header. This pass records
 > no additional promise state flips and no new green claims beyond the already
 > source-recorded scoped transitions; red/planned/yellow records keep their
 > owner-signed, receipt-first green gates.


### PR DESCRIPTION
## Summary

- Adds a dated #7027 audit note for the four world-first / largest-force promise records.
- Bumps the product-promise registry to 2026-06-29.3 with no state flips.
- Wires the audit into the affected records and adds focused regression coverage for blockers, qualified copy, and owner-signed/refuse-list language.

## Verification

- `true` (resolved from `command.public.pylon_khala.verify.b5bea41b6c623f7c09f1bf24`)
- `bun run --cwd apps/openagents.com/workers/api test -- src/product-promises.test.ts src/world-first-llm-computer-evidence-pack.test.ts`

Closes #7027