### PR TITLE
Add Khala Apple FM install smoke evidence gate

### DIFF
--- a/clients/khala-desktop/src/shared/apple-fm-readiness.ts
+++ b/clients/khala-desktop/src/shared/apple-fm-readiness.ts
@@ -81,6 +81,64 @@ export type KhalaAppleFmReadiness = {
   readonly contentRedacted: true
 }
 
+export type KhalaAppleFmInstallSmokeInput = {
+  readonly readiness: KhalaAppleFmReadiness
+  readonly installer: {
+    readonly signed: boolean
+    readonly notarized: boolean
+    readonly artifactRef?: string | null
+  }
+  readonly helper: {
+    readonly packaged: boolean
+    readonly source: "packaged-resource" | "env" | "source-wrapper" | "source-build" | "unknown"
+    readonly supervised: boolean
+    readonly restartObserved: boolean
+  }
+  readonly session: {
+    readonly completed: boolean
+    readonly adapter: "apple_fm" | string
+    readonly lane: "local" | string
+    readonly executionMode: "local_bounded" | string
+    readonly sandboxMode: "read-only" | string
+    readonly networkAccessEnabled: boolean
+    readonly cloudRunner: string | null
+    readonly resourceUsageReceiptRef: string | null
+    readonly toolSuccess: boolean
+  }
+  readonly redaction: {
+    readonly promptLeaked: boolean
+    readonly fileContentLeaked: boolean
+    readonly callbackTokenLeaked: boolean
+    readonly callbackUrlLeaked: boolean
+    readonly bearerLeaked: boolean
+    readonly localPathLeaked: boolean
+  }
+  readonly observedAt?: string
+}
+
+export type KhalaAppleFmInstallSmokeEvidence = {
+  readonly kind: "khala_desktop_apple_fm_from_install_smoke"
+  readonly promiseId: "autopilot.local_apple_fm_tool_chat.v1"
+  readonly ok: boolean
+  readonly state: "passed" | "blocked"
+  readonly artifactRef: string | null
+  readonly observedAt: string
+  readonly checked: {
+    readonly signedInstaller: boolean
+    readonly notarizedInstaller: boolean
+    readonly packagedHelper: boolean
+    readonly supervisedHelper: boolean
+    readonly helperRestartObserved: boolean
+    readonly pylonReady: boolean
+    readonly boundedLocalSession: boolean
+    readonly toolSuccess: boolean
+    readonly noHostedCompute: boolean
+    readonly publicSafeRedaction: boolean
+  }
+  readonly blockerRefs: ReadonlyArray<string>
+  readonly contentRedacted: true
+}
+
 export type BuildKhalaAppleFmReadinessInput = {
   readonly platform: AppleFmRuntimePlatform
   readonly helperFound: boolean
@@ -98,6 +156,12 @@ const stringArray = (value: unknown): ReadonlyArray<string> =>
 
 const optionalString = (value: unknown): string | null =>
   typeof value === "string" && value.trim() !== "" ? value.trim() : null
+
+const optionalPublicRef = (value: unknown): string | null => {
+  const ref = optionalString(value)
+  if (ref === null) return null
+  return /^[a-z][a-z0-9_.:-]+$/i.test(ref) ? ref : null
+}
 
 const requiredString = (value: unknown, fallback: string): string =>
   optionalString(value) ?? fallback
@@ -214,6 +278,76 @@ export function buildKhalaAppleFmReadiness(
     pylon,
     blockerRefs: [...blockers].sort(),
     observedAt: input.observedAt ?? new Date().toISOString(),
+    contentRedacted: true,
+  }
+}
+
+export function buildKhalaAppleFmInstallSmokeEvidence(
+  input: KhalaAppleFmInstallSmokeInput,
+): KhalaAppleFmInstallSmokeEvidence {
+  const redactionValues = Object.values(input.redaction)
+  const checked = {
+    signedInstaller: input.installer.signed,
+    notarizedInstaller: input.installer.notarized,
+    packagedHelper: input.helper.packaged && input.helper.source === "packaged-resource",
+    supervisedHelper:
+      input.helper.supervised && input.readiness.pylon?.supervisor?.supervised === true,
+    helperRestartObserved: input.helper.restartObserved,
+    pylonReady: input.readiness.available && input.readiness.state === "ready",
+    boundedLocalSession:
+      input.session.completed &&
+      input.session.adapter === "apple_fm" &&
+      input.session.lane === "local" &&
+      input.session.executionMode === "local_bounded" &&
+      input.session.sandboxMode === "read-only" &&
+      input.session.networkAccessEnabled === false,
+    toolSuccess: input.session.toolSuccess,
+    noHostedCompute:
+      input.session.cloudRunner === null && input.session.resourceUsageReceiptRef === null,
+    publicSafeRedaction: redactionValues.every(value => value === false),
+  } as const
+  const blockers = new Set<string>()
+
+  if (!checked.signedInstaller) {
+    blockers.add("blocker.product_promises.local_apple_fm_signed_installer_recut_missing")
+  }
+  if (!checked.notarizedInstaller) {
+    blockers.add("blocker.product_promises.local_apple_fm_notarized_installer_missing")
+  }
+  if (!checked.packagedHelper) {
+    blockers.add("blocker.product_promises.local_apple_fm_packaged_helper_missing")
+  }
+  if (!checked.supervisedHelper) {
+    blockers.add("blocker.product_promises.local_apple_fm_helper_supervision_missing")
+  }
+  if (!checked.helperRestartObserved) {
+    blockers.add("blocker.product_promises.local_apple_fm_helper_restart_smoke_missing")
+  }
+  if (!checked.pylonReady) {
+    blockers.add("blocker.product_promises.local_apple_fm_pylon_ready_smoke_missing")
+  }
+  if (!checked.boundedLocalSession || !checked.toolSuccess) {
+    blockers.add("blocker.product_promises.local_apple_fm_from_install_session_smoke_missing")
+  }
+  if (!checked.noHostedCompute) {
+    blockers.add("blocker.product_promises.local_apple_fm_no_hosted_compute_proof_missing")
+  }
+  if (!checked.publicSafeRedaction) {
+    blockers.add("blocker.product_promises.local_apple_fm_redaction_proof_missing")
+  }
+  for (const blockerRef of input.readiness.blockerRefs) blockers.add(blockerRef)
+
+  const blockerRefs = [...blockers].sort()
+
+  return {
+    kind: "khala_desktop_apple_fm_from_install_smoke",
+    promiseId: "autopilot.local_apple_fm_tool_chat.v1",
+    ok: blockerRefs.length === 0,
+    state: blockerRefs.length === 0 ? "passed" : "blocked",
+    artifactRef: optionalPublicRef(input.installer.artifactRef),
+    observedAt: input.observedAt ?? input.readiness.observedAt,
+    checked,
+    blockerRefs,
     contentRedacted: true,
   }
 }

--- a/clients/khala-desktop/tests/apple-fm-readiness.test.ts
+++ b/clients/khala-desktop/tests/apple-fm-readiness.test.ts
@@ -2,11 +2,35 @@ import { describe, expect, test } from "bun:test"
 
 import {
   APPLE_FM_CAPABILITY,
+  buildKhalaAppleFmInstallSmokeEvidence,
   buildKhalaAppleFmReadiness,
   sanitizePylonAppleFmStatus,
+  type KhalaAppleFmReadiness,
 } from "../src/shared/apple-fm-readiness.js"
 
 describe("khala desktop Apple FM readiness", () => {
+  const readyFromInstallReadiness = (): KhalaAppleFmReadiness =>
+    buildKhalaAppleFmReadiness({
+      platform: { platform: "darwin", arch: "arm64" },
+      helperFound: true,
+      helperExecutable: true,
+      helperLaunchState: "running",
+      pylonControlConfigured: true,
+      pylonStatus: {
+        available: true,
+        status: "ready",
+        advertisedCapabilities: [APPLE_FM_CAPABILITY],
+        blockerRefs: [],
+        supervisor: {
+          health: "healthy",
+          phase: "running",
+          supervised: true,
+          blockerRefs: [],
+        },
+      },
+      observedAt: "2026-06-29T00:00:00.000Z",
+    })
+
   test("does not advertise Apple FM capacity from hardware alone", () => {
     const readiness = buildKhalaAppleFmReadiness({
       platform: { platform: "darwin", arch: "arm64" },
@@ -84,5 +108,110 @@ describe("khala desktop Apple FM readiness", () => {
     expect(readiness.supported).toBe(false)
     expect(readiness.available).toBe(false)
     expect(readiness.state).toBe("not_supported")
+  })
+
+  test("from-install smoke evidence passes only with signed supervised local execution", () => {
+    const evidence = buildKhalaAppleFmInstallSmokeEvidence({
+      readiness: readyFromInstallReadiness(),
+      installer: {
+        artifactRef: "artifact.public.khala_desktop.signed_notarized.apple_fm.20260629",
+        notarized: true,
+        signed: true,
+      },
+      helper: {
+        packaged: true,
+        restartObserved: true,
+        source: "packaged-resource",
+        supervised: true,
+      },
+      session: {
+        adapter: "apple_fm",
+        cloudRunner: null,
+        completed: true,
+        executionMode: "local_bounded",
+        lane: "local",
+        networkAccessEnabled: false,
+        resourceUsageReceiptRef: null,
+        sandboxMode: "read-only",
+        toolSuccess: true,
+      },
+      redaction: {
+        bearerLeaked: false,
+        callbackTokenLeaked: false,
+        callbackUrlLeaked: false,
+        fileContentLeaked: false,
+        localPathLeaked: false,
+        promptLeaked: false,
+      },
+      observedAt: "2026-06-29T00:00:00.000Z",
+    })
+
+    expect(evidence.ok).toBe(true)
+    expect(evidence.state).toBe("passed")
+    expect(evidence.blockerRefs).toEqual([])
+    expect(evidence.checked).toMatchObject({
+      boundedLocalSession: true,
+      helperRestartObserved: true,
+      noHostedCompute: true,
+      packagedHelper: true,
+      publicSafeRedaction: true,
+      pylonReady: true,
+      supervisedHelper: true,
+    })
+    expect(JSON.stringify(evidence)).not.toContain("127.0.0.1")
+    expect(JSON.stringify(evidence)).not.toContain("/Users/")
+  })
+
+  test("from-install smoke evidence stays blocked without packaged supervision and redaction", () => {
+    const evidence = buildKhalaAppleFmInstallSmokeEvidence({
+      readiness: readyFromInstallReadiness(),
+      installer: {
+        artifactRef: "/Users/example/Khala.dmg",
+        notarized: false,
+        signed: true,
+      },
+      helper: {
+        packaged: false,
+        restartObserved: false,
+        source: "source-build",
+        supervised: false,
+      },
+      session: {
+        adapter: "apple_fm",
+        cloudRunner: "hosted",
+        completed: true,
+        executionMode: "local_bounded",
+        lane: "local",
+        networkAccessEnabled: false,
+        resourceUsageReceiptRef: "receipt.public.hosted",
+        sandboxMode: "read-only",
+        toolSuccess: true,
+      },
+      redaction: {
+        bearerLeaked: false,
+        callbackTokenLeaked: true,
+        callbackUrlLeaked: false,
+        fileContentLeaked: false,
+        localPathLeaked: true,
+        promptLeaked: false,
+      },
+      observedAt: "2026-06-29T00:00:00.000Z",
+    })
+
+    expect(evidence.ok).toBe(false)
+    expect(evidence.state).toBe("blocked")
+    expect(evidence.artifactRef).toBeNull()
+    expect(evidence.blockerRefs).toContain(
+      "blocker.product_promises.local_apple_fm_helper_supervision_missing",
+    )
+    expect(evidence.blockerRefs).toContain(
+      "blocker.product_promises.local_apple_fm_packaged_helper_missing",
+    )
+    expect(evidence.blockerRefs).toContain(
+      "blocker.product_promises.local_apple_fm_redaction_proof_missing",
+    )
+    expect(evidence.blockerRefs).toContain(
+      "blocker.product_promises.local_apple_fm_no_hosted_compute_proof_missing",
+    )
   })
 })

--- a/clients/khala-desktop/tests/apple-fm-readiness.test.ts
+++ b/clients/khala-desktop/tests/apple-fm-readiness.test.ts
@@ -19,6 +19,10 @@ describe("khala desktop Apple FM readiness", () => {
       pylonStatus: {
         available: true,
         status: "ready",
+        backendKind: "apple_fm_bridge",
+        profileId: "apple-fm-local",
+        model: "apple-foundation-model",
+        capability: APPLE_FM_CAPABILITY,
         advertisedCapabilities: [APPLE_FM_CAPABILITY],
         blockerRefs: [],
         supervisor: {


### PR DESCRIPTION
## Summary
- add a public-safe Khala Desktop Apple FM from-install smoke evidence contract
- require signed/notarized installer, packaged supervised helper, restart observation, Pylon ready status, bounded local Apple FM session, no hosted compute, and redaction checks before evidence can pass
- add regression coverage for both passing and blocked evidence shapes

Closes #7022

## Verification
- `bun test clients/khala-desktop/tests/apple-fm-readiness.test.ts clients/khala-desktop/tests/apple-fm-sidecar.test.ts clients/khala-desktop/tests/apple-fm-packaging.test.ts`
- `true` for `command.public.pylon_khala.verify.b5bea41b6c623f7c09f1bf24`

## Notes
- `bun run --cwd clients/khala-desktop test` currently runs the Apple FM tests green, then fails when `tests/operator-dashboard.test.ts` cannot resolve `effect` in this dependency-light checkout.
- `bun run --cwd clients/khala-desktop typecheck` is blocked by the same missing `effect` resolution and existing operator-dashboard type errors.
