### PR TITLE
fix: expose Artanis readiness blockers

### DIFF
--- a/apps/openagents.com/workers/api/src/artanis-labor-green-readiness.test.ts
+++ b/apps/openagents.com/workers/api/src/artanis-labor-green-readiness.test.ts
@@ -98,6 +98,10 @@ describe('artanis labor requester green-readiness projection', () => {
       ARTANIS_LABOR_LIVE_ENABLEMENT_BLOCKER,
       ARTANIS_LABOR_UNATTENDED_RECEIPTS_BLOCKER,
     ])
+    expect(readiness.remainingBlockerRefs).toEqual([
+      ARTANIS_LABOR_LIVE_ENABLEMENT_BLOCKER,
+      ARTANIS_LABOR_UNATTENDED_RECEIPTS_BLOCKER,
+    ])
     expect(readiness.unattendedRequestTarget).toBe(
       ARTANIS_LABOR_UNATTENDED_REQUEST_TARGET,
     )
@@ -118,6 +122,9 @@ describe('artanis labor requester green-readiness projection', () => {
     expect(readiness.liveEnablementProven).toBe(true)
     expect(readiness.unattendedRequestReceiptsProven).toBe(false)
     expect(readiness.greenGateMet).toBe(false)
+    expect(readiness.remainingBlockerRefs).toEqual([
+      ARTANIS_LABOR_UNATTENDED_RECEIPTS_BLOCKER,
+    ])
     expect(readiness.placedRequests).toHaveLength(1)
     expect(readiness.placedRequests[0]?.terminalState).toBe(
       'requested_pending_delivery',
@@ -142,6 +149,7 @@ describe('artanis labor requester green-readiness projection', () => {
     expect(readiness.unattendedRequestReceiptsProven).toBe(true)
     expect(readiness.greenGateMet).toBe(true)
     expect(artanisLaborGreenGateMet(readiness)).toBe(true)
+    expect(readiness.remainingBlockerRefs).toEqual([])
     expect(readiness.placedRequests).toHaveLength(
       ARTANIS_LABOR_UNATTENDED_REQUEST_TARGET,
     )

--- a/apps/openagents.com/workers/api/src/artanis-labor-green-readiness.ts
+++ b/apps/openagents.com/workers/api/src/artanis-labor-green-readiness.ts
@@ -82,6 +82,8 @@ export type ArtanisLaborGreenReadinessProjection = Readonly<{
   // The blocker tokens this surface tracks, named so the operator recording the
   // transition can cite the exact refs being cleared.
   blockerRefs: ReadonlyArray<string>
+  // The blockers still open under the live receipt evidence in this response.
+  remainingBlockerRefs: ReadonlyArray<string>
   // The number of placed receipts required before the receipts blocker clears.
   unattendedRequestTarget: number
   // The placed-request count over the projected feed window.
@@ -145,6 +147,12 @@ export const projectArtanisLaborGreenReadinessProjection = (
     placedRequestCount >= ARTANIS_LABOR_UNATTENDED_REQUEST_TARGET
   const greenGateMet =
     liveEnablementProven && unattendedRequestReceiptsProven
+  const remainingBlockerRefs = [
+    ...(liveEnablementProven ? [] : [ARTANIS_LABOR_LIVE_ENABLEMENT_BLOCKER]),
+    ...(unattendedRequestReceiptsProven
+      ? []
+      : [ARTANIS_LABOR_UNATTENDED_RECEIPTS_BLOCKER]),
+  ]
 
   return {
     authorityBoundary: AUTHORITY_BOUNDARY,
@@ -167,6 +175,7 @@ export const projectArtanisLaborGreenReadinessProjection = (
     placedRequestCount,
     placedRequests,
     publicSafe: true,
+    remainingBlockerRefs,
     staleness: liveAtReadStaleness([
       'artanis_labor_unattended_request_receipt_stored',
     ]),

--- a/apps/openagents.com/workers/api/src/artanis-responder-provenance.test.ts
+++ b/apps/openagents.com/workers/api/src/artanis-responder-provenance.test.ts
@@ -1,13 +1,37 @@
 import { describe, expect, test } from 'vitest'
 
 import {
+  ARTANIS_RESPONDER_EXTERNAL_CONTRIBUTOR_FLOW_BLOCKER,
+  ARTANIS_RESPONDER_TEN_UNATTENDED_TICKS_BLOCKER,
   boundedResponderSupportLimit,
   classifyAskerProvenance,
   projectArtanisResponderSupport,
   type ArtanisResponderActionRow,
 } from './artanis-responder-provenance'
+import type { ArtanisResponderTickReadinessProjection } from './artanis-responder-ticks'
 
 const nowIso = '2026-06-20T00:00:00.000Z'
+
+const tickReadiness = (
+  overrides: Partial<ArtanisResponderTickReadinessProjection> = {},
+): ArtanisResponderTickReadinessProjection => ({
+  authorityBoundary: 'test',
+  externalContributorAnsweredWithinTickWindow: true,
+  kind: 'artanis_pylon_support_responder_tick_readiness',
+  notes: [],
+  publicSafe: true,
+  qualifyingUnattendedResponderTickCount: 10,
+  staleness: {
+    composition: 'live_at_read',
+    contractVersion: 'projection_staleness.v1',
+    maxStalenessSeconds: 0,
+    rebuildsOn: ['test'],
+  },
+  tickTarget: 10,
+  tickWindows: [],
+  unattendedResponderTicksProven: true,
+  ...overrides,
+})
 
 const row = (
   overrides: Partial<ArtanisResponderActionRow>,
@@ -45,8 +69,8 @@ describe('classifyAskerProvenance', () => {
 
   test('pinned admin actor refs are owner_operator, never external', () => {
     expect(
-      classifyAskerProvenance('user:admin_chris', {
-        adminActorRefs: ['user:admin_chris'],
+      classifyAskerProvenance('user:admin_owner', {
+        adminActorRefs: ['user:admin_owner'],
       }),
     ).toBe('owner_operator')
   })
@@ -67,7 +91,11 @@ describe('classifyAskerProvenance', () => {
 
 describe('projectArtanisResponderSupport', () => {
   test('an answered external contributor proves the flow with a deref ref', () => {
-    const projection = projectArtanisResponderSupport([row({})], nowIso)
+    const projection = projectArtanisResponderSupport(
+      [row({})],
+      nowIso,
+      tickReadiness(),
+    )
     expect(projection.kind).toBe('artanis_pylon_support_responder_external_flow')
     expect(projection.publicSafe).toBe(true)
     expect(projection.staleness.contractVersion).toBe('projection_staleness.v1')
@@ -81,6 +109,11 @@ describe('projectArtanisResponderSupport', () => {
     expect(projection.externalInteractions[0]?.publicUrl).toContain(
       '#post-post.public.forum.artanis.status.42',
     )
+    expect(projection.blockerRefs).toEqual([
+      ARTANIS_RESPONDER_EXTERNAL_CONTRIBUTOR_FLOW_BLOCKER,
+      ARTANIS_RESPONDER_TEN_UNATTENDED_TICKS_BLOCKER,
+    ])
+    expect(projection.remainingBlockerRefs).toEqual([])
   })
 
   test('a tipped external interaction counts the economic leg', () => {
@@ -113,6 +146,10 @@ describe('projectArtanisResponderSupport', () => {
     expect(projection.ownerOperatorAnsweredCount).toBe(1)
     expect(projection.externalContributorAnsweredCount).toBe(0)
     expect(projection.externalContributorFlowProven).toBe(false)
+    expect(projection.remainingBlockerRefs).toEqual([
+      ARTANIS_RESPONDER_EXTERNAL_CONTRIBUTOR_FLOW_BLOCKER,
+      ARTANIS_RESPONDER_TEN_UNATTENDED_TICKS_BLOCKER,
+    ])
   })
 
   test('proposed and skipped actions are not answered interactions', () => {
@@ -160,6 +197,21 @@ describe('projectArtanisResponderSupport', () => {
     )
     expect(projection.externalContributorAnsweredCount).toBe(0)
     expect(projection.ownerOperatorAnsweredCount).toBe(0)
+  })
+
+  test('keeps the ten-tick blocker explicit until tick readiness reaches target', () => {
+    const projection = projectArtanisResponderSupport(
+      [row({})],
+      nowIso,
+      tickReadiness({
+        qualifyingUnattendedResponderTickCount: 9,
+        unattendedResponderTicksProven: false,
+      }),
+    )
+    expect(projection.externalContributorFlowProven).toBe(true)
+    expect(projection.remainingBlockerRefs).toEqual([
+      ARTANIS_RESPONDER_TEN_UNATTENDED_TICKS_BLOCKER,
+    ])
   })
 })
 

--- a/apps/openagents.com/workers/api/src/artanis-responder-provenance.ts
+++ b/apps/openagents.com/workers/api/src/artanis-responder-provenance.ts
@@ -41,6 +41,11 @@ export const ARTANIS_RESPONDER_SUPPORT_STALENESS: PublicProjectionStalenessContr
     'artanis_responder_actions.update',
   ])
 
+export const ARTANIS_RESPONDER_EXTERNAL_CONTRIBUTOR_FLOW_BLOCKER =
+  'blocker.product_promises.external_contributor_flow_unproven'
+export const ARTANIS_RESPONDER_TEN_UNATTENDED_TICKS_BLOCKER =
+  'blocker.product_promises.ten_unattended_responder_ticks_unaccrued'
+
 // The bounded asker-provenance enum. external_contributor is the only class
 // the green gate cares about; the others exist so the classifier is total
 // and the projection can honestly say WHY a given interaction does not count.
@@ -134,6 +139,10 @@ export type ArtanisResponderSupportProjection = Readonly<{
   // True once at least one external contributor has been answered end to end
   // with a dereferenceable reply post. This is the gate the blocker tracks.
   externalContributorFlowProven: boolean
+  // The product-promise blocker tokens tracked by this readiness surface.
+  blockerRefs: ReadonlyArray<string>
+  // The blockers still open under the live responder/tick evidence in this response.
+  remainingBlockerRefs: ReadonlyArray<string>
   // The external-contributor interactions, newest first, each with the
   // dereferenceable reply-post ref.
   externalInteractions: ReadonlyArray<ArtanisExternalSupportInteraction>
@@ -224,10 +233,27 @@ export const projectArtanisResponderSupport = (
   const externalContributorFlowProven = externalInteractions.some(
     interaction => interaction.replyPostRef !== null,
   )
+  const externalContributorAnsweredWithinTickWindow =
+    tickReadiness?.externalContributorAnsweredWithinTickWindow === true
+  const unattendedResponderTicksProven =
+    tickReadiness?.unattendedResponderTicksProven === true
+  const remainingBlockerRefs = [
+    ...(externalContributorFlowProven &&
+    externalContributorAnsweredWithinTickWindow
+      ? []
+      : [ARTANIS_RESPONDER_EXTERNAL_CONTRIBUTOR_FLOW_BLOCKER]),
+    ...(unattendedResponderTicksProven
+      ? []
+      : [ARTANIS_RESPONDER_TEN_UNATTENDED_TICKS_BLOCKER]),
+  ]
 
   return {
     authorityBoundary:
       'Read-only projection over the Artanis responder-action ledger. Grants no dispatch, spend, assignment, settlement, moderation, or registry authority and cannot create an interaction, a reply, or a tip. Asker provenance is a bounded identity-field classification (operator/owner/agent/user prefix plus known internal Artanis/admin refs); the mind still owns the question-class decision.',
+    blockerRefs: [
+      ARTANIS_RESPONDER_EXTERNAL_CONTRIBUTOR_FLOW_BLOCKER,
+      ARTANIS_RESPONDER_TEN_UNATTENDED_TICKS_BLOCKER,
+    ],
     externalContributorAnsweredCount,
     externalContributorFlowProven,
     externalContributorTippedCount,
@@ -241,6 +267,7 @@ export const projectArtanisResponderSupport = (
     ],
     ownerOperatorAnsweredCount,
     publicSafe: true,
+    remainingBlockerRefs,
     staleness: ARTANIS_RESPONDER_SUPPORT_STALENESS,
     ...(tickReadiness === undefined ? {} : { tickReadiness }),
   }

--- a/apps/openagents.com/workers/api/src/openagents-openapi.ts
+++ b/apps/openagents.com/workers/api/src/openagents-openapi.ts
@@ -1960,7 +1960,7 @@ const schemaComponents = (): JsonSchema => ({
     'Public-safe Artanis Tassadar distillation dataset receipt: a refs-only live-at-read manifest over accepted Artanis admin executor-trace closeouts. Returns receiptState, receiptRef/datasetRef when enough verified traces exist, required/source verified trace counts, digest prefixes, closeout receipt refs, clearsBlockerRefs/blockerRefs, and per-trace public refs. It exposes no raw trace bodies, private runner logs, prompts, provider payloads, wallet material, customer data, settlement claim, model-training claim, or model-promotion claim.',
   ),
   ArtanisResponderSupportResponse: objectSummary(
-    'Public-safe Artanis Pylon-support responder external-contributor-flow and tick-readiness projection: per-asker-provenance counts (externalContributorAnsweredCount, externalContributorTippedCount, ownerOperatorAnsweredCount), externalContributorFlowProven, external-contributor interactions with dereferenceable reply-post refs, and tickReadiness with the ten unattended responder tick target, qualifying tick count, tick windows, and externalContributorAnsweredWithinTickWindow. An external contributor is a registered non-owner, non-operator, non-Artanis identity; operator/owner test articles are classified owner_operator and never satisfy the gate. Carries generatedAt plus projection_staleness.v1 contracts (live_at_read, maxStalenessSeconds 0, rebuildsOn the responder-action and responder-tick ledger writes). Read-only projection; it grants no dispatch, spend, assignment, settlement, moderation, Forum-write, or registry-transition authority and cannot create an interaction, a reply, a tip, or a tick.',
+    'Public-safe Artanis Pylon-support responder external-contributor-flow and tick-readiness projection: per-asker-provenance counts (externalContributorAnsweredCount, externalContributorTippedCount, ownerOperatorAnsweredCount), externalContributorFlowProven, external-contributor interactions with dereferenceable reply-post refs, blockerRefs/remainingBlockerRefs for the product-promise gate, and tickReadiness with the ten unattended responder tick target, qualifying tick count, tick windows, and externalContributorAnsweredWithinTickWindow. An external contributor is a registered non-owner, non-operator, non-Artanis identity; operator/owner test articles are classified owner_operator and never satisfy the gate. Carries generatedAt plus projection_staleness.v1 contracts (live_at_read, maxStalenessSeconds 0, rebuildsOn the responder-action and responder-tick ledger writes). Read-only projection; it grants no dispatch, spend, assignment, settlement, moderation, Forum-write, or registry-transition authority and cannot create an interaction, a reply, a tip, or a tick.',
   ),
   LaborSelfServePayoutRequest: objectSummary(
     'Agent-authenticated self-serve labor payout request. The providerRef must match the bearer-authenticated actor; the route currently returns a typed plan plus an inert dispatch decision unless explicitly enabled.',
@@ -3732,6 +3732,7 @@ const schemaComponents = (): JsonSchema => ({
       'placedRequestCount',
       'placedRequests',
       'publicSafe',
+      'remainingBlockerRefs',
       'staleness',
       'unattendedRequestReceiptsProven',
       'unattendedRequestTarget',
@@ -3751,6 +3752,7 @@ const schemaComponents = (): JsonSchema => ({
       placedRequestCount: { type: 'integer' },
       placedRequests: { type: 'array', items: { type: 'object' } },
       publicSafe: { type: 'boolean' },
+      remainingBlockerRefs: { type: 'array', items: { type: 'string' } },
       staleness: {
         type: 'object',
         additionalProperties: false,
@@ -6010,7 +6012,7 @@ const paths = (): JsonSchema => ({
       operationId: 'getPublicArtanisLaborGreenReadiness',
       summary: 'Read the Artanis labor-requester green-readiness projection',
       description:
-        'Returns the public-safe green-readiness projection for artanis.labor_requester.v1: it folds the Artanis labor receipt feed onto the two named green-flip blockers and reports placedRequestCount (unattended request receipts that reserved escrow - a state only an operator-enabled tick can reach), liveEnablementProven (>=1 placed receipt), unattendedRequestReceiptsProven (>=10 placed receipts), greenGateMet (both - the mechanical receipt-evidence predicate only), per-terminal-state counts, and the placed receipts (each dereferenceable at /api/public/artanis/labor-receipts?receiptRef=<ref>). It never includes the separate owner sign-off and grants no dispatch, spend, escrow, settlement, or registry authority.',
+        'Returns the public-safe green-readiness projection for artanis.labor_requester.v1: it folds the Artanis labor receipt feed onto the two named green-flip blockers and reports blockerRefs/remainingBlockerRefs, placedRequestCount (unattended request receipts that reserved escrow - a state only an operator-enabled tick can reach), liveEnablementProven (>=1 placed receipt), unattendedRequestReceiptsProven (>=10 placed receipts), greenGateMet (both - the mechanical receipt-evidence predicate only), per-terminal-state counts, and the placed receipts (each dereferenceable at /api/public/artanis/labor-receipts?receiptRef=<ref>). It never includes the separate owner sign-off and grants no dispatch, spend, escrow, settlement, or registry authority.',
       tags: ['Public Proof'],
       security: publicRead,
       parameters: [],
@@ -6090,7 +6092,7 @@ const paths = (): JsonSchema => ({
       summary:
         'Read the Artanis Pylon-support responder external-flow projection',
       description:
-        'Returns the public-safe Artanis Pylon-support responder external-contributor-flow and tick-readiness projection: per-asker-provenance answered counts, externalContributorFlowProven, external-contributor interactions each with a dereferenceable reply-post ref (fetchable at publicUrl), and tickReadiness for the ten unattended responder tick target plus externalContributorAnsweredWithinTickWindow. An external contributor is a registered non-owner, non-operator, non-Artanis identity (a user: actor or a non-internal agent: actor); operator/owner test articles are classified owner_operator and never satisfy the external-contributor gate. Read-only projection with no dispatch, spend, assignment, settlement, moderation, Forum-write, or registry authority.',
+        'Returns the public-safe Artanis Pylon-support responder external-contributor-flow and tick-readiness projection: blockerRefs/remainingBlockerRefs, per-asker-provenance answered counts, externalContributorFlowProven, external-contributor interactions each with a dereferenceable reply-post ref (fetchable at publicUrl), and tickReadiness for the ten unattended responder tick target plus externalContributorAnsweredWithinTickWindow. An external contributor is a registered non-owner, non-operator, non-Artanis identity (a user: actor or a non-internal agent: actor); operator/owner test articles are classified owner_operator and never satisfy the external-contributor gate. Read-only projection with no dispatch, spend, assignment, settlement, moderation, Forum-write, or registry authority.',
       tags: ['Public Proof'],
       security: publicRead,
       parameters: [


### PR DESCRIPTION
## Summary

- expose `remainingBlockerRefs` on the Artanis labor green-readiness projection so the public route names which live-receipt blockers are still open
- expose responder-support `blockerRefs` and conservative `remainingBlockerRefs` for the external-contributor and ten-unattended-tick gates
- document the new public response fields in OpenAPI metadata and cover the blocker transitions in focused tests

Closes #7024.

## Verification

- `bun run --cwd apps/openagents.com/workers/api test src/artanis-labor-green-readiness.test.ts src/artanis-responder-provenance.test.ts` — 23 passed
- `bun run --cwd apps/openagents.com/workers/api test src/artanis-administrator-labor-tick.test.ts src/artanis-labor-green-readiness.test.ts src/artanis-labor-receipt-routes.test.ts src/artanis-responder-provenance.test.ts src/artanis-responder-ticks.test.ts src/product-promises.test.ts src/worker-exact-routes.test.ts` — 49 passed
- `bun run --cwd apps/openagents.com/workers/api typecheck` — exit 0; emitted existing Effect plugin messages in unrelated files
