### PR TITLE
refactor(openagents.com): route provider account list through Effect service

### DIFF
--- a/apps/openagents.com/workers/api/src/index.ts
+++ b/apps/openagents.com/workers/api/src/index.ts
@@ -7609,12 +7609,10 @@ const providerAccountRoutes = makeProviderAccountRoutes({
   handleProviderAccountUsageApi: (request, env, ctx) =>
     providerAccountUsageRoutes.handleProviderAccountUsageApi(request, env, ctx),
   handleProviderAccountsListApi: (request, env, ctx) =>
-    routeEffect('handle_provider_accounts_list_api', () =>
-      providerAccountBrowserHandlers.handleProviderAccountsListApi(
-        request,
-        env,
-        ctx,
-      ),
+    providerAccountBrowserHandlers.handleProviderAccountsListApi(
+      request,
+      env,
+      ctx,
     ),
   handleProviderDeviceLoginConnectedApi: (request, env, attemptId) =>
     routeEffect('handle_provider_device_login_connected_api', () =>

--- a/apps/openagents.com/workers/api/src/provider-account-browser-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/provider-account-browser-routes.test.ts
@@ -1,0 +1,74 @@
+import { Effect, Layer } from 'effect'
+import { describe, expect, test } from 'vitest'
+
+import { handleProviderAccountsListEffect } from './provider-account-browser-routes'
+import {
+  ProviderAccountLifecycleService,
+  type ProviderAccountLifecycleServiceShape,
+} from './provider-account-service'
+
+const unused = () => Effect.die('unused provider-account test service')
+
+describe('provider account browser routes', () => {
+  test('lists accounts through the lifecycle service layer', async () => {
+    const calls: Array<string> = []
+    const service: ProviderAccountLifecycleServiceShape = {
+      disconnectProviderAccountForUser: () => unused(),
+      issueProviderAccountGrant: () => unused(),
+      listForUser: userId =>
+        Effect.sync(() => {
+          calls.push(userId)
+
+          return { accounts: [], attempts: [] }
+        }),
+      recordDeviceLoginConnected: () => unused(),
+      recordDeviceLoginFailed: () => unused(),
+      recordProviderAccountHealth: () => unused(),
+      refreshChatGptCodexDeviceLoginForUser: () => unused(),
+      resolveProviderAccountGrant: () => unused(),
+      startChatGptCodexDeviceLogin: () => unused(),
+    }
+    const layer = Layer.succeed(ProviderAccountLifecycleService, service)
+    const dependencies = {
+      appendRefreshedSessionCookies: (response: Response) => {
+        response.headers.set('x-session-refreshed', 'true')
+
+        return response
+      },
+      deleteStartedCodexDeviceLogin: () => async () => undefined,
+      providerAuthSecretKey: (providerAccountRef: string) =>
+        `provider-auth/${providerAccountRef}`,
+      probeProviderApiKey: async () => ({
+        health: 'healthy' as const,
+        probeStatus: 200,
+      }),
+      readStartedCodexDeviceLogin: () => async () => undefined,
+      requireBrowserSession: async () => ({ user: { userId: 'user_1' } }),
+      storeConnectedCodexAuth: () => async () => 'codex-auth/provider_1',
+      storeConnectedProviderApiKey: () => async () => undefined,
+      storeStartedCodexDeviceLogin: () => async () => undefined,
+    }
+    const env = {
+      AUTH_STORAGE: {},
+      OPENAGENTS_DB: {},
+    } as unknown as {
+      AUTH_STORAGE: KVNamespace
+      OPENAGENTS_DB: D1Database
+    }
+    const ctx = {} as ExecutionContext
+
+    const response = await Effect.runPromise(
+      handleProviderAccountsListEffect(
+        new Request('https://openagents.com/api/provider-accounts'),
+        env,
+        ctx,
+        dependencies,
+      ).pipe(Effect.provide(layer)),
+    )
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('x-session-refreshed')).toBe('true')
+    expect(calls).toEqual(['user_1'])
+    expect(await response.json()).toEqual({ accounts: [], attempts: [] })
+  })
+})

--- a/apps/openagents.com/workers/api/src/provider-account-browser-routes.ts
+++ b/apps/openagents.com/workers/api/src/provider-account-browser-routes.ts
@@ -4,6 +4,7 @@ import {
   optionalString,
   readJsonObject,
 } from './json-boundary'
+import { Effect, Layer } from 'effect'
 import {
   type ProviderApiKeyProbe,
   type StoreConnectedProviderApiKey,
@@ -17,12 +18,15 @@ import {
   type StoreStartedCodexDeviceLogin,
   disconnectProviderAccountForUser,
   issueProviderAccountGrant,
-  listProviderAccountsForUser,
   makeD1ProviderAccountRepository,
+  makeProviderAccountLifecycleLayer,
   pollOpenAiCodexDeviceLogin,
+  ProviderAccountLifecycleService,
+  type ProviderAccountError,
   refreshChatGptCodexDeviceLoginForUser,
   startChatGptCodexDeviceLogin,
   startOpenAiCodexDeviceLogin,
+  providerAccountErrorFromUnknown,
 } from './provider-accounts'
 import {
   providerAccountRouteErrorMessage,
@@ -31,6 +35,7 @@ import {
 } from './provider-account-route-errors'
 import { logWorkerRouteError, observedPromise } from './observability'
 import { openAgentsDatabase } from './runtime'
+import type { RouteEffect } from './http/route-effects'
 
 type ProviderAccountBrowserEnv = Readonly<{
   AUTH_STORAGE: KVNamespace
@@ -69,7 +74,82 @@ type ProviderAccountBrowserDependencies<
   storeStartedCodexDeviceLogin: (
     kv: KVNamespace,
   ) => StoreStartedCodexDeviceLogin
+  providerAccountLifecycleLayer?: (
+    env: Env,
+  ) => Layer.Layer<ProviderAccountLifecycleService> | undefined
 }>
+
+const providerAccountLifecycleLayerForEnv = <
+  Session extends ProviderAccountBrowserSession,
+  Env extends ProviderAccountBrowserEnv,
+>(
+  dependencies: ProviderAccountBrowserDependencies<Session, Env>,
+  env: Env,
+) =>
+  dependencies.providerAccountLifecycleLayer?.(env) ??
+  makeProviderAccountLifecycleLayer({
+    deleteStartedDeviceLogin: dependencies.deleteStartedCodexDeviceLogin(
+      env.AUTH_STORAGE,
+    ),
+    pollDeviceLogin: secret => pollOpenAiCodexDeviceLogin(secret),
+    readStartedDeviceLogin: dependencies.readStartedCodexDeviceLogin(
+      env.AUTH_STORAGE,
+    ),
+    repository: makeD1ProviderAccountRepository(openAgentsDatabase(env)),
+    startDeviceLogin: () => startOpenAiCodexDeviceLogin(),
+    storeConnectedAuth: dependencies.storeConnectedCodexAuth(env.AUTH_STORAGE),
+    storeStartedDeviceLogin: dependencies.storeStartedCodexDeviceLogin(
+      env.AUTH_STORAGE,
+    ),
+  })
+
+export const handleProviderAccountsListEffect = <
+  Session extends ProviderAccountBrowserSession,
+  Env extends ProviderAccountBrowserEnv,
+>(
+  request: Request,
+  env: Env,
+  ctx: ExecutionContext,
+  dependencies: ProviderAccountBrowserDependencies<Session, Env>,
+): Effect.Effect<Response, never, ProviderAccountLifecycleService> => {
+  if (request.method !== 'GET') {
+    return Effect.succeed(methodNotAllowed(['GET']))
+  }
+
+  return Effect.gen(function* () {
+    const session = yield* Effect.tryPromise({
+      try: () => dependencies.requireBrowserSession(request, env, ctx),
+      catch: error =>
+        providerAccountErrorFromUnknown('require_browser_session', error),
+    })
+
+    if (session === undefined) {
+      return noStoreJsonResponse({ error: 'unauthorized' }, { status: 401 })
+    }
+
+    const service = yield* ProviderAccountLifecycleService
+    const bundle = yield* service.listForUser(session.user.userId)
+    const response = noStoreJsonResponse(bundle)
+
+    return dependencies.appendRefreshedSessionCookies(response, session)
+  }).pipe(
+    Effect.catch((error: ProviderAccountError) => {
+      logWorkerRouteError('provider_accounts_list_failed', error, {
+        errorName: providerAccountRouteErrorName(error),
+      })
+
+      return Effect.succeed(
+        noStoreJsonResponse(
+          {
+            error: 'provider_accounts_list_failed',
+            message: providerAccountRouteErrorMessage(error),
+          },
+          { status: providerAccountRouteErrorStatus(error) },
+        ),
+      )
+    }),
+  )
+}
 
 export const makeProviderAccountBrowserHandlers = <
   Session extends ProviderAccountBrowserSession,
@@ -77,28 +157,14 @@ export const makeProviderAccountBrowserHandlers = <
 >(
   dependencies: ProviderAccountBrowserDependencies<Session, Env>,
 ) => ({
-  handleProviderAccountsListApi: async (
+  handleProviderAccountsListApi: (
     request: Request,
     env: Env,
     ctx: ExecutionContext,
-  ): Promise<Response> => {
-    if (request.method !== 'GET') {
-      return methodNotAllowed(['GET'])
-    }
-
-    const session = await dependencies.requireBrowserSession(request, env, ctx)
-
-    if (session === undefined) {
-      return noStoreJsonResponse({ error: 'unauthorized' }, { status: 401 })
-    }
-
-    const repository = makeD1ProviderAccountRepository(openAgentsDatabase(env))
-    const response = noStoreJsonResponse(
-      await listProviderAccountsForUser(repository, session.user.userId),
-    )
-
-    return dependencies.appendRefreshedSessionCookies(response, session)
-  },
+  ): RouteEffect =>
+    handleProviderAccountsListEffect(request, env, ctx, dependencies).pipe(
+      Effect.provide(providerAccountLifecycleLayerForEnv(dependencies, env)),
+    ),
 
   handleProviderAccountDisconnectApi: async (
     request: Request,


### PR DESCRIPTION
## Summary

- Move the browser provider-account list route onto an internal Effect orchestration using `ProviderAccountLifecycleService`.
- Wire the Worker route directly to the returned `RouteEffect` instead of wrapping a raw Promise for this path.
- Add focused route coverage that substitutes the lifecycle service via an Effect layer.

Closes #7012.

## Verification

- `bun run --cwd apps/openagents.com/workers/api test src/provider-account-browser-routes.test.ts`
- `bun run --cwd apps/openagents.com/workers/api typecheck` (exits 0; existing Effect language-service messages remain in unrelated files)
- `true` for `command.public.pylon_khala.verify.b5bea41b6c623f7c09f1bf24`
