### PR TITLE
promise: reconcile Khala data privacy blockers

### DIFF
--- a/apps/openagents.com/workers/api/src/product-promises.test.ts
+++ b/apps/openagents.com/workers/api/src/product-promises.test.ts
@@ -428,6 +428,31 @@ describe('public product promises document', () => {
         'apps/openagents.com/workers/api/src/agentic-npm-composition-runtime.test.ts',
       ]),
     )
+    const freeTierTraceCapturePromise = decoded.promises.find(
+      promise =>
+        promise.promiseId === 'data.khala_free_tier_trace_capture.v1',
+    )
+    expect(freeTierTraceCapturePromise?.blockerRefs).not.toContain(
+      'blocker.product_promises.trace_capture_public_disclosure_alignment_required',
+    )
+    expect(freeTierTraceCapturePromise?.blockerRefs).toEqual(
+      expect.arrayContaining([
+        'blocker.product_promises.free_tier_capture_default_owner_gated',
+        'blocker.product_promises.trace_capture_reward_marker_inert',
+      ]),
+    )
+    expect(freeTierTraceCapturePromise?.verification).toContain(
+      'disclosure surface, and privacy-entitlement exclusion code now agree',
+    )
+    const paidCaptureOptoutPromise = decoded.promises.find(
+      promise => promise.promiseId === 'privacy.khala_paid_capture_optout.v1',
+    )
+    expect(paidCaptureOptoutPromise?.blockerRefs).toEqual(
+      expect.arrayContaining([
+        'blocker.product_promises.paid_privacy_owner_signoff_pending',
+        'blocker.product_promises.paid_khala_business_loop_not_green',
+      ]),
+    )
     expect(agenticNpmPromise?.safeCopy).toContain(
       'bounded source-level registry + install/use runtime core exists',
     )

--- a/apps/openagents.com/workers/api/src/product-promises.ts
+++ b/apps/openagents.com/workers/api/src/product-promises.ts
@@ -1074,11 +1074,10 @@ export const publicProductPromisesDocument = () => {
         ],
         blockerRefs: [
           'blocker.product_promises.free_tier_capture_default_owner_gated',
-          'blocker.product_promises.trace_capture_public_disclosure_alignment_required',
           'blocker.product_promises.trace_capture_reward_marker_inert',
         ],
         verification:
-          'Yellow requires the capture emitter, disclosure surface, and privacy-entitlement exclusion code to agree. Green requires production gate evidence, redaction/private-owner scoping evidence, public-copy owner sign-off, and no payout/settlement implication.',
+          'The capture emitter, disclosure surface, and privacy-entitlement exclusion code now agree: free capture is redacted and owner_only when armed, paid/privacy callers are excluded fail-closed, public sharing is opt-in only, and reward/payout markers remain inert. Green still requires production gate evidence, redaction/private-owner scoping evidence, public-copy owner sign-off, and no payout/settlement implication.',
         authorityBoundary:
           'Trace capture is data-retention behavior only. It grants no public trace publication, training-data sale, payout, settlement, billing, or confidential-compute authority.',
       },


### PR DESCRIPTION
## Summary
- Removes the stale `trace_capture_public_disclosure_alignment_required` blocker from `data.khala_free_tier_trace_capture.v1` now that disclosure, free-key mint embedding, capture visibility, and paid/privacy exclusion are aligned.
- Keeps the real remaining gates explicit: owner-gated production capture, inert reward/payout marker, paid-privacy owner signoff, and the paid Khala business loop.
- Adds product-promise regression assertions for the blocker set.

Closes #7019.

## Verification
- `bun run --cwd apps/openagents.com/workers/api test -- src/product-promises.test.ts src/free-key-mint-routes.test.ts src/inference/free-tier-data-sharing-disclosure.test.ts src/inference/inference-privacy-entitlement.test.ts src/inference/chat-completions-routes.test.ts -t "free-tier|free tier|paid-privacy|capture-default|auto-capture|data-sharing|product promises"`
- `bun run check:deploy` from `apps/openagents.com` (required Pylon verifier ref `command.public.pylon_khala.verify.b5bea41b6c623f7c09f1bf24`)
