### PR TITLE
test(autopilot): cover pylon growth scene tiers

### DIFF
--- a/apps/autopilot-desktop/tests/chat-world-scene.test.ts
+++ b/apps/autopilot-desktop/tests/chat-world-scene.test.ts
@@ -186,6 +186,44 @@ describe("projectChatWorldPylonScene", () => {
     expect(scene.growth.tier).toBeGreaterThanOrEqual(4)
   })
 
+  test("per-Pylon growth tiers come from public cumulative settled sats", () => {
+    const scene = projectChatWorldPylonScene(
+      snapshot({
+        pylonsOnlineNow: 3,
+        recentPylons: [
+          {
+            nostrPubkeyShort: "zero",
+            onlineNow: true,
+            cumulativeSettledSats: 0,
+          } satisfies LiveRecentPylon,
+          {
+            nostrPubkeyShort: "missing",
+            onlineNow: true,
+          } satisfies LiveRecentPylon,
+          {
+            nostrPubkeyShort: "earned",
+            onlineNow: true,
+            cumulativeSettledSats: 1_000_000,
+          } satisfies LiveRecentPylon,
+        ] as never,
+      }),
+    )
+
+    expect(scene.nodes.map((node) => node.growth.settledSats)).toEqual([
+      0,
+      0,
+      1_000_000,
+    ])
+    expect(scene.nodes[0]!.growth.tier).toBe(0)
+    expect(scene.nodes[0]!.growth.scale).toBe(1)
+    expect(scene.nodes[0]!.growth.brightness).toBe(0)
+    expect(scene.nodes[1]!.growth.tier).toBe(0)
+    expect(scene.nodes[2]!.growth.tier).toBeGreaterThan(scene.nodes[0]!.growth.tier)
+    expect(scene.nodes[2]!.growth.scale).toBeGreaterThan(scene.nodes[0]!.growth.scale)
+    expect(scene.nodes[2]!.growth.facets).toBeGreaterThan(scene.nodes[0]!.growth.facets)
+    expect(scene.nodes[2]!.growth.brightness).toBeGreaterThan(scene.nodes[0]!.growth.brightness)
+  })
+
   test("empty recentPylons with zero online → empty zero-state", () => {
     expect(projectChatWorldPylonScene(snapshot({ pylonsOnlineNow: 0 })).empty).toBe(true)
   })

--- a/apps/autopilot-desktop/tests/pylon-network-visualization.test.ts
+++ b/apps/autopilot-desktop/tests/pylon-network-visualization.test.ts
@@ -76,4 +76,50 @@ describe("pylonNetworkVisualizationOptions (bezier graph adapter)", () => {
       .map((n) => n.position.join(","))
     expect(new Set(positions).size).toBe(positions.length) // unique
   })
+
+  test("growth tiers change pylon role, status, and detail from settled sats", () => {
+    const opts = pylonNetworkVisualizationOptions({
+      ...projectPylonNetworkScene(null),
+      dormant: false,
+      onlineNow: 2,
+      nodes: [
+        {
+          id: "zero",
+          label: "zero",
+          tone: "online",
+          flowing: false,
+          growth: {
+            tier: 0,
+            scale: 1,
+            facets: 6,
+            brightness: 0,
+            settledSats: 0,
+          },
+        },
+        {
+          id: "earned",
+          label: "earned",
+          tone: "online",
+          flowing: false,
+          growth: {
+            tier: 4,
+            scale: 1.72,
+            facets: 14,
+            brightness: 0.8,
+            settledSats: 1_000_000,
+          },
+        },
+      ],
+    })
+    const zero = opts.nodes?.find((node) => node.id === "zero")
+    const earned = opts.nodes?.find((node) => node.id === "earned")
+
+    expect(zero?.role).toBe("lifecycle")
+    expect(zero?.status).toBe("queued")
+    expect(zero?.detail).toContain("tier 0 - 0 sats")
+    expect(earned?.role).toBe("run")
+    expect(earned?.status).toBe("verified")
+    expect(earned?.detail).toContain("tier 4 - 1000000 sats")
+    expect(earned?.detail).toContain("14 facets")
+  })
 })


### PR DESCRIPTION
## Summary
- Add scene projection coverage proving per-Pylon `cumulativeSettledSats` drives each growth descriptor, while zero or missing settled sats remain tier 0.
- Add renderer-option coverage proving growth tiers affect Pylon node role/status/detail from settled sats without changing default-on or payment authority claims.

Closes #6868.

## Verification
- `bun test apps/autopilot-desktop/tests/chat-world-scene.test.ts apps/autopilot-desktop/tests/pylon-network-visualization.test.ts` passed: 41 pass / 0 fail.
- `true` passed for `command.public.pylon_khala.verify.b5bea41b6c623f7c09f1bf24`.
- `bun run --cwd apps/openagents.com check:deploy` attempted; it failed in this bounded checkout at `../../packages/autopilot-control-protocol typecheck` because module resolution could not find `effect` / `@openagentsinc/design-tokens` typings in the local dependency cache. Earlier deploy guards completed before that point.