### PR TITLE
fix(promises): clear scoped MDK send readiness

### DIFF
--- a/apps/openagents.com/workers/api/src/forum/tip-smoke.test.ts
+++ b/apps/openagents.com/workers/api/src/forum/tip-smoke.test.ts
@@ -94,6 +94,8 @@ describe('Forum tip smoke fixture', () => {
       baseInput({
         mode: 'signet',
         operatorApprovedPayment: true,
+        sendReadinessCapacityRef:
+          'capacity.mdk_agent_wallet.send.sufficient_for_scoped_smoke',
         walletHomeMode: 'original_funded_wallet_home',
       }),
     )

--- a/apps/openagents.com/workers/api/src/forum/tip-smoke.ts
+++ b/apps/openagents.com/workers/api/src/forum/tip-smoke.ts
@@ -12,6 +12,7 @@ import { openAgentsRunnerGatewayPayloadHasPrivateMaterial } from '../runner-gate
 export const ForumTipSmokeStatus = S.Literals([
   'blocked_by_payer_wallet',
   'blocked_by_recipient_readiness',
+  'blocked_by_send_readiness_capacity',
   'blocked_by_spend_cap',
   'blocked_until_operator_authority',
   'documentation_only',
@@ -53,6 +54,12 @@ export const ForumTipSmokeInput = S.Struct({
   recipientReadinessRef: S.String,
   redactedEvidenceRef: S.String,
   routeStateRef: S.String,
+  sendReadinessCapacityRef: S.optionalKey(
+    S.Literals([
+      'capacity.mdk_agent_wallet.send.sufficient_for_scoped_smoke',
+      'capacity.mdk_agent_wallet.send.unproven',
+    ]),
+  ),
   spendCapBitcoinSatoshis: S.Number,
   tokenCacheRef: S.String,
   walletHomeMode: S.optionalKey(
@@ -174,6 +181,7 @@ const statusForInput = (
   input: ForumTipSmokeInput,
   agentWalletStatus:
     | 'blocked_by_spend_cap'
+    | 'blocked_by_send_readiness_capacity'
     | 'blocked_by_wallet_restore_mode'
     | 'blocked_until_operator_authority'
     | 'documentation_only'
@@ -193,6 +201,10 @@ const statusForInput = (
 
   if (agentWalletStatus === 'ready_for_signet') {
     return 'ready_for_signet'
+  }
+
+  if (agentWalletStatus === 'blocked_by_send_readiness_capacity') {
+    return 'blocked_by_send_readiness_capacity'
   }
 
   return input.mode === 'fake_sandbox'
@@ -406,6 +418,9 @@ export const planForumTipSmoke = (
     operatorApprovedPayment:
       input.operatorApprovedPayment && higherLevelPrerequisitesReady,
     routeStateRef: input.routeStateRef,
+    ...(input.sendReadinessCapacityRef === undefined
+      ? {}
+      : { sendReadinessCapacityRef: input.sendReadinessCapacityRef }),
     spendCapBitcoinSatoshis,
     tokenCacheRef: input.tokenCacheRef,
     walletHomeMode: input.walletHomeMode ?? 'unknown',

--- a/apps/openagents.com/workers/api/src/mdk-agent-wallet-smoke-fixture.test.ts
+++ b/apps/openagents.com/workers/api/src/mdk-agent-wallet-smoke-fixture.test.ts
@@ -17,6 +17,7 @@ const baseInput = (
   mode: 'fake_sandbox',
   operatorApprovedPayment: false,
   routeStateRef: 'route_state.fake_sandbox.l402_available',
+  sendReadinessCapacityRef: 'capacity.mdk_agent_wallet.send.unproven',
   spendCapBitcoinSatoshis: 10_000,
   tokenCacheRef: 'token_cache.local.redacted',
   walletHomeMode: 'unknown',
@@ -56,6 +57,8 @@ describe('OpenAgents MDK agent-wallet smoke fixture', () => {
       baseInput({
         mode: 'signet',
         operatorApprovedPayment: true,
+        sendReadinessCapacityRef:
+          'capacity.mdk_agent_wallet.send.sufficient_for_scoped_smoke',
         walletHomeMode: 'original_funded_wallet_home',
       }),
     )
@@ -86,12 +89,43 @@ describe('OpenAgents MDK agent-wallet smoke fixture', () => {
     )
   })
 
+  test('requires public-safe send capacity evidence before any send step', () => {
+    const projection = planOpenAgentsMdkAgentWalletSmoke(
+      baseInput({
+        mode: 'signet',
+        operatorApprovedPayment: true,
+        sendReadinessCapacityRef: 'capacity.mdk_agent_wallet.send.unproven',
+        walletHomeMode: 'original_funded_wallet_home',
+      }),
+    )
+
+    expect(projection.status).toBe('blocked_by_send_readiness_capacity')
+    expect(projection.sendReadinessCapacityRef).toBe(
+      'capacity.mdk_agent_wallet.send.unproven',
+    )
+    expect(projection.reasonRefs).toEqual([
+      'reason.agent_wallet_smoke.blocked_by_send_readiness_capacity',
+    ])
+    expect(
+      projection.steps.find(step => step.kind === 'send_readiness_preflight')
+        ?.noteRefs,
+    ).toEqual(
+      expect.arrayContaining([
+        'note.agent_wallet.scoped_send_capacity_required',
+        'capacity.mdk_agent_wallet.send.unproven',
+      ]),
+    )
+    expect(projection.steps.some(step => step.kind === 'send')).toBe(false)
+  })
+
   test('blocks payment plans that exceed the spend cap or lack live authority', () => {
     const overCap = planOpenAgentsMdkAgentWalletSmoke(
       baseInput({
         amountBitcoinSatoshis: 20_000,
         mode: 'signet',
         operatorApprovedPayment: true,
+        sendReadinessCapacityRef:
+          'capacity.mdk_agent_wallet.send.sufficient_for_scoped_smoke',
         spendCapBitcoinSatoshis: 10_000,
         walletHomeMode: 'original_funded_wallet_home',
       }),

--- a/apps/openagents.com/workers/api/src/mdk-agent-wallet-smoke-fixture.ts
+++ b/apps/openagents.com/workers/api/src/mdk-agent-wallet-smoke-fixture.ts
@@ -17,6 +17,7 @@ export type OpenAgentsMdkAgentWalletSmokeMode =
 
 export const OpenAgentsMdkAgentWalletSmokeStatus = S.Literals([
   'blocked_by_spend_cap',
+  'blocked_by_send_readiness_capacity',
   'blocked_by_wallet_restore_mode',
   'blocked_until_operator_authority',
   'documentation_only',
@@ -44,6 +45,12 @@ export const OpenAgentsMdkAgentWalletSmokeInput = S.Struct({
   mode: OpenAgentsMdkAgentWalletSmokeMode,
   operatorApprovedPayment: S.Boolean,
   routeStateRef: S.String,
+  sendReadinessCapacityRef: S.optionalKey(
+    S.Literals([
+      'capacity.mdk_agent_wallet.send.sufficient_for_scoped_smoke',
+      'capacity.mdk_agent_wallet.send.unproven',
+    ]),
+  ),
   spendCapBitcoinSatoshis: S.Number,
   tokenCacheRef: S.String,
   walletHomeMode: S.optionalKey(
@@ -71,6 +78,7 @@ export const OpenAgentsMdkAgentWalletSmokeProjection = S.Struct({
   payoutModeGate: MdkPayoutModeGateProjection,
   reasonRefs: S.Array(S.String),
   routeStateRef: S.String,
+  sendReadinessCapacityRef: S.String,
   spendCapBitcoinSatoshis: S.Number,
   status: OpenAgentsMdkAgentWalletSmokeStatus,
   steps: S.Array(OpenAgentsMdkAgentWalletSmokeStep),
@@ -99,8 +107,11 @@ const publicLiteralValues = new Set([
   'Authorization: L402 <l402_token_from_402_response>:<payment_preimage_from_wallet_output>',
   'balance',
   'blocked_by_spend_cap',
+  'blocked_by_send_readiness_capacity',
   'blocked_by_wallet_restore_mode',
   'blocked_until_operator_authority',
+  'capacity.mdk_agent_wallet.send.sufficient_for_scoped_smoke',
+  'capacity.mdk_agent_wallet.send.unproven',
   'curl',
   'documentation_only',
   'fake_sandbox',
@@ -139,6 +150,7 @@ const publicLiteralValues = new Set([
   'note.agent_wallet.operator_approved_signet_only',
   'note.agent_wallet.original_funded_home_required_for_send',
   'note.agent_wallet.receive_for_funding_test_only',
+  'note.agent_wallet.scoped_send_capacity_required',
   'note.agent_wallet.send_readiness_preflight_shared',
   'paid_retry',
   'receive',
@@ -226,7 +238,11 @@ const statusForInput = (
     ? 'blocked_by_spend_cap'
     : input.operatorApprovedPayment && input.mode === 'signet'
       ? (input.walletHomeMode ?? 'unknown') === 'original_funded_wallet_home'
-        ? 'ready_for_signet'
+        ? (input.sendReadinessCapacityRef ??
+            'capacity.mdk_agent_wallet.send.unproven') ===
+          'capacity.mdk_agent_wallet.send.sufficient_for_scoped_smoke'
+          ? 'ready_for_signet'
+          : 'blocked_by_send_readiness_capacity'
         : 'blocked_by_wallet_restore_mode'
       : input.mode === 'fake_sandbox'
         ? 'documentation_only'
@@ -261,6 +277,9 @@ const baseSteps = (
       `wallet_home.mdk_agent_wallet.${input.walletHomeMode ?? 'unknown'}`,
       'note.agent_wallet.original_funded_home_required_for_send',
       'note.agent_wallet.send_readiness_preflight_shared',
+      'note.agent_wallet.scoped_send_capacity_required',
+      input.sendReadinessCapacityRef ??
+        'capacity.mdk_agent_wallet.send.unproven',
       ...((input.walletHomeMode ?? 'unknown') === 'mnemonic_restore'
         ? ['note.agent_wallet.mnemonic_restore_not_send_ready']
         : []),
@@ -356,6 +375,9 @@ export const planOpenAgentsMdkAgentWalletSmoke = (
     payoutModeGate,
     reasonRefs: safeRefs([`reason.agent_wallet_smoke.${status}`]),
     routeStateRef: safeRef(input.routeStateRef) ?? 'route_state.redacted',
+    sendReadinessCapacityRef:
+      input.sendReadinessCapacityRef ??
+      'capacity.mdk_agent_wallet.send.unproven',
     spendCapBitcoinSatoshis: Math.max(
       0,
       Math.trunc(input.spendCapBitcoinSatoshis),

--- a/apps/openagents.com/workers/api/src/product-promises.test.ts
+++ b/apps/openagents.com/workers/api/src/product-promises.test.ts
@@ -366,9 +366,13 @@ describe('public product promises document', () => {
     // khala.own_capacity_codex_delegation.v1 promise green after live dispatch,
     // materialization, trace-status, proof, and no-spend closeout evidence.
     // Green is now exactly 31.
+    // The #7029 MDK send-readiness capacity pass clears the scoped
+    // payments.money_dev_kit.v1 blocker only for the original funded wallet
+    // home, backed by public-safe 1-sat receipts and capacity-sufficient
+    // preflight evidence. Green is now exactly 32.
     expect(
       decoded.promises.filter(promise => promise.state === 'green').length,
-    ).toBe(31)
+    ).toBe(32)
     expect(decoded.verificationSummary.evidenceRefCount).toBeGreaterThan(0)
     expect(decoded.verificationSummary.uniqueBlockerCount).toBeGreaterThan(0)
     expect(
@@ -1068,10 +1072,13 @@ describe('public product promises document', () => {
           state: 'green',
         }),
         expect.objectContaining({
-          blockerRefs: expect.arrayContaining([
-            'blocker.product_promises.mdk_agent_wallet_send_readiness_insufficient_capacity',
-          ]),
+          blockerRefs: [],
           evidenceRefs: expect.arrayContaining([
+            'apps/openagents.com/docs/nexus/2026-06-08-mdk-agent-wallet-send-readiness-preflight.md',
+            'apps/openagents.com/docs/nexus/2026-06-08-mdk-agent-wallet-outbound-capacity-restore-report.md',
+            'receipt.nexus_pylon.settlement.assignment_public_probe_gepa_paid_multi_pylon_20260608214500_1',
+            'receipt.nexus_pylon.settlement.assignment_public_probe_gepa_paid_multi_pylon_20260608214500_2',
+            'capacity.mdk_agent_wallet.send.sufficient_for_scoped_smoke',
             'docs/forum/2026-06-09-forum-mdk-webhook-reconciliation-audit.md',
             'route:/api/forum/paid-actions/mdk/webhooks',
             'script:apps/openagents.com/scripts/forum.mjs tip-post-smoke',
@@ -1079,7 +1086,9 @@ describe('public product promises document', () => {
             'apps/openagents.com/docs/mdk-forum-readiness-smoke.md',
           ]),
           promiseId: 'payments.money_dev_kit.v1',
-          state: 'yellow',
+          safeCopy: expect.stringContaining('Spark remains the primary'),
+          state: 'green',
+          unsafeCopy: expect.stringContaining('Do not claim MDK mnemonic restore'),
         }),
         expect.objectContaining({
           blockerRefs: [],

--- a/apps/openagents.com/workers/api/src/product-promises.ts
+++ b/apps/openagents.com/workers/api/src/product-promises.ts
@@ -1251,17 +1251,21 @@ export const publicProductPromisesDocument = () => {
         promiseId: 'payments.money_dev_kit.v1',
         productArea: 'payments',
         audience: ['agent', 'contributor', 'operator'],
-        state: 'yellow',
+        state: 'green',
         claim:
           'OpenAgents switched payments to Money Dev Kit: self-custodial Lightning agent wallet, single command setup, LSP/splice channels, immediate receive liquidity, and hosted checkout.',
         safeCopy:
-          'OpenAgents uses MDK hosted checkout and agent-wallet flows for scoped small-sats/L402 paths, and Forum tips can project confirmed live direct BOLT 12 MDK/provider payments as ordinary content tips. Broader payout, withdrawal, and accepted-work settlement claims remain scoped by their own route authority and wallet readiness.',
+          'OpenAgents uses MDK hosted checkout and a scoped local MDK agent-wallet bridge for small-sats/L402 paths. The MDK send-readiness claim is limited to the original funded wallet home with public-safe 1-sat settlement receipts and a capacity-sufficient preflight; Spark remains the primary agent/MPP payment rail. Broader custody, payout, withdrawal, and accepted-work settlement claims remain scoped by their own route authority and wallet readiness.',
         unsafeCopy:
-          'Do not claim MDK mnemonic restore or hosted MDK payout proves full send readiness or provider settlement.',
+          'Do not claim MDK mnemonic restore, hosted MDK checkout, or a positive wallet balance proves broad custody, full send readiness, payout, withdrawal, accepted-work settlement, or provider settlement.',
         evidenceRefs: [
           'apps/openagents.com/docs/mdk',
           'apps/pylon/docs/mdk-wallet-readiness-ledger.md',
+          'apps/openagents.com/docs/nexus/2026-06-08-mdk-agent-wallet-send-readiness-preflight.md',
           'apps/openagents.com/docs/nexus/2026-06-08-mdk-agent-wallet-outbound-capacity-restore-report.md',
+          'receipt.nexus_pylon.settlement.assignment_public_probe_gepa_paid_multi_pylon_20260608214500_1',
+          'receipt.nexus_pylon.settlement.assignment_public_probe_gepa_paid_multi_pylon_20260608214500_2',
+          'capacity.mdk_agent_wallet.send.sufficient_for_scoped_smoke',
           'docs/forum/2026-06-09-forum-mdk-webhook-reconciliation-audit.md',
           'route:/api/forum/paid-actions/mdk/webhooks',
           'script:apps/openagents.com/scripts/forum.mjs tip-post-smoke',
@@ -1270,13 +1274,11 @@ export const publicProductPromisesDocument = () => {
           'apps/openagents.com/docs/forum/2026-06-11-forum-tip-webhook-refund-live-smoke-evidence.md',
           'transition:promise_transition_c30b7327-e82b-4696-8886-97aafa454284',
         ],
-        blockerRefs: [
-          'blocker.product_promises.mdk_agent_wallet_send_readiness_insufficient_capacity',
-        ],
+        blockerRefs: [],
         verification:
-          'Run smoke:forum:mdk-readiness with a ready-recipient post, user-specified sats amount, explicit live-spend approval, public receipt lookup, and `tip-post-smoke --strict-smooth` from a funded production payer wallet. Separate wallet configured, receive-ready, positive balance, send-ready, direct payment sent, webhook-confirmed payment, timeout recovery, refund/reversal, accepted work, payout, and accepted-work settlement states.',
+          'Scoped send-readiness is proven only for the original funded MDK agent-wallet home with public-safe 1-sat settlement receipts (`receipt.nexus_pylon.settlement.assignment_public_probe_gepa_paid_multi_pylon_20260608214500_1` and `_2`) and the send-readiness preflight capacity ref `capacity.mdk_agent_wallet.send.sufficient_for_scoped_smoke`. The smoke fixture blocks send planning unless operator approval, original funded wallet-home mode, spend-cap compliance, and the capacity-sufficient ref are all present. Keep wallet configured, receive-ready, positive balance, send-ready, direct payment sent, webhook-confirmed payment, timeout recovery, refund/reversal, accepted work, payout, and accepted-work settlement states separate.',
         authorityBoundary:
-          'Payment proof does not bypass route auth, owner scope, moderation, deployment, payout, or settlement gates.',
+          'Scoped MDK send-readiness proof does not make MDK the primary agent/MPP rail and does not bypass route auth, owner scope, moderation, deployment, payout, withdrawal, custody, or settlement gates.',
       },
       {
         ...basePromiseFields,


### PR DESCRIPTION
## Summary

- add a public-safe MDK agent-wallet send-capacity evidence ref before a signet send step can be planned
- thread that capacity evidence through the Forum tip smoke wrapper so higher-level tip smokes cannot imply send readiness from balance/home alone
- clear `payments.money_dev_kit.v1` only for the scoped original-funded-wallet-home small-sats send-readiness claim, with public-safe 1-sat settlement receipts and Spark-primary copy preserved

Closes #7029

## Verification

- `bun run --cwd apps/openagents.com/workers/api test -- src/product-promises.test.ts src/mdk-agent-wallet-smoke-fixture.test.ts src/forum/tip-smoke.test.ts src/treasury-payment-mdk-agent-wallet-adapter.test.ts src/treasury-payment-authority.test.ts src/artanis-administrator-labor-tick.test.ts`
- `bun run --cwd apps/openagents.com/workers/api typecheck` (exits 0; prints existing Effect language-service messages in `src/artanis-activity-routes.ts`, `src/artanis-operator-tools.ts`, `src/artanis-public-report-routes.ts`, and `src/pylon-api-routes.ts`)
- assignment verification ref `command.public.pylon_khala.verify.b5bea41b6c623f7c09f1bf24`: covered by `src/artanis-administrator-labor-tick.test.ts`