### PR TITLE
Add marketplace composition lifecycle scaffold

### DIFF
--- a/apps/openagents.com/workers/api/src/marketplace-product-composition.test.ts
+++ b/apps/openagents.com/workers/api/src/marketplace-product-composition.test.ts
@@ -3,13 +3,19 @@ import { describe, expect, test } from 'vitest'
 import {
   MARKETPLACE_COMPOSE_AND_LIST_PROMISE,
   MARKETPLACE_PRODUCT_COMPOSITION_SCHEMA,
+  assembleComposedProduct,
   type ComposedProductDefinition,
   buildComposedProductDefinition,
+  composedProductBuilderAttributionRef,
   composedProductMonetizableLayers,
   composedProductPrimitives,
+  installComposedProduct,
   listComposedProducts,
+  makeInMemoryMarketplaceCompositionLifecycleStore,
   makeInMemoryComposedProductListingStore,
+  recordComposedProductUse,
   readComposedProduct,
+  selfServeListComposedProduct,
 } from './marketplace-product-composition'
 
 const okDefinition = (
@@ -114,6 +120,119 @@ describe('compose-and-list product definition model (#5515)', () => {
       { layer: 'inference', capabilityRef: 'inference.gateway.v1' },
       { layer: 'sandbox', capabilityRef: 'cloud.sandbox.v1' },
     ])
+  })
+
+  test('assembles a composed product with builder attribution and no payment authority', () => {
+    const definition = okDefinition({
+      productId: 'prod_alpha',
+      definitionVersion: 2,
+      builderRef: 'agent:builder',
+    })
+    const assembly = assembleComposedProduct(definition, {
+      assemblyId: 'assembly_1',
+      assembledAt: '2026-06-29T00:00:00.000Z',
+    })
+
+    expect(assembly).toMatchObject({
+      assemblyId: 'assembly_1',
+      productId: 'prod_alpha',
+      definitionVersion: 2,
+      builderRef: 'agent:builder',
+      builderAttributionRef:
+        'attribution.marketplace.composed_product.agent:builder.prod_alpha.v2',
+      componentRefs: definition.components,
+      billingAuthority: false,
+      settlementAuthority: false,
+    })
+    expect(composedProductBuilderAttributionRef(definition)).toBe(
+      assembly.builderAttributionRef,
+    )
+  })
+})
+
+describe('compose-and-list self-serve lifecycle scaffold (#6882)', () => {
+  test('persists listing, install, and use lifecycle with builder attribution', () => {
+    const store = makeInMemoryMarketplaceCompositionLifecycleStore()
+    const definition = okDefinition({
+      productId: 'prod_self_serve',
+      builderRef: 'agent:builder',
+      listingState: 'draft',
+    })
+
+    const listing = selfServeListComposedProduct(store, {
+      definition,
+      listingId: 'listing_1',
+      assemblyId: 'assembly_1',
+      listedAt: '2026-06-29T00:00:00.000Z',
+    })
+
+    expect(listing.definition.listingState).toBe('listed')
+    expect(store.listListings().map(record => record.listingId)).toEqual([
+      'listing_1',
+    ])
+    expect(listing.assembly.builderAttributionRef).toBe(
+      'attribution.marketplace.composed_product.agent:builder.prod_self_serve.v1',
+    )
+    expect(listing.assembly.billingAuthority).toBe(false)
+    expect(listing.assembly.settlementAuthority).toBe(false)
+
+    const installed = installComposedProduct(store, {
+      listingId: 'listing_1',
+      buyerRef: 'agent:buyer',
+      installId: 'install_1',
+      installedAt: '2026-06-29T00:01:00.000Z',
+    })
+
+    expect(installed.ok).toBe(true)
+    if (!installed.ok) {
+      throw new Error(installed.error.reason)
+    }
+    expect(installed.install).toMatchObject({
+      installId: 'install_1',
+      productId: 'prod_self_serve',
+      buyerRef: 'agent:buyer',
+      builderRef: 'agent:builder',
+      builderAttributionRef: listing.assembly.builderAttributionRef,
+      state: 'installed',
+      useCount: 0,
+      billingAuthority: false,
+      settlementAuthority: false,
+    })
+
+    const used = recordComposedProductUse(store, {
+      installId: 'install_1',
+      usedAt: '2026-06-29T00:02:00.000Z',
+    })
+
+    expect(used.ok).toBe(true)
+    if (!used.ok) {
+      throw new Error(used.error.reason)
+    }
+    expect(used.install.state).toBe('used')
+    expect(used.install.useCount).toBe(1)
+    expect(used.install.lastUsedAt).toBe('2026-06-29T00:02:00.000Z')
+    expect(store.listInstalls()).toEqual([used.install])
+  })
+
+  test('rejects install/use lifecycle references that were not self-serve listed', () => {
+    const store = makeInMemoryMarketplaceCompositionLifecycleStore()
+
+    const missingListing = installComposedProduct(store, {
+      listingId: 'missing',
+      buyerRef: 'agent:buyer',
+    })
+    expect(missingListing.ok).toBe(false)
+    if (!missingListing.ok) {
+      expect(missingListing.error.reason).toContain('listingId')
+    }
+
+    const missingInstall = recordComposedProductUse(store, {
+      installId: 'missing',
+    })
+    expect(missingInstall.ok).toBe(false)
+    if (!missingInstall.ok) {
+      expect(missingInstall.error.reason).toContain('installId')
+    }
   })
 })
 

--- a/apps/openagents.com/workers/api/src/marketplace-product-composition.ts
+++ b/apps/openagents.com/workers/api/src/marketplace-product-composition.ts
@@ -11,13 +11,13 @@
 // claim it is live. It is PURE:
 //   - it moves no money, runs no fulfillment, reads no wallet, writes no
 //     receipt, and provisions no primitive;
-//   - it only defines a typed, versioned product DEFINITION (a composition of
-//     primitive/market capability references) and a read-only listing
-//     projection over an injected store.
+//   - it defines a typed, versioned product DEFINITION (a composition of
+//     primitive/market capability references), a pure assembly/list/install/use
+//     lifecycle over an injected store, and a read-only listing projection.
 // The promise marketplace.compose_and_list_products.v1 STAYS `planned`. Nothing
-// here flips it green: there is no composition runtime, no install/use
-// lifecycle, no billing, attribution, rev-share, or settlement. A green flip
-// stays receipt-first and owner-signed per proof.claim_upgrade_receipts.v1.
+// here flips it green: there is no live durable self-serve write route, no
+// billing, rev-share, or settlement. A green flip stays receipt-first and
+// owner-signed per proof.claim_upgrade_receipts.v1.
 
 import { Schema as S } from 'effect'
 
@@ -25,7 +25,7 @@ import {
   type PublicProjectionStalenessContract,
   liveAtReadStaleness,
 } from './public-projection-staleness'
-import { currentIsoTimestamp } from './runtime-primitives'
+import { compactRandomId, currentIsoTimestamp } from './runtime-primitives'
 
 export const MARKETPLACE_PRODUCT_COMPOSITION_SCHEMA =
   'openagents.marketplace_product_composition.v1' as const
@@ -95,6 +95,54 @@ export const ComposedProductDefinition = S.Struct({
 })
 export type ComposedProductDefinition = typeof ComposedProductDefinition.Type
 
+export const MarketplaceInstallUseState = S.Literals(['installed', 'used'])
+export type MarketplaceInstallUseState = typeof MarketplaceInstallUseState.Type
+
+export const ComposedProductAssembly = S.Struct({
+  schema: S.Literal(MARKETPLACE_PRODUCT_COMPOSITION_SCHEMA),
+  assemblyId: S.String,
+  productId: S.String,
+  definitionVersion: S.Number,
+  builderRef: S.String,
+  builderAttributionRef: S.String,
+  componentRefs: S.Array(MarketplaceComponentRef),
+  assembledAt: S.String,
+  promiseId: S.Literal(MARKETPLACE_COMPOSE_AND_LIST_PROMISE),
+  billingAuthority: S.Boolean,
+  settlementAuthority: S.Boolean,
+})
+export type ComposedProductAssembly = typeof ComposedProductAssembly.Type
+
+export const SelfServeComposedProductListing = S.Struct({
+  schema: S.Literal(MARKETPLACE_PRODUCT_COMPOSITION_SCHEMA),
+  listingId: S.String,
+  definition: ComposedProductDefinition,
+  assembly: ComposedProductAssembly,
+  listedAt: S.String,
+  promiseId: S.Literal(MARKETPLACE_COMPOSE_AND_LIST_PROMISE),
+})
+export type SelfServeComposedProductListing =
+  typeof SelfServeComposedProductListing.Type
+
+export const ComposedProductInstallUseRecord = S.Struct({
+  schema: S.Literal(MARKETPLACE_PRODUCT_COMPOSITION_SCHEMA),
+  installId: S.String,
+  listingId: S.String,
+  productId: S.String,
+  buyerRef: S.String,
+  builderRef: S.String,
+  builderAttributionRef: S.String,
+  state: MarketplaceInstallUseState,
+  installedAt: S.String,
+  lastUsedAt: S.NullOr(S.String),
+  useCount: S.Number,
+  promiseId: S.Literal(MARKETPLACE_COMPOSE_AND_LIST_PROMISE),
+  billingAuthority: S.Boolean,
+  settlementAuthority: S.Boolean,
+})
+export type ComposedProductInstallUseRecord =
+  typeof ComposedProductInstallUseRecord.Type
+
 export class ComposedProductValidationError extends S.TaggedErrorClass<ComposedProductValidationError>()(
   'ComposedProductValidationError',
   {
@@ -103,6 +151,14 @@ export class ComposedProductValidationError extends S.TaggedErrorClass<ComposedP
 ) {}
 
 const isNonEmpty = (value: string): boolean => value.trim().length > 0
+
+const publicRefSegment = (value: string): string =>
+  value.trim().replace(/[^A-Za-z0-9_.:-]+/g, '_').slice(0, 80)
+
+export const composedProductBuilderAttributionRef = (
+  definition: ComposedProductDefinition,
+): string =>
+  `attribution.marketplace.composed_product.${publicRefSegment(definition.builderRef)}.${publicRefSegment(definition.productId)}.v${definition.definitionVersion}`
 
 /**
  * Build a typed product definition from raw input. PURE and validating:
@@ -233,6 +289,175 @@ export const composedProductMonetizableLayers = (
     }
   }
   return [...byLayer].map(([layer, capabilityRef]) => ({ layer, capabilityRef }))
+}
+
+export const assembleComposedProduct = (
+  definition: ComposedProductDefinition,
+  options: { assemblyId?: string; assembledAt?: string } = {},
+): ComposedProductAssembly => ({
+  schema: MARKETPLACE_PRODUCT_COMPOSITION_SCHEMA,
+  assemblyId: options.assemblyId ?? compactRandomId('assembly'),
+  productId: definition.productId,
+  definitionVersion: definition.definitionVersion,
+  builderRef: definition.builderRef,
+  builderAttributionRef: composedProductBuilderAttributionRef(definition),
+  componentRefs: definition.components,
+  assembledAt: options.assembledAt ?? currentIsoTimestamp(),
+  promiseId: MARKETPLACE_COMPOSE_AND_LIST_PROMISE,
+  billingAuthority: false,
+  settlementAuthority: false,
+})
+
+export type MarketplaceCompositionLifecycleStore = {
+  listListings: () => ReadonlyArray<SelfServeComposedProductListing>
+  listInstalls: () => ReadonlyArray<ComposedProductInstallUseRecord>
+  saveListing: (listing: SelfServeComposedProductListing) => void
+  saveInstall: (install: ComposedProductInstallUseRecord) => void
+}
+
+export const makeInMemoryMarketplaceCompositionLifecycleStore = (
+  seed: {
+    listings?: ReadonlyArray<SelfServeComposedProductListing>
+    installs?: ReadonlyArray<ComposedProductInstallUseRecord>
+  } = {},
+): MarketplaceCompositionLifecycleStore => {
+  const listings = [...(seed.listings ?? [])]
+  const installs = [...(seed.installs ?? [])]
+
+  return {
+    listListings: () => listings,
+    listInstalls: () => installs,
+    saveListing: listing => {
+      const existingIndex = listings.findIndex(
+        existing => existing.listingId === listing.listingId,
+      )
+      if (existingIndex >= 0) {
+        listings[existingIndex] = listing
+      } else {
+        listings.push(listing)
+      }
+    },
+    saveInstall: install => {
+      const existingIndex = installs.findIndex(
+        existing => existing.installId === install.installId,
+      )
+      if (existingIndex >= 0) {
+        installs[existingIndex] = install
+      } else {
+        installs.push(install)
+      }
+    },
+  }
+}
+
+export const selfServeListComposedProduct = (
+  store: MarketplaceCompositionLifecycleStore,
+  input: {
+    definition: ComposedProductDefinition
+    listingId?: string
+    listedAt?: string
+    assemblyId?: string
+  },
+): SelfServeComposedProductListing => {
+  const definition = { ...input.definition, listingState: 'listed' as const }
+  const listing = {
+    schema: MARKETPLACE_PRODUCT_COMPOSITION_SCHEMA,
+    listingId: input.listingId ?? compactRandomId('listing'),
+    definition,
+    assembly: assembleComposedProduct(definition, {
+      ...(input.assemblyId === undefined ? {} : { assemblyId: input.assemblyId }),
+      ...(input.listedAt === undefined ? {} : { assembledAt: input.listedAt }),
+    }),
+    listedAt: input.listedAt ?? currentIsoTimestamp(),
+    promiseId: MARKETPLACE_COMPOSE_AND_LIST_PROMISE,
+  }
+
+  store.saveListing(listing)
+  return listing
+}
+
+export const installComposedProduct = (
+  store: MarketplaceCompositionLifecycleStore,
+  input: {
+    listingId: string
+    buyerRef: string
+    installId?: string
+    installedAt?: string
+  },
+):
+  | { ok: true; install: ComposedProductInstallUseRecord }
+  | { ok: false; error: ComposedProductValidationError } => {
+  if (!isNonEmpty(input.buyerRef)) {
+    return {
+      ok: false,
+      error: new ComposedProductValidationError({
+        reason: 'buyerRef must be non-empty',
+      }),
+    }
+  }
+
+  const listing = store
+    .listListings()
+    .find(candidate => candidate.listingId === input.listingId)
+
+  if (listing === undefined) {
+    return {
+      ok: false,
+      error: new ComposedProductValidationError({
+        reason: 'listingId does not reference a self-serve listed product',
+      }),
+    }
+  }
+
+  const install = {
+    schema: MARKETPLACE_PRODUCT_COMPOSITION_SCHEMA,
+    installId: input.installId ?? compactRandomId('install'),
+    listingId: listing.listingId,
+    productId: listing.definition.productId,
+    buyerRef: input.buyerRef,
+    builderRef: listing.definition.builderRef,
+    builderAttributionRef: listing.assembly.builderAttributionRef,
+    state: 'installed' as const,
+    installedAt: input.installedAt ?? currentIsoTimestamp(),
+    lastUsedAt: null,
+    useCount: 0,
+    promiseId: MARKETPLACE_COMPOSE_AND_LIST_PROMISE,
+    billingAuthority: false,
+    settlementAuthority: false,
+  }
+
+  store.saveInstall(install)
+  return { ok: true, install }
+}
+
+export const recordComposedProductUse = (
+  store: MarketplaceCompositionLifecycleStore,
+  input: { installId: string; usedAt?: string },
+):
+  | { ok: true; install: ComposedProductInstallUseRecord }
+  | { ok: false; error: ComposedProductValidationError } => {
+  const install = store
+    .listInstalls()
+    .find(candidate => candidate.installId === input.installId)
+
+  if (install === undefined) {
+    return {
+      ok: false,
+      error: new ComposedProductValidationError({
+        reason: 'installId does not reference an installed composed product',
+      }),
+    }
+  }
+
+  const updated = {
+    ...install,
+    state: 'used' as const,
+    lastUsedAt: input.usedAt ?? currentIsoTimestamp(),
+    useCount: install.useCount + 1,
+  }
+
+  store.saveInstall(updated)
+  return { ok: true, install: updated }
 }
 
 /**

--- a/apps/openagents.com/workers/api/src/product-promises.test.ts
+++ b/apps/openagents.com/workers/api/src/product-promises.test.ts
@@ -398,8 +398,7 @@ describe('public product promises document', () => {
     )
     expect(composeAndListPromise?.blockerRefs).toEqual(
       expect.arrayContaining([
-        'blocker.product_promises.marketplace_composition_runtime_unbuilt',
-        'blocker.product_promises.marketplace_self_serve_listing_write_install_lifecycle_unbuilt',
+        'blocker.product_promises.marketplace_live_durable_self_serve_listing_install_lifecycle_missing',
         'blocker.product_promises.marketplace_billing_settlement_missing',
       ]),
     )
@@ -407,7 +406,7 @@ describe('public product promises document', () => {
       'route:/api/public/marketplace/composed-products',
     )
     expect(composeAndListPromise?.safeCopy).toContain(
-      'public read-only listing/discovery projection',
+      'injected assembly/list/install/use lifecycle store',
     )
     const agenticNpmPromise = decoded.promises.find(
       promise =>
@@ -915,12 +914,12 @@ describe('public product promises document', () => {
           promiseId: 'marketplace.compose_and_list_products.v1',
           state: 'planned',
           blockerRefs: expect.arrayContaining([
-            'blocker.product_promises.marketplace_composition_runtime_unbuilt',
-            'blocker.product_promises.marketplace_self_serve_listing_write_install_lifecycle_unbuilt',
+            'blocker.product_promises.marketplace_live_durable_self_serve_listing_install_lifecycle_missing',
             'blocker.product_promises.marketplace_billing_settlement_missing',
           ]),
           evidenceRefs: expect.arrayContaining([
             'apps/openagents.com/workers/api/src/marketplace-product-composition.ts',
+            'apps/openagents.com/workers/api/src/marketplace-product-composition.test.ts',
             'apps/openagents.com/workers/api/src/marketplace-composition-routes.ts',
             'route:/api/public/marketplace/composed-products',
           ]),

--- a/apps/openagents.com/workers/api/src/product-promises.ts
+++ b/apps/openagents.com/workers/api/src/product-promises.ts
@@ -3795,7 +3795,7 @@ export const publicProductPromisesDocument = () => {
         claim:
           'Agents and humans build their own products out of the OpenAgents Cloud primitives and open markets, then list those products for sale in the OpenAgents marketplace.',
         safeCopy:
-          'Compose-your-own-product-and-list-it-for-sale is the Episode 239 marketplace vision (docs/transcripts/239.md), and it is roadmap. A typed product-definition scaffold and public read-only listing/discovery projection exist at GET /api/public/marketplace/composed-products; the route is inert, planned-state, and empty by default unless injected/flag-armed. Adjacent planned lanes exist — the agentic-npm module registry (marketplace.agentic_npm_module_registry.v1) and WASM plugins (marketplace.wasm_plugins.v1) — but there is no live composition runtime that provisions primitives into a buyable product, no self-serve listing write/install/use lifecycle, no marketplace billing, attribution, rev-share, or settlement. Nobody has composed a product from the primitives and sold it through OpenAgents.',
+          'Compose-your-own-product-and-list-it-for-sale is the Episode 239 marketplace vision (docs/transcripts/239.md), and it is roadmap. A typed product-definition scaffold, injected assembly/list/install/use lifecycle store, builder attribution ref, and public read-only listing/discovery projection exist at GET /api/public/marketplace/composed-products; the route is inert, planned-state, and empty by default unless injected/flag-armed. Adjacent planned lanes exist — the agentic-npm module registry (marketplace.agentic_npm_module_registry.v1) and WASM plugins (marketplace.wasm_plugins.v1) — but there is no live durable self-serve write/install route that provisions primitives into a buyable product, no marketplace billing, rev-share, or settlement. Nobody has composed a product from the primitives and sold it through OpenAgents.',
         unsafeCopy:
           'Do not claim users or agents can build a live product from the primitives and list it for sale today, that an OpenAgents product marketplace is live, or that composed products are buyable, installable, fulfillable, billable, settled, or revenue-bearing. Do not present the inert read-only listing scaffold or planned module/plugin lanes as a live compose-and-sell marketplace.',
         evidenceRefs: [
@@ -3806,18 +3806,18 @@ export const publicProductPromisesDocument = () => {
           'promise:cloud.primitives_suite.v1',
           'promise:markets.open_protocol_markets.v1',
           'apps/openagents.com/workers/api/src/marketplace-product-composition.ts',
+          'apps/openagents.com/workers/api/src/marketplace-product-composition.test.ts',
           'apps/openagents.com/workers/api/src/marketplace-composition-routes.ts',
           'route:/api/public/marketplace/composed-products',
         ],
         blockerRefs: [
-          'blocker.product_promises.marketplace_composition_runtime_unbuilt',
-          'blocker.product_promises.marketplace_self_serve_listing_write_install_lifecycle_unbuilt',
+          'blocker.product_promises.marketplace_live_durable_self_serve_listing_install_lifecycle_missing',
           'blocker.product_promises.marketplace_billing_settlement_missing',
         ],
         verification:
-          'Planned until a composed product can be assembled from primitives, self-serve listed, discovered, installed/used by a buyer, and produce a dereferenceable paid receipt with attribution and rev-share to the builder. The current route proves only the inert typed definition + read-only listing/discovery scaffold. Per proof.demand_provenance.v1, an internally-built or injected listing is plumbing proof, not market proof.',
+          'Planned until a composed product can be assembled from primitives through a live durable self-serve route, listed, discovered, installed/used by a buyer, and produce a dereferenceable paid receipt with attribution and rev-share to the builder. The current code proves only the inert typed definition, injected assembly/list/install/use lifecycle scaffold, builder attribution ref, and read-only listing/discovery projection. Per proof.demand_provenance.v1, an internally-built or injected listing is plumbing proof, not market proof.',
         authorityBoundary:
-          'A compose-and-list vision and read-only listing scaffold grant no live composition runtime, self-serve listing write, install/use, fulfillment, billing, rev-share, payout, or public-marketplace-claim authority.',
+          'A compose-and-list vision, injected lifecycle scaffold, and read-only listing projection grant no live durable self-serve route, fulfillment, billing, rev-share, payout, settlement, or public-marketplace-claim authority.',
       },
       {
         ...basePromiseFields,


### PR DESCRIPTION
## Summary

- Add typed composed-product assembly, self-serve listing, install, and use lifecycle records over an injected store.
- Persist builder attribution through assembly and buyer install/use records while keeping billing and settlement authority false.
- Update the `marketplace.compose_and_list_products.v1` promise copy/blockers to reflect the new typed scaffold without claiming the marketplace is live.

Closes #6882.

## Verification

- `bun run --cwd apps/openagents.com/workers/api test -- src/marketplace-product-composition.test.ts src/marketplace-composition-routes.test.ts src/product-promises.test.ts`
- `bun run --cwd apps/openagents.com/workers/api typecheck`
- `bun run --cwd apps/openagents.com check:deploy`
