### PR TITLE
Wire active custom hostnames into site runtime

### DIFF
--- a/apps/openagents.com/workers/api/src/index.ts
+++ b/apps/openagents.com/workers/api/src/index.ts
@@ -922,6 +922,7 @@ import { handleSiteReferralPayoutsPublicApi } from './site-referral-payout-publi
 import { makeD1SiteReferralPayoutReceiptStore } from './site-referral-payout-receipts'
 import { makeSiteReferralRoutes } from './site-referral-routes'
 import { PENDING_REFERRAL_COOKIE } from './site-referrals'
+import { SiteRuntimeStorageError } from './site-runtime'
 import { makeSiteRuntimeRoutes } from './site-runtime-routes'
 import { makeSitesOrchestrationRoutes } from './sites-orchestration-routes'
 import { readBillingCreditPackages } from './stripe-billing'
@@ -9636,6 +9637,22 @@ const imageGenerationRoutes = makeImageGenerationRoutes({
 })
 
 const siteRuntimeRoutes = makeSiteRuntimeRoutes({
+  reservedHosts: new Set(['openagents.com', 'auth.openagents.com']),
+  resolveTenant: (request: Request, env: WorkerBindings) =>
+    makeTenantCustomHostnames(
+      openAgentsDatabase(env),
+    )
+      .resolveTenantByHostname(request.headers.get('Host') ?? '')
+      .pipe(
+        Effect.catchTag('TenantCustomHostnameStorageError', error =>
+          Effect.fail(
+            new SiteRuntimeStorageError({
+              error,
+              operation: 'siteRuntime.customHostname.resolveTenant',
+            }),
+          ),
+        ),
+      ),
   sitesHost: 'sites.openagents.com',
 })
 

--- a/apps/openagents.com/workers/api/src/product-promises.test.ts
+++ b/apps/openagents.com/workers/api/src/product-promises.test.ts
@@ -245,6 +245,11 @@ describe('public product promises document', () => {
     // claim/list path at /api/tenant/hostnames that writes only pending rows;
     // live provisioning stays owner-gated and INERT default-OFF), without
     // flipping the promise (stays yellow), so green remains exactly 24.
+    // The 2026-06-29.1 custom-hostname rendering pass clears
+    // hostname_rendering_context_switch_not_wired for already-active custom
+    // hostname rows by resolving the host to a tenant team and serving that
+    // team's active public Site through the Sites runtime; DNS verification and
+    // SSL issuance remain blocked, so the promise STAYS yellow.
     // The 2026-06-20.20 training ablation one-delta harness pass clears the
     // ablation_harness_missing blocker on training.ablation_system.v1 while
     // eval reproduction and paid dispatch remain blocked, so green remains

--- a/apps/openagents.com/workers/api/src/product-promises.ts
+++ b/apps/openagents.com/workers/api/src/product-promises.ts
@@ -3010,7 +3010,7 @@ export const publicProductPromisesDocument = () => {
         claim:
           'Autopilot Sites customers can serve their sites under custom branded hostnames.',
         safeCopy:
-          'Tenant custom-hostname registration, DNS-token verification, hostname→tenant mapping, request-time resolution, and a live Cloudflare custom-hostname client shipped in wave-3 (#4988/#4989). A CUSTOMER self-serve path is now mounted and live: a signed-in team owner/admin can claim a custom hostname for their own team and any team member can list their team’s claimed hostnames with the exact DNS TXT record to publish (GET/POST /api/tenant/hostnames, browser-session + team-role gated). The self-serve path is INERT by design: a claimed hostname is stored `pending` and never resolves or serves; it touches no live DNS, no SSL issuance, no origin binding, and no spend. Driving a hostname to `active` (live serving) stays the owner-gated Cloudflare provisioning core’s job, which is itself default-OFF until CLOUDFLARE_API_TOKEN and CLOUDFLARE_ZONE_ID are set. Automated SSL issuance and the tenant-scoped rendering context switch are still not wired.',
+          'Tenant custom-hostname registration, DNS-token verification, hostname→tenant mapping, request-time resolution, and a live Cloudflare custom-hostname client shipped in wave-3 (#4988/#4989). A CUSTOMER self-serve path is now mounted and live: a signed-in team owner/admin can claim a custom hostname for their own team and any team member can list their team’s claimed hostnames with the exact DNS TXT record to publish (GET/POST /api/tenant/hostnames, browser-session + team-role gated). The self-serve path is INERT by design: a claimed hostname is stored `pending` and never resolves or serves; it touches no live DNS, no SSL issuance, no origin binding, and no spend. Request-time rendering is wired for already-active custom-hostname rows: an active hostname resolves to its tenant team and serves that team’s active public Site through the existing Sites runtime. Driving a hostname to `active` (live serving) stays the owner-gated Cloudflare provisioning core’s job, which is itself default-OFF until CLOUDFLARE_API_TOKEN and CLOUDFLARE_ZONE_ID are set. Automated DNS verification and SSL issuance are still not wired.',
         unsafeCopy:
           'Do not claim that claiming a hostname makes a site live, that DNS/SSL/branding switching works end to end, or that a claimed hostname serves anything; self-serve claiming writes a pending row only, and live provisioning (Cloudflare for SaaS) stays owner-gated and default-OFF.',
         evidenceRefs: [
@@ -3020,16 +3020,17 @@ export const publicProductPromisesDocument = () => {
           'apps/openagents.com/workers/api/src/tenant-custom-hostname-self-serve-routes.ts',
           'apps/openagents.com/workers/api/src/tenant-custom-hostname-self-serve-routes.test.ts',
           'apps/openagents.com/workers/api/src/cloudflare-custom-hostname-client.ts',
+          'apps/openagents.com/workers/api/src/site-runtime-routes.ts',
+          'apps/openagents.com/workers/api/src/site-runtime-routes.test.ts',
           'route:/api/tenant/hostnames',
           'https://github.com/OpenAgentsInc/openagents/issues/4988',
           'https://github.com/OpenAgentsInc/openagents/issues/4989',
         ],
         blockerRefs: [
           'blocker.product_promises.hostname_ssl_issuance_not_wired',
-          'blocker.product_promises.hostname_rendering_context_switch_not_wired',
         ],
         verification:
-          'The customer self-serve claim/list path is mounted and gated (browser session + active team membership; only owner/admin may claim) and is covered by unit tests over the core and the routes; it writes only pending tenant_custom_hostnames rows and reports servingLive=false while provisioning is unarmed. Operator registration/verification still works and passes type checks. Green requires automated DNS verification + SSL provisioning (live Cloudflare for SaaS, owner-gated, default-OFF today) and request routing to tenant-scoped rendering.',
+          'The customer self-serve claim/list path is mounted and gated (browser session + active team membership; only owner/admin may claim) and is covered by unit tests over the core and the routes; it writes only pending tenant_custom_hostnames rows and reports servingLive=false while provisioning is unarmed. Operator registration/verification still works and passes type checks. site-runtime-routes.test.ts covers an active custom hostname resolving to the mapped tenant team and serving that team’s active public Site through the runtime. Green requires automated DNS verification + SSL provisioning (live Cloudflare for SaaS, owner-gated, default-OFF today).',
         authorityBoundary:
           'Hostname registration is not DNS authority, SSL certificate authority, or site-content publication authority.',
       },

--- a/apps/openagents.com/workers/api/src/site-runtime-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/site-runtime-routes.test.ts
@@ -19,6 +19,7 @@ type SiteRuntimeRow = Readonly<{
   site_status: string
   slug: string
   static_assets_manifest_json: string | null
+  team_id: string | null
   version_id: string | null
   visibility: string
   worker_module_r2_key: string | null
@@ -51,37 +52,39 @@ class SiteRuntimeDbStore {
           },
         },
       }),
+      team_id: 'team_otec',
       version_id: 'site_version_otec_previous',
       visibility: 'public',
       worker_module_r2_key: null,
     },
     {
-    access_mode: 'public',
-    active_deployment_id: 'site_deployment_otec',
-    build_status: 'saved',
-    deployment_id: 'site_deployment_otec',
-    deployment_status: 'active',
-    dispatch_namespace: null,
-    external_deployment_id: null,
-    d1_binding_name: null,
-    r2_binding_name: null,
-    runtime_kind: 'omega_static_r2',
-    runtime_script_name: null,
-    site_id: 'site_project_otec',
-    site_status: 'approved',
-    slug: 'otec',
-    static_assets_manifest_json: JSON.stringify({
-      assets: {
-        'index.html': {
-          cacheControl: 'public, max-age=120',
-          contentType: 'text/html; charset=utf-8',
-          r2Key: 'sites/otec/deployments/site_deployment_otec/index.html',
+      access_mode: 'public',
+      active_deployment_id: 'site_deployment_otec',
+      build_status: 'saved',
+      deployment_id: 'site_deployment_otec',
+      deployment_status: 'active',
+      dispatch_namespace: null,
+      external_deployment_id: null,
+      d1_binding_name: null,
+      r2_binding_name: null,
+      runtime_kind: 'omega_static_r2',
+      runtime_script_name: null,
+      site_id: 'site_project_otec',
+      site_status: 'approved',
+      slug: 'otec',
+      static_assets_manifest_json: JSON.stringify({
+        assets: {
+          'index.html': {
+            cacheControl: 'public, max-age=120',
+            contentType: 'text/html; charset=utf-8',
+            r2Key: 'sites/otec/deployments/site_deployment_otec/index.html',
+          },
         },
-      },
-    }),
-    version_id: 'site_version_otec',
-    visibility: 'public',
-    worker_module_r2_key: null,
+      }),
+      team_id: 'team_otec',
+      version_id: 'site_version_otec',
+      visibility: 'public',
+      worker_module_r2_key: null,
     },
   ]
 
@@ -112,16 +115,26 @@ class SiteRuntimeStatement implements D1PreparedStatement {
   first<T = Record<string, unknown>>(): Promise<T | null>
   first<T = unknown>(): Promise<T | null> {
     if (this.query.includes('FROM site_projects')) {
+      const isTeamQuery = this.query.includes('site_projects.team_id = ?')
       const isVersionQuery = this.query.includes('site_versions.id = ?')
       const versionId = isVersionQuery ? String(this.values[0]) : null
-      const slug = String(this.values[isVersionQuery ? 1 : 0])
-      const row = isVersionQuery
+      const row = isTeamQuery
         ? this.store.rows.find(
-            row => row.slug === slug && row.version_id === versionId,
+            row =>
+              row.team_id === String(this.values[0]) &&
+              row.deployment_id === row.active_deployment_id,
           )
-        : this.store.row?.slug === slug
-          ? this.store.row
-          : undefined
+        : (() => {
+            const slug = String(this.values[isVersionQuery ? 1 : 0])
+
+            return isVersionQuery
+              ? this.store.rows.find(
+                  row => row.slug === slug && row.version_id === versionId,
+                )
+              : this.store.row?.slug === slug
+                ? this.store.row
+                : undefined
+          })()
 
       return Promise.resolve((row as T | undefined) ?? null)
     }
@@ -209,13 +222,24 @@ class MemoryDispatchNamespace {
 }
 
 const routes = makeSiteRuntimeRoutes({ sitesHost: 'sites.openagents.com' })
+const customHostnameRoutes = makeSiteRuntimeRoutes({
+  reservedHosts: new Set(['openagents.com', 'auth.openagents.com']),
+  resolveTenant: () =>
+    Effect.succeed({
+      hostname: 'brand.example.com',
+      status: 'active',
+      teamId: 'team_otec',
+    }),
+  sitesHost: 'sites.openagents.com',
+})
 
 const runRoute = (
   store: SiteRuntimeDbStore,
   request: Request,
   dispatch = new MemoryDispatchNamespace(),
+  runtimeRoutes = routes,
 ): Promise<Response> => {
-  const route = routes.routeSiteRuntimeRequest(request, {
+  const route = runtimeRoutes.routeSiteRuntimeRequest(request, {
     ARTIFACTS: new MemoryR2Bucket() as unknown as R2Bucket,
     OPENAGENTS_DB: siteRuntimeDb(store),
     SITES_DISPATCH: dispatch as unknown as DispatchNamespace,
@@ -272,6 +296,35 @@ describe('site runtime routes', () => {
   test('does not match non-sites hosts', () => {
     const route = routes.routeSiteRuntimeRequest(
       new Request('https://openagents.com/otec'),
+      {
+        ARTIFACTS: new MemoryR2Bucket() as unknown as R2Bucket,
+        OPENAGENTS_DB: siteRuntimeDb(new SiteRuntimeDbStore()),
+        SITES_DISPATCH:
+          new MemoryDispatchNamespace() as unknown as DispatchNamespace,
+      },
+    )
+
+    expect(route).toBeUndefined()
+  })
+
+  test('serves the active public Site for an active custom hostname tenant', async () => {
+    const response = await runRoute(
+      new SiteRuntimeDbStore(),
+      new Request('https://brand.example.com/'),
+      new MemoryDispatchNamespace(),
+      customHostnameRoutes,
+    )
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('content-type')).toBe(
+      'text/html; charset=utf-8',
+    )
+    await expect(response.text()).resolves.toContain('<title>OTEC</title>')
+  })
+
+  test('does not claim reserved first-party hosts as custom hostnames', () => {
+    const route = customHostnameRoutes.routeSiteRuntimeRequest(
+      new Request('https://openagents.com/'),
       {
         ARTIFACTS: new MemoryR2Bucket() as unknown as R2Bucket,
         OPENAGENTS_DB: siteRuntimeDb(new SiteRuntimeDbStore()),

--- a/apps/openagents.com/workers/api/src/site-runtime-routes.ts
+++ b/apps/openagents.com/workers/api/src/site-runtime-routes.ts
@@ -7,6 +7,7 @@ import {
   SiteRuntimeService,
   SiteRuntimeStorageError,
 } from './site-runtime'
+import { type TenantRef } from './tenant-custom-hostnames'
 
 type SiteRuntimeRouteEnv = Readonly<{
   ARTIFACTS: R2Bucket
@@ -15,8 +16,13 @@ type SiteRuntimeRouteEnv = Readonly<{
 }>
 type HttpResponse = globalThis.Response
 
-type SiteRuntimeRoutesConfig = Readonly<{
+type SiteRuntimeRoutesConfig<Env extends SiteRuntimeRouteEnv> = Readonly<{
   sitesHost: string
+  reservedHosts?: ReadonlySet<string>
+  resolveTenant?: (
+    request: Request,
+    env: Env,
+  ) => Effect.Effect<TenantRef | null, SiteRuntimeStorageError>
 }>
 
 type ParsedSiteRuntimePath = Readonly<{
@@ -121,6 +127,23 @@ const parseSiteRuntimePath = (url: URL): ParsedSiteRuntimePath | null => {
   }
 }
 
+const parseCustomHostnameRuntimePath = (
+  url: URL,
+): Omit<ParsedSiteRuntimePath, 'slug' | 'versionId'> | null => {
+  const segments = url.pathname.split('/').filter(segment => segment !== '')
+
+  if (hasUnsafePathSegment(segments)) {
+    return null
+  }
+
+  const restPath = segments.join('/')
+
+  return {
+    candidatePaths: candidateAssetPaths(restPath, url.pathname),
+    dispatchPath: url.pathname === '' ? '/' : url.pathname,
+  }
+}
+
 const artifactHeaders = (
   object: R2ObjectBody,
   asset: SiteRuntimeStaticAsset,
@@ -190,14 +213,74 @@ const runSiteRuntimeRoute = (
     ),
   )
 
-export const makeSiteRuntimeRoutes = (config: SiteRuntimeRoutesConfig) => ({
+export const makeSiteRuntimeRoutes = <Env extends SiteRuntimeRouteEnv>(
+  config: SiteRuntimeRoutesConfig<Env>,
+) => ({
   routeSiteRuntimeRequest: (
     request: Request,
-    env: SiteRuntimeRouteEnv,
+    env: Env,
   ): Effect.Effect<HttpResponse> | undefined => {
     const url = new URL(request.url)
 
-    if (url.hostname !== config.sitesHost) {
+    if (url.hostname === config.sitesHost) {
+      if (url.search !== '') {
+        return Effect.succeed(redirectResponse(`${url.origin}${url.pathname}`))
+      }
+
+      const parsed = parseSiteRuntimePath(url)
+
+      if (parsed === null) {
+        return Effect.succeed(publicSiteNotFound())
+      }
+
+      return runSiteRuntimeRoute(
+        env,
+        Effect.gen(function* () {
+          const runtime = yield* SiteRuntimeService
+          const target =
+            parsed.versionId === null
+              ? yield* runtime.resolveRuntimeTarget(
+                  parsed.slug,
+                  parsed.candidatePaths,
+                )
+              : yield* runtime.resolveVersionRuntimeTarget(
+                  parsed.slug,
+                  parsed.versionId,
+                  parsed.candidatePaths,
+                )
+
+          if (target === null) {
+            return publicSiteNotFound()
+          }
+
+          if (target._tag === 'worker') {
+            return yield* workerDispatchResponse(
+              env.SITES_DISPATCH,
+              target,
+              request,
+              parsed.dispatchPath,
+            )
+          }
+
+          if (request.method !== 'GET' && request.method !== 'HEAD') {
+            return methodNotAllowed(['GET', 'HEAD'])
+          }
+
+          const object = yield* runtime.readArtifactObject(target)
+
+          return object === null
+            ? publicSiteNotFound()
+            : artifactResponse(request, object, target)
+        }),
+      )
+    }
+
+    const resolveTenant = config.resolveTenant
+
+    if (
+      resolveTenant === undefined ||
+      config.reservedHosts?.has(url.hostname) === true
+    ) {
       return undefined
     }
 
@@ -205,7 +288,7 @@ export const makeSiteRuntimeRoutes = (config: SiteRuntimeRoutesConfig) => ({
       return Effect.succeed(redirectResponse(`${url.origin}${url.pathname}`))
     }
 
-    const parsed = parseSiteRuntimePath(url)
+    const parsed = parseCustomHostnameRuntimePath(url)
 
     if (parsed === null) {
       return Effect.succeed(publicSiteNotFound())
@@ -214,18 +297,17 @@ export const makeSiteRuntimeRoutes = (config: SiteRuntimeRoutesConfig) => ({
     return runSiteRuntimeRoute(
       env,
       Effect.gen(function* () {
+        const tenant = yield* resolveTenant(request, env)
+
+        if (tenant === null) {
+          return publicSiteNotFound()
+        }
+
         const runtime = yield* SiteRuntimeService
-        const target =
-          parsed.versionId === null
-            ? yield* runtime.resolveRuntimeTarget(
-                parsed.slug,
-                parsed.candidatePaths,
-              )
-            : yield* runtime.resolveVersionRuntimeTarget(
-                parsed.slug,
-                parsed.versionId,
-                parsed.candidatePaths,
-              )
+        const target = yield* runtime.resolveRuntimeTargetByTeam(
+          tenant.teamId,
+          parsed.candidatePaths,
+        )
 
         if (target === null) {
           return publicSiteNotFound()

--- a/apps/openagents.com/workers/api/src/site-runtime.ts
+++ b/apps/openagents.com/workers/api/src/site-runtime.ts
@@ -41,6 +41,7 @@ export type SiteRuntimeTarget =
 
 type SiteRuntimeDeploymentRow = Readonly<{
   site_id: string
+  team_id: string | null
   slug: string
   site_status: string
   access_mode: string
@@ -110,6 +111,7 @@ const readRuntimeDeployment = (
     db
       .prepare(
         `SELECT site_projects.id AS site_id,
+                site_projects.team_id,
                 site_projects.slug,
                 site_projects.status AS site_status,
                 site_projects.access_mode,
@@ -142,6 +144,49 @@ const readRuntimeDeployment = (
       .first<SiteRuntimeDeploymentRow>(),
   )
 
+const readRuntimeDeploymentByTeam = (
+  db: D1Database,
+  teamId: string,
+): Effect.Effect<SiteRuntimeDeploymentRow | null, SiteRuntimeStorageError> =>
+  d1Effect('siteRuntime.deployments.readActiveByTeam', () =>
+    db
+      .prepare(
+        `SELECT site_projects.id AS site_id,
+                site_projects.team_id,
+                site_projects.slug,
+                site_projects.status AS site_status,
+                site_projects.access_mode,
+                site_projects.visibility,
+                site_projects.active_deployment_id,
+                site_deployments.id AS deployment_id,
+                site_deployments.status AS deployment_status,
+                site_deployments.runtime_kind,
+                site_deployments.runtime_script_name,
+                site_deployments.dispatch_namespace,
+                site_deployments.external_deployment_id,
+                site_versions.id AS version_id,
+                site_versions.build_status,
+                site_versions.worker_module_r2_key,
+                site_versions.static_assets_manifest_json,
+                site_versions.d1_binding_name,
+                site_versions.r2_binding_name
+           FROM site_projects
+           LEFT JOIN site_deployments
+             ON site_deployments.id = site_projects.active_deployment_id
+            AND site_deployments.site_id = site_projects.id
+           LEFT JOIN site_versions
+             ON site_versions.id = site_deployments.version_id
+            AND site_versions.site_id = site_projects.id
+          WHERE site_projects.team_id = ?
+            AND site_projects.archived_at IS NULL
+          ORDER BY site_projects.updated_at DESC,
+                   site_projects.created_at DESC
+          LIMIT 1`,
+      )
+      .bind(teamId)
+      .first<SiteRuntimeDeploymentRow>(),
+  )
+
 const readRuntimeVersion = (
   db: D1Database,
   slug: string,
@@ -151,6 +196,7 @@ const readRuntimeVersion = (
     db
       .prepare(
         `SELECT site_projects.id AS site_id,
+                site_projects.team_id,
                 site_projects.slug,
                 site_projects.status AS site_status,
                 site_projects.access_mode,
@@ -384,6 +430,31 @@ const resolveVersionRuntimeTarget = (
     return resolveManifestAsset(row, candidatePaths)
   })
 
+const resolveRuntimeTargetByTeam = (
+  db: D1Database,
+  teamId: string,
+  candidatePaths: ReadonlyArray<string>,
+): Effect.Effect<SiteRuntimeTarget | null, SiteRuntimeStorageError> =>
+  Effect.gen(function* () {
+    const row = yield* readRuntimeDeploymentByTeam(db, teamId)
+
+    if (row === null) {
+      return null
+    }
+
+    const workerDeployment = workerDeploymentFromRow(row)
+
+    if (workerDeployment !== null) {
+      return workerDeployment
+    }
+
+    if (!isPublicActiveStaticRuntimeRow(row)) {
+      return null
+    }
+
+    return resolveManifestAsset(row, candidatePaths)
+  })
+
 const readArtifactObject = (
   artifacts: R2Bucket,
   asset: SiteRuntimeStaticAsset,
@@ -402,6 +473,10 @@ export class SiteRuntimeService extends Context.Service<
     ) => Effect.Effect<SiteRuntimeStaticAsset | null, SiteRuntimeStorageError>
     readonly resolveRuntimeTarget: (
       slug: string,
+      candidatePaths: ReadonlyArray<string>,
+    ) => Effect.Effect<SiteRuntimeTarget | null, SiteRuntimeStorageError>
+    readonly resolveRuntimeTargetByTeam: (
+      teamId: string,
       candidatePaths: ReadonlyArray<string>,
     ) => Effect.Effect<SiteRuntimeTarget | null, SiteRuntimeStorageError>
     readonly resolveVersionRuntimeTarget: (
@@ -423,6 +498,15 @@ export class SiteRuntimeService extends Context.Service<
       resolveRuntimeTarget: Effect.fn('SiteRuntimeService.resolveRuntimeTarget')(
         (slug, candidatePaths) =>
           resolveRuntimeTarget(openAgentsDatabase(env), slug, candidatePaths),
+      ),
+      resolveRuntimeTargetByTeam: Effect.fn(
+        'SiteRuntimeService.resolveRuntimeTargetByTeam',
+      )((teamId, candidatePaths) =>
+        resolveRuntimeTargetByTeam(
+          openAgentsDatabase(env),
+          teamId,
+          candidatePaths,
+        ),
       ),
       resolveVersionRuntimeTarget: Effect.fn(
         'SiteRuntimeService.resolveVersionRuntimeTarget',


### PR DESCRIPTION
## Summary

- Wire active tenant custom-hostname rows into the Sites runtime so a resolved custom host serves that tenant team's active public Site.
- Preserve existing `sites.openagents.com/<slug>` behavior and exclude reserved first-party hosts from custom-host matching.
- Update the custom-hostname promise copy/evidence to clear only the rendering-context blocker while keeping DNS verification and SSL issuance blocked/yellow.

Closes #6840.

## Verification

- `bun run --cwd apps/openagents.com/workers/api test -- src/site-runtime-routes.test.ts src/product-promises.test.ts`
- `bun run --cwd apps/openagents.com/workers/api typecheck` (exits 0; prints existing Effect language-service advisory messages)
- `true` for `command.public.pylon_khala.verify.b5bea41b6c623f7c09f1bf24`
