### PR TITLE
test(pylon): guard heartbeat idempotency race

### DIFF
--- a/apps/openagents.com/workers/api/src/pylon-api-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/pylon-api-routes.test.ts
@@ -1089,7 +1089,7 @@ describe('Pylon API routes', () => {
     expect(failingDb.batchQueries).toHaveLength(2)
   })
 
-  test('D1 event creation is idempotent when the idempotency pre-read races a duplicate write (#6821)', async () => {
+  test('D1 event creation is idempotent when the idempotency pre-read races a duplicate heartbeat write (#6820)', async () => {
     const idempotencyKeyHash = 'hash.presence.duplicate'
     const existing = buildPylonApiEventRecord({
       body: {
@@ -1142,6 +1142,12 @@ describe('Pylon API routes', () => {
     expect(db.insertQueries).toHaveLength(1)
     expect(db.insertQueries[0]).toContain(
       'ON CONFLICT(idempotency_key_hash) DO UPDATE',
+    )
+    expect(db.events.get(idempotencyKeyHash)?.event_ref).toBe(
+      existing.eventRef,
+    )
+    expect(db.events.get(idempotencyKeyHash)?.created_at).toBe(
+      existing.createdAt,
     )
   })
 


### PR DESCRIPTION
## Summary
- Tie the Pylon D1 duplicate-heartbeat idempotency regression directly to the #6820 throughput-safeguard incident.
- Assert the duplicate-write race preserves the original stored event ref and timestamp instead of overwriting the row or surfacing a D1 uniqueness failure.

Closes #6820

## Verification
- `bun run --cwd apps/openagents.com/workers/api test -- src/pylon-api-routes.test.ts`
- `true` (resolved from `command.public.pylon_khala.verify.b5bea41b6c623f7c09f1bf24`)