### PR TITLE
Route active GLM failover across paid lanes

### DIFF
--- a/apps/openagents.com/workers/api/src/inference/chat-completions-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/chat-completions-routes.test.ts
@@ -3598,6 +3598,71 @@ describe('POST /v1/chat/completions', () => {
     expect(recorded).toEqual(servedWorkers)
   })
 
+  test('active GLM own-capacity failover keeps tool-bearing Khala requests on the tool lane', async () => {
+    const registry = new InferenceProviderRegistry()
+    registry.register(echoAdapter(VERTEX_GEMINI_ADAPTER_ID))
+    registry.register(echoAdapter(FIREWORKS_ADAPTER_ID))
+    registry.register(echoAdapter(HYDRALISK_GLM_52_REAP_504B_ADAPTER_ID))
+    registry.register(echoAdapter(OPENROUTER_KHALA_FALLBACK_ADAPTER_ID))
+
+    const failover = makeGlmOwnCapacityFailover({ failureThreshold: 1 })
+    failover.recordFailure(
+      new InferenceAdapterError({
+        adapterId: HYDRALISK_GLM_52_REAP_504B_ADAPTER_ID,
+        httpStatus: 503,
+        kind: 'route_admission_reserved_headroom_unavailable',
+        reason: 'GLM own-capacity lane has no reserved external headroom',
+        retryable: true,
+      }),
+    )
+
+    const response = await run(
+      handleChatCompletions(
+        chatRequest({
+          ...helloBody,
+          tool_choice: 'auto',
+          tools: [
+            {
+              function: {
+                description: 'Run a shell command.',
+                name: 'bash',
+                parameters: {
+                  additionalProperties: false,
+                  properties: { command: { type: 'string' } },
+                  required: ['command'],
+                  type: 'object',
+                },
+              },
+              type: 'function',
+            },
+          ],
+        }),
+        baseDeps({
+          dispatch: {
+            glmOwnCapacityFailover: failover,
+            sleep: () => Effect.void,
+          },
+          lanePlan: () => [
+            VERTEX_GEMINI_ADAPTER_ID,
+            FIREWORKS_ADAPTER_ID,
+            HYDRALISK_GLM_52_REAP_504B_ADAPTER_ID,
+            OPENROUTER_KHALA_FALLBACK_ADAPTER_ID,
+          ],
+          multiLaneBurnRotation: () => 0,
+          registry,
+        }),
+      ),
+    )
+
+    expect(response.status).toBe(200)
+    const body = (await response.json()) as {
+      openagents?: { worker?: string }
+    }
+    expect(body.openagents?.worker).toBe(
+      HYDRALISK_GLM_52_REAP_504B_ADAPTER_ID,
+    )
+  })
+
   test('hedges external requests to a warm lane when route dispatch hedging is configured', async () => {
     let primaryCalls = 0
     let hedgeCalls = 0

--- a/apps/openagents.com/workers/api/src/inference/chat-completions-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/chat-completions-routes.test.ts
@@ -67,6 +67,7 @@ import {
   HYDRALISK_GPT_OSS_120B_ADAPTER_ID,
   OPENROUTER_KHALA_FALLBACK_ADAPTER_ID,
   VERTEX_GEMINI_ADAPTER_ID,
+  makeGlmOwnCapacityFailover,
   selectAdapterPlan,
 } from './model-router'
 import {
@@ -3525,6 +3526,76 @@ describe('POST /v1/chat/completions', () => {
       },
     })
     expect(recorded[0]?.usage.totalTokens).toBeGreaterThan(0)
+  })
+
+  test('active GLM own-capacity failover spreads external Khala traffic across registered paid lanes (#6823)', async () => {
+    const registry = new InferenceProviderRegistry()
+    registry.register(echoAdapter(VERTEX_GEMINI_ADAPTER_ID))
+    registry.register(echoAdapter(FIREWORKS_ADAPTER_ID))
+    registry.register(echoAdapter(HYDRALISK_GLM_52_REAP_504B_ADAPTER_ID))
+    registry.register(echoAdapter(OPENROUTER_KHALA_FALLBACK_ADAPTER_ID))
+
+    const failover = makeGlmOwnCapacityFailover({ failureThreshold: 1 })
+    failover.recordFailure(
+      new InferenceAdapterError({
+        adapterId: HYDRALISK_GLM_52_REAP_504B_ADAPTER_ID,
+        httpStatus: 503,
+        kind: 'route_admission_reserved_headroom_unavailable',
+        reason: 'GLM own-capacity lane has no reserved external headroom',
+        retryable: true,
+      }),
+    )
+
+    const recorded: Array<string> = []
+    const servedWorkers: Array<string> = []
+    let rotation = 0
+
+    for (let index = 0; index < 4; index += 1) {
+      const response = await run(
+        handleChatCompletions(
+          chatRequest(helloBody, {
+            headers: {
+              [INFERENCE_CLIENT_HEADER]: 'public-api',
+              [INFERENCE_DEMAND_KIND_HEADER]: 'external',
+              [INFERENCE_DEMAND_SOURCE_HEADER]: 'public-api',
+            },
+          }),
+          baseDeps({
+            dispatch: {
+              glmOwnCapacityFailover: failover,
+              sleep: () => Effect.void,
+            },
+            lanePlan: () => [
+              HYDRALISK_GLM_52_REAP_504B_ADAPTER_ID,
+              VERTEX_GEMINI_ADAPTER_ID,
+              FIREWORKS_ADAPTER_ID,
+              OPENROUTER_KHALA_FALLBACK_ADAPTER_ID,
+            ],
+            multiLaneBurnRotation: () => rotation++,
+            recordTokensServed: input =>
+              Effect.sync(() => {
+                recorded.push(input.adapterId)
+              }),
+            registry,
+          }),
+        ),
+      )
+
+      expect(response.status).toBe(200)
+      const body = (await response.json()) as {
+        openagents?: { worker?: string }
+      }
+      servedWorkers.push(body.openagents!.worker!)
+    }
+
+    expect(servedWorkers).toEqual([
+      VERTEX_GEMINI_ADAPTER_ID,
+      FIREWORKS_ADAPTER_ID,
+      OPENROUTER_KHALA_FALLBACK_ADAPTER_ID,
+      VERTEX_GEMINI_ADAPTER_ID,
+    ])
+    expect(servedWorkers).not.toContain(HYDRALISK_GLM_52_REAP_504B_ADAPTER_ID)
+    expect(recorded).toEqual(servedWorkers)
   })
 
   test('hedges external requests to a warm lane when route dispatch hedging is configured', async () => {

--- a/apps/openagents.com/workers/api/src/inference/chat-completions-routes.ts
+++ b/apps/openagents.com/workers/api/src/inference/chat-completions-routes.ts
@@ -136,6 +136,7 @@ import {
 } from './metering-hook'
 import {
   type DispatchDeps,
+  type DispatchGlmOwnCapacityFailover,
   type DispatchHedgingPolicy,
   type DispatchLoadSheddingPolicy,
   type DispatchRouteAdmissionPolicy,
@@ -3015,6 +3016,7 @@ export const handleChatCompletions = (
       isMultiLaneBurnDemandSource(requestAttribution.demandSource)
     const glmOwnCapacityFailoverKhalaRequest =
       isKhalaModel(requestedModel) &&
+      !toolBearingKhalaRequest &&
       (requestAttribution?.demandKind === 'external' ||
         requestAttribution?.demandKind === undefined) &&
       deps.dispatch?.glmOwnCapacityFailover?.isActive() === true &&
@@ -3245,6 +3247,17 @@ export const handleChatCompletions = (
             reservedExternalHeadroomAvailable:
               effectiveRouteAdmission.reservedExternalHeadroomAvailable,
           })
+    const dispatchGlmOwnCapacityFailover:
+      | DispatchGlmOwnCapacityFailover
+      | undefined =
+      deps.dispatch?.glmOwnCapacityFailover === undefined
+        ? undefined
+        : glmOwnCapacityFailoverKhalaRequest
+          ? deps.dispatch.glmOwnCapacityFailover
+          : {
+              ...deps.dispatch.glmOwnCapacityFailover,
+              isActive: () => false,
+            }
     const dispatchDeps: DispatchDeps = {
       registry: deps.registry,
       plan: () => plannedIds,
@@ -3298,9 +3311,9 @@ export const handleChatCompletions = (
       ...(deps.dispatch?.failureTelemetry === undefined
         ? {}
         : { failureTelemetry: deps.dispatch.failureTelemetry }),
-      ...(deps.dispatch?.glmOwnCapacityFailover === undefined
+      ...(dispatchGlmOwnCapacityFailover === undefined
         ? {}
-        : { glmOwnCapacityFailover: deps.dispatch.glmOwnCapacityFailover }),
+        : { glmOwnCapacityFailover: dispatchGlmOwnCapacityFailover }),
     }
 
     if (inferenceRequest.stream) {

--- a/apps/openagents.com/workers/api/src/inference/chat-completions-routes.ts
+++ b/apps/openagents.com/workers/api/src/inference/chat-completions-routes.ts
@@ -3013,6 +3013,12 @@ export const handleChatCompletions = (
       isKhalaModel(requestedModel) &&
       requestAttribution?.demandKind === 'internal_stress' &&
       isMultiLaneBurnDemandSource(requestAttribution.demandSource)
+    const glmOwnCapacityFailoverKhalaRequest =
+      isKhalaModel(requestedModel) &&
+      (requestAttribution?.demandKind === 'external' ||
+        requestAttribution?.demandKind === undefined) &&
+      deps.dispatch?.glmOwnCapacityFailover?.isActive() === true &&
+      plannedIdsForModel.includes(HYDRALISK_GLM_52_REAP_504B_ADAPTER_ID)
     // INTERNAL FRONTIER-CODING OVERRIDE (MirrorCode gym rung). Honestly-tagged
     // internal frontier-coding eval load (`demand_kind=internal`,
     // `demand_source=gym_mirrorcode`) that is tool-bearing is routed to the
@@ -3027,6 +3033,16 @@ export const handleChatCompletions = (
       requestAttribution.demandSource === 'gym_mirrorcode'
     const basePlannedIds = callerPaidByok
       ? [OPENROUTER_KHALA_FALLBACK_ADAPTER_ID]
+      : glmOwnCapacityFailoverKhalaRequest
+        ? selectAdapterPlanForKhalaMultiLaneBurnRequest(
+            requestedModel,
+            plannedIdsForModel.filter(
+              id =>
+                id !== HYDRALISK_GLM_52_REAP_504B_ADAPTER_ID &&
+                deps.registry.resolve(id) !== undefined,
+            ),
+            (deps.multiLaneBurnRotation ?? nextMultiLaneBurnRotationIndex)(),
+          )
       : multiLaneBurnKhalaRequest
         ? // Rotate only across lanes that are actually registered (so the spread
           // lands on lanes that can serve), keeping the per-request round-robin


### PR DESCRIPTION
## Summary

- When the GLM own-capacity failover breaker is active for external Khala demand, skip the GLM lane and rotate across registered paid fallback lanes.
- Keep BYOK, normal routing, internal burn fan-out, and tool/coding overrides on their existing branches.
- Add regression coverage proving external Khala requests spread across Vertex, Fireworks, and OpenRouter while GLM is down and token recording follows the served lane.

Closes #6823.

## Verification

- `bun test apps/openagents.com/workers/api/src/inference/chat-completions-routes.test.ts`
- `bun run --cwd apps/openagents.com/workers/api test -- src/inference/chat-completions-routes.test.ts`
- `bun run --cwd apps/openagents.com/workers/api typecheck` (exits 0; existing Effect advisory messages only)
