### PR TITLE
Expose Autopilot decision closeout projections

### DIFF
--- a/apps/openagents.com/workers/api/src/openagents-capability-manifest-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/openagents-capability-manifest-routes.test.ts
@@ -324,6 +324,16 @@ describe('OpenAgents capability manifest route', () => {
           id: 'autopilot_decisions_queue',
         }),
         expect.objectContaining({
+          auth: 'browser_session_or_registered_agent_token_with_customer_orders.read',
+          href: 'https://openagents.com/api/autopilot/work/{workOrderRef}/decisions',
+          id: 'autopilot_work_decisions',
+        }),
+        expect.objectContaining({
+          auth: 'browser_session_or_registered_agent_token_with_customer_orders.read',
+          href: 'https://openagents.com/api/autopilot/decision-closeouts/{closeoutRef}',
+          id: 'autopilot_decision_closeout_receipt',
+        }),
+        expect.objectContaining({
           auth: 'browser_session',
           href: 'https://openagents.com/api/sites/builder-sessions',
           id: 'site_builder_sessions',
@@ -489,6 +499,18 @@ describe('OpenAgents capability manifest route', () => {
           auth: 'browser_session_or_registered_agent_token_with_customer_orders.write_and_idempotency_key',
           href: 'https://openagents.com/api/autopilot/decisions/{decisionRef}/actions',
           id: 'act_on_autopilot_decision',
+          status: 'available',
+        }),
+        expect.objectContaining({
+          auth: 'browser_session_or_registered_agent_token_with_customer_orders.read',
+          href: 'https://openagents.com/api/autopilot/work/{workOrderRef}/decisions',
+          id: 'autopilot_work_decisions',
+          status: 'available',
+        }),
+        expect.objectContaining({
+          auth: 'browser_session_or_registered_agent_token_with_customer_orders.read',
+          href: 'https://openagents.com/api/autopilot/decision-closeouts/{closeoutRef}',
+          id: 'autopilot_decision_closeout_receipt',
           status: 'available',
         }),
         expect.objectContaining({

--- a/apps/openagents.com/workers/api/src/openagents-capability-manifest.ts
+++ b/apps/openagents.com/workers/api/src/openagents-capability-manifest.ts
@@ -687,6 +687,22 @@ export const openAgentsCapabilityManifest = (): Effect.Effect<
           'Signed-in owners or owner-granted agents read the Autopilot decision queue: pending review decisions for delivered work, blocked customer-input decisions, and recent completed decisions with receipt refs. Every decision carries directEffectPermitted: false and the projection carries generatedAt rebuilt from live work-order records on each read.',
       },
       {
+        id: 'autopilot_work_decisions',
+        href: 'https://openagents.com/api/autopilot/work/{workOrderRef}/decisions',
+        method: 'GET',
+        auth: 'browser_session_or_registered_agent_token_with_customer_orders.read',
+        description:
+          'Signed-in owners or owner-granted agents read the pending and completed decision projection for one Autopilot work order, including decision closeout receipt refs. Read-only evidence; no deploy, spend, acceptance, payout, settlement, or Forum publication authority.',
+      },
+      {
+        id: 'autopilot_decision_closeout_receipt',
+        href: 'https://openagents.com/api/autopilot/decision-closeouts/{closeoutRef}',
+        method: 'GET',
+        auth: 'browser_session_or_registered_agent_token_with_customer_orders.read',
+        description:
+          'Signed-in owners or owner-granted agents dereference an Autopilot decision closeout receipt. Receipts are audit evidence only and directEffectPermitted remains false.',
+      },
+      {
         id: 'site_builder_sessions',
         href: 'https://openagents.com/api/sites/builder-sessions',
         method: 'POST',
@@ -1210,6 +1226,24 @@ export const openAgentsCapabilityManifest = (): Effect.Effect<
         status: 'available',
         description:
           'Signed-in owners or owner-granted agents act on a pending approve_pr_draft decision with accept, reject, or request_changes. The action records a gated review submission only (directEffectPermitted: false); it grants no deploy, spend, worker payout, settlement, or Forum publication authority.',
+      },
+      {
+        id: 'autopilot_work_decisions',
+        href: 'https://openagents.com/api/autopilot/work/{workOrderRef}/decisions',
+        method: 'GET',
+        auth: 'browser_session_or_registered_agent_token_with_customer_orders.read',
+        status: 'available',
+        description:
+          'Signed-in owners or owner-granted agents read the pending and completed decision projection for one Autopilot work order, including decision closeout receipt refs. Read-only evidence; no deploy, spend, acceptance, payout, settlement, or Forum publication authority.',
+      },
+      {
+        id: 'autopilot_decision_closeout_receipt',
+        href: 'https://openagents.com/api/autopilot/decision-closeouts/{closeoutRef}',
+        method: 'GET',
+        auth: 'browser_session_or_registered_agent_token_with_customer_orders.read',
+        status: 'available',
+        description:
+          'Signed-in owners or owner-granted agents dereference an Autopilot decision closeout receipt. Receipts are audit evidence only and directEffectPermitted remains false.',
       },
       {
         id: 'submit_site_feedback',

--- a/apps/openagents.com/workers/api/src/openagents-openapi-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/openagents-openapi-routes.test.ts
@@ -519,6 +519,17 @@ describe('OpenAgents OpenAPI route', () => {
       operationAt(body, '/api/autopilot/decisions', 'get').operationId,
     ).toBe('listAutopilotDecisions')
     expect(
+      operationAt(body, '/api/autopilot/work/{workOrderRef}/decisions', 'get')
+        .operationId,
+    ).toBe('listAutopilotWorkOrderDecisions')
+    expect(
+      operationAt(
+        body,
+        '/api/autopilot/decision-closeouts/{closeoutRef}',
+        'get',
+      ).operationId,
+    ).toBe('getAutopilotDecisionCloseout')
+    expect(
       operationAt(
         body,
         '/api/autopilot/decisions/{decisionRef}/actions',


### PR DESCRIPTION
## Summary
- Add capability-manifest entries for the owner-scoped Autopilot work-order decision projection and decision closeout receipt reader.
- Extend manifest and OpenAPI route tests so those receipt-backed decision surfaces remain discoverable.

Closes #6829.

## Verification
- `bun test apps/openagents.com/workers/api/src/autopilot-decision-routes.test.ts apps/openagents.com/workers/api/src/product-promises.test.ts` — 29 pass
- `bun run --cwd apps/openagents.com/workers/api test src/openagents-openapi-routes.test.ts src/openagents-capability-manifest-routes.test.ts` — 6 pass
- `bun run --cwd apps/openagents.com/apps/web test src/page/loggedIn/page/decisions.test.ts` — 1 pass
- `bun run --cwd apps/openagents.com check:deploy` — passed
