### PR TITLE
Gate Forge promotions on verification receipts

### DIFF
--- a/apps/openagents.com/workers/api/src/forge-control-plane-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/forge-control-plane-routes.test.ts
@@ -391,6 +391,118 @@ describe('Forge control-plane routes', () => {
     expect(decisionsBody.promotionDecisions).toHaveLength(1)
   })
 
+  test('fails closed when approved promotion lacks a current passing verification receipt', async () => {
+    const { run } = makeHarness()
+    const scopes = [
+      'forge:receipt:write',
+      'forge:promotion:decide',
+    ].join(' ')
+    const baseHead = '8e0c9b2eaf84c821caf555cae233a0d27e94d4ab'
+    const candidateHead = '9e0c9b2eaf84c821caf555cae233a0d27e94d4ac'
+    const promotionDecision = {
+      schema: 'openagents.forge.promotion.decision.v0.1',
+      tenant_ref: 'tenant.openagents',
+      promotion_ref: 'promotion.forge.6795',
+      queue_ref: 'queue.forge.main',
+      change_ref: 'change.forge.6795',
+      decision: 'approved',
+      base_head: baseHead,
+      candidate_head: candidateHead,
+      promoted_head: candidateHead,
+      verification_ref: 'verification.forge.6795',
+      gate_refs: ['gate.su4'],
+      blocker_refs: [],
+      decided_by_ref: 'agent.public.forge',
+      decided_at: '2026-06-28T17:03:00.000Z',
+      source_refs: ['github:OpenAgentsInc/openagents#6795'],
+      redacted: true,
+    }
+    const verificationReceipt = {
+      schema: 'openagents.forge.verification.receipt.v0.1',
+      tenant_ref: 'tenant.openagents',
+      verification_ref: 'verification.forge.6795',
+      change_ref: 'change.forge.6795',
+      repository_ref: 'repo:OpenAgentsInc/openagents',
+      base_ref: 'refs/heads/main',
+      base_head: baseHead,
+      head_ref: 'refs/heads/forge-6795',
+      head_head: candidateHead,
+      packfile_ref: 'packfile.forge.6795',
+      packfile_sha256: 'sha256:verification',
+      executor_identity_ref: 'agent.public.forge',
+      command_ref: 'cmd.test',
+      command_args: ['bun', 'test'],
+      exit_code: 1,
+      verdict: 'failed',
+      started_at: now,
+      completed_at: '2026-06-28T17:02:00.000Z',
+      artifact_refs: ['artifact:test-log'],
+      log_sha256: 'sha256:log',
+      source_refs: ['github:OpenAgentsInc/openagents#6795'],
+      redacted: true,
+    }
+
+    const missingResponse = await run(
+      requestJson('/api/forge/promotion-decisions', {
+        json: promotionDecision,
+        headers: authHeaders(scopes),
+        method: 'POST',
+      }),
+    )
+    const missingBody = (await missingResponse.json()) as { error: string }
+    expect(missingResponse.status).toBe(409)
+    expect(missingBody.error).toBe('forge_promotion_verification_receipt_missing')
+
+    const failedReceiptResponse = await run(
+      requestJson('/api/forge/verification-receipts', {
+        json: verificationReceipt,
+        headers: authHeaders(scopes),
+        method: 'POST',
+      }),
+    )
+    expect(failedReceiptResponse.status).toBe(201)
+
+    const failedResponse = await run(
+      requestJson('/api/forge/promotion-decisions', {
+        json: promotionDecision,
+        headers: authHeaders(scopes),
+        method: 'POST',
+      }),
+    )
+    const failedBody = (await failedResponse.json()) as { error: string }
+    expect(failedResponse.status).toBe(409)
+    expect(failedBody.error).toBe(
+      'forge_promotion_verification_receipt_not_current_passing',
+    )
+
+    const staleReceiptResponse = await run(
+      requestJson('/api/forge/verification-receipts', {
+        json: {
+          ...verificationReceipt,
+          exit_code: 0,
+          verdict: 'passed',
+          head_head: 'ae0c9b2eaf84c821caf555cae233a0d27e94d4ad',
+        },
+        headers: authHeaders(scopes),
+        method: 'POST',
+      }),
+    )
+    expect(staleReceiptResponse.status).toBe(201)
+
+    const staleResponse = await run(
+      requestJson('/api/forge/promotion-decisions', {
+        json: promotionDecision,
+        headers: authHeaders(scopes),
+        method: 'POST',
+      }),
+    )
+    const staleBody = (await staleResponse.json()) as { error: string }
+    expect(staleResponse.status).toBe(409)
+    expect(staleBody.error).toBe(
+      'forge_promotion_verification_receipt_not_current_passing',
+    )
+  })
+
   test('imports the public OpenAgents main ref into canonical refs idempotently', async () => {
     const { canonicalStore, run } = makeHarness()
     const headers = authHeaders('forge:admin forge:change:read')

--- a/apps/openagents.com/workers/api/src/forge-control-plane-routes.ts
+++ b/apps/openagents.com/workers/api/src/forge-control-plane-routes.ts
@@ -612,6 +612,49 @@ const routeVerificationReceipts = async <Bindings>(
   return noStoreJsonResponse({ verificationReceipt }, { status: 201 })
 }
 
+const assertApprovedPromotionHasCurrentPassingVerification = async (
+  store: ForgeCoordinationStore,
+  receipt: typeof ForgePromotionDecisionReceipt.Type,
+): Promise<void> => {
+  if (receipt.decision !== 'approved') {
+    return
+  }
+
+  if (receipt.verification_ref === null) {
+    throw new ForgeControlPlaneHttpError(
+      409,
+      'forge_promotion_verification_receipt_required',
+      'Approved Forge promotion decisions require a receipt-backed passing verification.',
+    )
+  }
+
+  const verification = (
+    await store.listVerificationReceipts(receipt.tenant_ref, 100, receipt.change_ref)
+  ).find(candidate => candidate.verification_ref === receipt.verification_ref)
+
+  if (verification === undefined) {
+    throw new ForgeControlPlaneHttpError(
+      409,
+      'forge_promotion_verification_receipt_missing',
+      'Approved Forge promotion decisions require an existing verification receipt for the same change.',
+    )
+  }
+
+  if (
+    verification.verdict !== 'passed' ||
+    verification.exit_code !== 0 ||
+    verification.base_head !== receipt.base_head ||
+    verification.head_head !== receipt.candidate_head ||
+    receipt.promoted_head !== receipt.candidate_head
+  ) {
+    throw new ForgeControlPlaneHttpError(
+      409,
+      'forge_promotion_verification_receipt_not_current_passing',
+      'Approved Forge promotion decisions require a passing verification receipt for the exact base and candidate heads being promoted.',
+    )
+  }
+}
+
 const routePromotionDecisions = async <Bindings>(
   dependencies: ForgeControlPlaneRouteDependencies<Bindings>,
   request: Request,
@@ -647,6 +690,7 @@ const routePromotionDecisions = async <Bindings>(
     'forge:promotion:decide',
     receipt.tenant_ref,
   )
+  await assertApprovedPromotionHasCurrentPassingVerification(store, receipt)
   const promotionDecision = await store.recordPromotionDecisionReceipt(
     receipt,
     routeNowIso(dependencies),


### PR DESCRIPTION
## Summary

- require approved Forge promotion decisions to reference an existing verification receipt for the same change
- reject promotion when the receipt is missing, failed, stale to the base/head refs, or not promoting the verified candidate head
- add route coverage for missing, failed, and stale receipt fail-closed behavior

Closes #6795

## Verification

- `bun run --cwd apps/openagents.com/workers/api test -- src/forge-control-plane-routes.test.ts`
- `bun run --cwd apps/openagents.com/workers/api typecheck` (exited 0; emitted existing Effect diagnostics in unrelated files)

Note: the requested opaque command ref `command.public.pylon_khala.verify.b5bea41b6c623f7c09f1bf24` was not resolvable to argv from local checkout metadata; the focused Forge verification above was run directly.
