### PR TITLE
Stop AgentCL Vertex runs at the spend cap

### DIFF
--- a/apps/openagents.com/workers/api/src/inference/gym/agentcl.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/gym/agentcl.test.ts
@@ -354,6 +354,12 @@ describe('AgentCL repo-reuse gym environment', () => {
     })
     expect(
       assessAgentClVertexRunnerCircuitBreaker({
+        estimatedSpendUsdCents: 5000,
+        consecutiveBillingOrQuotaErrors: 0,
+      }),
+    ).toEqual({ tripped: true, reason: 'spend_cap_exceeded' })
+    expect(
+      assessAgentClVertexRunnerCircuitBreaker({
         estimatedSpendUsdCents: 5001,
         consecutiveBillingOrQuotaErrors: 0,
       }),

--- a/apps/openagents.com/workers/api/src/inference/gym/agentcl.ts
+++ b/apps/openagents.com/workers/api/src/inference/gym/agentcl.ts
@@ -1026,7 +1026,7 @@ export const assessAgentClVertexRunnerCircuitBreaker = (
     'owner.approval.agentcl.vertex_stress.required',
   )
   const reason =
-    input.estimatedSpendUsdCents > runnerPlan.budgetGuard.spendCapUsdCents
+    input.estimatedSpendUsdCents >= runnerPlan.budgetGuard.spendCapUsdCents
       ? 'spend_cap_exceeded'
       : input.consecutiveBillingOrQuotaErrors >=
           runnerPlan.budgetGuard.abortOnConsecutiveBillingOrQuotaErrors


### PR DESCRIPTION
## Summary

- stop the AgentCL Vertex runner circuit breaker at the $50 cap boundary instead of only after it exceeds the cap
- add a regression assertion for the exact 5000-cent cap case

Closes #6762

## Verification

- `true` (`command.public.pylon_khala.verify.b5bea41b6c623f7c09f1bf24`)
- `bun run --cwd apps/openagents.com/workers/api test -- src/inference/gym/agentcl.test.ts src/inference/gym/agentcl-vertex-runner.test.ts`
