### PR TITLE
docs(promises): record standing registry sweep

### DIFF
--- a/docs/promises/registry.md
+++ b/docs/promises/registry.md
@@ -74,10 +74,12 @@
 >
 > `2026-06-29` standing sweep: recent mainline accepted-outcome economics,
 > Tassadar CPU-transform, referral, small-model proxy, WASM plugin, Verse scene,
-> native email, marketplace, metrics, terminal-agent audit, supervisor
-> replenishment, GLM failover, Apple FM sidecar, and operator-safety merges were
-> checked against the current `2026-06-29.2` registry header. This pass records
-> no additional promise state flips and no new green claims beyond the already
+> native email, marketplace, metrics, terminal-agent audit, Codex tool-layer
+> study, supervisor replenishment, GLM failover, Apple FM sidecar, owner-scoped
+> fleet state, account-reset safety, VMQ fast-forward planning, public agent
+> task-board UI, Effect usage audit, and operator-safety merges were checked
+> against the current `2026-06-29.2` registry header. This pass records no
+> additional promise state flips and no new green claims beyond the already
 > source-recorded scoped transitions; red/planned/yellow records keep their
 > owner-signed, receipt-first green gates.
 >


### PR DESCRIPTION
## Summary

- Updates the narrative product-promise registry standing sweep to cover recent main merges after the current `2026-06-29.2` registry refresh.
- Keeps the machine-readable registry unchanged because this audit found no source-record mismatch and no new green-transition evidence.

Refs #6709.

## Verification

- `bun install --frozen-lockfile`
- `bun run --cwd apps/openagents.com/workers/api test -- src/product-promises.test.ts`