### PR TITLE
Harden standing issue priority triage

### DIFF
--- a/scripts/github-issue-triage.test.ts
+++ b/scripts/github-issue-triage.test.ts
@@ -7,6 +7,8 @@ import {
   inferRelevantFiles,
   issueHasAnyLabel,
   issueHasPriorityLabel,
+  issueNeedsPriorityTriage,
+  PRIORITY_LABELS,
   renderTriageComment,
   tokenizeIssueText,
   triageIssue,
@@ -121,8 +123,16 @@ describe("github issue triage output", () => {
     expect(issueHasAnyLabel(issue({ labels: [{ name: "standing-task" }] }))).toBe(true)
   })
 
-  test("builds the default candidate query from newly opened unlabeled issues", () => {
-    expect(buildCandidateIssueSearch(false)).toBe("is:issue is:open no:label sort:created-desc")
+  test("keeps non-priority labeled issues in the priority triage queue", () => {
+    expect(issueNeedsPriorityTriage(issue({ labels: [] }))).toBe(true)
+    expect(issueNeedsPriorityTriage(issue({ labels: [{ name: "standing-task" }] }))).toBe(true)
+    expect(issueNeedsPriorityTriage(issue({ labels: [{ name: "prio:2-issue-triage" }] }))).toBe(false)
+  })
+
+  test("builds the default candidate query from issues missing priority labels", () => {
+    expect(buildCandidateIssueSearch(false)).toBe(
+      `is:issue is:open ${PRIORITY_LABELS.map(label => `-label:"${label}"`).join(" ")} sort:created-desc`,
+    )
     expect(buildCandidateIssueSearch(true)).toBe("is:issue is:open sort:created-desc")
   })
 

--- a/scripts/github-issue-triage.ts
+++ b/scripts/github-issue-triage.ts
@@ -145,6 +145,8 @@ export const issueHasPriorityLabel = (issue: GitHubIssue): boolean =>
 
 export const issueHasAnyLabel = (issue: GitHubIssue): boolean => issue.labels.length > 0
 
+export const issueNeedsPriorityTriage = (issue: GitHubIssue): boolean => !issueHasPriorityLabel(issue)
+
 export const tokenizeIssueText = (value: string): ReadonlyArray<string> =>
   uniqueSorted(
     value
@@ -311,7 +313,9 @@ export const listRepositoryFiles = (cwd: string): ReadonlyArray<string> => {
 }
 
 export const buildCandidateIssueSearch = (includeLabeled: boolean): string =>
-  includeLabeled ? "is:issue is:open sort:created-desc" : "is:issue is:open no:label sort:created-desc"
+  includeLabeled
+    ? "is:issue is:open sort:created-desc"
+    : `is:issue is:open ${PRIORITY_LABELS.map(label => `-label:"${label}"`).join(" ")} sort:created-desc`
 
 const listCandidateIssues = (
   repo: string,
@@ -378,7 +382,7 @@ const main = () => {
   const options = parseArgs(Bun.argv.slice(2))
   const repositoryFiles = listRepositoryFiles(process.cwd())
   const candidates = listCandidateIssues(options.repo, options.limit, options.includeLabeled).filter(
-    issue => options.includeLabeled || !issueHasAnyLabel(issue),
+    issue => options.includeLabeled || issueNeedsPriorityTriage(issue),
   )
   const openIssues = listOpenIssues(options.repo, Math.max(options.limit, 100))
   const decisions = candidates.map(issue =>


### PR DESCRIPTION
## Summary
- Treat open issues that lack a `prio:*` label as triage candidates even when they already have other labels like `standing-task`.
- Keep `--include-labeled` as the broad opt-in path, while the default queue now excludes only existing priority labels.
- Add focused coverage for non-priority labeled issues remaining in the priority triage queue.

Closes #6708

## Verification
- `bun run test:github-issue-triage`