### PR TITLE
feat(forge): record GitHub mirror receipts

### DIFF
--- a/apps/forge/src/index.test.ts
+++ b/apps/forge/src/index.test.ts
@@ -84,6 +84,9 @@ describe("Forge UI Worker", () => {
     expect(body.preview.apiBasePath).toBe("/api/forge")
     expect(body.preview.dogfoodLanes).toHaveLength(1)
     expect(body.preview.dogfoodLanes[0]?.issueRef).toBe("#6797")
+    expect(body.preview.mirrors[0]?.mirrorRef).toBe(
+      "mirror.github.openagents.main.su6",
+    )
   })
 
   it("renders a direct route shell without the old logged-in Forge page", () => {
@@ -117,6 +120,8 @@ describe("Forge UI Worker", () => {
     expect(html).toContain(OPENAGENTS_FORGE_DEFAULT_BRANCH_REF)
     expect(html).toContain("OpenAgentsInc/openagents default branch")
     expect(html).toContain("/api/forge/refs live canonical store")
+    expect(html).toContain("GitHub Mirror Receipts")
+    expect(html).toContain("mirror.github.openagents.main.su6")
   })
 
   it("reports health without claiming any coordination authority", async () => {

--- a/apps/forge/src/index.ts
+++ b/apps/forge/src/index.ts
@@ -157,6 +157,16 @@ export const ForgeShellRefItem = Schema.Struct({
 })
 export type ForgeShellRefItem = typeof ForgeShellRefItem.Type
 
+export const ForgeShellMirrorItem = Schema.Struct({
+  mirrorRef: Schema.String,
+  promotionRef: Schema.String,
+  sourceCanonicalRef: Schema.String,
+  destinationGithubRef: Schema.String,
+  commitId: Schema.String,
+  status: Schema.String,
+})
+export type ForgeShellMirrorItem = typeof ForgeShellMirrorItem.Type
+
 export const ForgeShellDogfoodLane = Schema.Struct({
   laneRef: Schema.String,
   issueRef: Schema.String,
@@ -189,6 +199,7 @@ export const ForgeShellSnapshot = Schema.Struct({
   verification: Schema.Array(ForgeShellVerificationItem),
   mergeQueue: Schema.Array(ForgeShellQueueItem),
   refs: Schema.Array(ForgeShellRefItem),
+  mirrors: Schema.Array(ForgeShellMirrorItem),
 })
 export type ForgeShellSnapshot = typeof ForgeShellSnapshot.Type
 
@@ -387,6 +398,16 @@ export const forgeShellPreviewState: ForgeShellSnapshot = {
       target: "virtual merge queue heads",
       authority: "Blueprint gates",
       state: "contracted",
+    },
+  ],
+  mirrors: [
+    {
+      mirrorRef: "mirror.github.openagents.main.su6",
+      promotionRef: "promotion.forge.su6.nextActualPromotion",
+      sourceCanonicalRef: "refs/forge/promoted/openagents/main",
+      destinationGithubRef: "refs/heads/main",
+      commitId: "Forge-promoted commit id only",
+      status: "pending-promotion-receipt",
     },
   ],
 }
@@ -1200,6 +1221,41 @@ const renderQueue = (): string => `<section class="forge-panel" data-span="wide"
   </div>
 </section>`
 
+const renderMirrorReceipts = (): string => `<section class="forge-panel" data-span="wide">
+  <div class="forge-panel-head">
+    <h3 class="forge-panel-title">GitHub Mirror Receipts</h3>
+    <span class="forge-table-caption">${forgeShellPreviewState.mirrors.length} receipts</span>
+  </div>
+  <div class="forge-table-wrap">
+    <table class="forge-table">
+      <thead>
+        <tr>
+          <th>Mirror</th>
+          <th>Promotion</th>
+          <th>Source</th>
+          <th>Destination</th>
+          <th>Commit</th>
+          <th>Status</th>
+        </tr>
+      </thead>
+      <tbody>
+        ${forgeShellPreviewState.mirrors
+          .map(
+            item => `<tr>
+              <td class="forge-code">${escapeHtml(item.mirrorRef)}</td>
+              <td class="forge-code">${escapeHtml(item.promotionRef)}</td>
+              <td class="forge-code">${escapeHtml(item.sourceCanonicalRef)}</td>
+              <td class="forge-code">${escapeHtml(item.destinationGithubRef)}</td>
+              <td class="forge-muted">${escapeHtml(item.commitId)}</td>
+              <td>${renderStatus(item.status)}</td>
+            </tr>`,
+          )
+          .join("\n")}
+      </tbody>
+    </table>
+  </div>
+</section>`
+
 const renderRefs = (): string => `<section class="forge-panel" data-span="wide">
   <div class="forge-panel-head">
     <h3 class="forge-panel-title">Canonical Refs</h3>
@@ -1231,7 +1287,8 @@ const renderRefs = (): string => `<section class="forge-panel" data-span="wide">
       </tbody>
     </table>
   </div>
-</section>`
+</section>
+${renderMirrorReceipts()}`
 
 const renderRouteContent = (routeId: ForgeShellRouteId): string => {
   switch (routeId) {

--- a/apps/openagents.com/workers/api/migrations/0259_forge_github_mirror_receipts.sql
+++ b/apps/openagents.com/workers/api/migrations/0259_forge_github_mirror_receipts.sql
@@ -1,0 +1,39 @@
+-- FORGE SU-6 (#6796): GitHub mirror receipts for Forge-promoted commits.
+--
+-- GitHub is a downstream mirror only. These rows record attempts to mirror a
+-- Forge promotion ref to a GitHub ref; they do not authorize promotion.
+
+CREATE TABLE IF NOT EXISTS forge_github_mirror_receipts (
+  tenant_ref TEXT NOT NULL,
+  mirror_ref TEXT NOT NULL,
+  repository_ref TEXT NOT NULL,
+  promotion_ref TEXT NOT NULL,
+  change_ref TEXT NOT NULL,
+  source_canonical_ref TEXT NOT NULL,
+  destination_github_ref TEXT NOT NULL,
+  commit_id TEXT NOT NULL,
+  status TEXT NOT NULL CHECK (status IN ('pending', 'mirrored', 'refused', 'errored')),
+  attempted_at TEXT NOT NULL,
+  mirrored_at TEXT,
+  refusal_reason TEXT,
+  error_reason TEXT,
+  retry_count INTEGER NOT NULL DEFAULT 0,
+  idempotency_key TEXT NOT NULL,
+  source_refs_json TEXT NOT NULL DEFAULT '[]',
+  redacted INTEGER NOT NULL DEFAULT 1 CHECK (redacted = 1),
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  PRIMARY KEY (tenant_ref, mirror_ref)
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_forge_github_mirror_receipts_idempotency
+  ON forge_github_mirror_receipts (tenant_ref, idempotency_key);
+
+CREATE INDEX IF NOT EXISTS idx_forge_github_mirror_receipts_change
+  ON forge_github_mirror_receipts (tenant_ref, change_ref, attempted_at);
+
+CREATE INDEX IF NOT EXISTS idx_forge_github_mirror_receipts_promotion
+  ON forge_github_mirror_receipts (tenant_ref, promotion_ref, attempted_at);
+
+CREATE INDEX IF NOT EXISTS idx_forge_github_mirror_receipts_status
+  ON forge_github_mirror_receipts (tenant_ref, status, attempted_at);

--- a/apps/openagents.com/workers/api/src/forge-control-plane-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/forge-control-plane-routes.test.ts
@@ -63,6 +63,10 @@ const controlPlaneReceiptsMigration = readFileSync(
   new URL('../migrations/0254_forge_control_plane_receipts.sql', import.meta.url),
   'utf8',
 )
+const githubMirrorReceiptsMigration = readFileSync(
+  new URL('../migrations/0259_forge_github_mirror_receipts.sql', import.meta.url),
+  'utf8',
+)
 const canonicalGitMigration = readFileSync(
   new URL('../migrations/0255_forge_git_canonical_store.sql', import.meta.url),
   'utf8',
@@ -76,6 +80,7 @@ const makeStores = (): Readonly<{
   db.exec('PRAGMA foreign_keys = ON')
   db.exec(coordinationMigration)
   db.exec(controlPlaneReceiptsMigration)
+  db.exec(githubMirrorReceiptsMigration)
   db.exec(canonicalGitMigration)
   const d1 = new SqliteD1(db) as unknown as D1Database
   return {
@@ -389,6 +394,74 @@ describe('Forge control-plane routes', () => {
       promotionDecisions: ReadonlyArray<unknown>
     }
     expect(decisionsBody.promotionDecisions).toHaveLength(1)
+  })
+
+  test('records GitHub mirror receipts as promotion-derived downstream state', async () => {
+    const { run } = makeHarness()
+    const scopes = [
+      'forge:mirror:read',
+      'forge:mirror:write',
+    ].join(' ')
+    const receipt = {
+      schema: 'openagents.forge.github_mirror.receipt.v0.1',
+      tenant_ref: 'tenant.openagents',
+      mirror_ref: 'mirror.github.openagents.main.6796',
+      repository_ref: 'repo.openagents.openagents',
+      promotion_ref: 'promotion.forge.6796',
+      change_ref: 'change.forge.6796',
+      source_canonical_ref: 'refs/forge/promoted/openagents/main',
+      destination_github_ref: 'refs/heads/main',
+      commit_id: '9e0c9b2eaf84c821caf555cae233a0d27e94d4ac',
+      status: 'mirrored',
+      attempted_at: '2026-06-28T17:04:00.000Z',
+      mirrored_at: '2026-06-28T17:04:03.000Z',
+      refusal_reason: null,
+      error_reason: null,
+      retry_count: 0,
+      idempotency_key:
+        'tenant.openagents:repo.openagents.openagents:promotion.forge.6796:refs/heads/main',
+      source_refs: ['github:OpenAgentsInc/openagents#6796'],
+      redacted: true,
+    }
+
+    const firstResponse = await run(
+      requestJson('/api/forge/github-mirror-receipts', {
+        json: receipt,
+        headers: authHeaders(scopes),
+        method: 'POST',
+      }),
+    )
+    expect(firstResponse.status).toBe(201)
+    const firstBody = (await firstResponse.json()) as {
+      githubMirrorReceipt: { promotion_ref: string; status: string }
+    }
+    expect(firstBody.githubMirrorReceipt).toMatchObject({
+      promotion_ref: 'promotion.forge.6796',
+      status: 'mirrored',
+    })
+
+    const secondResponse = await run(
+      requestJson('/api/forge/github-mirror-receipts', {
+        json: { ...receipt, retry_count: 1 },
+        headers: authHeaders(scopes),
+        method: 'POST',
+      }),
+    )
+    expect(secondResponse.status).toBe(201)
+
+    const listResponse = await run(
+      new Request(
+        'https://openagents.com/api/forge/github-mirror-receipts?tenantRef=tenant.openagents&changeRef=change.forge.6796',
+        { headers: authHeaders(scopes) },
+      ),
+    )
+    const listBody = (await listResponse.json()) as {
+      githubMirrorReceipts: ReadonlyArray<{ retry_count: number }>
+    }
+
+    expect(listResponse.status).toBe(200)
+    expect(listBody.githubMirrorReceipts).toHaveLength(1)
+    expect(listBody.githubMirrorReceipts[0]?.retry_count).toBe(1)
   })
 
   test('imports the public OpenAgents main ref into canonical refs idempotently', async () => {

--- a/apps/openagents.com/workers/api/src/forge-control-plane-routes.ts
+++ b/apps/openagents.com/workers/api/src/forge-control-plane-routes.ts
@@ -2,6 +2,7 @@ import {
   ForgeCoordinationChangeState,
   ForgeCoordinationIssueState,
   ForgeCoordinationStatusState,
+  ForgeGithubMirrorReceipt,
   ForgeMergeQueueLedgerState,
   ForgePromotionDecisionReceipt,
   ForgeVerificationReceipt,
@@ -655,6 +656,49 @@ const routePromotionDecisions = async <Bindings>(
   return noStoreJsonResponse({ promotionDecision }, { status: 201 })
 }
 
+const routeGithubMirrorReceipts = async <Bindings>(
+  dependencies: ForgeControlPlaneRouteDependencies<Bindings>,
+  request: Request,
+  env: Bindings,
+  url: URL,
+) => {
+  const store = dependencies.makeStore(env)
+
+  if (request.method === 'GET') {
+    const tenantRef = tenantRefFromQuery(url)
+    await requireScope(dependencies, request, env, 'forge:mirror:read', tenantRef)
+    const limit = limitFromQuery(url)
+    return noStoreJsonResponse({
+      githubMirrorReceipts: await store.listGithubMirrorReceipts(
+        tenantRef,
+        limit,
+        optionalQuery(url, 'changeRef'),
+      ),
+      limit,
+      tenantRef,
+    })
+  }
+
+  if (request.method !== 'POST') {
+    return methodNotAllowed(['GET', 'POST'])
+  }
+
+  const receipt = await decodeBody(request, ForgeGithubMirrorReceipt)
+  await requireScope(
+    dependencies,
+    request,
+    env,
+    'forge:mirror:write',
+    receipt.tenant_ref,
+  )
+  const githubMirrorReceipt = await store.recordGithubMirrorReceipt(
+    receipt,
+    routeNowIso(dependencies),
+  )
+
+  return noStoreJsonResponse({ githubMirrorReceipt }, { status: 201 })
+}
+
 const sha256Hex = async (value: string): Promise<string> => {
   const bytes = await crypto.subtle.digest(
     'SHA-256',
@@ -873,6 +917,12 @@ export const makeForgeControlPlaneRoutes = <Bindings>(
     if (route.length === 1 && route[0] === 'promotion-decisions') {
       return routeEffect(() =>
         routePromotionDecisions(dependencies, request, env, url),
+      )
+    }
+
+    if (route.length === 1 && route[0] === 'github-mirror-receipts') {
+      return routeEffect(() =>
+        routeGithubMirrorReceipts(dependencies, request, env, url),
       )
     }
 

--- a/apps/openagents.com/workers/api/src/forge-coordination-store.ts
+++ b/apps/openagents.com/workers/api/src/forge-coordination-store.ts
@@ -3,6 +3,7 @@ import {
   decodeForgeCoordinationPrRow,
   decodeForgeCoordinationStatusRow,
   decodeForgeDispatchLeaseRow,
+  decodeForgeGithubMirrorReceipt,
   decodeForgeMergeQueueLedgerRow,
   decodeForgePromotionDecisionReceipt,
   decodeForgeVerificationReceipt,
@@ -14,6 +15,7 @@ import {
   type ForgeCoordinationStatusRow,
   type ForgeCoordinationStatusState,
   type ForgeDispatchLeaseRow,
+  type ForgeGithubMirrorReceipt,
   type ForgeMergeQueueLedgerRow,
   type ForgeMergeQueueLedgerState,
   type ForgePromotionDecisionReceipt,
@@ -138,6 +140,15 @@ export type ForgeCoordinationStore = Readonly<{
     limit: number,
     changeRef?: string,
   ) => Promise<ReadonlyArray<ForgePromotionDecisionReceipt>>
+  recordGithubMirrorReceipt: (
+    receipt: ForgeGithubMirrorReceipt,
+    createdAt: string,
+  ) => Promise<ForgeGithubMirrorReceipt>
+  listGithubMirrorReceipts: (
+    tenantRef: string,
+    limit: number,
+    changeRef?: string,
+  ) => Promise<ReadonlyArray<ForgeGithubMirrorReceipt>>
 }>
 
 const StringArray = S.Array(S.String)
@@ -186,6 +197,26 @@ type ForgePromotionDecisionReceiptRow = Readonly<{
   blocker_refs_json: string
   decided_by_ref: string
   decided_at: string
+  source_refs_json: string
+  redacted: number | boolean
+}>
+
+type ForgeGithubMirrorReceiptRow = Readonly<{
+  tenant_ref: string
+  mirror_ref: string
+  repository_ref: string
+  promotion_ref: string
+  change_ref: string
+  source_canonical_ref: string
+  destination_github_ref: string
+  commit_id: string
+  status: string
+  attempted_at: string
+  mirrored_at: string | null
+  refusal_reason: string | null
+  error_reason: string | null
+  retry_count: number
+  idempotency_key: string
   source_refs_json: string
   redacted: number | boolean
 }>
@@ -239,6 +270,30 @@ const promotionDecisionReceiptFromRow = (
     blocker_refs: stringArrayFromJson(row.blocker_refs_json),
     decided_by_ref: row.decided_by_ref,
     decided_at: row.decided_at,
+    source_refs: stringArrayFromJson(row.source_refs_json),
+    redacted: row.redacted === true || row.redacted === 1,
+  })
+
+const githubMirrorReceiptFromRow = (
+  row: ForgeGithubMirrorReceiptRow,
+): ForgeGithubMirrorReceipt =>
+  decodeForgeGithubMirrorReceipt({
+    schema: 'openagents.forge.github_mirror.receipt.v0.1',
+    tenant_ref: row.tenant_ref,
+    mirror_ref: row.mirror_ref,
+    repository_ref: row.repository_ref,
+    promotion_ref: row.promotion_ref,
+    change_ref: row.change_ref,
+    source_canonical_ref: row.source_canonical_ref,
+    destination_github_ref: row.destination_github_ref,
+    commit_id: row.commit_id,
+    status: row.status,
+    attempted_at: row.attempted_at,
+    mirrored_at: row.mirrored_at,
+    refusal_reason: row.refusal_reason,
+    error_reason: row.error_reason,
+    retry_count: row.retry_count,
+    idempotency_key: row.idempotency_key,
     source_refs: stringArrayFromJson(row.source_refs_json),
     redacted: row.redacted === true || row.redacted === 1,
   })
@@ -958,5 +1013,118 @@ export const makeD1ForgeCoordinationStore = (
             .all<ForgePromotionDecisionReceiptRow>()
 
     return rows.results.map(promotionDecisionReceiptFromRow)
+  },
+
+  async recordGithubMirrorReceipt(receipt, createdAt) {
+    const decoded = decodeForgeGithubMirrorReceipt(receipt)
+    await db
+      .prepare(
+        `
+          INSERT INTO forge_github_mirror_receipts (
+            tenant_ref,
+            mirror_ref,
+            repository_ref,
+            promotion_ref,
+            change_ref,
+            source_canonical_ref,
+            destination_github_ref,
+            commit_id,
+            status,
+            attempted_at,
+            mirrored_at,
+            refusal_reason,
+            error_reason,
+            retry_count,
+            idempotency_key,
+            source_refs_json,
+            redacted,
+            created_at,
+            updated_at
+          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1, ?, ?)
+          ON CONFLICT (tenant_ref, mirror_ref) DO UPDATE SET
+            repository_ref = excluded.repository_ref,
+            promotion_ref = excluded.promotion_ref,
+            change_ref = excluded.change_ref,
+            source_canonical_ref = excluded.source_canonical_ref,
+            destination_github_ref = excluded.destination_github_ref,
+            commit_id = excluded.commit_id,
+            status = excluded.status,
+            attempted_at = excluded.attempted_at,
+            mirrored_at = excluded.mirrored_at,
+            refusal_reason = excluded.refusal_reason,
+            error_reason = excluded.error_reason,
+            retry_count = excluded.retry_count,
+            idempotency_key = excluded.idempotency_key,
+            source_refs_json = excluded.source_refs_json,
+            updated_at = excluded.updated_at
+        `,
+      )
+      .bind(
+        decoded.tenant_ref,
+        decoded.mirror_ref,
+        decoded.repository_ref,
+        decoded.promotion_ref,
+        decoded.change_ref,
+        decoded.source_canonical_ref,
+        decoded.destination_github_ref,
+        decoded.commit_id,
+        decoded.status,
+        decoded.attempted_at,
+        decoded.mirrored_at,
+        decoded.refusal_reason,
+        decoded.error_reason,
+        decoded.retry_count,
+        decoded.idempotency_key,
+        jsonArray(decoded.source_refs),
+        createdAt,
+        createdAt,
+      )
+      .run()
+
+    const row = await db
+      .prepare(
+        `
+          SELECT *
+          FROM forge_github_mirror_receipts
+          WHERE tenant_ref = ? AND mirror_ref = ?
+        `,
+      )
+      .bind(decoded.tenant_ref, decoded.mirror_ref)
+      .first<ForgeGithubMirrorReceiptRow>()
+
+    return githubMirrorReceiptFromRow(
+      rowOrFail(row, 'forge github mirror receipt'),
+    )
+  },
+
+  async listGithubMirrorReceipts(tenantRef, limit, changeRef) {
+    const rows =
+      changeRef === undefined
+        ? await db
+            .prepare(
+              `
+                SELECT *
+                FROM forge_github_mirror_receipts
+                WHERE tenant_ref = ?
+                ORDER BY attempted_at DESC, mirror_ref DESC
+                LIMIT ?
+              `,
+            )
+            .bind(tenantRef, limitRows(limit))
+            .all<ForgeGithubMirrorReceiptRow>()
+        : await db
+            .prepare(
+              `
+                SELECT *
+                FROM forge_github_mirror_receipts
+                WHERE tenant_ref = ? AND change_ref = ?
+                ORDER BY attempted_at DESC, mirror_ref DESC
+                LIMIT ?
+              `,
+            )
+            .bind(tenantRef, changeRef, limitRows(limit))
+            .all<ForgeGithubMirrorReceiptRow>()
+
+    return rows.results.map(githubMirrorReceiptFromRow)
   },
 })

--- a/apps/openagents.com/workers/api/src/openagents-openapi-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/openagents-openapi-routes.test.ts
@@ -346,6 +346,10 @@ describe('OpenAgents OpenAPI route', () => {
     expect(
       operationAt(body, '/api/forge/promotion-decisions', 'post').operationId,
     ).toBe('recordForgePromotionDecision')
+    expect(
+      operationAt(body, '/api/forge/github-mirror-receipts', 'post')
+        .operationId,
+    ).toBe('recordForgeGithubMirrorReceipt')
     expect(operationAt(body, '/api/agents/claims', 'post').operationId).toBe(
       'requestAgentOwnerClaim',
     )

--- a/apps/openagents.com/workers/api/src/openagents-openapi.ts
+++ b/apps/openagents.com/workers/api/src/openagents-openapi.ts
@@ -1640,6 +1640,13 @@ const schemaComponents = (): JsonSchema => ({
   ForgePromotionDecisionListEnvelope: objectSummary(
     'Forge promotion decision receipt list. Contains tenantRef, limit, and redacted promotion decision receipts filtered optionally by changeRef. Requires forge:queue:read or admin authority.',
   ),
+  ForgeGithubMirrorReceiptEnvelope: envelope(
+    'githubMirrorReceipt',
+    '#/components/schemas/ForgeGithubMirrorReceipt',
+  ),
+  ForgeGithubMirrorReceiptListEnvelope: objectSummary(
+    'Forge GitHub mirror receipt list. Contains tenantRef, limit, and redacted downstream mirror receipts filtered optionally by changeRef. Requires forge:mirror:read or admin authority.',
+  ),
   ForgeVerificationReceiptEnvelope: envelope(
     'verificationReceipt',
     '#/components/schemas/ForgeVerificationReceipt',
@@ -3911,6 +3918,9 @@ const requestSchemas = (): JsonSchema => ({
   ),
   ForgePromotionDecisionReceipt: objectSummary(
     'Redacted Forge promotion decision receipt matching openagents.forge.promotion.decision.v0.1. Carries queue/change refs, decision state, heads, gate/blocker refs, deciding actor ref, timestamp, and source refs only.',
+  ),
+  ForgeGithubMirrorReceipt: objectSummary(
+    'Redacted Forge GitHub mirror receipt matching openagents.forge.github_mirror.receipt.v0.1. Carries the Forge promotion ref, source canonical ref, downstream GitHub ref, commit id, mirror status, timestamps, retry count, and refusal/error reason only. It records downstream visibility and never authorizes promotion.',
   ),
   CreateOperatorSiteRequest: objectSummary(
     'Operator request for creating a Site project from an order or prompt.',
@@ -6774,6 +6784,46 @@ const paths = (): JsonSchema => ({
         '201': okJson(
           'Stored Forge promotion decision.',
           '#/components/schemas/ForgePromotionDecisionEnvelope',
+        ),
+        ...errorResponses(),
+      },
+    }),
+  },
+  '/api/forge/github-mirror-receipts': {
+    get: operation({
+      operationId: 'listForgeGithubMirrorReceipts',
+      summary: 'List Forge GitHub mirror receipts',
+      description:
+        'Lists redacted Forge GitHub mirror receipts for a tenant, optionally filtered by changeRef. Requires forge:mirror:read or admin authority. These rows are downstream mirror state only; GitHub cannot authorize promotion.',
+      tags: ['Forge'],
+      security: forgeControlPlaneBearer,
+      parameters: [
+        queryParam('tenantRef', 'Required Forge tenant ref.'),
+        queryParam('changeRef', 'Optional change ref filter.'),
+        queryParam('limit', 'Optional result limit, clamped to 1..100.'),
+      ],
+      responses: {
+        '200': okJson(
+          'Forge GitHub mirror receipts.',
+          '#/components/schemas/ForgeGithubMirrorReceiptListEnvelope',
+        ),
+        ...errorResponses(),
+      },
+    }),
+    post: operation({
+      operationId: 'recordForgeGithubMirrorReceipt',
+      summary: 'Record Forge GitHub mirror receipt',
+      description:
+        'Records a redacted Forge GitHub mirror receipt using the shared openagents.forge.github_mirror.receipt.v0.1 schema. Requires forge:mirror:write or admin authority. The receipt must name a Forge promotion ref and records only downstream GitHub mirror state.',
+      tags: ['Forge'],
+      security: forgeControlPlaneBearer,
+      requestBody: jsonContent(
+        '#/components/schemas/ForgeGithubMirrorReceipt',
+      ),
+      responses: {
+        '201': okJson(
+          'Stored Forge GitHub mirror receipt.',
+          '#/components/schemas/ForgeGithubMirrorReceiptEnvelope',
         ),
         ...errorResponses(),
       },

--- a/packages/forge-protocol/src/index.test.ts
+++ b/packages/forge-protocol/src/index.test.ts
@@ -14,6 +14,7 @@ import {
   decodeForgeDispatchDecision,
   decodeForgeDispatchMessage,
   decodeForgeDispatchWorkItem,
+  decodeForgeGithubMirrorReceipt,
   decodeForgePromotionDecisionReceipt,
   decodeForgeTenantRow,
   decodeForgeVerificationReceipt,
@@ -332,5 +333,29 @@ describe("@openagentsinc/forge-protocol", () => {
     });
     expect(promotion.decision).toBe("approved");
     expect(promotion.promoted_head).toBe(verification.head_head);
+
+    const mirror = decodeForgeGithubMirrorReceipt({
+      schema: "openagents.forge.github_mirror.receipt.v0.1",
+      tenant_ref: "tenant.openagents",
+      mirror_ref: "mirror.github.openagents.main.6768",
+      repository_ref: "repo.openagents.openagents",
+      promotion_ref: promotion.promotion_ref,
+      change_ref: promotion.change_ref,
+      source_canonical_ref: "refs/forge/promoted/openagents/main",
+      destination_github_ref: "refs/heads/main",
+      commit_id: promotion.promoted_head,
+      status: "mirrored",
+      attempted_at: "2026-06-28T16:03:00.000Z",
+      mirrored_at: "2026-06-28T16:03:05.000Z",
+      refusal_reason: null,
+      error_reason: null,
+      retry_count: 0,
+      idempotency_key:
+        "tenant.openagents:repo.openagents.openagents:promotion.forge.6768:refs/heads/main",
+      source_refs: promotion.source_refs,
+      redacted: true,
+    });
+    expect(mirror.promotion_ref).toBe(promotion.promotion_ref);
+    expect(mirror.destination_github_ref).toBe("refs/heads/main");
   });
 });

--- a/packages/forge-protocol/src/index.ts
+++ b/packages/forge-protocol/src/index.ts
@@ -98,6 +98,8 @@ export const ForgeControlPlaneScope = S.Literals([
   "forge:lease:write",
   "forge:queue:read",
   "forge:queue:write",
+  "forge:mirror:read",
+  "forge:mirror:write",
   "forge:receipt:write",
   "forge:promotion:decide",
   "forge:admin",
@@ -113,6 +115,8 @@ export const forgeControlPlaneScopes: ReadonlyArray<ForgeControlPlaneScope> = [
   "forge:lease:write",
   "forge:queue:read",
   "forge:queue:write",
+  "forge:mirror:read",
+  "forge:mirror:write",
   "forge:receipt:write",
   "forge:promotion:decide",
   "forge:admin",
@@ -166,6 +170,14 @@ export const ForgePromotionDecisionState = S.Literals([
 ]);
 export type ForgePromotionDecisionState =
   typeof ForgePromotionDecisionState.Type;
+
+export const ForgeGithubMirrorStatus = S.Literals([
+  "pending",
+  "mirrored",
+  "refused",
+  "errored",
+]);
+export type ForgeGithubMirrorStatus = typeof ForgeGithubMirrorStatus.Type;
 
 export const ForgeDispatchGitAccessDelivery = S.Literals([
   "out_of_band",
@@ -464,6 +476,28 @@ export const ForgePromotionDecisionReceipt = S.Struct({
 export type ForgePromotionDecisionReceipt =
   typeof ForgePromotionDecisionReceipt.Type;
 
+export const ForgeGithubMirrorReceipt = S.Struct({
+  schema: S.Literal("openagents.forge.github_mirror.receipt.v0.1"),
+  tenant_ref: S.String,
+  mirror_ref: S.String,
+  repository_ref: S.String,
+  promotion_ref: S.String,
+  change_ref: S.String,
+  source_canonical_ref: S.String,
+  destination_github_ref: S.String,
+  commit_id: S.String,
+  status: ForgeGithubMirrorStatus,
+  attempted_at: S.String,
+  mirrored_at: S.NullOr(S.String),
+  refusal_reason: S.NullOr(S.String),
+  error_reason: S.NullOr(S.String),
+  retry_count: S.Number,
+  idempotency_key: S.String,
+  source_refs: S.Array(S.String),
+  redacted: S.Literal(true),
+});
+export type ForgeGithubMirrorReceipt = typeof ForgeGithubMirrorReceipt.Type;
+
 export const ForgeDispatchMessage = S.Union([
   ForgeDispatchWorkItem,
   ForgeDispatchDecision,
@@ -528,6 +562,9 @@ export const decodeForgeVerificationReceipt = S.decodeUnknownSync(
 );
 export const decodeForgePromotionDecisionReceipt = S.decodeUnknownSync(
   ForgePromotionDecisionReceipt,
+);
+export const decodeForgeGithubMirrorReceipt = S.decodeUnknownSync(
+  ForgeGithubMirrorReceipt,
 );
 
 export const forgeCoordinationStatusStateForNip34Kind = (


### PR DESCRIPTION
## Summary

- Add the shared Forge GitHub mirror receipt contract and dedicated mirror control-plane scopes.
- Persist idempotent mirror receipts in D1 and expose `/api/forge/github-mirror-receipts` for list/record flows.
- Surface mirror receipt state in the Forge shell refs view and OpenAPI contract.

## Verification

- `bun test packages/forge-protocol/src/index.test.ts`
- `bun test apps/forge/src/index.test.ts`
- `bun run --cwd apps/openagents.com/workers/api test -- src/openagents-openapi-routes.test.ts src/forge-control-plane-routes.test.ts`
- `bun run --cwd packages/forge-protocol typecheck`
- `bun run --cwd apps/forge typecheck`
- `bun run --cwd apps/openagents.com/workers/api typecheck`
- `bun run --cwd apps/openagents.com check:deploy`

Closes #6796
