### PR TITLE
fix(pylon): plan VMQ fast-forward locally

### DIFF
--- a/apps/pylon/src/blueprint-gates/virtual-merge-queue.test.ts
+++ b/apps/pylon/src/blueprint-gates/virtual-merge-queue.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test"
 
+import { PYLON_COMMAND_CATALOG } from "../cli-catalog.js"
 import {
   planVirtualMergeQueuePrFastForward,
   projectVirtualMergeQueue,
@@ -474,5 +475,18 @@ describe("virtual merge queue", () => {
       state: "blocked",
       blockedReasonRef: "virtual_merge_queue.pr_fast_forward.blocked.invalid_branch",
     })
+  })
+
+  test("catalog exposes PR fast-forward planning as a local read-only command", () => {
+    const command = PYLON_COMMAND_CATALOG.find((entry) => entry.command === "vmq")
+
+    expect(command).toMatchObject({
+      command: "vmq",
+      mutates: false,
+      spends: false,
+      json: true,
+    })
+    expect(command?.needsNode).toBeUndefined()
+    expect(command?.args.map((arg) => arg.name)).toContain("pr-fast-forward-plan")
   })
 })

--- a/apps/pylon/src/cli-catalog.ts
+++ b/apps/pylon/src/cli-catalog.ts
@@ -238,10 +238,9 @@ export const PYLON_COMMAND_CATALOG: readonly PylonCommandEntry[] = [
   },
   {
     command: "vmq",
-    summary: "Plan Pylon virtual merge queue supervisor operations through the running node.",
+    summary: "Plan Pylon virtual merge queue supervisor operations from local JSON inputs.",
     mutates: false,
     spends: false,
-    needsNode: true,
     json: true,
     args: [
       pos("pr-fast-forward-plan", "Subcommand."),

--- a/apps/pylon/src/index.ts
+++ b/apps/pylon/src/index.ts
@@ -130,6 +130,11 @@ import {
   type PylonDevCommandSpec,
 } from "./dev-loop.js"
 import {
+  planVirtualMergeQueuePrFastForward,
+  type VirtualMergeQueuePrFastForwardRequest,
+  type VirtualMergeQueueProjection,
+} from "./blueprint-gates/virtual-merge-queue.js"
+import {
   rejectCodexLocalDangerForPublicPath,
   runCodexComposerStream,
 } from "./codex-composer.js"
@@ -2756,6 +2761,8 @@ async function main() {
 
   // #6695 VMQ supervisor API: expose the node-local PR fast-forward planner so
   // supervisors can verify the next actual promotion before any git push exists.
+  // The planner is pure, so the CLI can run it directly without requiring a
+  // live node control server.
   if (args[0] === "vmq") {
     const command = args[1]
     const options = parseCliOptions(args.slice(2))
@@ -2766,16 +2773,9 @@ async function main() {
         if (!projectionPath || !requestPath) {
           throw new Error("vmq pr-fast-forward-plan requires --projection <json> and --request <json>")
         }
-        const projection = JSON.parse(await readFile(projectionPath, "utf8"))
-        const request = JSON.parse(await readFile(requestPath, "utf8"))
-        const { result } = await runControlCommand(
-          {
-            type: "virtual_merge_queue.pr_fast_forward.plan",
-            projection,
-            request,
-          },
-          Bun.env,
-        )
+        const projection = JSON.parse(await readFile(projectionPath, "utf8")) as VirtualMergeQueueProjection
+        const request = JSON.parse(await readFile(requestPath, "utf8")) as VirtualMergeQueuePrFastForwardRequest
+        const result = planVirtualMergeQueuePrFastForward({ projection, request })
         process.stdout.write(`${JSON.stringify({ ok: true, result }, null, 2)}\n`)
         return
       }


### PR DESCRIPTION
Addresses #6695.

## Summary
- run `pylon vmq pr-fast-forward-plan` through the pure VMQ planner instead of requiring a running node control server
- advertise the VMQ command as local/read-only in the command catalog
- add a focused catalog regression alongside the existing PR fast-forward planner tests

## Verification
- `bun test apps/pylon/src/blueprint-gates/virtual-merge-queue.test.ts`
- required ref `command.public.pylon_khala.verify.b5bea41b6c623f7c09f1bf24` resolved to `true` and passed

Note: #6695 already has open PRs (#7132, #7134); this PR is the smallest local-CLI canary slice.