### PR TITLE
fix(khala-desktop): stop Apple FM sidecar on shutdown

### DIFF
--- a/clients/khala-desktop/src/bun/apple-fm-sidecar.ts
+++ b/clients/khala-desktop/src/bun/apple-fm-sidecar.ts
@@ -23,6 +23,13 @@ export type AppleFmSidecarHost = {
   readonly stop: () => void
 }
 
+type AppleFmShutdownEvent = "beforeExit" | "exit" | "SIGINT" | "SIGTERM"
+
+type AppleFmShutdownProcess = {
+  readonly once: (event: AppleFmShutdownEvent, handler: (...args: ReadonlyArray<unknown>) => void) => unknown
+  readonly exit?: (code?: number) => never
+}
+
 type AppleFmSidecarHostOptions = {
   readonly env?: Readonly<Record<string, string | undefined>>
   readonly platform?: NodeJS.Platform
@@ -215,4 +222,27 @@ export function createAppleFmSidecarHost(
       }
     },
   }
+}
+
+export function installAppleFmSidecarShutdownHandlers(
+  host: AppleFmSidecarHost,
+  processLike: AppleFmShutdownProcess = process,
+): void {
+  let stopped = false
+  const stopOnce = () => {
+    if (stopped) return
+    stopped = true
+    host.stop()
+  }
+
+  processLike.once("beforeExit", stopOnce)
+  processLike.once("exit", stopOnce)
+  processLike.once("SIGINT", () => {
+    stopOnce()
+    processLike.exit?.(130)
+  })
+  processLike.once("SIGTERM", () => {
+    stopOnce()
+    processLike.exit?.(143)
+  })
 }

--- a/clients/khala-desktop/src/bun/index.ts
+++ b/clients/khala-desktop/src/bun/index.ts
@@ -9,7 +9,10 @@ import {
   KHALA_DESKTOP_RPC_MAX_REQUEST_TIME_MS,
   type KhalaDesktopRPCSchema,
 } from "../shared/rpc.js"
-import { createAppleFmSidecarHost } from "./apple-fm-sidecar.js"
+import {
+  createAppleFmSidecarHost,
+  installAppleFmSidecarShutdownHandlers,
+} from "./apple-fm-sidecar.js"
 
 const baseUrl =
   Bun.env.PYLON_OPENAGENTS_BASE_URL ??
@@ -47,9 +50,7 @@ const rpc = BrowserView.defineRPC<KhalaDesktopRPCSchema>({
   },
 })
 
-process.on("beforeExit", () => {
-  appleFmSidecar.stop()
-})
+installAppleFmSidecarShutdownHandlers(appleFmSidecar)
 
 new BrowserWindow({
   title: "Khala Fleet",

--- a/clients/khala-desktop/tests/apple-fm-sidecar.test.ts
+++ b/clients/khala-desktop/tests/apple-fm-sidecar.test.ts
@@ -3,7 +3,10 @@ import { dirname, join } from "node:path"
 import { tmpdir } from "node:os"
 import { describe, expect, test } from "bun:test"
 
-import { createAppleFmSidecarHost } from "../src/bun/apple-fm-sidecar.js"
+import {
+  createAppleFmSidecarHost,
+  installAppleFmSidecarShutdownHandlers,
+} from "../src/bun/apple-fm-sidecar.js"
 import {
   APPLE_FM_BRIDGE_RESOURCES_SUBPATH,
 } from "../src/shared/apple-fm-packaging.js"
@@ -97,5 +100,41 @@ describe("Khala Desktop Apple FM sidecar host", () => {
       host.stop()
       rmSync(resourcesDir, { force: true, recursive: true })
     }
+  })
+
+  test("stops a launched helper on process shutdown signals", async () => {
+    const handlers = new Map<string, (...args: ReadonlyArray<unknown>) => void>()
+    const exits: number[] = []
+    let stopCount = 0
+
+    installAppleFmSidecarShutdownHandlers(
+      {
+        readiness: async () => {
+          throw new Error("not used")
+        },
+        stop() {
+          stopCount += 1
+        },
+      },
+      {
+        once(event, handler) {
+          handlers.set(event, handler)
+        },
+        exit(code) {
+          exits.push(code ?? 0)
+          throw new Error("exit")
+        },
+      },
+    )
+
+    expect([...handlers.keys()].sort()).toEqual(["SIGINT", "SIGTERM", "beforeExit", "exit"])
+
+    handlers.get("beforeExit")?.()
+    handlers.get("exit")?.()
+    expect(stopCount).toBe(1)
+
+    expect(() => handlers.get("SIGTERM")?.()).toThrow("exit")
+    expect(stopCount).toBe(1)
+    expect(exits).toEqual([143])
   })
 })


### PR DESCRIPTION
## Summary
- install shared shutdown handlers for the Khala Desktop Apple FM sidecar host
- stop the launched helper on normal exit and SIGINT/SIGTERM termination paths
- cover idempotent shutdown behavior in the sidecar host tests

Closes #6978

## Verification
- bun test clients/khala-desktop/tests/apple-fm-sidecar.test.ts
- bun run --cwd clients/khala-desktop verify
- true (command.public.pylon_khala.verify.b5bea41b6c623f7c09f1bf24)