### PR TITLE
fix pylon account reset status

### DIFF
--- a/apps/pylon/src/account-status.ts
+++ b/apps/pylon/src/account-status.ts
@@ -5,7 +5,9 @@ import {
 } from "./account-registry.js"
 import {
   isAccountAvailable,
+  loadManualQuotaResetRecord,
   loadQuotaRecord,
+  type ManualQuotaResetRecord,
   type QuotaRecord,
 } from "./account-quota-ledger.js"
 import {
@@ -50,6 +52,14 @@ function fallbackCooldownExpiresAt(record: QuotaRecord): string | null {
 function cooldownExpiresAt(record: QuotaRecord | null, now: Date): string | null {
   if (record === null || isAccountAvailable(record, now)) return null
   return fallbackCooldownExpiresAt(record)
+}
+
+function manualResetsRemainingFor(
+  configured: number | null,
+  record: ManualQuotaResetRecord,
+): number | null {
+  const hasLedgerState = record.updatedAt !== new Date(0).toISOString() || record.resetEvents.length > 0
+  return hasLedgerState ? record.manualResetsRemaining : configured ?? record.manualResetsRemaining
 }
 
 function usageFromPercent(cap: number | null, usedPercent: number): number {
@@ -101,6 +111,10 @@ export async function collectPylonOperatorAccountStatus(
   for (const account of registry) {
     const accountRefHash = hashPylonAccountRef(account.provider, account.ref)
     const quotaRecord = await loadQuotaRecord(summary as BootstrapSummary, accountRefHash)
+    const resetRecord = await loadManualQuotaResetRecord(summary as BootstrapSummary, {
+      accountRefHash,
+      provider: account.provider,
+    })
     const usageEntry = usageStore.accounts[accountRefHash]
     accounts.push({
       accountRefHash,
@@ -111,7 +125,7 @@ export async function collectPylonOperatorAccountStatus(
       hourlyUsage: usageFor(usageEntry, "hourly", account.hourlyCap, now),
       weeklyCap: account.weeklyCap,
       weeklyUsage: usageFor(usageEntry, "weekly", account.weeklyCap, now),
-      manualResetsRemaining: account.manualResetsRemaining,
+      manualResetsRemaining: manualResetsRemainingFor(account.manualResetsRemaining, resetRecord),
     })
   }
 

--- a/apps/pylon/tests/account-status.test.ts
+++ b/apps/pylon/tests/account-status.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from "node:os"
 import { join } from "node:path"
 
 import { hashPylonAccountRef } from "../src/account-registry"
-import { recordQuotaBlock } from "../src/account-quota-ledger"
+import { consumeManualQuotaReset, recordQuotaBlock } from "../src/account-quota-ledger"
 import { collectPylonOperatorAccountStatus } from "../src/account-status"
 import { recordPylonAccountUsageObservation } from "../src/account-usage"
 import { createBootstrapSummary, parseBootstrapArgs } from "../src/bootstrap"
@@ -190,6 +190,56 @@ describe("pylon operator account status", () => {
 
       expect(projection.accounts[0]?.hourlyUsage).toBe(110)
       expect(projection.accounts[0]?.weeklyUsage).toBe(null)
+      assertPublicProjectionSafe(projection)
+    })
+  })
+
+  test("surfaces consumed manual reset allowance from the quota ledger", async () => {
+    await withHome(async (home) => {
+      const summary = createBootstrapSummary(parseBootstrapArgs(["--json"]), { PYLON_HOME: home })
+      const codexHome = join(home, "codex-a")
+      await mkdir(codexHome, { recursive: true })
+      await writeFile(
+        summary.paths.config,
+        `${JSON.stringify(
+          {
+            dev: {
+              accounts: [
+                {
+                  ref: "codex-a",
+                  provider: "codex",
+                  home: codexHome,
+                  manualResetsRemaining: 3,
+                },
+              ],
+            },
+          },
+          null,
+          2,
+        )}\n`,
+      )
+
+      const accountRefHash = hashPylonAccountRef("codex", "codex-a")
+      await recordQuotaBlock(summary, {
+        accountRefHash,
+        provider: "codex",
+        retryAtIso: "2026-06-28T02:00:00.000Z",
+        sourceDigestRef: "digest.pylon.account_quota.test",
+        now: new Date("2026-06-28T01:00:00.000Z"),
+      })
+      await consumeManualQuotaReset(summary, {
+        accountRefHash,
+        provider: "codex",
+        now: new Date("2026-06-28T01:05:00.000Z"),
+      })
+
+      const projection = await collectPylonOperatorAccountStatus(summary, {
+        now: new Date("2026-06-28T01:10:00.000Z"),
+      })
+
+      expect(projection.accounts[0]?.manualResetsRemaining).toBe(2)
+      expect(projection.accounts[0]?.isRateLimited).toBe(false)
+      expect(projection.accounts[0]?.cooldownExpiresAt).toBe(null)
       assertPublicProjectionSafe(projection)
     })
   })


### PR DESCRIPTION
## Summary
- Read manual reset allowance from the Pylon quota ledger in the operator account status projection once ledger state exists.
- Keep configured registry allowance as the initial fallback before any manual-reset ledger event exists.
- Add a regression test proving a consumed manual reset clears the active quota block and appears in operator status.

Closes #6637.

## Verification
- `bun test apps/pylon/tests/account-status.test.ts`
- `bun test apps/pylon/tests/account-status.test.ts apps/pylon/tests/account-quota-ledger.test.ts apps/pylon/tests/account-usage.test.ts`

Note: I could not find a local mapping for required command ref `command.public.pylon_khala.verify.b5bea41b6c623f7c09f1bf24` in the checkout, sibling task cache, or Pylon metadata. I checked the Pylon `command.public.pylon_khala.verify.<sha>` derivation against likely focused Bun commands and then ran the relevant focused verification above.