### PR TITLE
fix(glm): admit stress burn past stale headroom snapshot

### DIFF
--- a/apps/openagents.com/workers/api/src/inference/chat-completions-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/chat-completions-routes.test.ts
@@ -2807,7 +2807,7 @@ describe('POST /v1/chat/completions', () => {
     })
   })
 
-  test('rejects internal_stress route admission when reserved external headroom is unavailable', async () => {
+  test('admits internal_stress route dispatch when only reserved external headroom is unavailable', async () => {
     let dispatched = false
     const registry = new InferenceProviderRegistry()
     registry.register({
@@ -2837,19 +2837,12 @@ describe('POST /v1/chat/completions', () => {
       ),
     )
 
-    expect(response.status).toBe(429)
-    expect(response.headers.get('retry-after')).toBe('1')
-    expect(dispatched).toBe(false)
+    expect(response.status).toBe(200)
+    expect(dispatched).toBe(true)
     const body = (await response.json()) as {
-      error?: { code?: string; message?: string; retryable?: boolean }
+      openagents?: { worker?: string }
     }
-    expect(body.error).toEqual({
-      code: 'route_admission_reserved_headroom_unavailable',
-      message:
-        'internal_stress rejected because reserved external headroom is unavailable: glm_aggregate_external_headroom_zero',
-      retryable: true,
-      type: 'route_admission_reserved_headroom_unavailable',
-    })
+    expect(body.openagents?.worker).toBe('primary')
   })
 
   test('keeps external route demand admitted when breached SLO shedding is external-labeled', async () => {
@@ -3253,7 +3246,7 @@ describe('POST /v1/chat/completions', () => {
     })
   })
 
-  test('global coordinator is not registered when route admission rejects internal_stress before dispatch', async () => {
+  test('global coordinator registers internal_stress even when route headroom snapshot is unavailable', async () => {
     let registerCalls = 0
     const coordinator: InternalStressPreemptionCoordinator = {
       preempt: async () => undefined,
@@ -3269,10 +3262,7 @@ describe('POST /v1/chat/completions', () => {
     const stressResponse = await run(
       handleChatCompletions(
         chatRequest(
-          {
-            ...helloBody,
-            stream: true,
-          },
+          helloBody,
           {
             headers: {
               [INFERENCE_DEMAND_KIND_HEADER]: 'internal_stress',
@@ -3292,13 +3282,8 @@ describe('POST /v1/chat/completions', () => {
       ),
     )
 
-    expect(stressResponse.status).toBe(429)
-    expect(await stressResponse.json()).toMatchObject({
-      error: {
-        code: 'route_admission_reserved_headroom_unavailable',
-      },
-    })
-    expect(registerCalls).toBe(0)
+    expect(stressResponse.status).toBe(200)
+    expect(registerCalls).toBe(1)
   })
 
   test('wired GLM saturation proof: internal_stress yields while external overflows and records exact served tokens', async () => {

--- a/apps/openagents.com/workers/api/src/inference/chat-completions-routes.ts
+++ b/apps/openagents.com/workers/api/src/inference/chat-completions-routes.ts
@@ -3119,13 +3119,8 @@ export const handleChatCompletions = (
     const traceEmitOptIn = resolveKhalaChatTraceOptIn({ rawBody, request })
 
     const routeDemandClass = routeDemandClassFromAttribution(requestAttribution)
-    const internalStressRouteAdmissionRejected =
-      routeDemandClass === 'internal_stress' &&
-      deps.routeAdmission !== undefined &&
-      deps.routeAdmission.reservedExternalHeadroomAvailable === false
     const preemptionAbortController =
       routeDemandClass === 'internal_stress' &&
-      !internalStressRouteAdmissionRejected &&
       (deps.internalStressPreemption !== undefined ||
         deps.internalStressCoordinator !== undefined)
         ? new AbortController()

--- a/apps/openagents.com/workers/api/src/inference/model-router.ts
+++ b/apps/openagents.com/workers/api/src/inference/model-router.ts
@@ -735,9 +735,10 @@ export type DispatchDeps = Readonly<{
   // Optional SLO shedding. Only non-external demand can be shed; external demand
   // continues through normal dispatch even when the SLO snapshot is breached.
   shedding?: DispatchLoadSheddingPolicy | undefined
-  // Optional typed route admission guard. It only refuses internal_stress when
-  // the control-plane snapshot says reserved external headroom is unavailable;
-  // external demand still dispatches through the normal lane plan.
+  // Optional typed route admission metadata. It is carried for observability and
+  // external preemption decisions, but dispatch does not hard-reject
+  // internal_stress from a coarse reservation snapshot. The GLM adapter remains
+  // the authority on real pool capacity and can still return typed saturation.
   admission?: DispatchRouteAdmissionPolicy | undefined
   // Optional typed scheduler hook. It can preempt one in-flight internal_stress
   // request only when external demand arrives and reserved external headroom is
@@ -899,24 +900,6 @@ const shedError = (
       shedding.demandClass === 'internal_stress'
         ? `internal_stress yielded because external SLO is breached: ${shedding.slo.reason}`
         : `request shed because SLO is breached: ${shedding.slo.reason}`,
-    retryable: true,
-  })
-
-const shouldRejectAdmission = (
-  admission: DispatchRouteAdmissionPolicy | undefined,
-): boolean =>
-  admission !== undefined &&
-  admission.demandClass === 'internal_stress' &&
-  !admission.reservedExternalHeadroomAvailable
-
-const admissionError = (
-  admission: DispatchRouteAdmissionPolicy,
-): InferenceAdapterError =>
-  new InferenceAdapterError({
-    adapterId: 'router',
-    httpStatus: 429,
-    kind: 'route_admission_reserved_headroom_unavailable',
-    reason: `internal_stress rejected because reserved external headroom is unavailable: ${admission.reason}`,
     retryable: true,
   })
 
@@ -1193,16 +1176,6 @@ export const dispatchWithOverflowWithMetadata = <A>(
     const backoff = deps.backoff ?? DEFAULT_OVERFLOW_BACKOFF
     const sleep = deps.sleep ?? Effect.sleep
     const retryCount = normalizedRetryCount(deps.retry)
-
-    const admission = deps.admission
-    if (shouldRejectAdmission(admission) && admission !== undefined) {
-      const error = admissionError(admission)
-      recordFailureTelemetry(
-        deps.failureTelemetry,
-        telemetryForError(error, 'load_shed'),
-      )
-      return yield* Effect.fail(error)
-    }
 
     const shedding = deps.shedding
     if (shouldShedRequest(shedding) && shedding !== undefined) {


### PR DESCRIPTION
## Summary

- Stop using the coarse reserved-external-headroom route admission snapshot as a pre-dispatch hard reject for `internal_stress` traffic.
- Keep external protection intact through SLO shedding and external-demand preemption of active stress work.
- Update chat route coverage so GLM saturation stress reaches dispatch and registers with the coordinator even when the local headroom snapshot says unavailable.

Fixes #6963.

## Verification

- `bun run --cwd apps/openagents.com/workers/api test -- src/inference/chat-completions-routes.test.ts src/inference/model-router.test.ts`

Note: the assignment requested verification command ref `command.public.pylon_khala.verify.b5bea41b6c623f7c09f1bf24`. The bounded workspace and local Pylon lease record did not retain a reverse mapping from that SHA-256 command ref to argv, so I ran the focused issue verifier above through the same package test entrypoint.
