### PR TITLE
fix(khala-desktop): fail closed on Apple FM supervisor blockers

### DIFF
--- a/clients/khala-desktop/src/shared/apple-fm-readiness.ts
+++ b/clients/khala-desktop/src/shared/apple-fm-readiness.ts
@@ -154,7 +154,8 @@ export function buildKhalaAppleFmReadiness(
     pylon.available &&
     pylon.status === "ready" &&
     pylon.advertisedCapabilities.includes(pylon.capability) &&
-    pylon.blockerRefs.length === 0
+    pylon.blockerRefs.length === 0 &&
+    (pylon.supervisor?.blockerRefs.length ?? 0) === 0
   const helperUsable = input.helperFound && input.helperExecutable !== false
 
   const blockers = new Set<string>()

--- a/clients/khala-desktop/tests/apple-fm-readiness.test.ts
+++ b/clients/khala-desktop/tests/apple-fm-readiness.test.ts
@@ -47,6 +47,34 @@ describe("khala desktop Apple FM readiness", () => {
     expect(readiness.usageTruth).toBe("estimated")
   })
 
+  test("fails closed when the Pylon supervisor reports blockers", () => {
+    const readiness = buildKhalaAppleFmReadiness({
+      platform: { platform: "darwin", arch: "arm64" },
+      helperFound: true,
+      helperExecutable: true,
+      helperLaunchState: "running",
+      pylonControlConfigured: true,
+      pylonStatus: {
+        available: true,
+        status: "ready",
+        advertisedCapabilities: [APPLE_FM_CAPABILITY],
+        blockerRefs: [],
+        supervisor: {
+          health: "running",
+          phase: "ready",
+          supervised: true,
+          blockerRefs: ["blocker.pylon.apple_fm.bridge_unreachable"],
+        },
+      },
+      observedAt: "2026-06-29T00:00:00.000Z",
+    })
+
+    expect(readiness.available).toBe(false)
+    expect(readiness.state).toBe("running")
+    expect(readiness.blockerRefs).toContain("blocker.khala_desktop.apple_fm.pylon_not_ready")
+    expect(readiness.blockerRefs).toContain("blocker.pylon.apple_fm.bridge_unreachable")
+  })
+
   test("keeps Pylon status public-safe and omits loopback paths and tokens", () => {
     const status = sanitizePylonAppleFmStatus({
       available: false,


### PR DESCRIPTION
## Summary
- Require Pylon Apple FM supervisor blocker refs to be empty before Khala Desktop marks local Apple FM ready.
- Keep supervisor blockers surfaced in public-safe readiness while leaving the sidecar in a non-available running state.
- Add a focused readiness regression test for supervisor-blocked ready-looking Pylon status.

Closes #6978

## Verification
- bun test clients/khala-desktop/tests/apple-fm-readiness.test.ts clients/khala-desktop/tests/apple-fm-sidecar.test.ts clients/khala-desktop/tests/apple-fm-packaging.test.ts
- bun run --cwd clients/khala-desktop verify

Note: the requested verifier ref `command.public.pylon_khala.verify.b5bea41b6c623f7c09f1bf24` was present only as an opaque task label in local metadata; no concrete command mapping was available. For the scoped Khala Desktop change, I ran the package verifier above.