### PR TITLE
Bound MirrorCode Phase 0 launch rows

### DIFF
--- a/apps/openagents.com/workers/api/src/inference/gym/mirrorcode-contract.ts
+++ b/apps/openagents.com/workers/api/src/inference/gym/mirrorcode-contract.ts
@@ -371,6 +371,26 @@ const decisionGradeFor = (
 const tokenAttributionProofRefFor = (runId: string): string =>
   `proof.gym.mirrorcode.exact_token_rows.${runId.replace(/[^A-Za-z0-9_.:-]/g, '_')}`
 
+const assertPhase0LaunchCaps = (launch: MirrorCodeLaunchRequest): void => {
+  if (
+    launch.maxTokens !== undefined &&
+    launch.maxTokens > MIRRORCODE_PHASE0_DEFAULT_MAX_TOKENS
+  ) {
+    throw new MirrorCodeRunError(
+      `maxTokens must be <= ${MIRRORCODE_PHASE0_DEFAULT_MAX_TOKENS} for Phase-0 launch intents.`,
+    )
+  }
+  if (
+    launch.maxWallClockSeconds !== undefined &&
+    launch.maxWallClockSeconds >
+      MIRRORCODE_PHASE0_DEFAULT_MAX_WALL_CLOCK_SECONDS
+  ) {
+    throw new MirrorCodeRunError(
+      `maxWallClockSeconds must be <= ${MIRRORCODE_PHASE0_DEFAULT_MAX_WALL_CLOCK_SECONDS} for Phase-0 launch intents.`,
+    )
+  }
+}
+
 // Build the public-safe stored run from a raw ingest body. Validates the shape,
 // re-asserts the public-safety boundary, and derives the honesty fields. Throws
 // MirrorCodeRunError on any rejection so nothing unsafe is ever stored.
@@ -467,6 +487,7 @@ export const buildMirrorCodeLaunchRun = (
       'MirrorCode launch intents are smoke-only; post the scored decision_grade result with exactTokenUsageEventRefs after execution.',
     )
   }
+  assertPhase0LaunchCaps(launch)
 
   return buildMirrorCodeRun({
     runId: `mc-${launch.bucket.toLowerCase()}-${taskPart}-${languagePart}-${timestampPart}`,

--- a/apps/openagents.com/workers/api/src/inference/gym/mirrorcode-contract.ts
+++ b/apps/openagents.com/workers/api/src/inference/gym/mirrorcode-contract.ts
@@ -84,6 +84,8 @@ export const MIRRORCODE_DEMAND_SOURCE = 'gym_mirrorcode'
 export const MIRRORCODE_GENERALIZATION_SET_ID = 'mirrorcode_public_tasks_no_rag'
 export const MIRRORCODE_MEMORY_POLICY = 'no_rag_public_tasks_only'
 export const MIRRORCODE_TOKEN_ATTRIBUTION_TRUTH = 'exact_rows_as_proof'
+export const MIRRORCODE_PHASE0_DEFAULT_MAX_TOKENS = 1_000_000
+export const MIRRORCODE_PHASE0_DEFAULT_MAX_WALL_CLOCK_SECONDS = 3_600
 
 // Field bounds enforced in `buildMirrorCodeRun` (the codebase avoids inline
 // Schema length/number refinements; the build boundary is the single place that
@@ -111,6 +113,10 @@ export const MirrorCodeRunInput = S.Struct({
   passRate: S.optional(S.NullOr(S.Number)),
   // Total tokens spent by this sample (the honest token-sink contribution).
   tokens: S.Struct({ total: S.Number }),
+  // Optional public-safe execution caps. Launch intents always set these; older
+  // scored records may omit them.
+  maxTokens: S.optional(S.Number),
+  maxWallClockSeconds: S.optional(S.Number),
   // Exact downstream token rows backing `tokens.total`. Required before a
   // decision-grade run can publish into the gym ladder.
   exactTokenUsageEventRefs: S.optional(S.Array(S.String)),
@@ -130,6 +136,8 @@ export const MirrorCodeLaunchRequest = S.Struct({
   taskId: S.String,
   bucket: MirrorCodeBucket,
   language: S.optional(S.NullOr(S.String)),
+  maxTokens: S.optional(S.Number),
+  maxWallClockSeconds: S.optional(S.Number),
   grade: S.optional(MirrorCodeRunGrade),
 })
 export type MirrorCodeLaunchRequest = typeof MirrorCodeLaunchRequest.Type
@@ -144,6 +152,8 @@ export const MirrorCodeRun = S.Struct({
   status: MirrorCodeRunStatus,
   passRate: S.NullOr(S.Number),
   tokensTotal: S.Number,
+  maxTokens: S.optional(S.Number),
+  maxWallClockSeconds: S.optional(S.Number),
   exactTokenUsageEventRefs: S.Array(S.String),
   tokenAttributionTruth: S.Literal(MIRRORCODE_TOKEN_ATTRIBUTION_TRUTH),
   tokenAttributionProofRef: S.String,
@@ -281,6 +291,24 @@ const assertBounds = (input: MirrorCodeRunInput): void => {
     throw new MirrorCodeRunError('tokens.total must be a non-negative number.')
   }
   if (
+    input.maxTokens !== undefined &&
+    (!Number.isFinite(input.maxTokens) ||
+      input.maxTokens < 1 ||
+      !Number.isInteger(input.maxTokens))
+  ) {
+    throw new MirrorCodeRunError('maxTokens must be a positive integer.')
+  }
+  if (
+    input.maxWallClockSeconds !== undefined &&
+    (!Number.isFinite(input.maxWallClockSeconds) ||
+      input.maxWallClockSeconds < 1 ||
+      !Number.isInteger(input.maxWallClockSeconds))
+  ) {
+    throw new MirrorCodeRunError(
+      'maxWallClockSeconds must be a positive integer.',
+    )
+  }
+  if (
     input.passRate !== undefined &&
     input.passRate !== null &&
     (!Number.isFinite(input.passRate) ||
@@ -385,6 +413,8 @@ export const buildMirrorCodeRun = (raw: unknown): MirrorCodeRun => {
     status,
     passRate,
     tokensTotal: input.tokens.total,
+    maxTokens: input.maxTokens,
+    maxWallClockSeconds: input.maxWallClockSeconds,
     exactTokenUsageEventRefs,
     tokenAttributionTruth: MIRRORCODE_TOKEN_ATTRIBUTION_TRUTH,
     tokenAttributionProofRef: tokenAttributionProofRefFor(input.runId),
@@ -427,6 +457,11 @@ export const buildMirrorCodeLaunchRun = (
     throw new MirrorCodeRunError('taskId must contain a public-safe id.')
   }
   assertPublicTarget(launch)
+  if (launch.bucket !== 'S') {
+    throw new MirrorCodeRunError(
+      'MirrorCode launch intents are Phase-0 S-bucket smoke runs only.',
+    )
+  }
   if (launch.grade === 'decision_grade') {
     throw new MirrorCodeRunError(
       'MirrorCode launch intents are smoke-only; post the scored decision_grade result with exactTokenUsageEventRefs after execution.',
@@ -442,6 +477,10 @@ export const buildMirrorCodeLaunchRun = (
     status: 'queued',
     passRate: null,
     tokens: { total: 0 },
+    maxTokens: launch.maxTokens ?? MIRRORCODE_PHASE0_DEFAULT_MAX_TOKENS,
+    maxWallClockSeconds:
+      launch.maxWallClockSeconds ??
+      MIRRORCODE_PHASE0_DEFAULT_MAX_WALL_CLOCK_SECONDS,
     startedAt: nowIso,
     finishedAt: null,
     summary: `Owner-gated MirrorCode launch queued for ${launch.taskId} (${launch.bucket} bucket) through openagents/khala.`,

--- a/apps/openagents.com/workers/api/src/inference/gym/mirrorcode-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/gym/mirrorcode-routes.test.ts
@@ -111,9 +111,41 @@ describe('buildMirrorCodeRun', () => {
     expect(built.runId).toBe('mc-s-qsv-select-python-20260627020304')
     expect(built.status).toBe('queued')
     expect(built.tokensTotal).toBe(0)
+    expect(built.maxTokens).toBe(1_000_000)
+    expect(built.maxWallClockSeconds).toBe(3_600)
     expect(built.passRate).toBeNull()
     expect(built.decisionGrade).toBe(false)
     expect(built.summary).toContain('Owner-gated MirrorCode launch queued')
+  })
+
+  test('builds an owner-gated queued launch row with explicit hard caps', () => {
+    const built = buildMirrorCodeLaunchRun(
+      {
+        kind: 'launch',
+        taskId: 'cal',
+        bucket: 'S',
+        language: 'python',
+        maxTokens: 50_000,
+        maxWallClockSeconds: 600,
+      },
+      '2026-06-27T02:03:04.000Z',
+    )
+    expect(built.maxTokens).toBe(50_000)
+    expect(built.maxWallClockSeconds).toBe(600)
+  })
+
+  test('rejects an owner-gated launch outside the Phase-0 S bucket', () => {
+    expect(() =>
+      buildMirrorCodeLaunchRun(
+        {
+          kind: 'launch',
+          taskId: 'sed',
+          bucket: 'M',
+          language: 'python',
+        },
+        '2026-06-27T02:03:04.000Z',
+      ),
+    ).toThrow(MirrorCodeRunError)
   })
 
   test('rejects an owner-gated launch for an unknown public target', () => {
@@ -367,12 +399,20 @@ describe('handleMirrorCodeRunsApi POST', () => {
     expect(response.status).toBe(202)
     const body = (await response.json()) as {
       kind: string
-      run: { runId: string; status: string; tokensTotal: number }
+      run: {
+        maxTokens?: number
+        maxWallClockSeconds?: number
+        runId: string
+        status: string
+        tokensTotal: number
+      }
     }
     expect(body.kind).toBe('mirrorcode_run_launched')
     expect(body.run.runId).toBe('mc-s-qsv-select-python-20260627020304')
     expect(body.run.status).toBe('queued')
     expect(body.run.tokensTotal).toBe(0)
+    expect(body.run.maxTokens).toBe(1_000_000)
+    expect(body.run.maxWallClockSeconds).toBe(3_600)
     expect(storedRunId).toBe('mc-s-qsv-select-python-20260627020304')
   })
 

--- a/apps/openagents.com/workers/api/src/inference/gym/mirrorcode-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/gym/mirrorcode-routes.test.ts
@@ -134,6 +134,33 @@ describe('buildMirrorCodeRun', () => {
     expect(built.maxWallClockSeconds).toBe(600)
   })
 
+  test('rejects owner-gated launch caps above Phase-0 hard caps', () => {
+    expect(() =>
+      buildMirrorCodeLaunchRun(
+        {
+          kind: 'launch',
+          taskId: 'cal',
+          bucket: 'S',
+          language: 'python',
+          maxTokens: 1_000_001,
+        },
+        '2026-06-27T02:03:04.000Z',
+      ),
+    ).toThrow(MirrorCodeRunError)
+    expect(() =>
+      buildMirrorCodeLaunchRun(
+        {
+          kind: 'launch',
+          taskId: 'cal',
+          bucket: 'S',
+          language: 'python',
+          maxWallClockSeconds: 3_601,
+        },
+        '2026-06-27T02:03:04.000Z',
+      ),
+    ).toThrow(MirrorCodeRunError)
+  })
+
   test('rejects an owner-gated launch outside the Phase-0 S bucket', () => {
     expect(() =>
       buildMirrorCodeLaunchRun(
@@ -444,6 +471,36 @@ describe('handleMirrorCodeRunsApi POST', () => {
     expect(stored).toBe(0)
     const body = (await response.json()) as { reason: string }
     expect(body.reason).toContain('launch intents are smoke-only')
+  })
+
+  test('authorized POST rejects launch caps above the Phase-0 hard cap without storing', async () => {
+    let stored = 0
+    const response = await run(
+      handleMirrorCodeRunsApi(
+        postRequest({
+          kind: 'launch',
+          taskId: 'qsv_select',
+          bucket: 'S',
+          language: 'python',
+          maxTokens: 1_000_001,
+        }),
+        {
+          requireAdminApiToken: async () => true,
+          nowIso: () => '2026-06-27T02:03:04.000Z',
+          store: {
+            listRuns: () => Effect.succeed([]),
+            getRun: () => Effect.sync(() => undefined),
+            upsertRun: () => Effect.sync(() => {
+              stored += 1
+            }),
+          },
+        },
+      ),
+    )
+    expect(response.status).toBe(400)
+    expect(stored).toBe(0)
+    const body = (await response.json()) as { reason: string }
+    expect(body.reason).toContain('maxTokens must be <=')
   })
 
   test('authorized POST with task contents is rejected 400', async () => {


### PR DESCRIPTION
## Summary
- add public-safe token and wall-clock cap fields to MirrorCode run/launch records
- default owner-gated launch rows to bounded Phase 0 smoke caps
- reject launch intents outside the S bucket so the demo queue cannot accidentally start M/L MirrorCode runs

Closes #6376

## Verification
- `bun run --cwd apps/openagents.com/workers/api test -- src/inference/gym/mirrorcode-routes.test.ts`
- `bun run --cwd apps/openagents.com/workers/api test -- src/inference/gym/mirrorcode-routes.test.ts src/inference/gym/mirrorcode-ladder-integration.test.ts src/inference/gym/ladder.test.ts src/inference/gym/ladder-routes.test.ts`
- `bun run --cwd apps/openagents.com/workers/api typecheck`
- `true` (`command.public.pylon_khala.verify.b5bea41b6c623f7c09f1bf24`)
