### PR TITLE
fix(khala): add serving-rate monitor

### DIFF
--- a/apps/openagents.com/workers/api/src/index.ts
+++ b/apps/openagents.com/workers/api/src/index.ts
@@ -466,6 +466,7 @@ import {
   matchMirrorCodeRunByIdRequest,
 } from './inference/gym/mirrorcode-routes'
 import { makeD1MirrorCodeRunStore } from './inference/gym/mirrorcode-store'
+import { runServingRateMonitorScheduled } from './inference/serving-rate-monitor'
 import {
   handleOperatorKhalaHeadToHeadApi,
   handlePublicKhalaHeadToHeadApi,
@@ -13951,6 +13952,21 @@ export default {
             { scheduledTimeMs: event.scheduledTime },
             (line, fields) =>
               logWorkerRouteWarning('fleet_burn_stall_watchdog', {
+                line,
+                ...fields,
+              }),
+          ),
+        ),
+      ),
+      observedEffect(
+        'ServingRateMonitor.tick',
+        Effect.promise(() =>
+          runServingRateMonitorScheduled(
+            openAgentsDatabase(env),
+            env,
+            { scheduledTimeMs: event.scheduledTime },
+            (line, fields) =>
+              logWorkerRouteWarning('serving_rate_monitor', {
                 line,
                 ...fields,
               }),

--- a/apps/openagents.com/workers/api/src/inference/serving-rate-monitor.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/serving-rate-monitor.test.ts
@@ -1,0 +1,218 @@
+import { describe, expect, test } from 'vitest'
+
+import {
+  classifyServingRateMonitor,
+  readServingRateMonitorConfig,
+  runServingRateMonitorTick,
+  SERVING_RATE_GLM_DOWN_REASON_REF,
+  SERVING_RATE_LOW_REASON_REF,
+  SERVING_RATE_MONITOR_TOKEN_FLOOR_PER_HOUR,
+  type ServingRateMonitorStore,
+} from './serving-rate-monitor'
+
+const NOW_ISO = '2026-06-29T15:00:00.000Z'
+
+const makeStore = (
+  input: Partial<ServingRateMonitorStore> &
+    Readonly<{
+      latestHeartbeatAt?: string | null
+      recentAlert?: boolean
+      tokensLastHour: number
+    }>,
+): Readonly<{
+  inserted: Array<unknown>
+  store: ServingRateMonitorStore
+}> => {
+  const inserted: Array<unknown> = []
+  const { latestHeartbeatAt, recentAlert, tokensLastHour, ...overrides } = input
+  const store: ServingRateMonitorStore = {
+    hasRecentAlert: async () => recentAlert ?? false,
+    insertAlert: async record => {
+      inserted.push(record)
+    },
+    latestHealthyGlmHeartbeatAt: async () =>
+      latestHeartbeatAt === undefined ? NOW_ISO : latestHeartbeatAt,
+    tokensSince: async () => tokensLastHour,
+    ...overrides,
+  }
+  return { inserted, store }
+}
+
+const config = {
+  cadenceMinutes: 5,
+  enabled: true,
+  glmDownMinutes: 15,
+  tokenFloorPerHour: SERVING_RATE_MONITOR_TOKEN_FLOOR_PER_HOUR,
+}
+
+describe('classifyServingRateMonitor', () => {
+  test('healthy when hourly tokens meet floor and GLM heartbeat is fresh', () => {
+    const result = classifyServingRateMonitor({
+      glmDownMinutes: 15,
+      latestHealthyGlmHeartbeatAt: '2026-06-29T14:59:00.000Z',
+      nowIso: NOW_ISO,
+      tokenFloorPerHour: SERVING_RATE_MONITOR_TOKEN_FLOOR_PER_HOUR,
+      tokensLastHour: SERVING_RATE_MONITOR_TOKEN_FLOOR_PER_HOUR,
+    })
+
+    expect(result.status).toBe('healthy')
+    expect(result.alertKinds).toEqual([])
+    expect(result.reasonRefs).toEqual([])
+  })
+
+  test('alerts when aggregate tokens/hour drops below the configured floor', () => {
+    const result = classifyServingRateMonitor({
+      glmDownMinutes: 15,
+      latestHealthyGlmHeartbeatAt: '2026-06-29T14:59:00.000Z',
+      nowIso: NOW_ISO,
+      tokenFloorPerHour: SERVING_RATE_MONITOR_TOKEN_FLOOR_PER_HOUR,
+      tokensLastHour: SERVING_RATE_MONITOR_TOKEN_FLOOR_PER_HOUR - 1,
+    })
+
+    expect(result.status).toBe('serving_rate_low')
+    expect(result.alertKinds).toEqual(['serving_rate_low'])
+    expect(result.reasonRefs).toContain(SERVING_RATE_LOW_REASON_REF)
+  })
+
+  test('alerts when no healthy GLM heartbeat is inside the down window', () => {
+    const result = classifyServingRateMonitor({
+      glmDownMinutes: 15,
+      latestHealthyGlmHeartbeatAt: '2026-06-29T14:44:59.000Z',
+      nowIso: NOW_ISO,
+      tokenFloorPerHour: SERVING_RATE_MONITOR_TOKEN_FLOOR_PER_HOUR,
+      tokensLastHour: SERVING_RATE_MONITOR_TOKEN_FLOOR_PER_HOUR + 1,
+    })
+
+    expect(result.status).toBe('glm_down')
+    expect(result.alertKinds).toEqual(['glm_down'])
+    expect(result.reasonRefs).toContain(SERVING_RATE_GLM_DOWN_REASON_REF)
+  })
+
+  test('returns both alert kinds when serving rate and GLM health are bad', () => {
+    const result = classifyServingRateMonitor({
+      glmDownMinutes: 15,
+      latestHealthyGlmHeartbeatAt: null,
+      nowIso: NOW_ISO,
+      tokenFloorPerHour: SERVING_RATE_MONITOR_TOKEN_FLOOR_PER_HOUR,
+      tokensLastHour: 0,
+    })
+
+    expect(result.status).toBe('glm_down')
+    expect(result.alertKinds).toEqual(['serving_rate_low', 'glm_down'])
+  })
+})
+
+describe('readServingRateMonitorConfig', () => {
+  test('defaults to a 5 minute Cloudflare cron cadence and 50M/hr floor', () => {
+    const result = readServingRateMonitorConfig({})
+
+    expect(result).toEqual({
+      cadenceMinutes: 5,
+      enabled: true,
+      glmDownMinutes: 15,
+      tokenFloorPerHour: 50_000_000,
+    })
+  })
+
+  test('parses deployment overrides', () => {
+    const result = readServingRateMonitorConfig({
+      SERVING_RATE_MONITOR_CADENCE_MINUTES: '10',
+      SERVING_RATE_MONITOR_ENABLED: 'false',
+      SERVING_RATE_MONITOR_GLM_DOWN_MINUTES: '20',
+      SERVING_RATE_MONITOR_TOKEN_FLOOR_PER_HOUR: '123',
+    })
+
+    expect(result).toEqual({
+      cadenceMinutes: 10,
+      enabled: false,
+      glmDownMinutes: 20,
+      tokenFloorPerHour: 123,
+    })
+  })
+})
+
+describe('runServingRateMonitorTick', () => {
+  test('healthy tick writes no alert rows', async () => {
+    const { inserted, store } = makeStore({
+      tokensLastHour: SERVING_RATE_MONITOR_TOKEN_FLOOR_PER_HOUR + 1,
+    })
+
+    const result = await runServingRateMonitorTick({
+      config,
+      makeId: () => 'alert-id-1',
+      nowIso: NOW_ISO,
+      store,
+    })
+
+    expect(result.classification.status).toBe('healthy')
+    expect(result.alertRefs).toEqual([])
+    expect(inserted).toEqual([])
+  })
+
+  test('low serving rate writes one public-safe alert row', async () => {
+    const logs: Array<unknown> = []
+    const { inserted, store } = makeStore({
+      tokensLastHour: 10,
+    })
+
+    const result = await runServingRateMonitorTick({
+      config,
+      log: (line, fields) => logs.push({ fields, line }),
+      makeId: () => 'feedfacecafebeef',
+      nowIso: NOW_ISO,
+      store,
+    })
+
+    expect(result.alertRefs).toHaveLength(1)
+    expect(inserted).toHaveLength(1)
+    expect(inserted[0]).toMatchObject({
+      burnTokensWindow: 10,
+      classification: 'serving_rate_low',
+      reasonRef: SERVING_RATE_LOW_REASON_REF,
+      stallThresholdTokens: SERVING_RATE_MONITOR_TOKEN_FLOOR_PER_HOUR,
+      windowMinutes: 60,
+    })
+    expect(logs).toHaveLength(1)
+  })
+
+  test('stale GLM plus low rate writes both alert rows', async () => {
+    const { inserted, store } = makeStore({
+      latestHeartbeatAt: null,
+      tokensLastHour: 0,
+    })
+
+    const result = await runServingRateMonitorTick({
+      config,
+      makeId: () => `id-${inserted.length}`,
+      nowIso: NOW_ISO,
+      store,
+    })
+
+    expect(result.classification.alertKinds).toEqual([
+      'serving_rate_low',
+      'glm_down',
+    ])
+    expect(result.alertRefs).toHaveLength(2)
+    expect(
+      inserted.map(row => (row as { classification: string }).classification),
+    ).toEqual(['serving_rate_low', 'glm_down'])
+  })
+
+  test('recent same-kind alert suppresses duplicate writes', async () => {
+    const { inserted, store } = makeStore({
+      recentAlert: true,
+      tokensLastHour: 0,
+    })
+
+    const result = await runServingRateMonitorTick({
+      config,
+      makeId: () => 'id-duplicate',
+      nowIso: NOW_ISO,
+      store,
+    })
+
+    expect(result.classification.status).toBe('serving_rate_low')
+    expect(result.alertRefs).toEqual([])
+    expect(inserted).toEqual([])
+  })
+})

--- a/apps/openagents.com/workers/api/src/inference/serving-rate-monitor.ts
+++ b/apps/openagents.com/workers/api/src/inference/serving-rate-monitor.ts
@@ -1,0 +1,384 @@
+import {
+  epochMillisToIsoTimestamp,
+  isoTimestampAfterIso,
+  randomUuid,
+} from '../runtime-primitives'
+import { HYDRALISK_GLM_52_REAP_504B_MODEL_ID } from './pricing'
+
+export const SERVING_RATE_MONITOR_CADENCE_MINUTES = 5
+export const SERVING_RATE_MONITOR_TOKEN_FLOOR_PER_HOUR = 50_000_000
+export const SERVING_RATE_MONITOR_GLM_DOWN_MINUTES = 15
+
+export type ServingRateMonitorAlertKind = 'glm_down' | 'serving_rate_low'
+export type ServingRateMonitorStatus =
+  | 'disabled'
+  | 'glm_down'
+  | 'healthy'
+  | 'serving_rate_low'
+
+export const SERVING_RATE_LOW_REASON_REF =
+  'blocker.public.serving_rate.tokens_per_hour_below_floor'
+export const SERVING_RATE_GLM_DOWN_REASON_REF =
+  'blocker.public.serving_rate.glm_lane_down'
+
+export type ServingRateMonitorConfig = Readonly<{
+  enabled: boolean
+  cadenceMinutes: number
+  glmDownMinutes: number
+  tokenFloorPerHour: number
+}>
+
+export type ServingRateMonitorClassificationInput = Readonly<{
+  glmDownMinutes: number
+  latestHealthyGlmHeartbeatAt: string | null
+  nowIso: string
+  tokenFloorPerHour: number
+  tokensLastHour: number
+}>
+
+export type ServingRateMonitorClassification = Readonly<{
+  alertKinds: ReadonlyArray<ServingRateMonitorAlertKind>
+  glmHealthy: boolean
+  latestHealthyGlmHeartbeatAt: string | null
+  reasonRefs: ReadonlyArray<string>
+  status: ServingRateMonitorStatus
+  tokenFloorPerHour: number
+  tokensLastHour: number
+}>
+
+export type ServingRateMonitorStore = Readonly<{
+  hasRecentAlert: (
+    classification: ServingRateMonitorAlertKind,
+    sinceIso: string,
+  ) => Promise<boolean>
+  insertAlert: (record: ServingRateMonitorAlertRecord) => Promise<void>
+  latestHealthyGlmHeartbeatAt: () => Promise<string | null>
+  tokensSince: (sinceIso: string) => Promise<number>
+}>
+
+export type ServingRateMonitorAlertRecord = Readonly<{
+  id: string
+  alertRef: string
+  detectedAt: string
+  classification: ServingRateMonitorAlertKind
+  reasonRef: string
+  burnTokensWindow: number
+  windowMinutes: number
+  stallThresholdTokens: number
+  recoveryActions: ReadonlyArray<string>
+  createdAt: string
+}>
+
+export type ServingRateMonitorTickResult = Readonly<{
+  alertRefs: ReadonlyArray<string>
+  classification: ServingRateMonitorClassification
+  enabled: boolean
+  ranAt: string
+}>
+
+const nonNegativeInt = (value: number): number => Math.max(0, Math.trunc(value))
+
+const parseBool = (value: unknown, fallback: boolean): boolean => {
+  if (typeof value !== 'string' || value.trim() === '') {
+    return fallback
+  }
+  return value.trim().toLowerCase() === 'true'
+}
+
+const parsePositiveInt = (value: unknown, fallback: number): number => {
+  if (typeof value !== 'string' || value.trim() === '') {
+    return fallback
+  }
+  const parsed = Number.parseInt(value.trim(), 10)
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback
+}
+
+const isIsoWithinMinutes = (
+  timestamp: string | null,
+  nowIso: string,
+  minutes: number,
+): boolean => {
+  if (timestamp === null) {
+    return false
+  }
+  const observedMs = Date.parse(timestamp)
+  const nowMs = Date.parse(nowIso)
+  return (
+    Number.isFinite(observedMs) &&
+    Number.isFinite(nowMs) &&
+    nowMs - observedMs <= minutes * 60_000
+  )
+}
+
+const alertRefFor = (
+  kind: ServingRateMonitorAlertKind,
+  nowIso: string,
+  id: string,
+): string => `serving_rate_alert.${kind}.${nowIso}.${id.slice(0, 8)}`
+
+const shouldRunAt = (
+  scheduledTimeMs: number,
+  cadenceMinutes: number,
+): boolean => {
+  const minute = Math.floor(scheduledTimeMs / 60_000)
+  return minute % Math.max(1, cadenceMinutes) === 0
+}
+
+export const readServingRateMonitorConfig = (
+  env: unknown,
+): ServingRateMonitorConfig => {
+  const record = (env ?? {}) as Record<string, unknown>
+  return {
+    cadenceMinutes: parsePositiveInt(
+      record.SERVING_RATE_MONITOR_CADENCE_MINUTES,
+      SERVING_RATE_MONITOR_CADENCE_MINUTES,
+    ),
+    enabled: parseBool(record.SERVING_RATE_MONITOR_ENABLED, true),
+    glmDownMinutes: parsePositiveInt(
+      record.SERVING_RATE_MONITOR_GLM_DOWN_MINUTES,
+      SERVING_RATE_MONITOR_GLM_DOWN_MINUTES,
+    ),
+    tokenFloorPerHour: parsePositiveInt(
+      record.SERVING_RATE_MONITOR_TOKEN_FLOOR_PER_HOUR,
+      SERVING_RATE_MONITOR_TOKEN_FLOOR_PER_HOUR,
+    ),
+  }
+}
+
+export const classifyServingRateMonitor = (
+  input: ServingRateMonitorClassificationInput,
+): ServingRateMonitorClassification => {
+  const tokensLastHour = nonNegativeInt(input.tokensLastHour)
+  const tokenFloorPerHour = Math.max(1, nonNegativeInt(input.tokenFloorPerHour))
+  const glmHealthy = isIsoWithinMinutes(
+    input.latestHealthyGlmHeartbeatAt,
+    input.nowIso,
+    input.glmDownMinutes,
+  )
+  const servingRateLow = tokensLastHour < tokenFloorPerHour
+  const alertKinds: ReadonlyArray<ServingRateMonitorAlertKind> = [
+    ...(servingRateLow ? (['serving_rate_low'] as const) : []),
+    ...(!glmHealthy ? (['glm_down'] as const) : []),
+  ]
+  const reasonRefs = [
+    ...(servingRateLow ? [SERVING_RATE_LOW_REASON_REF] : []),
+    ...(!glmHealthy ? [SERVING_RATE_GLM_DOWN_REASON_REF] : []),
+  ]
+  const status: ServingRateMonitorStatus = !glmHealthy
+    ? 'glm_down'
+    : servingRateLow
+      ? 'serving_rate_low'
+      : 'healthy'
+
+  return {
+    alertKinds,
+    glmHealthy,
+    latestHealthyGlmHeartbeatAt: input.latestHealthyGlmHeartbeatAt,
+    reasonRefs,
+    status,
+    tokenFloorPerHour,
+    tokensLastHour,
+  }
+}
+
+export const runServingRateMonitorTick = async (
+  input: Readonly<{
+    config: ServingRateMonitorConfig
+    log?: (line: string, fields: Record<string, unknown>) => void
+    makeId: () => string
+    nowIso: string
+    store: ServingRateMonitorStore
+  }>,
+): Promise<ServingRateMonitorTickResult> => {
+  const log = input.log ?? (() => {})
+  if (!input.config.enabled) {
+    return {
+      alertRefs: [],
+      classification: {
+        alertKinds: [],
+        glmHealthy: false,
+        latestHealthyGlmHeartbeatAt: null,
+        reasonRefs: [],
+        status: 'disabled',
+        tokenFloorPerHour: input.config.tokenFloorPerHour,
+        tokensLastHour: 0,
+      },
+      enabled: false,
+      ranAt: input.nowIso,
+    }
+  }
+
+  const oneHourAgoIso = isoTimestampAfterIso(input.nowIso, -60 * 60_000)
+  const [tokensLastHour, latestHealthyGlmHeartbeatAt] = await Promise.all([
+    input.store.tokensSince(oneHourAgoIso),
+    input.store.latestHealthyGlmHeartbeatAt(),
+  ])
+  const classification = classifyServingRateMonitor({
+    glmDownMinutes: input.config.glmDownMinutes,
+    latestHealthyGlmHeartbeatAt,
+    nowIso: input.nowIso,
+    tokenFloorPerHour: input.config.tokenFloorPerHour,
+    tokensLastHour,
+  })
+
+  const dedupeSinceIso = isoTimestampAfterIso(
+    input.nowIso,
+    -input.config.cadenceMinutes * 60_000,
+  )
+  const insertedAlertRefs = (
+    await Promise.all(
+      classification.alertKinds.map(async kind => {
+        if (await input.store.hasRecentAlert(kind, dedupeSinceIso)) {
+          return null
+        }
+        const id = input.makeId()
+        const reasonRef =
+          kind === 'serving_rate_low'
+            ? SERVING_RATE_LOW_REASON_REF
+            : SERVING_RATE_GLM_DOWN_REASON_REF
+        const alertRef = alertRefFor(kind, input.nowIso, id)
+        await input.store.insertAlert({
+          alertRef,
+          burnTokensWindow: classification.tokensLastHour,
+          classification: kind,
+          createdAt: input.nowIso,
+          detectedAt: input.nowIso,
+          id,
+          reasonRef,
+          recoveryActions: [
+            'monitor.serving_rate.read_only',
+            `monitor.glm.latest_healthy_at.${latestHealthyGlmHeartbeatAt ?? 'missing'}`,
+          ],
+          stallThresholdTokens: classification.tokenFloorPerHour,
+          windowMinutes: 60,
+        })
+        log('SERVING-RATE monitor alert', {
+          alertRef,
+          classification: kind,
+          latestHealthyGlmHeartbeatAt: latestHealthyGlmHeartbeatAt ?? 'missing',
+          reasonRef,
+          tokenFloorPerHour: classification.tokenFloorPerHour,
+          tokensLastHour: classification.tokensLastHour,
+        })
+        return alertRef
+      }),
+    )
+  ).filter((ref): ref is string => ref !== null)
+
+  return {
+    alertRefs: insertedAlertRefs,
+    classification,
+    enabled: true,
+    ranAt: input.nowIso,
+  }
+}
+
+export const makeD1ServingRateMonitorStore = (
+  db: D1Database,
+): ServingRateMonitorStore => ({
+  hasRecentAlert: async (classification, sinceIso) => {
+    const row = await db
+      .prepare(
+        `SELECT alert_ref
+           FROM fleet_alerts
+          WHERE classification = ?
+            AND detected_at >= ?
+          ORDER BY detected_at DESC
+          LIMIT 1`,
+      )
+      .bind(classification, sinceIso)
+      .first<{ alert_ref: string | null }>()
+    return typeof row?.alert_ref === 'string'
+  },
+  insertAlert: async record => {
+    await db
+      .prepare(
+        `INSERT INTO fleet_alerts
+          (id, alert_ref, detected_at, classification, reason_ref,
+           burn_tokens_window, window_minutes, stall_threshold_tokens,
+           active_assignments, queued_assignments, recovery_actions_json,
+           recovered_lease_count, created_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, 0, 0, ?, 0, ?)`,
+      )
+      .bind(
+        record.id,
+        record.alertRef,
+        record.detectedAt,
+        record.classification,
+        record.reasonRef,
+        record.burnTokensWindow,
+        record.windowMinutes,
+        record.stallThresholdTokens,
+        JSON.stringify(record.recoveryActions),
+        record.createdAt,
+      )
+      .run()
+  },
+  latestHealthyGlmHeartbeatAt: async () => {
+    const row = await db
+      .prepare(
+        `SELECT observed_at
+           FROM token_usage_events
+          WHERE model = ?
+            AND (
+              (
+                demand_source = 'glm-pool-heartbeat'
+                AND json_extract(safe_metadata_json, '$.heartbeatKind') = 'glm_pool_heartbeat'
+                AND (
+                  json_extract(safe_metadata_json, '$.watchdogStatus') = 'healthy'
+                  OR json_extract(safe_metadata_json, '$.healthStatus') IN ('ok', 'ready', 'healthy')
+                  OR json_extract(safe_metadata_json, '$.modelsStatus') IN ('ok', 'ready', 'healthy')
+                )
+              )
+              OR (
+                demand_source = 'heartbeat'
+                AND provider = 'hydralisk-vllm-glm-5p2-reap-504b'
+                AND total_tokens > 0
+              )
+            )
+          ORDER BY observed_at DESC
+          LIMIT 1`,
+      )
+      .bind(HYDRALISK_GLM_52_REAP_504B_MODEL_ID)
+      .first<{ observed_at: string | null }>()
+    return typeof row?.observed_at === 'string' ? row.observed_at : null
+  },
+  tokensSince: async sinceIso => {
+    const row = await db
+      .prepare(
+        `SELECT COALESCE(SUM(total_tokens), 0) AS tokens
+           FROM token_usage_events
+          WHERE observed_at >= ?`,
+      )
+      .bind(sinceIso)
+      .first<{ tokens: number | null }>()
+    return nonNegativeInt(row?.tokens ?? 0)
+  },
+})
+
+export const runServingRateMonitorScheduled = async (
+  db: D1Database,
+  env: unknown,
+  input: Readonly<{ scheduledTimeMs: number }>,
+  log: (line: string, fields: Record<string, unknown>) => void,
+): Promise<ServingRateMonitorTickResult | null> => {
+  const config = readServingRateMonitorConfig(env)
+  if (!shouldRunAt(input.scheduledTimeMs, config.cadenceMinutes)) {
+    return null
+  }
+  const nowIso = epochMillisToIsoTimestamp(input.scheduledTimeMs)
+  try {
+    return await runServingRateMonitorTick({
+      config,
+      log,
+      makeId: () => randomUuid(),
+      nowIso,
+      store: makeD1ServingRateMonitorStore(db),
+    })
+  } catch (error) {
+    log('ServingRateMonitor tick failed', {
+      errorName: error instanceof Error ? error.name : 'unknown',
+    })
+    return null
+  }
+}

--- a/apps/openagents.com/workers/api/src/operator-fleet-status-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/operator-fleet-status-routes.test.ts
@@ -92,6 +92,18 @@ const rowsForSql = (sql: string): ReadonlyArray<Record<string, unknown>> => {
   }
 
   if (sql.includes('FROM fleet_alerts')) {
+    if (sql.includes('serving_rate_low')) {
+      return [
+        {
+          active_assignments: 0,
+          alert_ref: 'serving_rate_alert.serving_rate_low.2026-06-27T18:39:00.000Z.feedface',
+          classification: 'serving_rate_low',
+          detected_at: '2026-06-27T18:39:00.000Z',
+          queued_assignments: 0,
+          reason_ref: 'blocker.public.serving_rate.tokens_per_hour_below_floor',
+        },
+      ]
+    }
     return [
       {
         active_assignments: 1,
@@ -191,7 +203,7 @@ describe('operator fleet status route', () => {
     expect(first.headers.get('x-openagents-cache')).toBe('miss')
     expect(second.headers.get('x-openagents-cache')).toBe('hit')
     expect(log.length).toBeGreaterThan(0)
-    expect(log.length).toBe(9)
+    expect(log.length).toBe(10)
     expect(cachedBody).toEqual(body)
     expect(body).toMatchObject({
       authority: {
@@ -255,6 +267,13 @@ describe('operator fleet status route', () => {
         ],
       },
       schemaVersion: 'operator.fleet_status.v1',
+      servingRateMonitor: {
+        latestAlert: {
+          classification: 'serving_rate_low',
+          reasonRef: 'blocker.public.serving_rate.tokens_per_hour_below_floor',
+        },
+        state: 'SERVING_RATE_LOW',
+      },
       supervisor: {
         availableCodexSlots: 3,
         desiredCodexSlots: 2,

--- a/apps/openagents.com/workers/api/src/operator-fleet-status-routes.ts
+++ b/apps/openagents.com/workers/api/src/operator-fleet-status-routes.ts
@@ -164,6 +164,7 @@ const buildFleetStatusSnapshot = async (
     assignments,
     providerAccounts,
     latestAlert,
+    latestServingRateAlert,
     today,
     yesterday,
     window,
@@ -214,6 +215,16 @@ const buildFleetStatusSnapshot = async (
       `SELECT alert_ref, classification, detected_at, reason_ref,
               active_assignments, queued_assignments
          FROM fleet_alerts
+        WHERE classification = 'stalled'
+        ORDER BY detected_at DESC
+        LIMIT 1`,
+    ),
+    safeFirst<AlertRow>(
+      db,
+      `SELECT alert_ref, classification, detected_at, reason_ref,
+              active_assignments, queued_assignments
+         FROM fleet_alerts
+        WHERE classification IN ('serving_rate_low', 'glm_down')
         ORDER BY detected_at DESC
         LIMIT 1`,
     ),
@@ -324,6 +335,10 @@ const buildFleetStatusSnapshot = async (
 
   const latestAlertAgeMs =
     latestAlert === null ? Number.POSITIVE_INFINITY : millisBetween(latestAlert.detected_at, nowIso)
+  const latestServingRateAlertAgeMs =
+    latestServingRateAlert === null
+      ? Number.POSITIVE_INFINITY
+      : millisBetween(latestServingRateAlert.detected_at, nowIso)
   const watchdogState =
     latestAlert === null || latestAlertAgeMs > 5 * 60_000
       ? 'HEALTHY'
@@ -444,6 +459,26 @@ const buildFleetStatusSnapshot = async (
         detectedAt: latestAlert.detected_at,
       }],
       sourceRefs: ['d1:fleet_alerts', 'd1:pylon_api_assignments'],
+    },
+    servingRateMonitor: {
+      state:
+        latestServingRateAlert === null ||
+        latestServingRateAlertAgeMs > 15 * 60_000
+          ? 'HEALTHY'
+          : latestServingRateAlert.classification === 'glm_down'
+            ? 'GLM_DOWN'
+            : 'SERVING_RATE_LOW',
+      latestAlert:
+        latestServingRateAlert === null ||
+        latestServingRateAlertAgeMs > 15 * 60_000
+          ? null
+          : {
+              alertRef: latestServingRateAlert.alert_ref,
+              classification: latestServingRateAlert.classification,
+              detectedAt: latestServingRateAlert.detected_at,
+              reasonRef: latestServingRateAlert.reason_ref,
+            },
+      sourceRefs: ['d1:fleet_alerts', 'd1:token_usage_events'],
     },
     glm: {
       status: glmTotal === 0 ? 'unknown' : glmReady === glmTotal ? 'ready' : 'degraded',


### PR DESCRIPTION
Closes #6824.

## Summary
- Adds a Cloudflare Worker scheduled serving-rate monitor that checks aggregate tokens/hour and GLM heartbeat freshness every 5 minutes.
- Writes public-safe alert rows for `serving_rate_low` and `glm_down` into the existing D1 alert sink and emits structured Worker logs.
- Surfaces the latest serving-rate monitor state on the existing operator fleet status endpoint without changing serving, payment, or dispatch authority.

## Verification
- `bun run --cwd apps/openagents.com/workers/api test -- src/inference/serving-rate-monitor.test.ts src/operator-fleet-status-routes.test.ts`
- `true` (`command.public.pylon_khala.verify.b5bea41b6c623f7c09f1bf24`)
- `bun run --cwd apps/openagents.com/workers/api typecheck` exited 0; emitted pre-existing Effect lint messages in unrelated files.
