### PR TITLE
fix(khala-desktop): accept Apple FM bridge port flag

### DIFF
--- a/apps/pylon/swift/foundation-bridge/Sources/foundation-bridge/main.swift
+++ b/apps/pylon/swift/foundation-bridge/Sources/foundation-bridge/main.swift
@@ -11,7 +11,7 @@ private let maxRequestBytes = 1_048_576
 @main
 enum FoundationBridge {
     static func main() async throws {
-        let port = parsePort(CommandLine.arguments.dropFirst().first)
+        let port = parsePort(CommandLine.arguments.dropFirst())
         let handler = AppleFmHandler()
         let server = try HttpServer(port: port, handler: handler)
         server.start()
@@ -19,11 +19,19 @@ enum FoundationBridge {
         dispatchMain()
     }
 
-    private static func parsePort(_ value: String?) -> UInt16 {
-        guard let value, let port = UInt16(value) else {
-            return defaultPort
+    private static func parsePort(_ arguments: ArraySlice<String>) -> UInt16 {
+        if let portFlagIndex = arguments.firstIndex(of: "--port") {
+            let nextIndex = arguments.index(after: portFlagIndex)
+            if nextIndex < arguments.endIndex, let port = UInt16(arguments[nextIndex]) {
+                return port
+            }
         }
-        return port
+
+        if let first = arguments.first, let port = UInt16(first) {
+            return port
+        }
+
+        return defaultPort
     }
 }
 


### PR DESCRIPTION
## Summary
- update the Swift Foundation Models bridge to accept the supervised desktop launcher's `--port <port>` argument shape
- preserve the existing positional port argument for source/manual runs

Closes #6973

## Verification
- `bun test clients/khala-desktop/tests/apple-fm-packaging.test.ts clients/khala-desktop/tests/apple-fm-readiness.test.ts clients/khala-desktop/tests/apple-fm-sidecar.test.ts`
- `bun test apps/pylon/tests/apple-fm-bridge-launcher.test.ts apps/pylon/tests/apple-fm-bridge-helper.test.ts apps/pylon/tests/apple-fm-supervised-launch.test.ts`
- `swift build -c release --package-path apps/pylon/swift/foundation-bridge`
- live helper smoke: compiled `foundation-bridge --port 11439` responded on `/health`
- `bun run --cwd apps/openagents.com check:deploy`

Note: I could not recover a local resolver for `command.public.pylon_khala.verify.b5bea41b6c623f7c09f1bf24`; the full issue-listed deploy gate above was run after focused verification.
