### PR TITLE
fix(triage): skip already prioritized issues

### DIFF
--- a/scripts/github-issue-triage.test.ts
+++ b/scripts/github-issue-triage.test.ts
@@ -8,6 +8,7 @@ import {
   issueHasAnyLabel,
   issueHasPriorityLabel,
   renderTriageComment,
+  shouldTriageIssue,
   tokenizeIssueText,
   triageIssue,
   type GitHubIssue,
@@ -124,6 +125,13 @@ describe("github issue triage output", () => {
   test("builds the default candidate query from newly opened unlabeled issues", () => {
     expect(buildCandidateIssueSearch(false)).toBe("is:issue is:open no:label sort:created-desc")
     expect(buildCandidateIssueSearch(true)).toBe("is:issue is:open sort:created-desc")
+  })
+
+  test("selects only unlabeled issues by default and only unprioritized issues when labeled issues are included", () => {
+    expect(shouldTriageIssue(issue({ labels: [] }), false)).toBe(true)
+    expect(shouldTriageIssue(issue({ labels: [{ name: "bug" }] }), false)).toBe(false)
+    expect(shouldTriageIssue(issue({ labels: [{ name: "bug" }] }), true)).toBe(true)
+    expect(shouldTriageIssue(issue({ labels: [{ name: "prio:0-pr-burndown" }] }), true)).toBe(false)
   })
 
   test("builds a scoped execution plan and rendered comment", () => {

--- a/scripts/github-issue-triage.ts
+++ b/scripts/github-issue-triage.ts
@@ -313,6 +313,9 @@ export const listRepositoryFiles = (cwd: string): ReadonlyArray<string> => {
 export const buildCandidateIssueSearch = (includeLabeled: boolean): string =>
   includeLabeled ? "is:issue is:open sort:created-desc" : "is:issue is:open no:label sort:created-desc"
 
+export const shouldTriageIssue = (issue: GitHubIssue, includeLabeled: boolean): boolean =>
+  includeLabeled ? !issueHasPriorityLabel(issue) : !issueHasAnyLabel(issue)
+
 const listCandidateIssues = (
   repo: string,
   limit: number,
@@ -377,8 +380,8 @@ const parseArgs = (
 const main = () => {
   const options = parseArgs(Bun.argv.slice(2))
   const repositoryFiles = listRepositoryFiles(process.cwd())
-  const candidates = listCandidateIssues(options.repo, options.limit, options.includeLabeled).filter(
-    issue => options.includeLabeled || !issueHasAnyLabel(issue),
+  const candidates = listCandidateIssues(options.repo, options.limit, options.includeLabeled).filter(issue =>
+    shouldTriageIssue(issue, options.includeLabeled),
   )
   const openIssues = listOpenIssues(options.repo, Math.max(options.limit, 100))
   const decisions = candidates.map(issue =>


### PR DESCRIPTION
## Summary

- add a shared `shouldTriageIssue` predicate for the standing GitHub issue triage loop
- keep default behavior scoped to unlabeled issues
- when `--include-labeled` is used, include labeled issues only if they do not already have a `prio:*` label, avoiding repeated churn on already-prioritized backlog items

Closes #6708.

## Verification

- `bun test scripts/github-issue-triage.test.ts` (11 pass)
- `bun run test:github-issue-triage` (11 pass)

Note: the requested opaque verification ref `command.public.pylon_khala.verify.b5bea41b6c623f7c09f1bf24` was not materialized in this checkout or environment; the focused triage verifier maps locally to `command.public.pylon_khala.verify.56c2b2efff8b8bdbcc3488d2`.