### PR TITLE
Fix MirrorCode backstop public ref skipping

### DIFF
--- a/apps/openagents.com/workers/api/src/inference/gym/mirrorcode-backstop-burn.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/gym/mirrorcode-backstop-burn.test.ts
@@ -56,6 +56,20 @@ describe('MirrorCode standing backstop burn', () => {
     ])
   })
 
+  test('skips completed and active public task refs before filling the next batch', () => {
+    const plan = buildMirrorCodeBackstopBatchPlan({
+      maxTasks: 3,
+      completedTaskRefs: ['task.public.gym.mirrorcode.s.qsv-select.python'],
+      activeTaskRefs: ['task.public.gym.mirrorcode.s.jq-simple.python'],
+    })
+
+    expect(plan.tasks.map(task => task.taskId)).toEqual([
+      'gron',
+      'bitwise',
+      'hexyl',
+    ])
+  })
+
   test('builds a ledger-ready report with pass rate and exact token evidence separated', () => {
     const passed = buildMirrorCodeRun({
       runId: 'mc-backstop-s-cal-python-0001',

--- a/apps/openagents.com/workers/api/src/inference/gym/mirrorcode-backstop-burn.ts
+++ b/apps/openagents.com/workers/api/src/inference/gym/mirrorcode-backstop-burn.ts
@@ -166,6 +166,9 @@ export const buildMirrorCodeBackstopBatchPlan = (
       candidate =>
         !skippedRefs.has(
           taskKey(candidate.bucket, candidate.taskId, candidate.language),
+        ) &&
+        !skippedRefs.has(
+          taskRefFor(candidate.bucket, candidate.taskId, candidate.language),
         ),
     )
     .slice(0, boundedBatchSize(input.maxTasks))


### PR DESCRIPTION
## Summary
- Fix the #6923 MirrorCode backstop batch planner to skip already completed or active public task refs, not only legacy internal task keys.
- Add a regression test covering public `task.public.gym.mirrorcode...` refs so the standing backstop loop does not re-plan active ledger tasks.

Refs #6923

## Verification
- `true` (`command.public.pylon_khala.verify.b5bea41b6c623f7c09f1bf24`)
- `python3 apps/openagents.com/scripts/mirrorcode/backstop_eval_test.py`
- `bun run --cwd apps/openagents.com/workers/api test -- src/inference/gym/mirrorcode-backstop-burn.test.ts`
- `bun run --cwd apps/openagents.com/workers/api typecheck` exited 0 with existing Effect diagnostic messages.
