### PR TITLE
fix(pylon): surface codex execution refusal reasons

### DIFF
--- a/apps/pylon/src/codex-agent-executor.ts
+++ b/apps/pylon/src/codex-agent-executor.ts
@@ -124,12 +124,21 @@ export type CodexAgentRunOutcome =
   | "workspace_escape_blocked"
   | "refused"
 
+export type CodexAgentExecutionRefusalReason =
+  | "credentials_revoked"
+  | "usage_limited"
+  | "rate_limited"
+  | "network"
+  | "timeout"
+  | "other"
+
 export type CodexAgentRunResult = {
   outcome: CodexAgentRunOutcome
   turnCount: number
   editedFileCount: number
   commandCount: number
   sessionRef: string | null
+  executionRefusalReason?: CodexAgentExecutionRefusalReason
 }
 
 export type CodexAgentRunner = (input: CodexAgentRunInput) => Promise<CodexAgentRunResult>
@@ -237,6 +246,59 @@ export function codexAgentTaskFrom(codingAssignment: unknown): CodexAgentTaskPay
 function boundedNumber(value: number | undefined, fallback: number, max: number): number {
   if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) return fallback
   return Math.min(Math.floor(value), max)
+}
+
+function errorTextFromUnknown(error: unknown): string {
+  if (error instanceof Error) {
+    const cause = error.cause === undefined ? "" : ` ${errorTextFromUnknown(error.cause)}`
+    return `${error.name} ${error.message}${cause}`
+  }
+  if (typeof error === "string") return error
+  if (error !== null && typeof error === "object") {
+    const record = error as { message?: unknown; stderr?: unknown; output?: unknown; status?: unknown; code?: unknown }
+    return [record.message, record.stderr, record.output, record.status, record.code]
+      .filter((value): value is string | number => typeof value === "string" || typeof value === "number")
+      .join(" ")
+  }
+  return ""
+}
+
+export function classifyCodexAgentExecutionRefusal(
+  error: unknown,
+): CodexAgentExecutionRefusalReason {
+  const text = errorTextFromUnknown(error).toLowerCase()
+  if (/revok/.test(text)) return "credentials_revoked"
+  if (/usage limit|usage cap|quota|billing limit|insufficient quota/.test(text)) return "usage_limited"
+  if (/rate limit|too many requests|\b429\b/.test(text)) return "rate_limited"
+  if (/timed? ?out|timeout|deadline|etimedout/.test(text)) return "timeout"
+  if (
+    /network|socket|websocket|wss:|dns|econn|enotfound|eai_again|fetch failed|connection|tls|certificate/.test(
+      text,
+    )
+  ) {
+    return "network"
+  }
+  return "other"
+}
+
+function executionRefusalCloseout(reason: CodexAgentExecutionRefusalReason) {
+  if (reason === "other") {
+    return {
+      blockerRefs: ["blocker.assignment.codex_agent_execution_refused"],
+      resultRef: "result.public.pylon.codex_agent_task.execution_refused",
+      summaryRef: "summary.public.pylon.codex_agent_task.execution_refused",
+      message: "Local Codex thread ended with an execution error before completing the task.",
+    }
+  }
+  return {
+    blockerRefs: [
+      "blocker.assignment.codex_agent_execution_refused",
+      `blocker.assignment.codex_agent_${reason}`,
+    ],
+    resultRef: `result.public.pylon.codex_agent_task.${reason}`,
+    summaryRef: `summary.public.pylon.codex_agent_task.${reason}`,
+    message: `Local Codex thread refused before completing the task (reason: ${reason}).`,
+  }
 }
 
 /**
@@ -861,6 +923,7 @@ export async function runWithCodexSdk(input: CodexAgentRunInput): Promise<CodexA
   let pendingRawEvents: Array<RawCodexThreadEvent> = []
   let pendingChunkItems: Array<CodexTurnReportItem> = []
   let pendingChunkRawEvents: Array<RawCodexThreadEvent> = []
+  let refusalReason: CodexAgentExecutionRefusalReason | undefined
 
   const flushEventChunk = async (turnIndex: number) => {
     if (pendingChunkRawEvents.length === 0) return
@@ -949,7 +1012,12 @@ export async function runWithCodexSdk(input: CodexAgentRunInput): Promise<CodexA
         pendingChunkRawEvents = []
         activeTurnIndex = 0
       }
-      if (event.type === "turn.failed" || event.type === "error") failed = true
+      if (event.type === "turn.failed" || event.type === "error") {
+        failed = true
+        if (event.error?.message !== undefined) {
+          refusalReason = classifyCodexAgentExecutionRefusal(event.error.message)
+        }
+      }
       if (event.type === "item.completed" && event.item?.type === "command_execution") {
         commandCount += 1
         await emitCodexProgress(input.onProgress, {
@@ -1001,7 +1069,14 @@ export async function runWithCodexSdk(input: CodexAgentRunInput): Promise<CodexA
     return { outcome: "budget_exceeded", turnCount, editedFileCount, commandCount, sessionRef }
   }
   if (failed) {
-    return { outcome: "refused", turnCount, editedFileCount, commandCount, sessionRef }
+    return {
+      outcome: "refused",
+      turnCount,
+      editedFileCount,
+      commandCount,
+      sessionRef,
+      ...(refusalReason === undefined ? {} : { executionRefusalReason: refusalReason }),
+    }
   }
   return { outcome: "completed", turnCount, editedFileCount, commandCount, sessionRef }
 }
@@ -1291,15 +1366,13 @@ export async function executeCodexAgentAssignment(
       ...(options.onProgress === undefined ? {} : { onProgress: options.onProgress }),
       workspaceRef: materialized.workspaceRef,
     })
-  } catch {
+  } catch (error) {
+    const refusal = executionRefusalCloseout(classifyCodexAgentExecutionRefusal(error))
     await releaseCodexAgentWorkspace({ materialized, now })
     return refusalRecord({
       lease,
       runRef,
-      blockerRefs: ["blocker.assignment.codex_agent_execution_refused"],
-      resultRef: "result.public.pylon.codex_agent_task.execution_refused",
-      summaryRef: "summary.public.pylon.codex_agent_task.execution_refused",
-      message: "Local Codex thread refused with a typed execution error.",
+      ...refusal,
     })
   }
 
@@ -1325,14 +1398,12 @@ export async function executeCodexAgentAssignment(
     })
   }
   if (run.outcome === "refused") {
+    const refusal = executionRefusalCloseout(run.executionRefusalReason ?? "other")
     await releaseCodexAgentWorkspace({ materialized, now })
     return refusalRecord({
       lease,
       runRef,
-      blockerRefs: ["blocker.assignment.codex_agent_execution_refused"],
-      resultRef: "result.public.pylon.codex_agent_task.execution_refused",
-      summaryRef: "summary.public.pylon.codex_agent_task.execution_refused",
-      message: "Local Codex thread ended with an execution error before completing the task.",
+      ...refusal,
     })
   }
 

--- a/apps/pylon/src/codex-agent-executor.ts
+++ b/apps/pylon/src/codex-agent-executor.ts
@@ -687,6 +687,7 @@ export async function prepareWorkspaceDependencies(input: {
 type CodexThreadEvent = {
   type?: string
   thread_id?: string
+  message?: string
   usage?: {
     input_tokens?: number
     cached_input_tokens?: number
@@ -1014,8 +1015,9 @@ export async function runWithCodexSdk(input: CodexAgentRunInput): Promise<CodexA
       }
       if (event.type === "turn.failed" || event.type === "error") {
         failed = true
-        if (event.error?.message !== undefined) {
-          refusalReason = classifyCodexAgentExecutionRefusal(event.error.message)
+        const errorMessage = event.error?.message ?? event.message
+        if (errorMessage !== undefined) {
+          refusalReason = classifyCodexAgentExecutionRefusal(errorMessage)
         }
       }
       if (event.type === "item.completed" && event.item?.type === "command_execution") {

--- a/apps/pylon/tests/codex-agent-executor.test.ts
+++ b/apps/pylon/tests/codex-agent-executor.test.ts
@@ -6,6 +6,7 @@ import { tmpdir } from "node:os"
 import {
   CODEX_AGENT_SUM_REPAIR_FIXTURE_REF,
   CODEX_AGENT_TASK_SCHEMA,
+  classifyCodexAgentExecutionRefusal,
   codexAgentTaskFrom,
   effectiveSandboxMode,
   executeCodexAgentAssignment,
@@ -90,6 +91,21 @@ async function withState<T>(fn: (state: Awaited<ReturnType<typeof ensurePylonLoc
 }
 
 describe("codex agent task recognition", () => {
+  test("classifies Codex account execution refusals without exposing raw messages", () => {
+    expect(
+      classifyCodexAgentExecutionRefusal(
+        new Error(
+          "Your access token could not be refreshed because your refresh token was revoked. Please log out and sign in again.",
+        ),
+      ),
+    ).toBe("credentials_revoked")
+    expect(classifyCodexAgentExecutionRefusal("usage limit reached for this account")).toBe("usage_limited")
+    expect(classifyCodexAgentExecutionRefusal("429 too many requests")).toBe("rate_limited")
+    expect(classifyCodexAgentExecutionRefusal("WebSocket connection failed")).toBe("network")
+    expect(classifyCodexAgentExecutionRefusal("operation timed out")).toBe("timeout")
+    expect(classifyCodexAgentExecutionRefusal("sdk exploded")).toBe("other")
+  })
+
   test("recognizes the typed work class and passes everything else through", async () => {
     expect(codexAgentTaskFrom(codexAgentCodingAssignment)).not.toBeNull()
     expect(codexAgentTaskFrom({ kind: "job.public.tassadar_executor_trace", tassadar: {} })).toBeNull()
@@ -208,6 +224,48 @@ describe("codex agent task recognition", () => {
       })
       expect(record?.status).toBe("rejected")
       expect(record?.blockerRefs).toEqual(["blocker.assignment.codex_agent_execution_refused"])
+    })
+  })
+
+  test("surfaces specific Codex auth and usage refusal blockers from runner errors", async () => {
+    await withState(async (state) => {
+      const revokedRunner: CodexAgentRunner = async () => {
+        throw new Error(
+          "Your access token could not be refreshed because your refresh token was revoked. Please log out and sign in again.",
+        )
+      }
+      const revoked = await executeCodexAgentAssignment(state, lease, now, {
+        codexAgentRunner: revokedRunner,
+        codexAgentProbe: readyProbe,
+      })
+      expect(revoked?.status).toBe("rejected")
+      expect(revoked?.blockerRefs).toEqual([
+        "blocker.assignment.codex_agent_execution_refused",
+        "blocker.assignment.codex_agent_credentials_revoked",
+      ])
+      expect(revoked?.resultRefs).toContain("result.public.pylon.codex_agent_task.credentials_revoked")
+      expect(JSON.stringify(revoked)).not.toContain("refresh token was revoked")
+      assertPublicProjectionSafe(revoked)
+
+      const usageLimited: CodexAgentRunner = async () => ({
+        outcome: "refused",
+        executionRefusalReason: "usage_limited",
+        turnCount: 1,
+        editedFileCount: 0,
+        commandCount: 0,
+        sessionRef: null,
+      })
+      const usage = await executeCodexAgentAssignment(state, lease, now, {
+        codexAgentRunner: usageLimited,
+        codexAgentProbe: readyProbe,
+      })
+      expect(usage?.status).toBe("rejected")
+      expect(usage?.blockerRefs).toEqual([
+        "blocker.assignment.codex_agent_execution_refused",
+        "blocker.assignment.codex_agent_usage_limited",
+      ])
+      expect(usage?.resultRefs).toContain("result.public.pylon.codex_agent_task.usage_limited")
+      assertPublicProjectionSafe(usage)
     })
   })
 

--- a/apps/pylon/tests/codex-agent-executor.test.ts
+++ b/apps/pylon/tests/codex-agent-executor.test.ts
@@ -422,6 +422,48 @@ describe("codex agent task recognition", () => {
     })
   })
 
+  test("classifies SDK stream error events with top-level messages", async () => {
+    mock.module(CODEX_AGENT_SDK_PACKAGE, () => ({
+      Codex: class {
+        startThread() {
+          return {
+            runStreamed: async () => ({
+              events: (async function* () {
+                yield { type: "thread.started", thread_id: "thread-codex-stream-error" }
+                yield { type: "turn.started" }
+                yield {
+                  type: "error",
+                  message:
+                    "Codex stream error: You've hit your usage limit. Visit settings to purchase more credits.",
+                }
+              })(),
+            }),
+          }
+        }
+      },
+    }))
+
+    const result = await runWithCodexSdk({
+      assignmentRef: "assignment.public.codex_agent.stream_error",
+      cwd: "/tmp",
+      instructions: "Run a mocked Codex turn.",
+      leaseRef: "lease.public.codex_agent.stream_error",
+      networkAccessEnabled: true,
+      pylonRef: "pylon.public.codex_agent.stream_error",
+      runRef: "run.public.codex_agent.stream_error",
+      sandboxMode: "danger-full-access",
+      timeoutMs: 1_000,
+      workspaceRef: "workspace.public.codex_agent.stream_error",
+    })
+
+    expect(result).toMatchObject({
+      executionRefusalReason: "usage_limited",
+      outcome: "refused",
+      sessionRef: expect.stringMatching(/^session\.pylon\.codex_agent\./),
+      turnCount: 0,
+    })
+  })
+
   test("SDK turn reporter failures do not fail the local Codex task", async () => {
     const reports: Array<unknown> = []
     mock.module(CODEX_AGENT_SDK_PACKAGE, () => ({


### PR DESCRIPTION
Closes #6902.

### Changes
- Classify Codex execution refusals into public-safe reasons: credentials_revoked, usage_limited, rate_limited, network, timeout, and other.
- Carry classified refusal reasons from SDK error events and thrown runner errors into closeout blocker/result/summary refs without exposing raw Codex error text.
- Add focused regression coverage for revoked-token and usage-limited refusals.

### Verification
- bun run --cwd apps/pylon test -- tests/codex-agent-executor.test.ts
- bun run --cwd apps/pylon typecheck

Note: the task requested verification ref command.public.pylon_khala.verify.b5bea41b6c623f7c09f1bf24, but the recreated local lease metadata retained only the command ref, not its argv. The focused Pylon executor test and typecheck above were run in this checkout.