### PR TITLE
docs(fanout): align marketplace work-class claims

### DIFF
--- a/apps/openagents.com/INVARIANTS.md
+++ b/apps/openagents.com/INVARIANTS.md
@@ -2460,25 +2460,24 @@ check:architecture` inside `check:deploy`) discovers `/api/public/...`
     (`generatedAt`, `live_at_read` contract). The surface is flag-gated
     (`SELF_SERVE_FANOUT_ENABLED`, default off => empty store) and the payload
     always reports `inert: true` / `promiseState: 'yellow'` / `selfServe: true`
-    / `workClass: 'code_task'`, surfacing the cleared self-serve blocker and the
-    still-uncleared plugin-marketplace blocker. It models a customer-initiated
-    single-action fanout plan (the lane-C gate decision plus the linked market
-    work-request the fanout would list) over the existing server-side lane-C
-    gate. The dispatch seam (`dispatchSelfServeFanout`) is flag-gated INERT and
-    is unreachable from this read-only route; the surface lists nothing on the
-    market and moves no money.
+    / default `workClass: 'code_task'`, while stored plans may carry any live
+    catalog work class, including `data_labeling`. It models a
+    customer-initiated single-action fanout plan (the lane-C gate decision plus
+    the linked market work-request the fanout would list) over the existing
+    server-side lane-C gate. The dispatch seam (`dispatchSelfServeFanout`) is
+    flag-gated INERT and is unreachable from this read-only route; the surface
+    lists nothing on the market and moves no money.
   - `GET /api/public/autopilot/marketplace-work-classes` — live at read over the
     in-module marketplace work-class catalog (promise
     `autopilot.control_center_fanout_marketplace.v1`, yellow) — compliant
     (`generatedAt`, `live_at_read` contract). Read-only registry view: it lists
-    every registered work class with its `status`, names the single live class
-    (`code_task`), and always reports `pluginMarketplaceBeyondCodeTaskLive: false`
-    with the still-uncleared plugin-marketplace-beyond-code_task blocker in
-    `unclearedBlockerRefs`. Optional `?workClass=` narrows to one class. No flag
-    and no store: `assertCatalogInvariants` (inside the projection) throws rather
-    than let any plugin class silently flip live, so the surface can never
-    over-claim a live plugin marketplace; it lists nothing executable and moves no
-    money.
+    every registered work class with its `status`, names the live classes
+    (`code_task` and `data_labeling`), and reports
+    `pluginMarketplaceBeyondCodeTaskLive: true` without flipping the yellow
+    promise green. Optional `?workClass=` narrows to one class. No flag and no
+    store: `assertCatalogInvariants` (inside the projection) throws rather than
+    let non-code support regress silently, while the route itself dispatches
+    nothing, opens no escrow, and moves no money.
   - `GET /api/public/markets/signature-monetization/metering` — live at read
     over the INERT signature usage-metering store (promise
     `marketplace.signature_monetization.v1`, red) — compliant (`generatedAt`,

--- a/apps/openagents.com/scripts/check-zero-debt-architecture.mjs
+++ b/apps/openagents.com/scripts/check-zero-debt-architecture.mjs
@@ -323,11 +323,12 @@ const budgetChecks = [
     // +1 (93 -> 94) for the marketplace work-class catalog surface
     // (marketplace-work-class-catalog-routes.ts,
     // autopilot.control_center_fanout_marketplace.v1, yellow): a read-only
-    // registry projection of the listable marketplace work classes that always
-    // reports the still-uncleared plugin-marketplace-beyond-code_task blocker and
-    // clears nothing. It returns `Effect.Effect<Response>` like the sibling
-    // public read handlers. Ratchet back down when these public-projection
-    // handlers are extracted behind shared route mappers.
+    // registry projection of the listable marketplace work classes, including
+    // the first live non-code plugin class. It remains a yellow read-only
+    // contract view with no dispatch side effects, and returns
+    // `Effect.Effect<Response>` like the sibling public read handlers. Ratchet
+    // back down when these public-projection handlers are extracted behind shared
+    // route mappers.
     // +1 (94 -> 95) for the OpenAI-compatible single-model retrieve dispatcher
     // (inference/models-routes.ts, inference.gateway_credits_business.v1, red):
     // routeModelRetrieveRequest dispatches the path-param GET /v1/models/{model}

--- a/apps/openagents.com/workers/api/src/config.ts
+++ b/apps/openagents.com/workers/api/src/config.ts
@@ -29,11 +29,10 @@ export type OpenAgentsWorkerConfigEnv = Readonly<{
   // store) and the dispatch seam (dispatchSelfServeFanout) lists nothing. Set
   // "true"/"1"/"on" to arm the (still yellow/inert) surface. The plan makes no
   // broad-live-marketplace claim and the promise stays yellow regardless; the
-  // capability clears only blocker.product_promises.self_serve_fanout_missing
-  // (a customer-initiated single-action fanout planner/route exists), while
-  // blocker.product_promises.plugin_marketplace_beyond_code_task_missing stays
-  // uncleared (code_task work class only). A green flip stays receipt-first and
-  // owner-signed with a dereferenceable settlement receipt.
+  // capability clears blocker.product_promises.self_serve_fanout_missing and
+  // can carry live catalog work classes beyond code_task, but the dispatch seam
+  // stays inert until armed. A green flip still requires receipt-first
+  // owner-signed settlement evidence from an armed self-serve fanout.
   SELF_SERVE_FANOUT_ENABLED?: string | undefined
   // Labor self-serve earning payout flag (promise
   // provider.compliant_usage_labor.v1, yellow). Default OFF: the

--- a/apps/openagents.com/workers/api/src/index.ts
+++ b/apps/openagents.com/workers/api/src/index.ts
@@ -10887,12 +10887,13 @@ const exactRouteRegistry = makeExactRouteRegistry<Env>([
     // Self-serve control-center fanout scaffold (promise
     // autopilot.control_center_fanout_marketplace.v1, yellow). INERT: the store
     // is empty unless SELF_SERVE_FANOUT_ENABLED is armed, and the response
-    // always reports inert/yellow/selfServe with workClass code_task. It models
-    // a customer-initiated single-action fanout plan (gate decision + the linked
-    // market work-request the fanout would list) over the existing lane-C gate;
-    // the dispatch seam (dispatchSelfServeFanout) lists nothing. It clears only
-    // the self-serve blocker (the plugin-marketplace-beyond-code_task blocker
-    // stays uncleared) and makes no broad-live-marketplace claim. Read-only.
+    // always reports inert/yellow/selfServe with the default workClass code_task
+    // plus any stored plans' typed work classes. It models a customer-initiated
+    // single-action fanout plan (gate decision + the linked market work-request
+    // the fanout would list) over the existing lane-C gate; the dispatch seam
+    // (dispatchSelfServeFanout) lists nothing unless explicitly armed. It clears
+    // the self-serve blocker and can carry live catalog work classes beyond
+    // code_task, but still makes no green/broad-marketplace claim. Read-only.
     path: SelfServeFanoutEndpoint,
     handler: (request, env) =>
       handleSelfServeFanoutApi(request, {
@@ -10902,11 +10903,11 @@ const exactRouteRegistry = makeExactRouteRegistry<Env>([
   {
     // Marketplace work-class catalog (promise
     // autopilot.control_center_fanout_marketplace.v1, yellow). Read-only registry
-    // view: it lists every registered work class with its status, names the single
-    // live class (code_task), and always reports the still-uncleared
-    // plugin-marketplace-beyond-code_task blocker. No flag, no store, nothing
-    // executable — the projection's assertCatalogInvariants throws rather than let
-    // any plugin class silently flip live. Makes no broad-live-marketplace claim.
+    // view: it lists every registered work class with its status and names the
+    // live classes, including the first non-code plugin class (data_labeling).
+    // No flag, no store, and no dispatch side effect: the projection's
+    // assertCatalogInvariants throws rather than let non-code support regress
+    // silently. Makes no green/broad-live-marketplace claim.
     path: MarketplaceWorkClassCatalogEndpoint,
     handler: request => handleMarketplaceWorkClassCatalogApi(request),
   },

--- a/apps/openagents.com/workers/api/src/marketplace-work-class-catalog-routes.ts
+++ b/apps/openagents.com/workers/api/src/marketplace-work-class-catalog-routes.ts
@@ -2,13 +2,13 @@
 // (promise autopilot.control_center_fanout_marketplace.v1, yellow).
 //
 // HONESTY / SCOPE: this route exposes the catalog projection unchanged. It is
-// ALWAYS honest: `inert: true`, `promiseState: 'yellow'`, the single live work
-// class (`code_task`), and the still-uncleared plugin-marketplace-beyond-code_task
-// blocker. There is NO flag and NO store to arm here because the catalog makes no
-// live claim of its own — `code_task` is the only live class and
-// `assertCatalogInvariants` (called inside the projection) throws rather than let
-// any plugin class silently flip live. This route lists nothing executable; it is
-// purely a read-only registry view. Read-only (GET only).
+// ALWAYS honest: `promiseState: 'yellow'`, the live work classes (`code_task`
+// plus the first non-code plugin class, `data_labeling`), and no green promise
+// flip. There is NO flag and NO store to arm here because the catalog is a
+// read-only contract view; `assertCatalogInvariants` (called inside the
+// projection) throws rather than let the non-code support regress silently. This
+// route dispatches nothing, opens no escrow, and moves no money. Read-only (GET
+// only).
 
 import { Effect } from 'effect'
 

--- a/docs/launch/vertex-fleet/autopilot.control_center_fanout_marketplace.v1.md
+++ b/docs/launch/vertex-fleet/autopilot.control_center_fanout_marketplace.v1.md
@@ -21,36 +21,38 @@ from the code whether a class like `data_labeling` was real or aspirational.
 - `MarketplaceWorkClassDefinition` — the typed contract a plugin work class must
   satisfy to be listable: `requiredCapabilityRefs`, `verificationCommandRef`,
   `settlementStream`, and an explicit `status` (`live` | `inert_scaffold`).
-- `MARKETPLACE_WORK_CLASS_CATALOG` — the catalog. `code_task` is the **only**
-  `live` class (the class #4783 settled under); `data_labeling`,
-  `content_writing`, and `research_brief` are registered `inert_scaffold`
-  entries — contracts only, nothing wired, no money moves.
+- `MARKETPLACE_WORK_CLASS_CATALOG` — the catalog. `code_task` is the first
+  `live` class (the class #4783 settled under); `data_labeling` is the first
+  `live` non-code plugin class; `content_writing` and `research_brief` remain
+  registered `inert_scaffold` entries.
 - `assertCatalogInvariants` — enforces honesty **in code**: ids are unique,
-  `code_task` is present and live, and **no class beyond `code_task` may be
-  `live`**. A misedit that flips a plugin class to live throws rather than
-  silently over-claiming.
-- `isPluginMarketplaceBeyondCodeTaskLive` — the single predicate a future
-  green flip must make true; today it is always `false`.
+  `code_task` is present and live, and at least one class beyond `code_task` is
+  live. A misedit that removes non-code support throws rather than silently
+  regressing the promise evidence.
+- `isPluginMarketplaceBeyondCodeTaskLive` — the predicate proving that the
+  planner/catalog has live support beyond code tasks; green still requires
+  armed self-serve settlement evidence.
 - `projectMarketplaceWorkClassCatalog` — a public-safe projection (yellow,
-  inert, `live_at_read`) that reports the still-uncleared plugin blocker.
+  read-only, `live_at_read`) that reports the live work classes without flipping
+  the promise green.
 
 ## Honesty / blocker status
 
-- **Cleared:** none. This change clears no blocker.
-- **Stays:** `blocker.product_promises.plugin_marketplace_beyond_code_task_missing`
-  — only `code_task` is live; every plugin class beyond it is an inert scaffold.
-  The catalog enforces this invariant and reports the blocker on every
-  projection. The promise STAYS yellow.
+- **Advanced:** `blocker.product_promises.plugin_marketplace_beyond_code_task_missing`
+  — the catalog and planner now carry the first live non-code work class,
+  `data_labeling`, with a capability ref and validator command.
+- **Stays yellow:** the route is read-only and the self-serve dispatch seam
+  remains inert until armed. Green still requires receipt-first owner-signed
+  settlement evidence against an armed self-serve fanout.
 
 This is the **registry seam** a future owner-armed, receipt-first change would
 flip a class to `live` against (per `proof.claim_upgrade_receipts.v1`).
 
 ## What genuinely remains for green
 
-1. At least one work class **beyond `code_task`** wired end to end: a provider
-   advertising its capability, a validator re-running its verification command,
-   and escrow settling on its stream — i.e.
-   `isPluginMarketplaceBeyondCodeTaskLive()` becomes `true`.
+1. An armed self-serve run for a non-code work class with a provider advertising
+   its capability, a validator re-running its verification command, and escrow
+   settling on its stream.
 2. An owner-signed, receipt-first upgrade recording the live plugin class plus a
    settled fanout against an armed self-serve run.
 
@@ -59,12 +61,12 @@ flip a class to `live` against (per `proof.claim_upgrade_receipts.v1`).
 - `workers/api/src/marketplace-work-class-catalog.ts` — catalog + contract +
   invariants + projection
 - `workers/api/src/marketplace-work-class-catalog.test.ts` — 9 tests
-  (live/inert split, invariant rejection of an over-claiming live class,
+  (live/inert split, invariant rejection of missing non-code support,
   duplicate/missing-live rejection, honest projection)
 - `workers/api/src/marketplace-work-class-catalog-routes.ts` — public read-only
   route `GET /api/public/autopilot/marketplace-work-classes` exposing the catalog
   projection (optional `?workClass=` narrows to one class). No flag/store; honest
-  envelope (yellow/inert, plugin blocker uncleared) on every response.
+  yellow/read-only envelope on every response.
 - `workers/api/src/marketplace-work-class-catalog-routes.test.ts` — 4 route tests
   (non-GET 405, honest listing, `?workClass=` narrowing, unknown-id → null)
 - Wired into `workers/api/src/index.ts` route table (read-only, no env).
@@ -74,6 +76,6 @@ flip a class to `live` against (per `proof.claim_upgrade_receipts.v1`).
 The catalog projection previously had no public surface; a reviewer could only
 see it via unit tests. This change exposes it at
 `GET /api/public/autopilot/marketplace-work-classes` (read-only, alongside
-`/api/public/autopilot/self-serve-fanout`). The blocker still STAYS uncleared —
-the route reports `pluginMarketplaceBeyondCodeTaskLive: false` and lists the
-plugin classes as `inert_scaffold` on every response.
+`/api/public/autopilot/self-serve-fanout`). The route now reports
+`pluginMarketplaceBeyondCodeTaskLive: true`, lists `data_labeling` as live, and
+keeps the promise yellow pending armed settlement evidence.


### PR DESCRIPTION
## Summary
- Align public fanout/catalog comments and invariant text with the current #6893 implementation: `data_labeling` is the first live non-code plugin work class while the promise remains yellow.
- Update the vertex-fleet promise note and zero-debt architecture budget comment so they no longer describe the marketplace catalog as code-task-only or blocker-uncleared.
- Keep the claim boundary receipt-first: read-only catalog route, inert self-serve dispatch until armed, no green flip or settlement claim.

Closes #6893.

## Verification
- PASS: `bun test apps/openagents.com/workers/api/src/marketplace-work-class-catalog.test.ts apps/openagents.com/workers/api/src/marketplace-work-class-catalog-routes.test.ts apps/openagents.com/workers/api/src/self-serve-fanout.test.ts apps/openagents.com/workers/api/src/autopilot-work-routes.test.ts apps/openagents.com/workers/api/src/product-promises.test.ts` (90 pass)
- PASS: `git diff --check`
- ATTEMPTED: `bun run --cwd apps/openagents.com check:deploy` (required by issue verification). It progressed through architecture, contract-drift, projection-freshness, Pylon typecheck, Pylon security harness, and web typecheck, then failed in existing Worker API typecheck diagnostics unrelated to this change:
  - `src/artanis-activity-routes.ts(594,5): effect(catchUnfailableEffect)`
  - `src/artanis-operator-tools.ts(569,9): effect(tryCatchInEffectGen)`
  - `src/artanis-public-report-routes.ts(139,9): effect(effectSucceedWithVoid)`
  - `src/pylon-api-routes.ts(336,12): effect(effectSucceedWithVoid)`

Note: the assignment named verification ref `command.public.pylon_khala.verify.b5bea41b6c623f7c09f1bf24`, but no local metadata mapping for that hash was present in the bounded checkout. The issue body's explicit verifier is `bun run --cwd apps/openagents.com check:deploy`, which is the command attempted above.
