### PR TITLE
docs(artanis): close RLM composition architecture audit

### DIFF
--- a/docs/artanis/2026-06-28-artanis-rlm-composition-architecture.md
+++ b/docs/artanis/2026-06-28-artanis-rlm-composition-architecture.md
@@ -40,6 +40,54 @@ Each returned turn carries an `rlmTrace` with:
 - `compositionInstruction`
 - `used`
 
+## Implemented Closure Slice
+
+Issue #6654 is satisfied by the current operator path at the reasoning layer:
+
+- Long-form owner turns are detected by `shouldUseArtanisRlmComposition`.
+- The operator asks Khala for a typed decomposition instead of answering the
+  owner directly.
+- Each subquery is executed as its own `openagents/khala` request.
+- The final owner answer is composed from the returned evidence packets.
+- The returned `rlmTrace` records the program ref, Blueprint signature ref,
+  decomposition, evidence packets, served model ids, and composition
+  instruction.
+- The #6651 continue-on-length loop still wraps planner, subquery, and
+  composition calls, so single-completion limits are a local fallback rather
+  than the architecture.
+
+The regression coverage is
+`apps/openagents.com/workers/api/src/artanis-operator.test.ts`, specifically the
+`#6654 Artanis RLM composition` tests. The focused verification command is:
+
+```sh
+bun run --cwd apps/openagents.com/workers/api test -- src/artanis-operator.test.ts
+```
+
+## FRLM Projection Primitives
+
+The broader federated conductor primitives already exist in
+`apps/pylon/src/frlm-conductor-execution.ts` and are covered by
+`apps/pylon/tests/frlm-conductor-execution.test.ts`.
+
+Those primitives model the historical FRLM conductor shape without granting new
+runtime authority:
+
+- `planFrlmConductorExecution` projects recursive fanout, linear fallback,
+  budget/depth blockers, evidence refs, and execution-plan refs.
+- `scheduleFrlmConductor` computes public-safe recursive batches and local
+  fallback steps from Pylon slot refs.
+- `composeFrlmRecursiveResponse` deterministically composes completed subquery
+  response segments.
+- `emitFrlmRlmStepTrace` emits public-safe RLM step traces with redacted content
+  and evidence refs.
+
+The operator implementation above is the owner-chat reasoning slice; the Pylon
+FRLM module is the projection/scheduling slice. A later integration can wire the
+two by persisting the operator `rlmTrace` as FRLM evidence rows and then letting
+the conductor schedule recursive Pylon/Codex fanout under its existing budget,
+slot, and fallback blockers.
+
 ## Blueprint Grounding
 
 This is intentionally aligned with `autonomous-ops-v1`:
@@ -61,3 +109,10 @@ behind the existing Artanis approval-gate and gated-tool boundaries.
 The #6651 continue-on-length loop remains in place for each individual planner,
 subquery, or composition completion. It is now the fallback inside a larger RLM
 run, not the primary architecture for long answers.
+
+The current owner-chat slice deliberately suppresses operator tools while
+running the RLM decomposition pass. That keeps this issue closed at the
+composition layer without accidentally widening authority. Tool-backed recursive
+execution should be promoted only after it carries explicit FRLM conductor rows,
+BudgetPolicy refs, Pylon slot refs, and approval-gate evidence for any
+state-changing action.

--- a/docs/artanis/README.md
+++ b/docs/artanis/README.md
@@ -65,6 +65,9 @@ Artanis acts only within explicit, bounded authority:
 - Full status: `2026-06-10-artanis-pylon-tassadar-full-status-audit.md`,
   `2026-06-10-artanis-production-tick-and-tassadar-evolution-audit.md`.
 - Implementation deep-dive: `2026-06-06-artanis-implementation-audit.md`.
+- RLM composition: `2026-06-28-artanis-rlm-composition-architecture.md`
+  covers the #6654 Artanis owner-chat RLM slice and the matching FRLM conductor
+  projection primitives.
 - Deploy readiness: `2026-06-07-artanis-deploy-readiness-full-audit.md`,
   `2026-06-06-production-launch-gate-runbook.md`.
 - Treasury / payouts: `treasury-runbook.md`, `tips-buffer-runbook.md`.


### PR DESCRIPTION
## Summary

- Records the implemented #6654 Artanis RLM owner-chat closure slice in the architecture doc.
- Connects the operator `rlmTrace` path to the existing Pylon FRLM conductor projection primitives.
- Adds the RLM architecture doc to the Artanis docs index and keeps the authority boundary explicit.

Closes #6654

## Verification

- `bun run --cwd apps/openagents.com/workers/api test -- src/artanis-operator.test.ts` (38 passed)
- `bun test apps/pylon/tests/frlm-conductor-execution.test.ts` (23 passed)
- `bun run --cwd apps/openagents.com/workers/api typecheck` (exit 0; emitted existing Effect language-service diagnostics)