### PR TITLE
Guard agent character creation promise copy

### DIFF
--- a/apps/openagents.com/workers/api/src/product-promises.test.ts
+++ b/apps/openagents.com/workers/api/src/product-promises.test.ts
@@ -431,6 +431,29 @@ describe('public product promises document', () => {
     expect(agenticNpmPromise?.safeCopy).toContain(
       'bounded source-level registry + install/use runtime core exists',
     )
+    const agentCharacterCreationPromise = decoded.promises.find(
+      promise =>
+        promise.promiseId === 'autopilot.agent_character_creation.v1',
+    )
+    expect(agentCharacterCreationPromise?.state).toBe('planned')
+    expect(agentCharacterCreationPromise?.evidenceRefs).toEqual(
+      expect.arrayContaining([
+        'https://github.com/OpenAgentsInc/openagents/issues/6861',
+        'promise:autopilot.agent_world_scene.v1',
+        'promise:labor.forum_work_requests.v1',
+      ]),
+    )
+    expect(agentCharacterCreationPromise?.blockerRefs).toEqual([
+      'blocker.product_promises.agent_character_creation_not_built',
+      'blocker.product_promises.agent_character_creation_auto_forum_intro_unproven',
+      'blocker.product_promises.agent_character_creation_auto_work_search_unproven',
+    ])
+    expect(agentCharacterCreationPromise?.safeCopy).toContain(
+      'It is not a shipped onboarding flow.',
+    )
+    expect(agentCharacterCreationPromise?.unsafeCopy).toContain(
+      'Do not say character-creation onboarding is live',
+    )
     const currentCopy = [
       decoded.currentMonorepoStatus.summary,
       ...decoded.currentMonorepoStatus.caveats,

--- a/apps/openagents.com/workers/api/src/product-promises.ts
+++ b/apps/openagents.com/workers/api/src/product-promises.ts
@@ -4100,6 +4100,7 @@ export const publicProductPromisesDocument = () => {
           'docs/launch/2026-06-20-agent-mmorpg-hud-autopilot-audit-and-plan.md',
           'https://github.com/OpenAgentsInc/openagents/issues/5730',
           'https://github.com/OpenAgentsInc/openagents/issues/5738',
+          'https://github.com/OpenAgentsInc/openagents/issues/6861',
           'promise:autopilot.agent_world_scene.v1',
           'promise:autopilot.desktop_gui_client.v1',
           'promise:labor.forum_work_requests.v1',


### PR DESCRIPTION
## Summary
- add issue #6861 as an explicit evidence/tracking ref for `autopilot.agent_character_creation.v1`
- add a product-promise regression guard that keeps the promise planned, preserves the three open blockers, and prevents live/onboarding over-claims before real receipts exist

## Verification
- `bun run --cwd apps/openagents.com/workers/api test -- src/product-promises.test.ts`
- `bun run --cwd apps/openagents.com check:deploy`

Closes #6861
