### PR TITLE
Add marketplace composition lifecycle scaffold

### DIFF
--- a/apps/openagents.com/workers/api/src/marketplace-product-composition.test.ts
+++ b/apps/openagents.com/workers/api/src/marketplace-product-composition.test.ts
@@ -142,6 +142,10 @@ describe('compose-and-list product definition model (#5515)', () => {
     const listed = selfServeListComposedProduct(definition, assembly, {
       listedAt: '2026-06-29T00:01:00.000Z',
     })
+    expect(listed.ok).toBe(true)
+    if (!listed.ok) {
+      throw new Error(`expected listed product: ${listed.error.reason}`)
+    }
     expect(listed.definition.listingState).toBe('listed')
     expect(listed.listingReceipt.selfServe).toBe(true)
     expect(listed.listingReceipt.builderAttribution).toEqual(
@@ -171,6 +175,10 @@ describe('compose-and-list product definition model (#5515)', () => {
     const definition = okDefinition()
     const assembly = assembleComposedProduct(definition)
     const listed = selfServeListComposedProduct(definition, assembly)
+    expect(listed.ok).toBe(true)
+    if (!listed.ok) {
+      throw new Error(`expected listed product: ${listed.error.reason}`)
+    }
 
     const lifecycle = recordComposedProductInstallUse(listed.listingReceipt, {
       buyerRef: ' ',
@@ -178,6 +186,21 @@ describe('compose-and-list product definition model (#5515)', () => {
     expect(lifecycle.ok).toBe(false)
     if (!lifecycle.ok) {
       expect(lifecycle.error.reason).toContain('buyerRef')
+    }
+  })
+
+  test('self-serve listing requires the assembly receipt to match the definition', () => {
+    const definition = okDefinition()
+    const otherDefinition = okDefinition({
+      productId: 'prod_other_pack',
+      definitionVersion: 2,
+    })
+    const otherAssembly = assembleComposedProduct(otherDefinition)
+
+    const listed = selfServeListComposedProduct(definition, otherAssembly)
+    expect(listed.ok).toBe(false)
+    if (!listed.ok) {
+      expect(listed.error.reason).toContain('assembly receipt')
     }
   })
 })

--- a/apps/openagents.com/workers/api/src/marketplace-product-composition.test.ts
+++ b/apps/openagents.com/workers/api/src/marketplace-product-composition.test.ts
@@ -3,13 +3,16 @@ import { describe, expect, test } from 'vitest'
 import {
   MARKETPLACE_COMPOSE_AND_LIST_PROMISE,
   MARKETPLACE_PRODUCT_COMPOSITION_SCHEMA,
+  assembleComposedProduct,
   type ComposedProductDefinition,
   buildComposedProductDefinition,
   composedProductMonetizableLayers,
   composedProductPrimitives,
   listComposedProducts,
   makeInMemoryComposedProductListingStore,
+  recordComposedProductInstallUse,
   readComposedProduct,
+  selfServeListComposedProduct,
 } from './marketplace-product-composition'
 
 const okDefinition = (
@@ -114,6 +117,68 @@ describe('compose-and-list product definition model (#5515)', () => {
       { layer: 'inference', capabilityRef: 'inference.gateway.v1' },
       { layer: 'sandbox', capabilityRef: 'cloud.sandbox.v1' },
     ])
+  })
+
+  test('assembles, self-serve lists, and records buyer install/use with builder attribution (#6882)', () => {
+    const definition = okDefinition()
+    const assembly = assembleComposedProduct(definition, {
+      assembledAt: '2026-06-29T00:00:00.000Z',
+    })
+    expect(assembly.productId).toBe(definition.productId)
+    expect(assembly.fulfillmentMode).toBe('no_spend_public_fixture')
+    expect(assembly.billingState).toBe('not_configured')
+    expect(assembly.primitiveRefs).toEqual([
+      'primitive.public.inference',
+      'primitive.public.sandbox',
+    ])
+    expect(assembly.builderAttribution).toEqual({
+      builderRef: 'agent:raynor',
+      attributionRef:
+        'attribution.public.marketplace_composed_product.prod_research_pack.1',
+      revSharePolicyRef:
+        'revshare.policy.public.marketplace_composed_product.pending_billing',
+    })
+
+    const listed = selfServeListComposedProduct(definition, assembly, {
+      listedAt: '2026-06-29T00:01:00.000Z',
+    })
+    expect(listed.definition.listingState).toBe('listed')
+    expect(listed.listingReceipt.selfServe).toBe(true)
+    expect(listed.listingReceipt.builderAttribution).toEqual(
+      assembly.builderAttribution,
+    )
+
+    const lifecycle = recordComposedProductInstallUse(
+      listed.listingReceipt,
+      {
+        buyerRef: 'buyer:public-fixture',
+        installedAt: '2026-06-29T00:02:00.000Z',
+        usedAt: '2026-06-29T00:03:00.000Z',
+      },
+    )
+    expect(lifecycle.ok).toBe(true)
+    if (lifecycle.ok) {
+      expect(lifecycle.lifecycleReceipt.installState).toBe('used')
+      expect(lifecycle.lifecycleReceipt.billingState).toBe('not_configured')
+      expect(lifecycle.lifecycleReceipt.settlementState).toBe('not_applicable')
+      expect(lifecycle.lifecycleReceipt.builderAttribution).toEqual(
+        assembly.builderAttribution,
+      )
+    }
+  })
+
+  test('install/use lifecycle requires a buyer ref', () => {
+    const definition = okDefinition()
+    const assembly = assembleComposedProduct(definition)
+    const listed = selfServeListComposedProduct(definition, assembly)
+
+    const lifecycle = recordComposedProductInstallUse(listed.listingReceipt, {
+      buyerRef: ' ',
+    })
+    expect(lifecycle.ok).toBe(false)
+    if (!lifecycle.ok) {
+      expect(lifecycle.error.reason).toContain('buyerRef')
+    }
   })
 })
 

--- a/apps/openagents.com/workers/api/src/marketplace-product-composition.ts
+++ b/apps/openagents.com/workers/api/src/marketplace-product-composition.ts
@@ -328,29 +328,47 @@ export const selfServeListComposedProduct = (
     listingRef?: string
     listedAt?: string
   } = {},
-): {
-  definition: ComposedProductDefinition
-  listingReceipt: ComposedProductListingWriteReceipt
-} => ({
-  definition: {
-    ...definition,
-    listingState: 'listed',
-  },
-  listingReceipt: {
-    schema: MARKETPLACE_PRODUCT_COMPOSITION_SCHEMA,
-    promiseId: MARKETPLACE_COMPOSE_AND_LIST_PROMISE,
-    listingRef:
-      input.listingRef ??
-      `listing.public.marketplace_composed_product.${definition.productId}.${definition.definitionVersion}`,
-    assemblyRef: assembly.assemblyRef,
-    productId: definition.productId,
-    builderAttribution: assembly.builderAttribution,
-    listedAt: input.listedAt ?? currentIsoTimestamp(),
-    listingState: 'listed',
-    selfServe: true,
-    billingState: 'not_configured',
-  },
-})
+):
+  | {
+      ok: true
+      definition: ComposedProductDefinition
+      listingReceipt: ComposedProductListingWriteReceipt
+    }
+  | { ok: false; error: ComposedProductValidationError } => {
+  if (
+    assembly.productId !== definition.productId ||
+    assembly.definitionVersion !== definition.definitionVersion
+  ) {
+    return {
+      ok: false,
+      error: new ComposedProductValidationError({
+        reason: 'assembly receipt must match the composed product definition',
+      }),
+    }
+  }
+
+  return {
+    ok: true,
+    definition: {
+      ...definition,
+      listingState: 'listed',
+    },
+    listingReceipt: {
+      schema: MARKETPLACE_PRODUCT_COMPOSITION_SCHEMA,
+      promiseId: MARKETPLACE_COMPOSE_AND_LIST_PROMISE,
+      listingRef:
+        input.listingRef ??
+        `listing.public.marketplace_composed_product.${definition.productId}.${definition.definitionVersion}`,
+      assemblyRef: assembly.assemblyRef,
+      productId: definition.productId,
+      builderAttribution: assembly.builderAttribution,
+      listedAt: input.listedAt ?? currentIsoTimestamp(),
+      listingState: 'listed',
+      selfServe: true,
+      billingState: 'not_configured',
+    },
+  }
+}
 
 export const recordComposedProductInstallUse = (
   listing: ComposedProductListingWriteReceipt,

--- a/apps/openagents.com/workers/api/src/marketplace-product-composition.ts
+++ b/apps/openagents.com/workers/api/src/marketplace-product-composition.ts
@@ -8,16 +8,15 @@
 // for sale.
 //
 // SCOPE / HONESTY: this is an INERT scaffold toward that marketplace, NOT a
-// claim it is live. It is PURE:
+// paid marketplace claim. It is PURE:
 //   - it moves no money, runs no fulfillment, reads no wallet, writes no
 //     receipt, and provisions no primitive;
-//   - it only defines a typed, versioned product DEFINITION (a composition of
-//     primitive/market capability references) and a read-only listing
-//     projection over an injected store.
+//   - it defines a typed, versioned product definition plus bounded no-spend
+//     assemble/list/install-use lifecycle receipts over public-safe refs.
 // The promise marketplace.compose_and_list_products.v1 STAYS `planned`. Nothing
-// here flips it green: there is no composition runtime, no install/use
-// lifecycle, no billing, attribution, rev-share, or settlement. A green flip
-// stays receipt-first and owner-signed per proof.claim_upgrade_receipts.v1.
+// here flips it green: there is no billing, paid sale receipt, rev-share
+// settlement, or live primitive provisioning. A green flip stays receipt-first
+// and owner-signed per proof.claim_upgrade_receipts.v1.
 
 import { Schema as S } from 'effect'
 
@@ -95,6 +94,61 @@ export const ComposedProductDefinition = S.Struct({
 })
 export type ComposedProductDefinition = typeof ComposedProductDefinition.Type
 
+export const MarketplaceBuilderAttribution = S.Struct({
+  builderRef: S.String,
+  attributionRef: S.String,
+  revSharePolicyRef: S.String,
+})
+export type MarketplaceBuilderAttribution =
+  typeof MarketplaceBuilderAttribution.Type
+
+export const ComposedProductAssemblyReceipt = S.Struct({
+  schema: S.Literal(MARKETPLACE_PRODUCT_COMPOSITION_SCHEMA),
+  promiseId: S.Literal(MARKETPLACE_COMPOSE_AND_LIST_PROMISE),
+  assemblyRef: S.String,
+  productId: S.String,
+  definitionVersion: S.Number,
+  builderAttribution: MarketplaceBuilderAttribution,
+  primitiveRefs: S.Array(S.String),
+  assembledAt: S.String,
+  fulfillmentMode: S.Literal('no_spend_public_fixture'),
+  billingState: S.Literal('not_configured'),
+})
+export type ComposedProductAssemblyReceipt =
+  typeof ComposedProductAssemblyReceipt.Type
+
+export const ComposedProductListingWriteReceipt = S.Struct({
+  schema: S.Literal(MARKETPLACE_PRODUCT_COMPOSITION_SCHEMA),
+  promiseId: S.Literal(MARKETPLACE_COMPOSE_AND_LIST_PROMISE),
+  listingRef: S.String,
+  assemblyRef: S.String,
+  productId: S.String,
+  builderAttribution: MarketplaceBuilderAttribution,
+  listedAt: S.String,
+  listingState: S.Literal('listed'),
+  selfServe: S.Literal(true),
+  billingState: S.Literal('not_configured'),
+})
+export type ComposedProductListingWriteReceipt =
+  typeof ComposedProductListingWriteReceipt.Type
+
+export const ComposedProductBuyerLifecycleReceipt = S.Struct({
+  schema: S.Literal(MARKETPLACE_PRODUCT_COMPOSITION_SCHEMA),
+  promiseId: S.Literal(MARKETPLACE_COMPOSE_AND_LIST_PROMISE),
+  lifecycleRef: S.String,
+  listingRef: S.String,
+  productId: S.String,
+  buyerRef: S.String,
+  builderAttribution: MarketplaceBuilderAttribution,
+  installedAt: S.String,
+  usedAt: S.String,
+  installState: S.Literal('used'),
+  billingState: S.Literal('not_configured'),
+  settlementState: S.Literal('not_applicable'),
+})
+export type ComposedProductBuyerLifecycleReceipt =
+  typeof ComposedProductBuyerLifecycleReceipt.Type
+
 export class ComposedProductValidationError extends S.TaggedErrorClass<ComposedProductValidationError>()(
   'ComposedProductValidationError',
   {
@@ -103,6 +157,14 @@ export class ComposedProductValidationError extends S.TaggedErrorClass<ComposedP
 ) {}
 
 const isNonEmpty = (value: string): boolean => value.trim().length > 0
+
+const defaultAttribution = (
+  definition: ComposedProductDefinition,
+): MarketplaceBuilderAttribution => ({
+  builderRef: definition.builderRef,
+  attributionRef: `attribution.public.marketplace_composed_product.${definition.productId}.${definition.definitionVersion}`,
+  revSharePolicyRef: 'revshare.policy.public.marketplace_composed_product.pending_billing',
+})
 
 /**
  * Build a typed product definition from raw input. PURE and validating:
@@ -233,6 +295,103 @@ export const composedProductMonetizableLayers = (
     }
   }
   return [...byLayer].map(([layer, capabilityRef]) => ({ layer, capabilityRef }))
+}
+
+export const assembleComposedProduct = (
+  definition: ComposedProductDefinition,
+  input: {
+    assemblyRef?: string
+    builderAttribution?: MarketplaceBuilderAttribution
+    assembledAt?: string
+  } = {},
+): ComposedProductAssemblyReceipt => ({
+  schema: MARKETPLACE_PRODUCT_COMPOSITION_SCHEMA,
+  promiseId: MARKETPLACE_COMPOSE_AND_LIST_PROMISE,
+  assemblyRef:
+    input.assemblyRef ??
+    `assembly.public.marketplace_composed_product.${definition.productId}.${definition.definitionVersion}`,
+  productId: definition.productId,
+  definitionVersion: definition.definitionVersion,
+  builderAttribution: input.builderAttribution ?? defaultAttribution(definition),
+  primitiveRefs: composedProductPrimitives(definition).map(
+    primitive => `primitive.public.${primitive}`,
+  ),
+  assembledAt: input.assembledAt ?? currentIsoTimestamp(),
+  fulfillmentMode: 'no_spend_public_fixture',
+  billingState: 'not_configured',
+})
+
+export const selfServeListComposedProduct = (
+  definition: ComposedProductDefinition,
+  assembly: ComposedProductAssemblyReceipt,
+  input: {
+    listingRef?: string
+    listedAt?: string
+  } = {},
+): {
+  definition: ComposedProductDefinition
+  listingReceipt: ComposedProductListingWriteReceipt
+} => ({
+  definition: {
+    ...definition,
+    listingState: 'listed',
+  },
+  listingReceipt: {
+    schema: MARKETPLACE_PRODUCT_COMPOSITION_SCHEMA,
+    promiseId: MARKETPLACE_COMPOSE_AND_LIST_PROMISE,
+    listingRef:
+      input.listingRef ??
+      `listing.public.marketplace_composed_product.${definition.productId}.${definition.definitionVersion}`,
+    assemblyRef: assembly.assemblyRef,
+    productId: definition.productId,
+    builderAttribution: assembly.builderAttribution,
+    listedAt: input.listedAt ?? currentIsoTimestamp(),
+    listingState: 'listed',
+    selfServe: true,
+    billingState: 'not_configured',
+  },
+})
+
+export const recordComposedProductInstallUse = (
+  listing: ComposedProductListingWriteReceipt,
+  input: {
+    buyerRef: string
+    lifecycleRef?: string
+    installedAt?: string
+    usedAt?: string
+  },
+):
+  | { ok: true; lifecycleReceipt: ComposedProductBuyerLifecycleReceipt }
+  | { ok: false; error: ComposedProductValidationError } => {
+  if (!isNonEmpty(input.buyerRef)) {
+    return {
+      ok: false,
+      error: new ComposedProductValidationError({
+        reason: 'buyerRef must be non-empty',
+      }),
+    }
+  }
+
+  const installedAt = input.installedAt ?? currentIsoTimestamp()
+  return {
+    ok: true,
+    lifecycleReceipt: {
+      schema: MARKETPLACE_PRODUCT_COMPOSITION_SCHEMA,
+      promiseId: MARKETPLACE_COMPOSE_AND_LIST_PROMISE,
+      lifecycleRef:
+        input.lifecycleRef ??
+        `lifecycle.public.marketplace_composed_product.${listing.productId}.${input.buyerRef}`,
+      listingRef: listing.listingRef,
+      productId: listing.productId,
+      buyerRef: input.buyerRef,
+      builderAttribution: listing.builderAttribution,
+      installedAt,
+      usedAt: input.usedAt ?? installedAt,
+      installState: 'used',
+      billingState: 'not_configured',
+      settlementState: 'not_applicable',
+    },
+  }
 }
 
 /**

--- a/apps/openagents.com/workers/api/src/product-promises.test.ts
+++ b/apps/openagents.com/workers/api/src/product-promises.test.ts
@@ -343,6 +343,10 @@ describe('public product promises document', () => {
     // /api/public/marketplace/composed-products read surface. Runtime,
     // self-serve write/install lifecycle, and billing blockers remain, so
     // green remains exactly 26.
+    // The 2026-06-29.1 compose-and-list lifecycle pass adds no-spend
+    // assemble/list/install-use receipts with builder attribution, replacing
+    // the unbuilt runtime/lifecycle blockers with the paid-listing runtime
+    // blocker. Billing/settlement remains, so no promise flips green.
     // The agentic-npm runtime pass clears the stale source-level registry and
     // install/use blocker by acknowledging the bounded runtime core plus
     // install/use evidence rows. Paid public marketplace and billing/settlement
@@ -396,10 +400,15 @@ describe('public product promises document', () => {
     expect(composeAndListPromise?.blockerRefs).not.toContain(
       'blocker.product_promises.marketplace_listing_lifecycle_unbuilt',
     )
+    expect(composeAndListPromise?.blockerRefs).not.toContain(
+      'blocker.product_promises.marketplace_composition_runtime_unbuilt',
+    )
+    expect(composeAndListPromise?.blockerRefs).not.toContain(
+      'blocker.product_promises.marketplace_self_serve_listing_write_install_lifecycle_unbuilt',
+    )
     expect(composeAndListPromise?.blockerRefs).toEqual(
       expect.arrayContaining([
-        'blocker.product_promises.marketplace_composition_runtime_unbuilt',
-        'blocker.product_promises.marketplace_self_serve_listing_write_install_lifecycle_unbuilt',
+        'blocker.product_promises.marketplace_paid_listing_runtime_missing',
         'blocker.product_promises.marketplace_billing_settlement_missing',
       ]),
     )
@@ -407,7 +416,7 @@ describe('public product promises document', () => {
       'route:/api/public/marketplace/composed-products',
     )
     expect(composeAndListPromise?.safeCopy).toContain(
-      'public read-only listing/discovery projection',
+      'no-spend assemble/list/install-use lifecycle receipts',
     )
     const agenticNpmPromise = decoded.promises.find(
       promise =>
@@ -915,8 +924,7 @@ describe('public product promises document', () => {
           promiseId: 'marketplace.compose_and_list_products.v1',
           state: 'planned',
           blockerRefs: expect.arrayContaining([
-            'blocker.product_promises.marketplace_composition_runtime_unbuilt',
-            'blocker.product_promises.marketplace_self_serve_listing_write_install_lifecycle_unbuilt',
+            'blocker.product_promises.marketplace_paid_listing_runtime_missing',
             'blocker.product_promises.marketplace_billing_settlement_missing',
           ]),
           evidenceRefs: expect.arrayContaining([

--- a/apps/openagents.com/workers/api/src/product-promises.ts
+++ b/apps/openagents.com/workers/api/src/product-promises.ts
@@ -3795,9 +3795,9 @@ export const publicProductPromisesDocument = () => {
         claim:
           'Agents and humans build their own products out of the OpenAgents Cloud primitives and open markets, then list those products for sale in the OpenAgents marketplace.',
         safeCopy:
-          'Compose-your-own-product-and-list-it-for-sale is the Episode 239 marketplace vision (docs/transcripts/239.md), and it is roadmap. A typed product-definition scaffold and public read-only listing/discovery projection exist at GET /api/public/marketplace/composed-products; the route is inert, planned-state, and empty by default unless injected/flag-armed. Adjacent planned lanes exist — the agentic-npm module registry (marketplace.agentic_npm_module_registry.v1) and WASM plugins (marketplace.wasm_plugins.v1) — but there is no live composition runtime that provisions primitives into a buyable product, no self-serve listing write/install/use lifecycle, no marketplace billing, attribution, rev-share, or settlement. Nobody has composed a product from the primitives and sold it through OpenAgents.',
+          'Compose-your-own-product-and-list-it-for-sale is the Episode 239 marketplace vision (docs/transcripts/239.md), and it is roadmap. A typed product-definition scaffold, bounded no-spend assemble/list/install-use lifecycle receipts with builder attribution, and public read-only listing/discovery projection exist at GET /api/public/marketplace/composed-products; the route is inert, planned-state, and empty by default unless injected/flag-armed. Adjacent planned lanes exist — the agentic-npm module registry (marketplace.agentic_npm_module_registry.v1) and WASM plugins (marketplace.wasm_plugins.v1) — but there is no marketplace billing, paid sale receipt, rev-share settlement, or live primitive provisioning. Nobody has sold a composed product through OpenAgents.',
         unsafeCopy:
-          'Do not claim users or agents can build a live product from the primitives and list it for sale today, that an OpenAgents product marketplace is live, or that composed products are buyable, installable, fulfillable, billable, settled, or revenue-bearing. Do not present the inert read-only listing scaffold or planned module/plugin lanes as a live compose-and-sell marketplace.',
+          'Do not claim users or agents can build a live paid product from the primitives and list it for sale today, that an OpenAgents product marketplace is live, or that composed products are buyable, billable, settled, revenue-bearing, or backed by live primitive provisioning. Do not present the no-spend lifecycle scaffold, inert read-only listing route, or planned module/plugin lanes as a live compose-and-sell marketplace.',
         evidenceRefs: [
           'docs/transcripts/239.md',
           'docs/promises/2026-06-19-episode-239-lets-make-money-registry-reconciliation.md',
@@ -3810,14 +3810,13 @@ export const publicProductPromisesDocument = () => {
           'route:/api/public/marketplace/composed-products',
         ],
         blockerRefs: [
-          'blocker.product_promises.marketplace_composition_runtime_unbuilt',
-          'blocker.product_promises.marketplace_self_serve_listing_write_install_lifecycle_unbuilt',
+          'blocker.product_promises.marketplace_paid_listing_runtime_missing',
           'blocker.product_promises.marketplace_billing_settlement_missing',
         ],
         verification:
-          'Planned until a composed product can be assembled from primitives, self-serve listed, discovered, installed/used by a buyer, and produce a dereferenceable paid receipt with attribution and rev-share to the builder. The current route proves only the inert typed definition + read-only listing/discovery scaffold. Per proof.demand_provenance.v1, an internally-built or injected listing is plumbing proof, not market proof.',
+          'Planned until a composed product can be assembled from primitives, self-serve listed, discovered, installed/used by a buyer, and produce a dereferenceable paid receipt with attribution and rev-share to the builder. The current source proves only the inert typed definition plus no-spend assemble/list/install-use lifecycle receipts, and the public route proves only read-only listing/discovery. Per proof.demand_provenance.v1, an internally-built or injected listing is plumbing proof, not market proof.',
         authorityBoundary:
-          'A compose-and-list vision and read-only listing scaffold grant no live composition runtime, self-serve listing write, install/use, fulfillment, billing, rev-share, payout, or public-marketplace-claim authority.',
+          'A compose-and-list vision plus no-spend lifecycle scaffold grant no paid listing, live primitive provisioning, fulfillment, billing, rev-share, payout, or public-marketplace-claim authority.',
       },
       {
         ...basePromiseFields,


### PR DESCRIPTION
## Summary
- add typed no-spend assemble, self-serve list, and buyer install/use lifecycle receipts for composed marketplace products
- record builder attribution and pending rev-share policy refs without introducing billing, settlement, or live primitive provisioning authority
- update the product-promise copy/tests so #6882's runtime/lifecycle gap is represented as a paid-listing/billing blocker instead of an entirely unbuilt scaffold

## Verification
- `bun run --cwd apps/openagents.com/workers/api test -- src/marketplace-product-composition.test.ts src/marketplace-composition-routes.test.ts src/product-promises.test.ts`
- `bun run --cwd apps/openagents.com check:deploy`

Closes #6882
