### PR TITLE
Wire avatar refs into world movement payloads

### DIFF
--- a/apps/openagents.com/apps/web/src/scene/tassadarCloudflareWorld.test.ts
+++ b/apps/openagents.com/apps/web/src/scene/tassadarCloudflareWorld.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest'
 
-import { tassadarCloudflareWorldSubscriptionQueries } from './tassadarCloudflareWorld'
+import {
+  TASSADAR_REGION_BOUNDS,
+  tassadarAvatarPositionCommandPayload,
+  tassadarCloudflareWorldSubscriptionQueries,
+} from './tassadarCloudflareWorld'
 
 describe('tassadar Cloudflare world subscription plan', () => {
   it('subscribes to timeline-backed public activity world events', () => {
@@ -17,5 +21,49 @@ describe('tassadar Cloudflare world subscription plan', () => {
     expect(queries).toContain(
       'cloudflare-world:region=region.run.tassadar.executor.20260615.street',
     )
+  })
+
+  it('builds avatar_position commands for the joined web avatar', () => {
+    const payload = tassadarAvatarPositionCommandPayload({
+      actorRef: 'actor.public.web',
+      characterId: 'web',
+      position: {
+        movementMode: 'walking',
+        pitch: 0.2,
+        positionX: 12,
+        positionY: 0,
+        positionZ: -9,
+        yaw: 1.4,
+      },
+    })
+
+    expect(payload).toEqual({
+      animation: 'walk',
+      avatarRef: 'avatar.actor-public-web.web',
+      position: { x: 12, y: 0, z: -9 },
+      rotationY: 1.4,
+    })
+  })
+
+  it('clamps avatar_position commands to the starter region', () => {
+    const payload = tassadarAvatarPositionCommandPayload({
+      actorRef: 'actor.public.web',
+      characterId: 'web',
+      position: {
+        movementMode: 'running',
+        pitch: 0,
+        positionX: 999,
+        positionY: -10,
+        positionZ: -999,
+        yaw: 0,
+      },
+    })
+
+    expect(payload.animation).toBe('run')
+    expect(payload.position).toEqual({
+      x: TASSADAR_REGION_BOUNDS.maxX,
+      y: TASSADAR_REGION_BOUNDS.minY,
+      z: TASSADAR_REGION_BOUNDS.minZ,
+    })
   })
 })

--- a/apps/openagents.com/apps/web/src/scene/tassadarCloudflareWorld.ts
+++ b/apps/openagents.com/apps/web/src/scene/tassadarCloudflareWorld.ts
@@ -92,6 +92,17 @@ export type TassadarPylonChatInput = Readonly<{
   pylonRef: string
 }>
 
+export type TassadarAvatarPositionCommandPayload = Readonly<{
+  animation: 'idle' | 'run' | 'walk'
+  avatarRef: string
+  position: Readonly<{
+    x: number
+    y: number
+    z: number
+  }>
+  rotationY: number
+}>
+
 const text = (value: string | null): string => value?.trim() ?? ''
 
 const runRefForSummary = (summary: TassadarRunPublicSummary): string =>
@@ -157,6 +168,26 @@ const movementModeToAnimation = (
     : movementMode === 'walking'
       ? 'walk'
       : 'idle'
+
+export const tassadarAvatarPositionCommandPayload = (
+  input: Readonly<{
+    actorRef: string
+    characterId: string
+    position: TassadarLocalAvatarPosition
+  }>,
+): TassadarAvatarPositionCommandPayload => {
+  const clamped = clampTassadarLocalAvatarPosition(input.position)
+  return {
+    animation: movementModeToAnimation(clamped.movementMode),
+    avatarRef: worldAvatarRefForCharacter(input.actorRef, input.characterId),
+    position: {
+      x: clamped.positionX,
+      y: clamped.positionY,
+      z: clamped.positionZ,
+    },
+    rotationY: clamped.yaw,
+  }
+}
 
 const readModelRows = (
   readModel: ClientWorld,
@@ -449,16 +480,11 @@ export const startTassadarCloudflareWorldSubscription = async (
       })
     },
     updateLocalAvatar: position => {
-      const clamped = clampTassadarLocalAvatarPosition(position)
-      callCommand('set_avatar_position', {
-        position: {
-          x: clamped.positionX,
-          y: clamped.positionY,
-          z: clamped.positionZ,
-        },
-        rotationY: clamped.yaw,
-        animation: movementModeToAnimation(clamped.movementMode),
-      })
+      callCommand('set_avatar_position', tassadarAvatarPositionCommandPayload({
+        actorRef,
+        characterId,
+        position,
+      }))
     },
   }
 }


### PR DESCRIPTION
## Summary
- Add a typed helper for Tassadar Cloudflare-world `set_avatar_position` payloads.
- Include the stable joined web `avatarRef` in local avatar movement commands instead of relying on server-side actor inference.
- Cover the payload with focused tests for avatar identity, animation mapping, and starter-region clamping.

Closes #6859.

## Verification
- `bun run --cwd apps/openagents.com/apps/web test src/scene/tassadarCloudflareWorld.test.ts`
- `bun run --cwd apps/openagents.com check:deploy`
