### PR TITLE
Clarify voice ingest capability envelope

### DIFF
--- a/apps/openagents.com/workers/api/src/product-promises.ts
+++ b/apps/openagents.com/workers/api/src/product-promises.ts
@@ -3147,7 +3147,7 @@ export const publicProductPromisesDocument = () => {
           'blocker.product_promises.voice_proposal_and_approval_ui_missing',
         ],
         verification:
-          'Voice evidence contracts and projection logic pass tests. Green requires an ingestion endpoint, a transcription service, proposal generation, and an approval UI, with every proposed action gated server-side.',
+          'Voice evidence contracts, projection logic, the pure transcript-to-program-input ingest core, and the flag-gated POST /api/mobile/voice-sessions/ingest endpoint pass tests. The endpoint accepts only already-transcribed, redacted, ref-only segments and explicitly reports no STT call, no audio capture, no action proposal generation, no approval UI, no approval mutation, and no execution. Green still requires an STT service and capture path, AI action proposal generation, and an approval UI with every proposed action gated server-side.',
         authorityBoundary:
           'A voice transcript is evidence of user intent, not command authority; all proposed actions require server-side policy checks and explicit approval.',
       },

--- a/apps/openagents.com/workers/api/src/voice-program-ingest-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/voice-program-ingest-routes.test.ts
@@ -87,6 +87,13 @@ describe('handleVoiceProgramIngestApi', () => {
     expect(payload.executesProgramRun).toBe(false)
     expect(payload.callsTranscriptionService).toBe(false)
     expect(payload.capturesAudio).toBe(false)
+    expect(payload.generatesActionProposals).toBe(false)
+    expect(payload.rendersApprovalUi).toBe(false)
+    expect(payload.approvalMutationAllowed).toBe(false)
+    expect(payload.actionExecutionAllowed).toBe(false)
+    expect(payload.providerMutationAllowed).toBe(false)
+    expect(payload.paymentMutationAllowed).toBe(false)
+    expect(payload.publicClaimUpgradeAllowed).toBe(false)
     // The named blocker this endpoint clears, and the two that stay gated.
     expect(payload.blockerCleared).toBe(VOICE_PROGRAM_INGEST_BLOCKERS.cleared)
     expect(payload.blockerCleared).toBe(
@@ -114,6 +121,15 @@ describe('handleVoiceProgramIngestApi', () => {
     // The envelope echoes that nothing executes; only program INPUT is proposed.
     expect(payload.executesProgramRun).toBe(false)
     expect(payload.proposesProgramInputOnly).toBe(true)
+    expect(payload.callsTranscriptionService).toBe(false)
+    expect(payload.capturesAudio).toBe(false)
+    expect(payload.generatesActionProposals).toBe(false)
+    expect(payload.rendersApprovalUi).toBe(false)
+    expect(payload.approvalMutationAllowed).toBe(false)
+    expect(payload.actionExecutionAllowed).toBe(false)
+    expect(payload.providerMutationAllowed).toBe(false)
+    expect(payload.paymentMutationAllowed).toBe(false)
+    expect(payload.publicClaimUpgradeAllowed).toBe(false)
     // The blocker this clears stays surfaced; settlement-adjacent blockers stay.
     expect(payload.blockerCleared).toBe(
       'blocker.product_promises.voice_ingestion_endpoint_missing',

--- a/apps/openagents.com/workers/api/src/voice-program-ingest-routes.ts
+++ b/apps/openagents.com/workers/api/src/voice-program-ingest-routes.ts
@@ -67,6 +67,18 @@ export const VOICE_PROGRAM_INGEST_BLOCKERS = {
   ],
 } as const
 
+const voiceProgramIngestCapabilityEnvelope = {
+  capturesAudio: false,
+  callsTranscriptionService: false,
+  generatesActionProposals: false,
+  rendersApprovalUi: false,
+  approvalMutationAllowed: false,
+  actionExecutionAllowed: false,
+  providerMutationAllowed: false,
+  paymentMutationAllowed: false,
+  publicClaimUpgradeAllowed: false,
+} as const
+
 // Parse the VOICE_PROGRAM_INGEST_ENABLED flag. Default OFF: anything other than
 // an explicit truthy token leaves the endpoint inert.
 export const isVoiceProgramIngestEnabled = (
@@ -90,13 +102,12 @@ const inertPayload = (): Record<string, unknown> => ({
   promiseState: 'red',
   inert: true,
   enabled: false,
+  ...voiceProgramIngestCapabilityEnvelope,
   // Echo the read-only authority boundary so callers can see this endpoint
   // never executes, mutates, captures audio, or settles.
   authorityBoundary: 'read_only_voice_session_evidence',
   executesProgramRun: false,
   proposesProgramInputOnly: true,
-  capturesAudio: false,
-  callsTranscriptionService: false,
   blockerCleared: VOICE_PROGRAM_INGEST_BLOCKERS.cleared,
   remainingBlockers: VOICE_PROGRAM_INGEST_BLOCKERS.remaining,
   note:
@@ -267,6 +278,7 @@ export const handleVoiceProgramIngestApi = async (
     promiseId: VOICE_PROGRAM_INGEST_PROMISE_ID,
     promiseState: 'red' as const,
     enabled: true as const,
+    ...voiceProgramIngestCapabilityEnvelope,
     executesProgramRun: false as const,
     proposesProgramInputOnly: true as const,
     blockerCleared: VOICE_PROGRAM_INGEST_BLOCKERS.cleared,


### PR DESCRIPTION
## Summary

- Add an explicit voice-ingest capability envelope to the inert and armed `/api/mobile/voice-sessions/ingest` responses.
- Pin that the endpoint does not call STT, capture audio, generate action proposals, render approval UI, mutate approvals/providers/payments, execute actions, or upgrade public claims.
- Update the `mobile.voice_session_evidence_transcript_ingest.v1` promise verification copy so it no longer says an ingestion endpoint is still missing, while keeping the promise red and the remaining STT/action-proposal/approval-UI blockers visible.

Closes #6846

## Verification

- `bun run --cwd apps/openagents.com/workers/api test -- src/voice-program-ingest-routes.test.ts` (6 passed)
- `bun run --cwd apps/openagents.com/workers/api test -- src/product-promises.test.ts src/voice-program-ingest-routes.test.ts` (16 passed)
- `bun run --cwd apps/openagents.com check:deploy` (exit 0; includes web/API typechecks, web focused suite, and API focused suite)

Note: the task named `command.public.pylon_khala.verify.b5bea41b6c623f7c09f1bf24`, but no in-checkout metadata mapped that opaque ref to an argv vector. I ran the issue-listed broad verifier, `bun run --cwd apps/openagents.com check:deploy`, plus the focused tests above.
