### PR TITLE
fix(khala): require sustained lockout replenishment

### DIFF
--- a/clients/khala-cli/src/fleet-run.test.ts
+++ b/clients/khala-cli/src/fleet-run.test.ts
@@ -6,6 +6,7 @@ import {
   parseFleetIssueList,
   plannedReplenishmentRounds,
   runKhalaFleetSupervisor,
+  shouldDispatchReplenishment,
   validateFleetRunVerify,
 } from "./fleet-run.js"
 import type { KhalaFleetStatus } from "./fleet.js"
@@ -80,6 +81,10 @@ describe("fleet run planning", () => {
   })
 
   test("keeps lockout recovery in the short supervisor cadence", () => {
+    expect(shouldDispatchReplenishment(0)).toBe(false)
+    expect(shouldDispatchReplenishment(1)).toBe(false)
+    expect(shouldDispatchReplenishment(2)).toBe(true)
+
     const firstLockoutWait = nextFleetSupervisorDelay({
       anyRefused: true,
       lockout: true,

--- a/clients/khala-cli/src/fleet-run.ts
+++ b/clients/khala-cli/src/fleet-run.ts
@@ -65,7 +65,7 @@ const DEFAULT_MAX_SLOTS = 8
 const SUPERVISOR_IDLE_MS = 2_000
 const REFUSED_BACKOFF_MS = 15_000
 const MAX_REFUSED_BACKOFF_MS = 120_000
-const LOCKOUT_REPLENISH_AFTER_ROUNDS = 1
+const LOCKOUT_REPLENISH_AFTER_ROUNDS = 2
 
 type FleetRunSlot = Omit<KhalaFleetRunRound, "ok" | "status" | "assignmentRef">
 
@@ -260,6 +260,10 @@ export function nextFleetSupervisorDelay(input: {
   return { delayMs: SUPERVISOR_IDLE_MS, refusedBackoffMs: REFUSED_BACKOFF_MS }
 }
 
+export function shouldDispatchReplenishment(consecutiveLockoutRounds: number): boolean {
+  return consecutiveLockoutRounds >= LOCKOUT_REPLENISH_AFTER_ROUNDS
+}
+
 async function runSupervisorLoop(input: {
   readonly env: Record<string, string | undefined>
   readonly plan: KhalaFleetRunPlan
@@ -282,7 +286,7 @@ async function runSupervisorLoop(input: {
     issueOffset = (issueOffset + round.length) % input.plan.issues.length
     const lockout = round.length > 0 && round.every(item => item.status === "refused")
     consecutiveLockoutRounds = lockout ? consecutiveLockoutRounds + 1 : 0
-    if (consecutiveLockoutRounds >= LOCKOUT_REPLENISH_AFTER_ROUNDS) {
+    if (shouldDispatchReplenishment(consecutiveLockoutRounds)) {
       const replenishmentPlan = plannedReplenishmentRounds(input.plan, dispatchedReplenishmentKeys)
       for (const slot of replenishmentPlan) {
         if (slot.dedupeKey !== undefined) dispatchedReplenishmentKeys.add(slot.dedupeKey)


### PR DESCRIPTION
## Summary
- Require two consecutive all-slot LOCKOUT/refused rounds before dispatching replenishment work.
- Keep LOCKOUT retries on the short supervisor cadence instead of entering long refused-work backoff.
- Add focused coverage for the sustained replenishment threshold.

Closes #6822

## Verification
- bun test clients/khala-cli/src/fleet-run.test.ts
- bun run --cwd clients/khala-cli typecheck
- true (required verifier ref command.public.pylon_khala.verify.b5bea41b6c623f7c09f1bf24)
