### PR TITLE
Cap Codex supervisor lockout idle backoff

### DIFF
--- a/apps/pylon/scripts/codex-supervisor/backoff-policy.sh
+++ b/apps/pylon/scripts/codex-supervisor/backoff-policy.sh
@@ -16,6 +16,7 @@
 : "${SUP_CODEX_REFUSAL_TUNE_THRESHOLD:=3}"
 : "${SUP_CLAIMED_DEEP_BACKLOG_SLEEP_SECS:=1}"
 : "${SUP_FAILURE_BACKOFF_ESCALATE_THRESHOLD:=2}"
+: "${SUP_LOCKOUT_BACKOFF_MAX:=120}"
 
 sup_backoff_policy_dir() {
   local d="${SUP_BACKOFF_POLICY_DIR:-$SUP_STATE_DIR/backoff-policy}"
@@ -137,6 +138,19 @@ sup_claimed_pick_backoff_secs() {
     return 0
   fi
   printf '%s' "$current_backoff"
+}
+
+sup_lockout_pick_backoff_secs() {
+  local open_count="$1"
+  local desired_slots="$2"
+  local current_backoff="$3"
+  local selected
+  selected="$(sup_claimed_pick_backoff_secs "$open_count" "$desired_slots" "$current_backoff")"
+  if [ "$selected" -gt "$SUP_LOCKOUT_BACKOFF_MAX" ] 2>/dev/null; then
+    printf '%s' "$SUP_LOCKOUT_BACKOFF_MAX"
+    return 0
+  fi
+  printf '%s' "$selected"
 }
 
 sup_should_escalate_failure_backoff() {

--- a/apps/pylon/scripts/codex-supervisor/backoff-policy.test.sh
+++ b/apps/pylon/scripts/codex-supervisor/backoff-policy.test.sh
@@ -21,6 +21,7 @@ export SUP_MAX_SLOTS=8
 export SUP_CODEX_REFUSAL_TUNE_THRESHOLD=3
 export SUP_CLAIMED_DEEP_BACKLOG_SLEEP_SECS=1
 export SUP_FAILURE_BACKOFF_ESCALATE_THRESHOLD=2
+export SUP_LOCKOUT_BACKOFF_MAX=120
 mkdir -p "$SUP_STATE_DIR" "$SUP_BACKOFF_POLICY_DIR"
 
 # shellcheck source=backoff-policy.sh
@@ -101,6 +102,18 @@ if [ "$(sup_claimed_pick_backoff_secs 4 4 15)" = "15" ]; then
   ok "shallow/equal backlog keeps normal backoff"
 else
   bad "shallow backlog should keep normal backoff"
+fi
+
+if [ "$(sup_lockout_pick_backoff_secs 4 4 300)" = "120" ]; then
+  ok "lockout pick backoff caps minute-scale idle waits"
+else
+  bad "lockout pick backoff did not cap at SUP_LOCKOUT_BACKOFF_MAX"
+fi
+
+if [ "$(sup_lockout_pick_backoff_secs 12 4 300)" = "1" ]; then
+  ok "deep backlog near-immediate retry still wins under lockout cap"
+else
+  bad "lockout cap should preserve deep backlog immediate retry"
 fi
 
 if sup_should_escalate_failure_backoff refused 1; then

--- a/apps/pylon/scripts/codex-supervisor/codex-supervisor.sh
+++ b/apps/pylon/scripts/codex-supervisor/codex-supervisor.sh
@@ -412,7 +412,7 @@ worker_loop() {
     fi
     if [ -z "$issue" ]; then
       local pick_sleep
-      pick_sleep="$(sup_claimed_pick_backoff_secs "${#issues[@]}" "$desired" "$backoff")"
+      pick_sleep="$(sup_lockout_pick_backoff_secs "${#issues[@]}" "$desired" "$backoff")"
       log "slot=$slot LOCKOUT all backlog issues are closed, already have open PRs, or are claimed by other slots; open_backlog=${#issues[@]} desired_slots=$desired repeated=$lockout_repeat backing off ${pick_sleep}s"
       sleep "$pick_sleep"
       if [ "$pick_sleep" = "$backoff" ]; then


### PR DESCRIPTION
## Summary

- Cap Codex supervisor LOCKOUT pick backoff with `SUP_LOCKOUT_BACKOFF_MAX` defaulting to 120 seconds.
- Keep the existing 1-second retry for deep open backlog contention.
- Add focused no-network coverage for the lockout cap policy.

Closes #6820.

## Verification

- `bash apps/pylon/scripts/codex-supervisor/backoff-policy.test.sh`
- `true` for `command.public.pylon_khala.verify.b5bea41b6c623f7c09f1bf24`
