### PR TITLE
fix(gym): reject unsafe MirrorCode run ids

### DIFF
--- a/apps/openagents.com/workers/api/src/inference/gym/mirrorcode-contract.ts
+++ b/apps/openagents.com/workers/api/src/inference/gym/mirrorcode-contract.ts
@@ -261,6 +261,9 @@ const assertBounds = (input: MirrorCodeRunInput): void => {
   if (input.runId.length < 1 || input.runId.length > MAX_RUN_ID_LENGTH) {
     throw new MirrorCodeRunError('runId must be 1..128 characters.')
   }
+  if (!PUBLIC_REF_PATTERN.test(input.runId)) {
+    throw new MirrorCodeRunError('runId must be a public-safe ref.')
+  }
   if (input.taskId.length < 1 || input.taskId.length > MAX_TASK_ID_LENGTH) {
     throw new MirrorCodeRunError('taskId must be 1..64 characters.')
   }

--- a/apps/openagents.com/workers/api/src/inference/gym/mirrorcode-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/gym/mirrorcode-routes.test.ts
@@ -94,6 +94,12 @@ describe('buildMirrorCodeRun', () => {
     ).toThrow(MirrorCodeRunError)
   })
 
+  test('rejects unsafe run ids before they can be stored or served', () => {
+    expect(() =>
+      buildMirrorCodeRun({ ...validInput, runId: 'mc unsafe/run id' }),
+    ).toThrow(MirrorCodeRunError)
+  })
+
   test('rejects a malformed body', () => {
     expect(() => buildMirrorCodeRun({ runId: 'x' })).toThrow(MirrorCodeRunError)
   })
@@ -425,6 +431,29 @@ describe('handleMirrorCodeRunsApi POST', () => {
     )
     expect(response.status).toBe(400)
     expect(stored).toBe(0)
+  })
+
+  test('authorized POST with unsafe run id is rejected before storage', async () => {
+    let stored = 0
+    const response = await run(
+      handleMirrorCodeRunsApi(
+        postRequest({ ...validInput, runId: 'mc unsafe/run id' }),
+        {
+          requireAdminApiToken: async () => true,
+          store: {
+            listRuns: () => Effect.succeed([]),
+            getRun: () => Effect.sync(() => undefined),
+            upsertRun: () => Effect.sync(() => {
+              stored += 1
+            }),
+          },
+        },
+      ),
+    )
+    expect(response.status).toBe(400)
+    expect(stored).toBe(0)
+    const body = (await response.json()) as { reason: string }
+    expect(body.reason).toContain('runId must be a public-safe ref')
   })
 })
 


### PR DESCRIPTION
Closes #6376.

## Summary
- hardens MirrorCode run ingest so posted runId values must be public-safe refs before storage/public serving
- adds builder and owner-gated POST regression coverage to ensure unsafe run IDs are rejected before D1 upsert

## Verification
- `bun run --cwd apps/openagents.com/workers/api test -- src/inference/gym/mirrorcode-routes.test.ts`
- `true` (`command.public.pylon_khala.verify.b5bea41b6c623f7c09f1bf24`)
- `bun run --cwd apps/openagents.com/workers/api test -- src/inference/gym/mirrorcode-routes.test.ts src/inference/gym/ladder.test.ts src/inference/gym/ladder-routes.test.ts src/inference/gym/mirrorcode-ladder-integration.test.ts src/tassadar-trace-corpus-generalization-guard.test.ts`
- `git diff --check`

Note: initial direct root-level `bun test apps/openagents.com/workers/api/src/inference/gym/mirrorcode-routes.test.ts` failed before running tests because this checkout's shared `node_modules` symlink did not yet expose `effect`/`vitest`. `bun install` refreshed dependency links with no tracked package changes, after which the package test commands above passed.