### PR TITLE
fix(artanis): route long-form asks through RLM

### DIFF
--- a/apps/openagents.com/workers/api/src/artanis-operator.test.ts
+++ b/apps/openagents.com/workers/api/src/artanis-operator.test.ts
@@ -636,6 +636,61 @@ describe('#6654 Artanis RLM composition', () => {
       requests.every(request => request.model === ARTANIS_OPERATOR_KHALA_MODEL),
     ).toBe(true)
   })
+
+  test('uses the RLM conductor on long-form asks even when operator tools exist', async () => {
+    const { calls, tool } = makeFakeReadTool('tool result should not be read')
+    const { client, requests } = makeScriptedKhalaClient([
+      textResult(
+        JSON.stringify({
+          compositionInstruction: 'Compose from the packets.',
+          subqueries: [
+            {
+              evidenceRefs: ['evidence.artanis.operator.rlm.state'],
+              id: 'state',
+              question: 'What state matters?',
+              signatureRef: ARTANIS_OPERATOR_RLM_SIGNATURE_REF,
+            },
+            {
+              evidenceRefs: ['evidence.artanis.operator.rlm.answer'],
+              id: 'answer',
+              question: 'What answer should be composed?',
+              signatureRef: ARTANIS_OPERATOR_RLM_SIGNATURE_REF,
+            },
+          ],
+        }),
+      ),
+      textResult('State packet.'),
+      textResult('Answer packet.'),
+      textResult('I composed the long-form answer from separate packets.'),
+    ])
+
+    const result = await Effect.runPromise(
+      artanisOperatorTurn({
+        awareness: exampleAwareness,
+        khalaClient: client,
+        memory: exampleMemory,
+        messages: [
+          {
+            content: 'write a detailed report for the owner',
+            role: 'user',
+          },
+        ],
+        ownerId: 'owner:github:14167547',
+        tools: [tool],
+      }),
+    )
+
+    expect('error' in result).toBe(false)
+    if ('error' in result) return
+    expect(result.reply).toBe(
+      'I composed the long-form answer from separate packets.',
+    )
+    expect(result.rlmTrace.used).toBe(true)
+    expect(result.toolInvocations).toEqual([])
+    expect(calls).toEqual([])
+    expect(requests).toHaveLength(4)
+    expect(requests.every(request => request.tools === undefined)).toBe(true)
+  })
 })
 
 describe('#6364 artanis operator bounded tool-calling loop', () => {

--- a/apps/openagents.com/workers/api/src/artanis-operator.ts
+++ b/apps/openagents.com/workers/api/src/artanis-operator.ts
@@ -672,6 +672,18 @@ const LONG_FORM_OWNER_CUES: ReadonlyArray<string> = [
   'write-up',
 ]
 
+const TOOL_GROUNDED_OWNER_CUES: ReadonlyArray<string> = [
+  'check ',
+  'grep ',
+  'inspect ',
+  'look up ',
+  'open ',
+  'read ',
+  'search ',
+  'summarize ',
+  'verify ',
+]
+
 const latestOwnerMessageContent = (
   messages: ReadonlyArray<ArtanisOperatorMessage>,
 ): string =>
@@ -682,6 +694,13 @@ export const shouldUseArtanisRlmComposition = (
 ): boolean => {
   const lower = latestOwnerMessageContent(messages).toLowerCase()
   return LONG_FORM_OWNER_CUES.some(cue => lower.includes(cue))
+}
+
+const shouldPreferArtanisToolLoop = (
+  messages: ReadonlyArray<ArtanisOperatorMessage>,
+): boolean => {
+  const lower = latestOwnerMessageContent(messages).toLowerCase()
+  return TOOL_GROUNDED_OWNER_CUES.some(cue => lower.includes(cue))
 }
 
 const normalizeArtanisRlmSubqueries = (
@@ -1335,7 +1354,15 @@ export const artanisOperatorTurn = (input: {
       messages: input.messages,
     })
 
-    if (tools.length === 0 && shouldUseArtanisRlmComposition(input.messages)) {
+    // Long-form owner asks use the RLM conductor even on the production route
+    // where operator tools are configured. The RLM pass remains read-only: its
+    // planner, subquery, and composition completions intentionally suppress
+    // tool definitions, so merely making the conductor reachable here does not
+    // widen spend, dispatch, or destructive authority.
+    if (
+      shouldUseArtanisRlmComposition(input.messages) &&
+      (tools.length === 0 || !shouldPreferArtanisToolLoop(input.messages))
+    ) {
       const composed = yield* runArtanisRlmComposition({
         baseMessages,
         khalaClient: input.khalaClient,


### PR DESCRIPTION
## Summary

- Makes long-form Artanis owner asks use the RLM conductor even on the production operator path where tools are configured.
- Keeps the RLM pass read-only by suppressing tool definitions inside planner, subquery, and composition calls.
- Preserves explicit tool-grounded asks such as read/check/verify/search/summarize on the existing tool loop.
- Adds regression coverage for long-form RLM composition with operator tools present.

Closes #6654

## Verification

- `bun run --cwd apps/openagents.com/workers/api test -- src/artanis-operator.test.ts`
- `true` (`command.public.pylon_khala.verify.b5bea41b6c623f7c09f1bf24`)
