### PR TITLE
Align AgentCL Vertex receipts with #6762

### DIFF
--- a/apps/openagents.com/workers/api/src/inference/gym/agentcl.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/gym/agentcl.test.ts
@@ -310,7 +310,7 @@ describe('AgentCL repo-reuse gym environment', () => {
     )
 
     expect(plan.schemaVersion).toBe(AGENTCL_VERTEX_RUNNER_PLAN_SCHEMA)
-    expect(plan.issueRef).toBe('public.issue.6766')
+    expect(plan.issueRef).toBe('public.issue.6762')
     expect(plan.lane).toEqual({
       laneRef: 'vertex-gemini',
       model: 'gemini-3.5-flash',
@@ -480,7 +480,7 @@ describe('AgentCL repo-reuse gym environment', () => {
     const report = buildAgentClVertexStressBaselineReport()
 
     expect(report.schemaVersion).toBe(AGENTCL_VERTEX_STRESS_REPORT_SCHEMA)
-    expect(report.issueRef).toBe('public.issue.6767')
+    expect(report.issueRef).toBe('public.issue.6762')
     expect(report.routing).toEqual({
       laneRef: 'vertex-gemini',
       model: 'gemini-3.5-flash',

--- a/apps/openagents.com/workers/api/src/inference/gym/agentcl.ts
+++ b/apps/openagents.com/workers/api/src/inference/gym/agentcl.ts
@@ -35,6 +35,7 @@ export const AGENTCL_TASK_RUNNER_RESULT_SCHEMA =
   'openagents.gym.agentcl_task_runner_result.v0' as const
 export const AGENTCL_VERTEX_RUNNER_PLAN_SCHEMA =
   'openagents.gym.agentcl_vertex_runner_plan.v0' as const
+export const AGENTCL_VERTEX_STRESS_ISSUE_REF = 'public.issue.6762' as const
 
 export const AgentClStreamKind = S.Literals(['naive', 'compositional'])
 export type AgentClStreamKind = typeof AgentClStreamKind.Type
@@ -267,7 +268,7 @@ export type AgentClVertexStressCircuitBreakerReason =
 
 export const AgentClVertexRunnerPlanV0 = S.Struct({
   schemaVersion: S.Literal(AGENTCL_VERTEX_RUNNER_PLAN_SCHEMA),
-  issueRef: S.Literal('public.issue.6766'),
+  issueRef: S.Literal(AGENTCL_VERTEX_STRESS_ISSUE_REF),
   lane: S.Struct({
     laneRef: S.Literal('vertex-gemini'),
     model: S.Literal('gemini-3.5-flash'),
@@ -315,7 +316,7 @@ export type AgentClCurvePoint = typeof AgentClCurvePoint.Type
 
 export const AgentClVertexStressReportV0 = S.Struct({
   schemaVersion: S.Literal(AGENTCL_VERTEX_STRESS_REPORT_SCHEMA),
-  issueRef: S.Literal('public.issue.6767'),
+  issueRef: S.Literal(AGENTCL_VERTEX_STRESS_ISSUE_REF),
   experimentId: S.String,
   runMode: AgentClVertexStressRunMode,
   routing: S.Struct({
@@ -976,7 +977,7 @@ export const buildAgentClVertexGeminiRunnerPlan = (
 ): AgentClVertexRunnerPlanV0 =>
   decodeVertexRunnerPlan({
     schemaVersion: AGENTCL_VERTEX_RUNNER_PLAN_SCHEMA,
-    issueRef: 'public.issue.6766',
+    issueRef: AGENTCL_VERTEX_STRESS_ISSUE_REF,
     lane: {
       laneRef: 'vertex-gemini',
       model: 'gemini-3.5-flash',
@@ -1278,7 +1279,7 @@ export const buildAgentClVertexStressBaselineReport = (
 
   return decodeVertexStressReport({
     schemaVersion: AGENTCL_VERTEX_STRESS_REPORT_SCHEMA,
-    issueRef: 'public.issue.6767',
+    issueRef: AGENTCL_VERTEX_STRESS_ISSUE_REF,
     experimentId: stressExperiment.id,
     runMode: input.runMode ?? 'fixture_baseline',
     routing: {
@@ -1326,7 +1327,7 @@ export const buildAgentClVertexStressBaselineReport = (
         : ['blocker.gym.agentcl.fixture_baseline_not_live_stress']),
     ],
     reportRefs: [
-      'public.issue.6767',
+      AGENTCL_VERTEX_STRESS_ISSUE_REF,
       'route.gym.agentcl.vertex_gemini35_flash',
       'cap.usd.agentcl.vertex_stress.50',
     ],


### PR DESCRIPTION
## Summary

- anchors AgentCL Vertex runner plan/report receipts to `public.issue.6762`
- keeps route/cap refs intact while making generated stress artifacts traceable to the parent AgentCL MVP issue
- updates focused AgentCL regression expectations

Closes #6762.

## Verification

- `bun run --cwd apps/openagents.com/workers/api test -- src/inference/gym/agentcl.test.ts src/inference/gym/agentcl-vertex-runner.test.ts` — 2 files passed, 39 tests passed
- `bun run --cwd apps/openagents.com/workers/api typecheck` — exited 0; emitted existing Effect language-service diagnostics in unrelated files

Note: the requested opaque verification ref `command.public.pylon_khala.verify.b5bea41b6c623f7c09f1bf24` was not recoverable to argv from the materialized checkout or local workspace lease metadata, so I ran the focused AgentCL verification covering this change.
