### PR TITLE
Require DSPy audit refs for GEPA standing loop

### DIFF
--- a/apps/openagents.com/workers/api/src/probe-gepa-standing-optimization-loop.test.ts
+++ b/apps/openagents.com/workers/api/src/probe-gepa-standing-optimization-loop.test.ts
@@ -19,6 +19,7 @@ const input = (
     candidateManifestRefs: [
       'candidate_manifest.probe_gepa_standing_loop.dspy_gepa_001',
     ],
+    dspyRlmAuditRefs: ['github.pr.openagents.6704'],
     effectAuthorityGateRefs: [
       'effect_authority_gate.blueprint.candidate_admission.v1',
     ],
@@ -54,6 +55,7 @@ describe('Probe GEPA standing optimization loop projection (#6707)', () => {
     expect(projection.livePromotionAllowed).toBe(false)
     expect(projection.evidenceRefs).toEqual([
       'eval_result.studybench.recent.low_quality_001',
+      'github.pr.openagents.6704',
       'optimizer_run.gepa_dspy.mutalisk.issue_6707.001',
       'trace.public.khala.redacted_recent_001',
     ])
@@ -78,11 +80,12 @@ describe('Probe GEPA standing optimization loop projection (#6707)', () => {
     )
   })
 
-  test('requires Mutalisk optimizer runs, candidate manifests, and authority gates before emission', () => {
+  test('requires the DSPy/RLM audit, Mutalisk optimizer runs, candidate manifests, and authority gates before emission', () => {
     const projection = projectProbeGepaStandingOptimizationLoop(
       input({
         candidateArtifactRefs: [],
         candidateManifestRefs: [],
+        dspyRlmAuditRefs: [],
         effectAuthorityGateRefs: [],
         mutaliskLaneRefs: [],
         optimizerRunRefs: [],
@@ -96,6 +99,7 @@ describe('Probe GEPA standing optimization loop projection (#6707)', () => {
     expect(projection.blockerRefs).toEqual([
       'blocker.probe_gepa_standing_loop.candidate_artifacts_missing',
       'blocker.probe_gepa_standing_loop.candidate_manifests_missing',
+      'blocker.probe_gepa_standing_loop.dspy_rlm_audit_missing',
       'blocker.probe_gepa_standing_loop.mutalisk_lane_missing',
       'blocker.probe_gepa_standing_loop.optimizer_run_refs_missing',
     ])

--- a/apps/openagents.com/workers/api/src/probe-gepa-standing-optimization-loop.ts
+++ b/apps/openagents.com/workers/api/src/probe-gepa-standing-optimization-loop.ts
@@ -24,6 +24,7 @@ export class ProbeGepaStandingOptimizationLoopInput extends S.Class<ProbeGepaSta
 )({
   candidateArtifactRefs: S.Array(S.String),
   candidateManifestRefs: S.Array(S.String),
+  dspyRlmAuditRefs: S.Array(S.String),
   effectAuthorityGateRefs: S.Array(S.String),
   evalResultRefs: S.Array(S.String),
   failureFamilyRefs: S.Array(S.String),
@@ -46,6 +47,7 @@ export class ProbeGepaStandingOptimizationLoopProjection extends S.Class<ProbeGe
   candidateArtifactsAdmissibleToAuthority: S.Boolean,
   candidateManifestRefs: S.Array(S.String),
   decision: ProbeGepaStandingOptimizationLoopDecision,
+  dspyRlmAuditRefs: S.Array(S.String),
   effectAuthorityGateRefs: S.Array(S.String),
   evidenceRefs: S.Array(S.String),
   failureFamilyRefs: S.Array(S.String),
@@ -103,6 +105,7 @@ const normalizeInput = (
     ...input,
     candidateArtifactRefs: uniqueRefs(input.candidateArtifactRefs),
     candidateManifestRefs: uniqueRefs(input.candidateManifestRefs),
+    dspyRlmAuditRefs: uniqueRefs(input.dspyRlmAuditRefs),
     effectAuthorityGateRefs: uniqueRefs(input.effectAuthorityGateRefs),
     evalResultRefs: uniqueRefs(input.evalResultRefs),
     failureFamilyRefs: uniqueRefs(input.failureFamilyRefs),
@@ -138,6 +141,9 @@ const blockerRefsFor = (
       : []),
     ...(candidateRequested && input.mutaliskLaneRefs.length === 0
       ? ['blocker.probe_gepa_standing_loop.mutalisk_lane_missing']
+      : []),
+    ...(candidateRequested && input.dspyRlmAuditRefs.length === 0
+      ? ['blocker.probe_gepa_standing_loop.dspy_rlm_audit_missing']
       : []),
     ...(candidateRequested && input.optimizerRunRefs.length === 0
       ? ['blocker.probe_gepa_standing_loop.optimizer_run_refs_missing']
@@ -204,6 +210,10 @@ export const projectProbeGepaStandingOptimizationLoop = (
     normalized.candidateManifestRefs,
   )
   assertSafeRefs(
+    'Probe GEPA standing loop DSPy/RLM audit refs',
+    normalized.dspyRlmAuditRefs,
+  )
+  assertSafeRefs(
     'Probe GEPA standing loop Effect authority gate refs',
     normalized.effectAuthorityGateRefs,
   )
@@ -229,6 +239,7 @@ export const projectProbeGepaStandingOptimizationLoop = (
   const evidenceRefs = uniqueRefs([
     ...normalized.sourceTraceRefs,
     ...normalized.evalResultRefs,
+    ...normalized.dspyRlmAuditRefs,
     ...normalized.optimizerRunRefs,
   ])
   const decision: ProbeGepaStandingOptimizationLoopDecision =
@@ -244,6 +255,7 @@ export const projectProbeGepaStandingOptimizationLoop = (
     candidateArtifactsAdmissibleToAuthority,
     candidateManifestRefs: normalized.candidateManifestRefs,
     decision,
+    dspyRlmAuditRefs: normalized.dspyRlmAuditRefs,
     effectAuthorityGateRefs: normalized.effectAuthorityGateRefs,
     evidenceRefs,
     failureFamilyRefs: normalized.failureFamilyRefs,


### PR DESCRIPTION
## Summary

- add explicit DSPy/RLM audit refs to the Probe GEPA standing optimization loop projection
- block candidate emission when the standing loop lacks #6704 audit grounding
- include the audit ref in public-safe evidence refs and focused regression coverage

Closes #6707.

## Verification

- `bun run --cwd apps/openagents.com/workers/api test -- src/probe-gepa-standing-optimization-loop.test.ts`
- `bun run --cwd apps/openagents.com/workers/api typecheck` (exit 0; Effect language-service advisory messages only)
- `true` (`command.public.pylon_khala.verify.b5bea41b6c623f7c09f1bf24`)
