### PR TITLE
fix(inference): fail over GLM no-headroom admission

### DIFF
--- a/apps/openagents.com/workers/api/src/inference/chat-completions-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/chat-completions-routes.test.ts
@@ -67,6 +67,7 @@ import {
   HYDRALISK_GPT_OSS_120B_ADAPTER_ID,
   OPENROUTER_KHALA_FALLBACK_ADAPTER_ID,
   VERTEX_GEMINI_ADAPTER_ID,
+  makeGlmOwnCapacityFailover,
   selectAdapterPlan,
 } from './model-router'
 import {
@@ -3418,6 +3419,127 @@ describe('POST /v1/chat/completions', () => {
         fallbackReason: 'glm_pool_saturated',
         glmSaturationPolicy: 'queue_then_overflow',
         queueWaitMs: 0,
+      },
+    })
+    expect(recorded[0]?.usage.totalTokens).toBeGreaterThan(0)
+  })
+
+  test('GLM no-headroom admission activates paid multi-lane failover for internal stress (#6823)', async () => {
+    let glmCalls = 0
+    let geminiCalls = 0
+    let fireworksCalls = 0
+    let openrouterCalls = 0
+    const alerts: Array<{
+      message: string
+      type: string
+    }> = []
+    const recorded: Array<{
+      adapterId: string
+      requestAttribution?: unknown
+      requestMetrics?: unknown
+      usage: InferenceUsage
+    }> = []
+    const registry = new InferenceProviderRegistry()
+    registry.register({
+      ...echoAdapter(HYDRALISK_GLM_52_REAP_504B_ADAPTER_ID),
+      complete: request => {
+        glmCalls += 1
+        return stubEchoAdapter.complete(request)
+      },
+    })
+    registry.register({
+      ...echoAdapter(VERTEX_GEMINI_ADAPTER_ID),
+      complete: request => {
+        geminiCalls += 1
+        return stubEchoAdapter.complete(request)
+      },
+    })
+    registry.register({
+      ...echoAdapter(FIREWORKS_ADAPTER_ID),
+      complete: request => {
+        fireworksCalls += 1
+        return stubEchoAdapter.complete(request)
+      },
+    })
+    registry.register({
+      ...echoAdapter(OPENROUTER_KHALA_FALLBACK_ADAPTER_ID),
+      complete: request => {
+        openrouterCalls += 1
+        return stubEchoAdapter.complete(request)
+      },
+    })
+
+    const deps = baseDeps({
+      dispatch: {
+        glmOwnCapacityFailover: makeGlmOwnCapacityFailover({
+          failureThreshold: 2,
+          onAlert: event => {
+            alerts.push({ message: event.message, type: event.type })
+          },
+        }),
+        sleep: () => Effect.void,
+      },
+      lanePlan: () => [
+        HYDRALISK_GLM_52_REAP_504B_ADAPTER_ID,
+        VERTEX_GEMINI_ADAPTER_ID,
+        FIREWORKS_ADAPTER_ID,
+        OPENROUTER_KHALA_FALLBACK_ADAPTER_ID,
+      ],
+      recordTokensServed: input =>
+        Effect.sync(() => {
+          recorded.push({
+            adapterId: input.adapterId,
+            requestAttribution: input.requestAttribution,
+            requestMetrics: input.requestMetrics,
+            usage: input.usage,
+          })
+        }),
+      registry,
+      routeAdmission: {
+        reason: 'glm_aggregate_external_headroom_zero',
+        reservedExternalHeadroomAvailable: false,
+      },
+    })
+
+    const stressRequest = () =>
+      chatRequest(helloBody, {
+        headers: {
+          [INFERENCE_CLIENT_HEADER]: 'stress-harness',
+          [INFERENCE_DEMAND_KIND_HEADER]: 'internal_stress',
+          [INFERENCE_DEMAND_SOURCE_HEADER]: 'glm-saturation',
+        },
+      })
+
+    const first = await run(handleChatCompletions(stressRequest(), deps))
+    const second = await run(handleChatCompletions(stressRequest(), deps))
+
+    expect(first.status).toBe(429)
+    expect(second.status).toBe(200)
+    const body = (await second.json()) as {
+      openagents?: {
+        routing?: { fallback_reason?: string | null }
+        worker?: string
+      }
+    }
+    expect(body.openagents?.worker).toBe(VERTEX_GEMINI_ADAPTER_ID)
+    expect(body.openagents?.routing?.fallback_reason).toBe(null)
+    expect(glmCalls).toBe(0)
+    expect(geminiCalls).toBe(1)
+    expect(fireworksCalls).toBe(0)
+    expect(openrouterCalls).toBe(0)
+    expect(alerts).toEqual([
+      {
+        message: 'GLM own-capacity down — failover active',
+        type: 'activated',
+      },
+    ])
+    expect(recorded).toHaveLength(1)
+    expect(recorded[0]).toMatchObject({
+      adapterId: VERTEX_GEMINI_ADAPTER_ID,
+      requestAttribution: {
+        demandClient: 'stress-harness',
+        demandKind: 'internal_stress',
+        demandSource: 'glm-saturation',
       },
     })
     expect(recorded[0]?.usage.totalTokens).toBeGreaterThan(0)

--- a/apps/openagents.com/workers/api/src/inference/chat-completions-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/chat-completions-routes.test.ts
@@ -4482,6 +4482,104 @@ describe('POST /v1/chat/completions', () => {
     expect(fireworksCalls).toBe(0)
   })
 
+  test('active GLM own-capacity failover does not divert tool-bearing Khala requests from GLM', async () => {
+    const registry = new InferenceProviderRegistry()
+    let glmCalls = 0
+    let fireworksCalls = 0
+    registry.register({
+      complete: request =>
+        Effect.sync(() => {
+          glmCalls += 1
+          expect(request.model).toBe(HYDRALISK_GLM_52_REAP_504B_MODEL_ID)
+          return {
+            content: '',
+            finishReason: 'tool_calls',
+            servedModel: HYDRALISK_GLM_52_REAP_504B_MODEL_ID,
+            toolCalls: [
+              {
+                function: { arguments: '{"command":"pwd"}', name: 'bash' },
+                id: 'call_bash',
+                type: 'function' as const,
+              },
+            ],
+            usage: { completionTokens: 3, promptTokens: 11, totalTokens: 14 },
+          }
+        }),
+      id: HYDRALISK_GLM_52_REAP_504B_ADAPTER_ID,
+      stream: () => Effect.sync(() => []),
+    })
+    registry.register({
+      complete: () =>
+        Effect.sync(() => {
+          fireworksCalls += 1
+          return {
+            content: 'wrong lane',
+            finishReason: 'stop',
+            servedModel: 'accounts/fireworks/models/deepseek-v4-flash',
+            usage: { completionTokens: 2, promptTokens: 7, totalTokens: 9 },
+          }
+        }),
+      id: FIREWORKS_ADAPTER_ID,
+      stream: () => Effect.sync(() => []),
+    })
+
+    const failover = makeGlmOwnCapacityFailover({ failureThreshold: 1 })
+    failover.recordFailure(
+      new InferenceAdapterError({
+        adapterId: HYDRALISK_GLM_52_REAP_504B_ADAPTER_ID,
+        httpStatus: 503,
+        kind: 'route_admission_reserved_headroom_unavailable',
+        reason: 'GLM own-capacity lane has no reserved external headroom',
+        retryable: true,
+      }),
+    )
+
+    const response = await run(
+      handleChatCompletions(
+        chatRequest({
+          messages: [{ content: 'Use the available tool.', role: 'user' }],
+          model: KHALA_MODEL_ID,
+          tool_choice: 'auto',
+          tools: [
+            {
+              function: {
+                description: 'Run a shell command.',
+                name: 'bash',
+                parameters: {
+                  additionalProperties: false,
+                  properties: { command: { type: 'string' } },
+                  required: ['command'],
+                  type: 'object',
+                },
+              },
+              type: 'function',
+            },
+          ],
+        }),
+        baseDeps({
+          dispatch: {
+            glmOwnCapacityFailover: failover,
+            sleep: () => Effect.void,
+          },
+          laneArming: hydraliskGlm52ReapReadyArming,
+          lanePlan: () => [
+            HYDRALISK_GLM_52_REAP_504B_ADAPTER_ID,
+            FIREWORKS_ADAPTER_ID,
+          ],
+          registry,
+        }),
+      ),
+    )
+
+    expect(response.status).toBe(200)
+    const body = (await response.json()) as {
+      openagents?: { worker: string }
+    }
+    expect(body.openagents?.worker).toBe(HYDRALISK_GLM_52_REAP_504B_ADAPTER_ID)
+    expect(glmCalls).toBe(1)
+    expect(fireworksCalls).toBe(0)
+  })
+
   test('a non-tool conversational Khala request prefers fast Fireworks over GLM when Gemini is absent', async () => {
     const registry = new InferenceProviderRegistry()
     let glmCalls = 0

--- a/apps/openagents.com/workers/api/src/inference/chat-completions-routes.ts
+++ b/apps/openagents.com/workers/api/src/inference/chat-completions-routes.ts
@@ -3229,6 +3229,11 @@ export const handleChatCompletions = (
             reservedExternalHeadroomAvailable:
               effectiveRouteAdmission.reservedExternalHeadroomAvailable,
           })
+    const dispatchGlmOwnCapacityFailover =
+      glmSaturationStressKhalaRequest &&
+      deps.dispatch?.glmOwnCapacityFailover !== undefined
+        ? deps.dispatch.glmOwnCapacityFailover
+        : undefined
     const dispatchDeps: DispatchDeps = {
       registry: deps.registry,
       plan: () => plannedIds,
@@ -3282,9 +3287,9 @@ export const handleChatCompletions = (
       ...(deps.dispatch?.failureTelemetry === undefined
         ? {}
         : { failureTelemetry: deps.dispatch.failureTelemetry }),
-      ...(deps.dispatch?.glmOwnCapacityFailover === undefined
+      ...(dispatchGlmOwnCapacityFailover === undefined
         ? {}
-        : { glmOwnCapacityFailover: deps.dispatch.glmOwnCapacityFailover }),
+        : { glmOwnCapacityFailover: dispatchGlmOwnCapacityFailover }),
     }
 
     if (inferenceRequest.stream) {

--- a/apps/openagents.com/workers/api/src/inference/model-router.ts
+++ b/apps/openagents.com/workers/api/src/inference/model-router.ts
@@ -300,6 +300,12 @@ const KHALA_STRONG_CODING_ADAPTER_PLAN: ReadonlyArray<string> = [
   OPENROUTER_KHALA_FALLBACK_ADAPTER_ID,
 ]
 
+const KHALA_PAID_FAILOVER_ADAPTER_PLAN: ReadonlyArray<string> = [
+  VERTEX_GEMINI_ADAPTER_ID,
+  FIREWORKS_ADAPTER_ID,
+  OPENROUTER_KHALA_FALLBACK_ADAPTER_ID,
+]
+
 const dedupeAdapterPlan = (
   adapterIds: ReadonlyArray<string>,
 ): ReadonlyArray<string> => {
@@ -444,6 +450,19 @@ export const selectAdapterPlanForKhalaMultiLaneBurnRequest = (
 ): ReadonlyArray<string> =>
   normalizeKhalaModelId(model) === KHALA_MODEL_ID
     ? rotateAdapterPlan(basePlan, rotationIndex)
+    : basePlan
+
+const selectAdapterPlanForKhalaPaidFailover = (
+  model: string,
+  basePlan: ReadonlyArray<string>,
+): ReadonlyArray<string> =>
+  normalizeKhalaModelId(model) === KHALA_MODEL_ID
+    ? dedupeAdapterPlan([
+        ...basePlan.filter(
+          adapterId => adapterId !== HYDRALISK_GLM_52_REAP_504B_ADAPTER_ID,
+        ),
+        ...KHALA_PAID_FAILOVER_ADAPTER_PLAN,
+      ])
     : basePlan
 
 // Resolve a requested model to its ORDERED list of candidate adapter ids
@@ -1042,7 +1061,8 @@ export const makeGlmOwnCapacityFailover = (
     isRecovered: () => input.isRecovered?.() === true,
     recordFailure: error => {
       if (
-        error.adapterId !== adapterId ||
+        (error.adapterId !== adapterId &&
+          !GLM_ROUTE_HEADROOM_FAILURE_KINDS.has(error.kind ?? '')) ||
         !isGlmOwnCapacityUnavailableFailure(error)
       ) {
         return
@@ -1193,15 +1213,19 @@ export const dispatchWithOverflowWithMetadata = <A>(
     const backoff = deps.backoff ?? DEFAULT_OVERFLOW_BACKOFF
     const sleep = deps.sleep ?? Effect.sleep
     const retryCount = normalizedRetryCount(deps.retry)
+    const glmOwnCapacityFailover = deps.glmOwnCapacityFailover
 
     const admission = deps.admission
     if (shouldRejectAdmission(admission) && admission !== undefined) {
       const error = admissionError(admission)
+      glmOwnCapacityFailover?.recordFailure(error)
       recordFailureTelemetry(
         deps.failureTelemetry,
         telemetryForError(error, 'load_shed'),
       )
-      return yield* Effect.fail(error)
+      if (glmOwnCapacityFailover?.isActive() !== true) {
+        return yield* Effect.fail(error)
+      }
     }
 
     const shedding = deps.shedding
@@ -1218,15 +1242,31 @@ export const dispatchWithOverflowWithMetadata = <A>(
       ? yield* deps.preemption!.preempt()
       : undefined
 
-    const adapterIds = planFor(request.model)
-    let healthQuarantinedLaneCount = 0
-    const glmOwnCapacityFailover = deps.glmOwnCapacityFailover
     const recoveredGlmOwnCapacity =
       glmOwnCapacityFailover?.isActive() === true &&
       glmOwnCapacityFailover.isRecovered()
     if (recoveredGlmOwnCapacity) {
       glmOwnCapacityFailover?.recordSuccess(glmOwnCapacityFailover.adapterId)
     }
+
+    const glmOwnCapacityFailoverActive =
+      glmOwnCapacityFailover?.isActive() === true
+    if (glmOwnCapacityFailoverActive) {
+      recordFailureTelemetry(deps.failureTelemetry, {
+        adapterId: glmOwnCapacityFailover.adapterId,
+        classifier: 'fallback',
+        kind: 'glm_own_capacity_failover_active',
+        retryable: true,
+        stage: 'fallback',
+      })
+    }
+    const adapterIds = glmOwnCapacityFailoverActive
+      ? selectAdapterPlanForKhalaPaidFailover(
+          request.model,
+          planFor(request.model),
+        )
+      : planFor(request.model)
+    let healthQuarantinedLaneCount = 0
     // Resolve to the lanes that are actually registered (skip absent partners).
     const adapters = adapterIds.flatMap(id => {
       const adapter = deps.registry.resolve(id)


### PR DESCRIPTION
## Summary

- Count router-level `route_admission_reserved_headroom_unavailable` failures toward the GLM own-capacity failover breaker.
- When the breaker is active, rewrite Khala GLM-only stress demand onto the paid fallback lanes (Vertex Gemini, Fireworks, OpenRouter) while keeping the existing failover alert telemetry.
- Add a route-level regression proving repeated no-headroom admission activates failover, serves through a paid lane, and still records exact token usage attribution.

Closes #6823

## Verification

- `bun run --cwd apps/openagents.com/workers/api test -- src/inference/model-router.test.ts`
- `bun run --cwd apps/openagents.com/workers/api test -- src/inference/chat-completions-routes.test.ts`
- `true` (`command.public.pylon_khala.verify.b5bea41b6c623f7c09f1bf24`)
