### PR TITLE
Wire custom hostname site rendering

### DIFF
--- a/apps/openagents.com/workers/api/src/index.ts
+++ b/apps/openagents.com/workers/api/src/index.ts
@@ -9636,6 +9636,17 @@ const imageGenerationRoutes = makeImageGenerationRoutes({
 })
 
 const siteRuntimeRoutes = makeSiteRuntimeRoutes({
+  reservedHosts: new Set([
+    'auth.openagents.com',
+    'localhost',
+    'openagents-staging.openagents.workers.dev',
+    'openagents.com',
+    '127.0.0.1',
+  ]),
+  resolveCustomHostname: (hostname, env) =>
+    makeTenantCustomHostnames(openAgentsDatabase(env)).resolveTenantByHostname(
+      hostname,
+    ),
   sitesHost: 'sites.openagents.com',
 })
 

--- a/apps/openagents.com/workers/api/src/product-promises.ts
+++ b/apps/openagents.com/workers/api/src/product-promises.ts
@@ -3010,7 +3010,7 @@ export const publicProductPromisesDocument = () => {
         claim:
           'Autopilot Sites customers can serve their sites under custom branded hostnames.',
         safeCopy:
-          'Tenant custom-hostname registration, DNS-token verification, hostname→tenant mapping, request-time resolution, and a live Cloudflare custom-hostname client shipped in wave-3 (#4988/#4989). A CUSTOMER self-serve path is now mounted and live: a signed-in team owner/admin can claim a custom hostname for their own team and any team member can list their team’s claimed hostnames with the exact DNS TXT record to publish (GET/POST /api/tenant/hostnames, browser-session + team-role gated). The self-serve path is INERT by design: a claimed hostname is stored `pending` and never resolves or serves; it touches no live DNS, no SSL issuance, no origin binding, and no spend. Driving a hostname to `active` (live serving) stays the owner-gated Cloudflare provisioning core’s job, which is itself default-OFF until CLOUDFLARE_API_TOKEN and CLOUDFLARE_ZONE_ID are set. Automated SSL issuance and the tenant-scoped rendering context switch are still not wired.',
+          'Tenant custom-hostname registration, DNS-token verification, hostname→tenant mapping, request-time resolution, and a live Cloudflare custom-hostname client shipped in wave-3 (#4988/#4989). A CUSTOMER self-serve path is now mounted and live: a signed-in team owner/admin can claim a custom hostname for their own team and any team member can list their team’s claimed hostnames with the exact DNS TXT record to publish (GET/POST /api/tenant/hostnames, browser-session + team-role gated). The self-serve path is INERT by design: a claimed hostname is stored `pending` and never resolves or serves; it touches no live DNS, no SSL issuance, no origin binding, and no spend. Request-time rendering now resolves an already-active custom hostname to the mapped tenant team’s public active Site runtime, so live serving is blocked on owner-gated provisioning to `active`, not on the rendering context switch. Driving a hostname to `active` stays the owner-gated Cloudflare provisioning core’s job, which is itself default-OFF until CLOUDFLARE_API_TOKEN and CLOUDFLARE_ZONE_ID are set. Automated SSL issuance is still not fully wired into a mounted owner-gated route.',
         unsafeCopy:
           'Do not claim that claiming a hostname makes a site live, that DNS/SSL/branding switching works end to end, or that a claimed hostname serves anything; self-serve claiming writes a pending row only, and live provisioning (Cloudflare for SaaS) stays owner-gated and default-OFF.',
         evidenceRefs: [
@@ -3019,6 +3019,8 @@ export const publicProductPromisesDocument = () => {
           'apps/openagents.com/workers/api/src/tenant-custom-hostname-self-serve.test.ts',
           'apps/openagents.com/workers/api/src/tenant-custom-hostname-self-serve-routes.ts',
           'apps/openagents.com/workers/api/src/tenant-custom-hostname-self-serve-routes.test.ts',
+          'apps/openagents.com/workers/api/src/site-runtime-routes.ts',
+          'apps/openagents.com/workers/api/src/site-runtime-routes.test.ts',
           'apps/openagents.com/workers/api/src/cloudflare-custom-hostname-client.ts',
           'route:/api/tenant/hostnames',
           'https://github.com/OpenAgentsInc/openagents/issues/4988',
@@ -3026,10 +3028,9 @@ export const publicProductPromisesDocument = () => {
         ],
         blockerRefs: [
           'blocker.product_promises.hostname_ssl_issuance_not_wired',
-          'blocker.product_promises.hostname_rendering_context_switch_not_wired',
         ],
         verification:
-          'The customer self-serve claim/list path is mounted and gated (browser session + active team membership; only owner/admin may claim) and is covered by unit tests over the core and the routes; it writes only pending tenant_custom_hostnames rows and reports servingLive=false while provisioning is unarmed. Operator registration/verification still works and passes type checks. Green requires automated DNS verification + SSL provisioning (live Cloudflare for SaaS, owner-gated, default-OFF today) and request routing to tenant-scoped rendering.',
+          'The customer self-serve claim/list path is mounted and gated (browser session + active team membership; only owner/admin may claim) and is covered by unit tests over the core and the routes; it writes only pending tenant_custom_hostnames rows and reports servingLive=false while provisioning is unarmed. Operator registration/verification still works and passes type checks. Site runtime route tests cover active custom-host request-time rendering: a custom hostname resolves to its tenant team and serves that team’s active public Site without a slug prefix while first-party hosts are not intercepted. Green still requires automated DNS verification + SSL provisioning (live Cloudflare for SaaS, owner-gated, default-OFF today) to advance claimed hostnames to active serving.',
         authorityBoundary:
           'Hostname registration is not DNS authority, SSL certificate authority, or site-content publication authority.',
       },

--- a/apps/openagents.com/workers/api/src/site-runtime-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/site-runtime-routes.test.ts
@@ -19,6 +19,9 @@ type SiteRuntimeRow = Readonly<{
   site_status: string
   slug: string
   static_assets_manifest_json: string | null
+  team_id: string | null
+  created_at: string
+  updated_at: string
   version_id: string | null
   visibility: string
   worker_module_r2_key: string | null
@@ -41,6 +44,9 @@ class SiteRuntimeDbStore {
       site_id: 'site_project_otec',
       site_status: 'approved',
       slug: 'otec',
+      team_id: 'team_otec',
+      created_at: '2026-06-01T00:00:00.000Z',
+      updated_at: '2026-06-01T00:00:00.000Z',
       static_assets_manifest_json: JSON.stringify({
         assets: {
           'index.html': {
@@ -56,37 +62,48 @@ class SiteRuntimeDbStore {
       worker_module_r2_key: null,
     },
     {
-    access_mode: 'public',
-    active_deployment_id: 'site_deployment_otec',
-    build_status: 'saved',
-    deployment_id: 'site_deployment_otec',
-    deployment_status: 'active',
-    dispatch_namespace: null,
-    external_deployment_id: null,
-    d1_binding_name: null,
-    r2_binding_name: null,
-    runtime_kind: 'omega_static_r2',
-    runtime_script_name: null,
-    site_id: 'site_project_otec',
-    site_status: 'approved',
-    slug: 'otec',
-    static_assets_manifest_json: JSON.stringify({
-      assets: {
-        'index.html': {
-          cacheControl: 'public, max-age=120',
-          contentType: 'text/html; charset=utf-8',
-          r2Key: 'sites/otec/deployments/site_deployment_otec/index.html',
+      access_mode: 'public',
+      active_deployment_id: 'site_deployment_otec',
+      build_status: 'saved',
+      deployment_id: 'site_deployment_otec',
+      deployment_status: 'active',
+      dispatch_namespace: null,
+      external_deployment_id: null,
+      d1_binding_name: null,
+      r2_binding_name: null,
+      runtime_kind: 'omega_static_r2',
+      runtime_script_name: null,
+      site_id: 'site_project_otec',
+      site_status: 'approved',
+      slug: 'otec',
+      team_id: 'team_otec',
+      created_at: '2026-06-02T00:00:00.000Z',
+      updated_at: '2026-06-02T00:00:00.000Z',
+      static_assets_manifest_json: JSON.stringify({
+        assets: {
+          'about/index.html': {
+            cacheControl: 'public, max-age=120',
+            contentType: 'text/html; charset=utf-8',
+            r2Key: 'sites/otec/deployments/site_deployment_otec/about.html',
+          },
+          'index.html': {
+            cacheControl: 'public, max-age=120',
+            contentType: 'text/html; charset=utf-8',
+            r2Key: 'sites/otec/deployments/site_deployment_otec/index.html',
+          },
         },
-      },
-    }),
-    version_id: 'site_version_otec',
-    visibility: 'public',
-    worker_module_r2_key: null,
+      }),
+      version_id: 'site_version_otec',
+      visibility: 'public',
+      worker_module_r2_key: null,
     },
   ]
 
   get row(): SiteRuntimeRow | null {
-    return this.rows.find(row => row.deployment_id === row.active_deployment_id) ?? null
+    return (
+      this.rows.find(row => row.deployment_id === row.active_deployment_id) ??
+      null
+    )
   }
 
   set row(value: SiteRuntimeRow | null) {
@@ -113,15 +130,22 @@ class SiteRuntimeStatement implements D1PreparedStatement {
   first<T = unknown>(): Promise<T | null> {
     if (this.query.includes('FROM site_projects')) {
       const isVersionQuery = this.query.includes('site_versions.id = ?')
-      const versionId = isVersionQuery ? String(this.values[0]) : null
-      const slug = String(this.values[isVersionQuery ? 1 : 0])
+      const isTeamQuery = this.query.includes('site_projects.team_id = ?')
       const row = isVersionQuery
         ? this.store.rows.find(
-            row => row.slug === slug && row.version_id === versionId,
+            row =>
+              row.slug === String(this.values[1]) &&
+              row.version_id === String(this.values[0]),
           )
-        : this.store.row?.slug === slug
-          ? this.store.row
-          : undefined
+        : isTeamQuery
+          ? this.store.rows.find(
+              row =>
+                row.team_id === String(this.values[0]) &&
+                row.deployment_id === row.active_deployment_id,
+            )
+          : this.store.row?.slug === String(this.values[0])
+            ? this.store.row
+            : undefined
 
       return Promise.resolve((row as T | undefined) ?? null)
     }
@@ -162,6 +186,13 @@ class MemoryR2Bucket {
       'sites/otec/deployments/site_deployment_otec/index.html',
       {
         body: '<!doctype html><title>OTEC</title>',
+        contentType: 'text/html; charset=utf-8',
+      },
+    ],
+    [
+      'sites/otec/deployments/site_deployment_otec/about.html',
+      {
+        body: '<!doctype html><title>About OTEC</title>',
         contentType: 'text/html; charset=utf-8',
       },
     ],
@@ -209,13 +240,24 @@ class MemoryDispatchNamespace {
 }
 
 const routes = makeSiteRuntimeRoutes({ sitesHost: 'sites.openagents.com' })
+const customHostnameRoutes = makeSiteRuntimeRoutes({
+  reservedHosts: new Set(['openagents.com']),
+  resolveCustomHostname: hostname =>
+    Effect.succeed(
+      hostname === 'brand.example.com'
+        ? { hostname, status: 'active', teamId: 'team_otec' }
+        : null,
+    ),
+  sitesHost: 'sites.openagents.com',
+})
 
 const runRoute = (
   store: SiteRuntimeDbStore,
   request: Request,
   dispatch = new MemoryDispatchNamespace(),
+  routeSet = routes,
 ): Promise<Response> => {
-  const route = routes.routeSiteRuntimeRequest(request, {
+  const route = routeSet.routeSiteRuntimeRequest(request, {
     ARTIFACTS: new MemoryR2Bucket() as unknown as R2Bucket,
     OPENAGENTS_DB: siteRuntimeDb(store),
     SITES_DISPATCH: dispatch as unknown as DispatchNamespace,
@@ -272,6 +314,34 @@ describe('site runtime routes', () => {
   test('does not match non-sites hosts', () => {
     const route = routes.routeSiteRuntimeRequest(
       new Request('https://openagents.com/otec'),
+      {
+        ARTIFACTS: new MemoryR2Bucket() as unknown as R2Bucket,
+        OPENAGENTS_DB: siteRuntimeDb(new SiteRuntimeDbStore()),
+        SITES_DISPATCH:
+          new MemoryDispatchNamespace() as unknown as DispatchNamespace,
+      },
+    )
+
+    expect(route).toBeUndefined()
+  })
+
+  test('serves an active tenant custom hostname without a slug prefix', async () => {
+    const response = await runRoute(
+      new SiteRuntimeDbStore(),
+      new Request('https://brand.example.com/about'),
+      new MemoryDispatchNamespace(),
+      customHostnameRoutes,
+    )
+
+    expect(response.status).toBe(200)
+    await expect(response.text()).resolves.toContain(
+      '<title>About OTEC</title>',
+    )
+  })
+
+  test('does not intercept reserved first-party hosts for custom hostname lookup', () => {
+    const route = customHostnameRoutes.routeSiteRuntimeRequest(
+      new Request('https://openagents.com/about'),
       {
         ARTIFACTS: new MemoryR2Bucket() as unknown as R2Bucket,
         OPENAGENTS_DB: siteRuntimeDb(new SiteRuntimeDbStore()),

--- a/apps/openagents.com/workers/api/src/site-runtime-routes.ts
+++ b/apps/openagents.com/workers/api/src/site-runtime-routes.ts
@@ -2,11 +2,15 @@ import { Effect } from 'effect'
 
 import { methodNotAllowed, redirectResponse } from './http/responses'
 import {
-  type SiteRuntimeStaticAsset,
-  type SiteRuntimeWorkerDeployment,
   SiteRuntimeService,
+  type SiteRuntimeStaticAsset,
   SiteRuntimeStorageError,
+  type SiteRuntimeWorkerDeployment,
 } from './site-runtime'
+import {
+  TenantCustomHostnameStorageError,
+  type TenantRef,
+} from './tenant-custom-hostnames'
 
 type SiteRuntimeRouteEnv = Readonly<{
   ARTIFACTS: R2Bucket
@@ -16,6 +20,14 @@ type SiteRuntimeRouteEnv = Readonly<{
 type HttpResponse = globalThis.Response
 
 type SiteRuntimeRoutesConfig = Readonly<{
+  reservedHosts?: ReadonlySet<string>
+  resolveCustomHostname?: (
+    hostname: string,
+    env: SiteRuntimeRouteEnv,
+  ) => Effect.Effect<
+    TenantRef | null,
+    SiteRuntimeStorageError | TenantCustomHostnameStorageError
+  >
   sitesHost: string
 }>
 
@@ -85,10 +97,7 @@ const parseSiteRuntimePath = (url: URL): ParsedSiteRuntimePath | null => {
   if (segments[1] === 'versions') {
     const versionId = segments[2]
 
-    if (
-      versionId === undefined ||
-      !SITE_VERSION_ID_PATTERN.test(versionId)
-    ) {
+    if (versionId === undefined || !SITE_VERSION_ID_PATTERN.test(versionId)) {
       return null
     }
 
@@ -118,6 +127,21 @@ const parseSiteRuntimePath = (url: URL): ParsedSiteRuntimePath | null => {
         : url.pathname.slice(`/${slug}`.length),
     slug,
     versionId: null,
+  }
+}
+
+const parseCustomHostnameSiteRuntimePath = (
+  url: URL,
+): Omit<ParsedSiteRuntimePath, 'slug' | 'versionId'> | null => {
+  const segments = url.pathname.split('/').filter(segment => segment !== '')
+
+  if (hasUnsafePathSegment(segments)) {
+    return null
+  }
+
+  return {
+    candidatePaths: candidateAssetPaths(segments.join('/'), url.pathname),
+    dispatchPath: url.pathname === '' ? '/' : url.pathname,
   }
 }
 
@@ -179,13 +203,16 @@ const runSiteRuntimeRoute = (
   env: SiteRuntimeRouteEnv,
   effect: Effect.Effect<
     HttpResponse,
-    SiteRuntimeStorageError,
+    SiteRuntimeStorageError | TenantCustomHostnameStorageError,
     SiteRuntimeService
   >,
 ): Effect.Effect<HttpResponse> =>
   effect.pipe(
     Effect.provide(SiteRuntimeService.layer(env)),
     Effect.catchTag('SiteRuntimeStorageError', () =>
+      Effect.succeed(publicSiteServerError()),
+    ),
+    Effect.catchTag('TenantCustomHostnameStorageError', () =>
       Effect.succeed(publicSiteServerError()),
     ),
   )
@@ -197,12 +224,64 @@ export const makeSiteRuntimeRoutes = (config: SiteRuntimeRoutesConfig) => ({
   ): Effect.Effect<HttpResponse> | undefined => {
     const url = new URL(request.url)
 
-    if (url.hostname !== config.sitesHost) {
+    if (
+      url.hostname !== config.sitesHost &&
+      (config.resolveCustomHostname === undefined ||
+        config.reservedHosts?.has(url.hostname) === true)
+    ) {
       return undefined
     }
 
     if (url.search !== '') {
       return Effect.succeed(redirectResponse(`${url.origin}${url.pathname}`))
+    }
+
+    if (url.hostname !== config.sitesHost) {
+      const parsed = parseCustomHostnameSiteRuntimePath(url)
+
+      if (parsed === null) {
+        return Effect.succeed(publicSiteNotFound())
+      }
+
+      return runSiteRuntimeRoute(
+        env,
+        Effect.gen(function* () {
+          const tenant = yield* config.resolveCustomHostname!(url.hostname, env)
+
+          if (tenant === null) {
+            return publicSiteNotFound()
+          }
+
+          const runtime = yield* SiteRuntimeService
+          const target = yield* runtime.resolveRuntimeTargetForTeam(
+            tenant.teamId,
+            parsed.candidatePaths,
+          )
+
+          if (target === null) {
+            return publicSiteNotFound()
+          }
+
+          if (target._tag === 'worker') {
+            return yield* workerDispatchResponse(
+              env.SITES_DISPATCH,
+              target,
+              request,
+              parsed.dispatchPath,
+            )
+          }
+
+          if (request.method !== 'GET' && request.method !== 'HEAD') {
+            return methodNotAllowed(['GET', 'HEAD'])
+          }
+
+          const object = yield* runtime.readArtifactObject(target)
+
+          return object === null
+            ? publicSiteNotFound()
+            : artifactResponse(request, object, target)
+        }),
+      )
     }
 
     const parsed = parseSiteRuntimePath(url)

--- a/apps/openagents.com/workers/api/src/site-runtime.ts
+++ b/apps/openagents.com/workers/api/src/site-runtime.ts
@@ -36,8 +36,7 @@ export type SiteRuntimeWorkerDeployment = Readonly<{
 }>
 
 export type SiteRuntimeTarget =
-  | SiteRuntimeStaticAsset
-  | SiteRuntimeWorkerDeployment
+  SiteRuntimeStaticAsset | SiteRuntimeWorkerDeployment
 
 type SiteRuntimeDeploymentRow = Readonly<{
   site_id: string
@@ -190,6 +189,53 @@ const readRuntimeVersion = (
       .first<SiteRuntimeDeploymentRow>(),
   )
 
+const readRuntimeDeploymentForTeam = (
+  db: D1Database,
+  teamId: string,
+): Effect.Effect<SiteRuntimeDeploymentRow | null, SiteRuntimeStorageError> =>
+  d1Effect('siteRuntime.deployments.readActiveByTeam', () =>
+    db
+      .prepare(
+        `SELECT site_projects.id AS site_id,
+                site_projects.slug,
+                site_projects.status AS site_status,
+                site_projects.access_mode,
+                site_projects.visibility,
+                site_projects.active_deployment_id,
+                site_deployments.id AS deployment_id,
+                site_deployments.status AS deployment_status,
+                site_deployments.runtime_kind,
+                site_deployments.runtime_script_name,
+                site_deployments.dispatch_namespace,
+                site_deployments.external_deployment_id,
+                site_versions.id AS version_id,
+                site_versions.build_status,
+                site_versions.worker_module_r2_key,
+                site_versions.static_assets_manifest_json,
+                site_versions.d1_binding_name,
+                site_versions.r2_binding_name
+           FROM site_projects
+           JOIN site_deployments
+             ON site_deployments.id = site_projects.active_deployment_id
+            AND site_deployments.site_id = site_projects.id
+           JOIN site_versions
+             ON site_versions.id = site_deployments.version_id
+            AND site_versions.site_id = site_projects.id
+          WHERE site_projects.team_id = ?
+            AND site_projects.archived_at IS NULL
+            AND site_projects.status NOT IN ('disabled', 'archived')
+            AND site_projects.access_mode = 'public'
+            AND site_projects.visibility = 'public'
+            AND site_deployments.status = 'active'
+            AND site_versions.build_status = 'saved'
+          ORDER BY site_projects.updated_at DESC,
+                   site_projects.created_at DESC
+          LIMIT 1`,
+      )
+      .bind(teamId)
+      .first<SiteRuntimeDeploymentRow>(),
+  )
+
 const isPublicActiveRuntimeRow = (row: SiteRuntimeDeploymentRow): boolean =>
   row.site_status !== 'disabled' &&
   row.site_status !== 'archived' &&
@@ -253,7 +299,8 @@ const isPublicVersionStaticRuntimeRow = (
   row: SiteRuntimeDeploymentRow,
 ): boolean =>
   isPublicSavedVersionRuntimeRow(row) &&
-  (row.runtime_kind === 'omega_static_r2' || row.static_assets_manifest_json !== null)
+  (row.runtime_kind === 'omega_static_r2' ||
+    row.static_assets_manifest_json !== null)
 
 const assetFromManifestEntry = (
   row: SiteRuntimeDeploymentRow,
@@ -296,7 +343,9 @@ const resolveManifestAsset = (
   candidatePaths: ReadonlyArray<string>,
 ): SiteRuntimeStaticAsset | null => {
   const decoded = Option.getOrUndefined(
-    decodeStaticAssetsManifest(parseJsonRecord(row.static_assets_manifest_json)),
+    decodeStaticAssetsManifest(
+      parseJsonRecord(row.static_assets_manifest_json),
+    ),
   )
 
   if (decoded === undefined) {
@@ -340,6 +389,31 @@ const resolveRuntimeTarget = (
 ): Effect.Effect<SiteRuntimeTarget | null, SiteRuntimeStorageError> =>
   Effect.gen(function* () {
     const row = yield* readRuntimeDeployment(db, slug)
+
+    if (row === null) {
+      return null
+    }
+
+    const workerDeployment = workerDeploymentFromRow(row)
+
+    if (workerDeployment !== null) {
+      return workerDeployment
+    }
+
+    if (!isPublicActiveStaticRuntimeRow(row)) {
+      return null
+    }
+
+    return resolveManifestAsset(row, candidatePaths)
+  })
+
+const resolveRuntimeTargetForTeam = (
+  db: D1Database,
+  teamId: string,
+  candidatePaths: ReadonlyArray<string>,
+): Effect.Effect<SiteRuntimeTarget | null, SiteRuntimeStorageError> =>
+  Effect.gen(function* () {
+    const row = yield* readRuntimeDeploymentForTeam(db, teamId)
 
     if (row === null) {
       return null
@@ -404,6 +478,10 @@ export class SiteRuntimeService extends Context.Service<
       slug: string,
       candidatePaths: ReadonlyArray<string>,
     ) => Effect.Effect<SiteRuntimeTarget | null, SiteRuntimeStorageError>
+    readonly resolveRuntimeTargetForTeam: (
+      teamId: string,
+      candidatePaths: ReadonlyArray<string>,
+    ) => Effect.Effect<SiteRuntimeTarget | null, SiteRuntimeStorageError>
     readonly resolveVersionRuntimeTarget: (
       slug: string,
       versionId: string,
@@ -420,9 +498,19 @@ export class SiteRuntimeService extends Context.Service<
         (slug, candidatePaths) =>
           resolveStaticAsset(openAgentsDatabase(env), slug, candidatePaths),
       ),
-      resolveRuntimeTarget: Effect.fn('SiteRuntimeService.resolveRuntimeTarget')(
-        (slug, candidatePaths) =>
-          resolveRuntimeTarget(openAgentsDatabase(env), slug, candidatePaths),
+      resolveRuntimeTarget: Effect.fn(
+        'SiteRuntimeService.resolveRuntimeTarget',
+      )((slug, candidatePaths) =>
+        resolveRuntimeTarget(openAgentsDatabase(env), slug, candidatePaths),
+      ),
+      resolveRuntimeTargetForTeam: Effect.fn(
+        'SiteRuntimeService.resolveRuntimeTargetForTeam',
+      )((teamId, candidatePaths) =>
+        resolveRuntimeTargetForTeam(
+          openAgentsDatabase(env),
+          teamId,
+          candidatePaths,
+        ),
       ),
       resolveVersionRuntimeTarget: Effect.fn(
         'SiteRuntimeService.resolveVersionRuntimeTarget',


### PR DESCRIPTION
## Summary
- Wire active tenant custom hostnames into the Site runtime route so a custom host serves the mapped tenant team's active public Site without a slug prefix.
- Keep first-party hosts reserved so the custom-host lookup does not intercept openagents.com/auth/local routes.
- Update custom-hostname promise evidence/copy to remove the rendering-context blocker while keeping SSL/DNS provisioning owner-gated and yellow.

Closes #6840

## Verification
- `bun run --cwd apps/openagents.com/workers/api test -- src/site-runtime-routes.test.ts src/product-promises.test.ts`
- `bun run --cwd apps/openagents.com/workers/api typecheck`
- `bun run --cwd apps/openagents.com check:deploy`
