### PR TITLE
fix(pylon): surface Codex execution refusal reasons

### DIFF
--- a/apps/pylon/scripts/codex-supervisor/backoff-policy.sh
+++ b/apps/pylon/scripts/codex-supervisor/backoff-policy.sh
@@ -113,6 +113,30 @@ sup_record_account_refusal() {
 
 sup_dispatch_failure_signature() {
   local out="$1"
+  if grep -qiE 'codex_agent_execution_refused\.credentials_revoked|credentials[_ -]?revoked|refresh token was revoked' "$out" 2>/dev/null; then
+    printf 'credentials_revoked'
+    return 0
+  fi
+  if grep -qiE 'codex_agent_execution_refused\.usage_limited|usage[_ -]?limited|usage limit' "$out" 2>/dev/null; then
+    printf 'usage_limited'
+    return 0
+  fi
+  if grep -qiE 'codex_agent_execution_refused\.rate_limited|rate[_ -]?limited|rate.?limit|too many requests|\b429\b' "$out" 2>/dev/null; then
+    printf 'rate_limited'
+    return 0
+  fi
+  if grep -qiE 'codex_agent_execution_refused\.timeout|timed? ?out|timeout' "$out" 2>/dev/null; then
+    printf 'timeout'
+    return 0
+  fi
+  if grep -qiE 'codex_agent_execution_refused\.auth_error|auth[_ -]?error|unauthorized|\b401\b|sign in again' "$out" 2>/dev/null; then
+    printf 'auth_error'
+    return 0
+  fi
+  if grep -qiE 'codex_agent_execution_refused\.network|network|websocket|\bwss\b|econnreset|enotfound|eai_again|fetch failed' "$out" 2>/dev/null; then
+    printf 'network'
+    return 0
+  fi
   if grep -qiE 'codex_agent_execution_refused|execution[_ -]?refused' "$out" 2>/dev/null; then
     printf 'codex_agent_execution_refused'
     return 0

--- a/apps/pylon/scripts/codex-supervisor/backoff-policy.test.sh
+++ b/apps/pylon/scripts/codex-supervisor/backoff-policy.test.sh
@@ -42,6 +42,10 @@ else
 fi
 
 printf '%s' '{"error":"codex_agent_execution_refused"}' > "$WORK/executor-refused.json"
+printf '%s' '{"blockerRefs":["blocker.assignment.codex_agent_execution_refused","blocker.assignment.codex_agent_execution_refused.credentials_revoked"]}' > "$WORK/revoked.json"
+printf '%s' '{"blockerRefs":["blocker.assignment.codex_agent_execution_refused.usage_limited"]}' > "$WORK/usage-limited.json"
+printf '%s' '{"blockerRefs":["blocker.assignment.codex_agent_execution_refused.rate_limited"]}' > "$WORK/specific-rate.json"
+printf '%s' '{"blockerRefs":["blocker.assignment.codex_agent_execution_refused.auth_error"]}' > "$WORK/auth-error.json"
 printf '%s' '{"error":"target_pylon_unavailable"}' > "$WORK/gate-refused.json"
 printf '%s' 'HTTP 429 too many requests' > "$WORK/rate.txt"
 printf '%s' 'plain failure' > "$WORK/other.txt"
@@ -50,6 +54,30 @@ if [ "$(sup_dispatch_failure_signature "$WORK/executor-refused.json")" = "codex_
   ok "executor refusal is classified distinctly"
 else
   bad "executor refusal classification failed"
+fi
+
+if [ "$(sup_dispatch_failure_signature "$WORK/revoked.json")" = "credentials_revoked" ]; then
+  ok "specific revoked credential refusal is surfaced"
+else
+  bad "revoked credential refusal classification failed"
+fi
+
+if [ "$(sup_dispatch_failure_signature "$WORK/usage-limited.json")" = "usage_limited" ]; then
+  ok "specific usage-limited refusal is surfaced"
+else
+  bad "usage-limited refusal classification failed"
+fi
+
+if [ "$(sup_dispatch_failure_signature "$WORK/specific-rate.json")" = "rate_limited" ]; then
+  ok "specific rate-limited refusal is surfaced"
+else
+  bad "specific rate-limited refusal classification failed"
+fi
+
+if [ "$(sup_dispatch_failure_signature "$WORK/auth-error.json")" = "auth_error" ]; then
+  ok "specific auth-error refusal is surfaced"
+else
+  bad "auth-error refusal classification failed"
 fi
 
 if [ "$(sup_dispatch_failure_signature "$WORK/gate-refused.json")" = "refused" ]; then

--- a/apps/pylon/src/codex-agent-executor.ts
+++ b/apps/pylon/src/codex-agent-executor.ts
@@ -124,12 +124,22 @@ export type CodexAgentRunOutcome =
   | "workspace_escape_blocked"
   | "refused"
 
+export type CodexAgentExecutionRefusalReason =
+  | "credentials_revoked"
+  | "usage_limited"
+  | "rate_limited"
+  | "network"
+  | "timeout"
+  | "auth_error"
+  | "other"
+
 export type CodexAgentRunResult = {
   outcome: CodexAgentRunOutcome
   turnCount: number
   editedFileCount: number
   commandCount: number
   sessionRef: string | null
+  refusalReason?: CodexAgentExecutionRefusalReason
 }
 
 export type CodexAgentRunner = (input: CodexAgentRunInput) => Promise<CodexAgentRunResult>
@@ -648,6 +658,49 @@ type CodexThreadEvent = {
 
 type RawCodexThreadEvent = Record<string, unknown>
 
+export function classifyCodexAgentExecutionError(error: unknown): CodexAgentExecutionRefusalReason {
+  const text = (() => {
+    if (error instanceof Error) return `${error.name}\n${error.message}\n${error.stack ?? ""}`
+    if (typeof error === "string") return error
+    if (error !== null && typeof error === "object") {
+      const record = error as { message?: unknown; stderr?: unknown; stdout?: unknown; code?: unknown; status?: unknown }
+      return [
+        typeof record.message === "string" ? record.message : "",
+        typeof record.stderr === "string" ? record.stderr : "",
+        typeof record.stdout === "string" ? record.stdout : "",
+        typeof record.code === "string" || typeof record.code === "number" ? String(record.code) : "",
+        typeof record.status === "string" || typeof record.status === "number" ? String(record.status) : "",
+      ].join("\n")
+    }
+    return ""
+  })().toLowerCase()
+
+  if (/revok/.test(text)) return "credentials_revoked"
+  if (/usage limit|quota/.test(text)) return "usage_limited"
+  if (/rate limit|too many requests|\b429\b/.test(text)) return "rate_limited"
+  if (/timeout|timed out|etimedout|abort(?:ed)?/.test(text)) return "timeout"
+  if (/network|websocket|\bwss\b|econnreset|enotfound|eai_again|fetch failed/.test(text)) return "network"
+  if (
+    /could not be refreshed|refresh token|token (?:has )?expired|expired token|unauthorized|\b401\b|not logged in|please (?:sign in|log ?in)|sign in again|authentication (?:failed|error)|invalid (?:token|credential)/.test(
+      text,
+    )
+  ) {
+    return "auth_error"
+  }
+  return "other"
+}
+
+function codexExecutionRefusalRefs(reason: CodexAgentExecutionRefusalReason) {
+  return {
+    blockerRefs: [
+      "blocker.assignment.codex_agent_execution_refused",
+      `blocker.assignment.codex_agent_execution_refused.${reason}`,
+    ],
+    resultRef: `result.public.pylon.codex_agent_task.execution_refused.${reason}`,
+    summaryRef: `summary.public.pylon.codex_agent_task.execution_refused.${reason}`,
+  }
+}
+
 function finiteToken(value: number | undefined): number {
   return typeof value === "number" && Number.isFinite(value) && value > 0
     ? Math.trunc(value)
@@ -861,6 +914,7 @@ export async function runWithCodexSdk(input: CodexAgentRunInput): Promise<CodexA
   let pendingRawEvents: Array<RawCodexThreadEvent> = []
   let pendingChunkItems: Array<CodexTurnReportItem> = []
   let pendingChunkRawEvents: Array<RawCodexThreadEvent> = []
+  let refusalReason: CodexAgentExecutionRefusalReason | undefined
 
   const flushEventChunk = async (turnIndex: number) => {
     if (pendingChunkRawEvents.length === 0) return
@@ -949,7 +1003,10 @@ export async function runWithCodexSdk(input: CodexAgentRunInput): Promise<CodexA
         pendingChunkRawEvents = []
         activeTurnIndex = 0
       }
-      if (event.type === "turn.failed" || event.type === "error") failed = true
+      if (event.type === "turn.failed" || event.type === "error") {
+        failed = true
+        refusalReason = classifyCodexAgentExecutionError(event.error?.message ?? event)
+      }
       if (event.type === "item.completed" && event.item?.type === "command_execution") {
         commandCount += 1
         await emitCodexProgress(input.onProgress, {
@@ -1001,7 +1058,14 @@ export async function runWithCodexSdk(input: CodexAgentRunInput): Promise<CodexA
     return { outcome: "budget_exceeded", turnCount, editedFileCount, commandCount, sessionRef }
   }
   if (failed) {
-    return { outcome: "refused", turnCount, editedFileCount, commandCount, sessionRef }
+    return {
+      outcome: "refused",
+      turnCount,
+      editedFileCount,
+      commandCount,
+      sessionRef,
+      refusalReason: refusalReason ?? "other",
+    }
   }
   return { outcome: "completed", turnCount, editedFileCount, commandCount, sessionRef }
 }
@@ -1291,15 +1355,17 @@ export async function executeCodexAgentAssignment(
       ...(options.onProgress === undefined ? {} : { onProgress: options.onProgress }),
       workspaceRef: materialized.workspaceRef,
     })
-  } catch {
+  } catch (error) {
+    const reason = classifyCodexAgentExecutionError(error)
+    const refusal = codexExecutionRefusalRefs(reason)
     await releaseCodexAgentWorkspace({ materialized, now })
     return refusalRecord({
       lease,
       runRef,
-      blockerRefs: ["blocker.assignment.codex_agent_execution_refused"],
-      resultRef: "result.public.pylon.codex_agent_task.execution_refused",
-      summaryRef: "summary.public.pylon.codex_agent_task.execution_refused",
-      message: "Local Codex thread refused with a typed execution error.",
+      blockerRefs: refusal.blockerRefs,
+      resultRef: refusal.resultRef,
+      summaryRef: refusal.summaryRef,
+      message: `Local Codex thread refused with a typed execution error (${reason}).`,
     })
   }
 
@@ -1325,14 +1391,16 @@ export async function executeCodexAgentAssignment(
     })
   }
   if (run.outcome === "refused") {
+    const reason = run.refusalReason ?? "other"
+    const refusal = codexExecutionRefusalRefs(reason)
     await releaseCodexAgentWorkspace({ materialized, now })
     return refusalRecord({
       lease,
       runRef,
-      blockerRefs: ["blocker.assignment.codex_agent_execution_refused"],
-      resultRef: "result.public.pylon.codex_agent_task.execution_refused",
-      summaryRef: "summary.public.pylon.codex_agent_task.execution_refused",
-      message: "Local Codex thread ended with an execution error before completing the task.",
+      blockerRefs: refusal.blockerRefs,
+      resultRef: refusal.resultRef,
+      summaryRef: refusal.summaryRef,
+      message: `Local Codex thread ended with an execution error before completing the task (${reason}).`,
     })
   }
 

--- a/apps/pylon/tests/codex-agent-executor.test.ts
+++ b/apps/pylon/tests/codex-agent-executor.test.ts
@@ -6,6 +6,7 @@ import { tmpdir } from "node:os"
 import {
   CODEX_AGENT_SUM_REPAIR_FIXTURE_REF,
   CODEX_AGENT_TASK_SCHEMA,
+  classifyCodexAgentExecutionError,
   codexAgentTaskFrom,
   effectiveSandboxMode,
   executeCodexAgentAssignment,
@@ -175,14 +176,35 @@ describe("codex agent task recognition", () => {
     })
   })
 
+  test("classifies Codex execution errors into public-safe refusal reasons", () => {
+    expect(
+      classifyCodexAgentExecutionError(
+        new Error("Your access token could not be refreshed because your refresh token was revoked."),
+      ),
+    ).toBe("credentials_revoked")
+    expect(classifyCodexAgentExecutionError("usage limit reached for account")).toBe("usage_limited")
+    expect(classifyCodexAgentExecutionError({ stderr: "429 too many requests" })).toBe("rate_limited")
+    expect(
+      classifyCodexAgentExecutionError(
+        Object.assign(new Error("fetch failed wss connection"), { code: "ENOTFOUND" }),
+      ),
+    ).toBe("network")
+    expect(classifyCodexAgentExecutionError(new Error("operation timed out"))).toBe("timeout")
+    expect(classifyCodexAgentExecutionError("unexpected sdk failure")).toBe("other")
+  })
+
   test("maps escape, budget, refusal, and thrown-runner outcomes to typed blockers", async () => {
     await withState(async (state) => {
       const outcomes = [
         { outcome: "workspace_escape_blocked", blocker: "blocker.assignment.codex_agent_workspace_escape_blocked" },
         { outcome: "budget_exceeded", blocker: "blocker.assignment.codex_agent_budget_exceeded" },
-        { outcome: "refused", blocker: "blocker.assignment.codex_agent_execution_refused" },
+        {
+          outcome: "refused",
+          blocker: "blocker.assignment.codex_agent_execution_refused",
+          specificBlocker: "blocker.assignment.codex_agent_execution_refused.other",
+        },
       ] as const
-      for (const { outcome, blocker } of outcomes) {
+      for (const { outcome, blocker, specificBlocker } of outcomes) {
         const runner: CodexAgentRunner = async () => ({
           outcome,
           turnCount: 1,
@@ -195,19 +217,28 @@ describe("codex agent task recognition", () => {
           codexAgentProbe: readyProbe,
         })
         expect(record?.status).toBe("rejected")
-        expect(record?.blockerRefs).toEqual([blocker])
+        expect(record?.blockerRefs).toContain(blocker)
+        if (specificBlocker !== undefined) {
+          expect(record?.blockerRefs).toContain(specificBlocker)
+        }
         assertPublicProjectionSafe(record)
       }
 
       const throwingRunner: CodexAgentRunner = async () => {
-        throw new Error("sdk exploded")
+        throw new Error("Your access token could not be refreshed because your refresh token was revoked.")
       }
       const record = await executeCodexAgentAssignment(state, lease, now, {
         codexAgentRunner: throwingRunner,
         codexAgentProbe: readyProbe,
       })
       expect(record?.status).toBe("rejected")
-      expect(record?.blockerRefs).toEqual(["blocker.assignment.codex_agent_execution_refused"])
+      expect(record?.blockerRefs).toEqual([
+        "blocker.assignment.codex_agent_execution_refused",
+        "blocker.assignment.codex_agent_execution_refused.credentials_revoked",
+      ])
+      expect(record?.resultRefs).toEqual([
+        "result.public.pylon.codex_agent_task.execution_refused.credentials_revoked",
+      ])
     })
   })
 


### PR DESCRIPTION
Closes #6902.

## Summary
- classify Codex SDK execution failures into public-safe refusal reasons (`credentials_revoked`, `usage_limited`, `rate_limited`, `network`, `timeout`, `auth_error`, `other`)
- carry the classified reason into assignment closeout blocker/result/summary refs while preserving the generic `codex_agent_execution_refused` blocker
- teach the Codex supervisor backoff parser to surface specific refusal reasons instead of collapsing them into the generic execution refusal signature

## Verification
- `bun test apps/pylon/tests/codex-agent-executor.test.ts`
- `bash apps/pylon/scripts/codex-supervisor/backoff-policy.test.sh`
- `bun run --cwd apps/pylon typecheck`
- `true` (`command.public.pylon_khala.verify.b5bea41b6c623f7c09f1bf24`)
