### PR TITLE
docs(promises): record Autopilot world visualization gate decision

### DIFF
--- a/apps/openagents.com/workers/api/src/product-promises.test.ts
+++ b/apps/openagents.com/workers/api/src/product-promises.test.ts
@@ -440,10 +440,47 @@ describe('public product promises document', () => {
       /latest stays 0\.2\.5|only published, installable Pylon|release candidate, not stable 0\.3\.0|Pylon v1\.0 is present in the monorepo as a release candidate/i,
     )
     expect(currentCopy).toContain('Pylon v1.0 has a stable source cut')
-    expect(currentCopy).toContain('Registry 2026-06-29.2')
+    expect(currentCopy).toContain('Registry 2026-06-29.3')
     expect(currentCopy).toContain('flips NO promise state')
+    expect(currentCopy).toContain(
+      'records the conservative Autopilot world-visualization gate decision',
+    )
     expect(currentCopy).toContain('Khala Desktop now carries source-level')
     expect(currentCopy).toContain('maxStalenessSeconds:0')
+    const worldScenePromise = decoded.promises.find(
+      promise => promise.promiseId === 'autopilot.agent_world_scene.v1',
+    )
+    const paymentVisualizationPromise = decoded.promises.find(
+      promise =>
+        promise.promiseId === 'autopilot.bitcoin_payment_visualization.v1',
+    )
+    const growthVisualizationPromise = decoded.promises.find(
+      promise =>
+        promise.promiseId === 'autopilot.pylon_growth_visualization.v1',
+    )
+    expect(worldScenePromise?.state).toBe('yellow')
+    expect(paymentVisualizationPromise?.state).toBe('yellow')
+    expect(growthVisualizationPromise?.state).toBe('yellow')
+    expect(worldScenePromise?.blockerRefs).toEqual([
+      'blocker.product_promises.agent_world_scene_intentionally_flag_gated',
+    ])
+    expect(paymentVisualizationPromise?.blockerRefs).toEqual([
+      'blocker.product_promises.payment_visualization_intentionally_flag_gated',
+    ])
+    expect(growthVisualizationPromise?.blockerRefs).toEqual([
+      'blocker.product_promises.pylon_growth_intentionally_flag_gated',
+    ])
+    for (const promise of [
+      worldScenePromise,
+      paymentVisualizationPromise,
+      growthVisualizationPromise,
+    ]) {
+      expect(promise?.safeCopy).toContain('2026-06-29 #7030 decision')
+      expect(promise?.safeCopy).toContain('off by default')
+      expect(promise?.evidenceRefs).toContain(
+        'docs/promises/2026-06-29-autopilot-world-visualization-gate-decision.md',
+      )
+    }
     const codexSuccessorPromise = decoded.promises.find(
       promise => promise.promiseId === 'autopilot.codex_probe_pylon_successor.v1',
     )

--- a/apps/openagents.com/workers/api/src/product-promises.ts
+++ b/apps/openagents.com/workers/api/src/product-promises.ts
@@ -4,7 +4,7 @@ import { currentIsoTimestamp } from './runtime-primitives'
 export const PublicProductPromisesEndpoint = '/api/public/product-promises'
 export const PublicProductPromisesSchemaVersion =
   'openagents.product_promises.v1'
-export const PublicProductPromisesVersion = '2026-06-29.2'
+export const PublicProductPromisesVersion = '2026-06-29.3'
 
 const reportPath = 'https://openagents.com/forum/f/product-promises'
 
@@ -72,6 +72,7 @@ const sourceRefs = [
   'clients/khala-desktop/tests/apple-fm-packaging.test.ts',
   'clients/khala-desktop/tests/apple-fm-readiness.test.ts',
   'clients/khala-desktop/tests/apple-fm-sidecar.test.ts',
+  'docs/promises/2026-06-29-autopilot-world-visualization-gate-decision.md',
   'docs/promises/2026-06-14-registry-reality-reconciliation-audit.md',
   'docs/promises/2026-06-17-training-monday-simulation-settlement-policy.md',
   'docs/promises/2026-06-18-training-monday-real-settlement-gate-met.md',
@@ -261,6 +262,7 @@ export const publicProductPromisesDocument = () => {
         'Registry 2026-06-28.3 implements #6891 for models.tassadar_percepta_executor.v1 and flips NO promise state. Pylon v1.0 now has a deterministic bounded CPU computation-transform fixture in apps/pylon/src/tassadar-cpu-transform-training.ts that runs one CPU-only optimization step, self-verifies loss improvement, emits receipt.models.tassadar_percepta_executor.cpu_transform_training.cpu_transform_fixture_v1, and keeps realBitcoinMoved:false / settlementState:not_settled. GET /api/public/models/tassadar-percepta-executor/cpu-transform-training-receipts now projects that public-safe receipt alongside the architecture and Artanis distillation dataset inputs, so the old pylon_v03_cpu_transform_training_receipts_missing blocker is replaced by blocker.product_promises.tassadar_cpu_transform_real_settlement_missing and blocker.product_promises.tassadar_cpu_transform_owner_green_signoff_missing. The promise STAYS planned: this is one fixture-scale receipt, not a trained model, not a paid earning path, not model promotion, and not a green transition; any future green flip remains receipt-first and owner-signed per proof.claim_upgrade_receipts.v1.',
         'Registry 2026-06-29.1 implements #6848 for payments.accepted_outcome_economics.v1 and flips NO promise state. The accepted-outcome economics spine now has a dereferenceable contributor accrual bundle at GET /api/public/payments/contributor-accrual-bundle?economicsId=... plus the settlement bundle at GET /api/public/accepted-outcome/settlement/{economicsId}; together they compose a gross-margin receipt, contributor accrual ledger entries, and an eight-state settlement machine from one stored accepted-outcome economics row. Tests prove the ledger and receipt share the same economicsId, reconcile gross margin exactly, reconcile pending_payout to the distributable ledger pool, keep public projections free of internal cents/raw payment material, and surface missing contributor provenance honestly. The old source-level blockers contributor_ledger_missing and gross_margin_receipts_missing are replaced by real_accepted_outcome_receipt_missing and owner_signed_green_transition_missing. The promise STAYS red because source/fixture receipt machinery is not a real accepted outcome carried through a money-moving settlement path, and any future green flip remains receipt-first and owner-signed per proof.claim_upgrade_receipts.v1.',
         'Registry 2026-06-29.2 is a current-main refresh after #6997/#6999/#7001/#7002/#7006 and flips NO promise state. The terminal-agent current-state audit and Codex tool-layer study are now cited as evidence for the Codex/Probe/Pylon runtime direction: current production coding delegation is still Pylon plus external agent SDK lanes and OpenAgents-native terminal tools remain a consolidation task, not a new green claim. The codex-supervisor LOCKOUT replenishment helper can create or reuse three bounded standing issues so owner-capacity supervisors do not idle indefinitely, but it creates no paid labor, payout, settlement, or broad availability claim. The inference router now has GLM own-capacity failover alerting and public-safe fallback telemetry for repeated no-headroom saturation, but the paid gateway still stays red until a dereferenceable paid receipt exists. Khala Desktop now carries source-level Electrobun Apple FM sidecar packaging/readiness plus redaction tests, but Apple FM local mode remains yellow until a signed/notarized from-install smoke with helper supervision exists. The Khala model-mix promise remains live-at-read with maxStalenessSeconds:0; the stale 2-second cache wording is not applied.',
+        'Registry 2026-06-29.3 records the conservative Autopilot world-visualization gate decision for #7030 and flips NO promise state. autopilot.agent_world_scene.v1, autopilot.bitcoin_payment_visualization.v1, and autopilot.pylon_growth_visualization.v1 stay yellow and intentionally flag-gated: the source-level and live in-app wiring remain valid evidence, but CHAT_WORLD_SCENE / CHAT_WORLD_PAYMENTS are not made default-on without a fresh owner-approved rollout receipt. The old default-off blockers are replaced with explicit intentional-gate blockers, so yellow no longer reads as stale wiring debt. Payment beams remain receipt-bound and idle-pruned; growth remains a settled-sats visualization only. No spend, payout, settlement, runtime mutation, multiplayer, or broad default-on product claim is created.',
       ],
     },
     promises: [
@@ -3988,7 +3990,7 @@ export const publicProductPromisesDocument = () => {
         claim:
           'The Autopilot chat is set inside a living 3D Pylon world: a glass-over-canvas scene rendered behind the conversation where each live Pylon appears as a crystal, driven by real pylon-stats data.',
         safeCopy:
-          'The agent world scene exists behind the Autopilot chat as a flag-gated, glass-over-canvas 3D render. The live in-app wiring is present: pylon-stats feeds the running scene through the chat-world subscription/reducer/view path, live Pylons render as crystals, and stale payment beams age out instead of implying current activity. The product default-on / stay-flag-gated decision is still owner-gated, so this remains a yellow, receipt-bounded claim.',
+          'The agent world scene exists behind the Autopilot chat as an intentionally flag-gated, glass-over-canvas 3D render. The live in-app wiring is present: pylon-stats feeds the running scene through the chat-world subscription/reducer/view path, live Pylons render as crystals, and stale payment beams age out instead of implying current activity. The 2026-06-29 #7030 decision keeps the scene off by default until a fresh owner-approved rollout receipt exists, so this remains a yellow, receipt-bounded claim.',
         unsafeCopy:
           'Do not say the 3D agent world is on by default for all users, that it is a finished shipped feature, that it is a walkable or multiplayer world (see world.multiplayer_agent_world.v1), or that the scene shows anything other than evidence-bound live Pylon state.',
         evidenceRefs: [
@@ -4006,14 +4008,15 @@ export const publicProductPromisesDocument = () => {
           'apps/autopilot-desktop/tests/chat-world-scene.test.ts',
           'apps/autopilot-desktop/tests/chat-world-subscriptions.test.ts',
           'apps/autopilot-desktop/tests/verse-launch-checklist.test.ts',
+          'docs/promises/2026-06-29-autopilot-world-visualization-gate-decision.md',
           'https://openagents.com/api/public/pylon-stats',
           'promise:repo.open_source_code_map.v1',
         ],
         blockerRefs: [
-          'blocker.product_promises.agent_world_scene_not_default_on',
+          'blocker.product_promises.agent_world_scene_intentionally_flag_gated',
         ],
         verification:
-          'Yellow is limited to what is merged to main: the P0 scene mount behind CHAT_WORLD_SCENE (PR #5742), P1 live Pylon crystals fed from the public pylon-stats projection (PR #5743), and the P2.5 in-app wiring path that carries pylon-stats through chat-world-subscriptions.ts -> GotChatWorldScene -> modelChatWorldScene -> verseSceneVisualization, plus idle expiry for evidence-bound payment beams. Focused proof: bun test tests/verse-launch-checklist.test.ts tests/chat-world-subscriptions.test.ts tests/chat-world-scene.test.ts in apps/autopilot-desktop. Green still requires the owner decision that the scene is default-on or explicitly remains flag-gated as the product, plus an owner-signed receipt-first upgrade per proof.claim_upgrade_receipts.v1.',
+          'Yellow is limited to what is merged to main: the P0 scene mount behind CHAT_WORLD_SCENE (PR #5742), P1 live Pylon crystals fed from the public pylon-stats projection (PR #5743), and the P2.5 in-app wiring path that carries pylon-stats through chat-world-subscriptions.ts -> GotChatWorldScene -> modelChatWorldScene -> verseSceneVisualization, plus idle expiry for evidence-bound payment beams. The 2026-06-29 #7030 decision keeps this intentionally flag-gated instead of default-on until a fresh owner-approved rollout receipt exists. Focused proof: bun test tests/verse-launch-checklist.test.ts tests/chat-world-subscriptions.test.ts tests/chat-world-scene.test.ts in apps/autopilot-desktop. Green still requires a default-on/staged-rollout receipt or an owner-signed green-scope decision per proof.claim_upgrade_receipts.v1.',
         authorityBoundary:
           'The agent world scene is a presentational projection of already-public Pylon state. It grants no runtime mutation, no spend, no settlement, no payout, and no authority over the data it visualizes, and it makes no separate Pylon earning, payment, multiplayer, or onboarding claim green.',
       },
@@ -4026,7 +4029,7 @@ export const publicProductPromisesDocument = () => {
         claim:
           'Real Bitcoin settlements are visualized in the agent world as gold particles flying agent-to-agent, each particle bound to a real settlement receipt and clickable to its evidence.',
         safeCopy:
-          'The Bitcoin payment visualization is wired into the live running agent-world scene behind the default-off CHAT_WORLD_PAYMENTS flag. It is evidence-bound by construction: a gold payment particle is only emitted for a real_bitcoin_moved or settlement_recorded event that proves realBitcoinMoved:true and carries at least one sourceRef, and the mappers refuse to emit a particle with no sourceRef or simulated settlement evidence.',
+          'The Bitcoin payment visualization is wired into the live running agent-world scene behind the intentionally flag-gated CHAT_WORLD_PAYMENTS flag. It is evidence-bound by construction: a gold payment particle is only emitted for a real_bitcoin_moved or settlement_recorded event that proves realBitcoinMoved:true and carries at least one sourceRef, and the mappers refuse to emit a particle with no sourceRef or simulated settlement evidence. The 2026-06-29 #7030 decision keeps it off by default until a fresh owner-approved rollout receipt exists.',
         unsafeCopy:
           'Do not say payment particles are live for all users, that the visualization is on by default, that it shows simulated or unbacked payments, or that visualizing a settlement implies any new earning, payout, or settlement authority.',
         evidenceRefs: [
@@ -4041,14 +4044,15 @@ export const publicProductPromisesDocument = () => {
           'apps/autopilot-desktop/tests/chat-world-scene.test.ts',
           'apps/autopilot-desktop/tests/chat-world-subscriptions.test.ts',
           'apps/autopilot-desktop/tests/chat-world-visualization.test.ts',
+          'docs/promises/2026-06-29-autopilot-world-visualization-gate-decision.md',
           'promise:autopilot.agent_world_scene.v1',
           'promise:training.decentralized_training_launch.v1',
         ],
         blockerRefs: [
-          'blocker.product_promises.payment_visualization_flag_default_off',
+          'blocker.product_promises.payment_visualization_intentionally_flag_gated',
         ],
         verification:
-          'Yellow covers the live wiring behind CHAT_WORLD_PAYMENTS: chat-world-subscriptions.ts backfills and streams public activity-timeline events into GotChatWorldPaymentParticle, update.ts stores the bounded active set, view.ts composes modelChatWorldParticles through withChatWorldPaymentLayer, and chat-world-visualization.ts turns each accepted particle into clickable beam/burst endpoint evidence. PAYMENT_EVENT_KINDS remains exactly {real_bitcoin_moved, settlement_recorded}; realBitcoinMoved:true and sourceRefs are required, so an event with no sourceRef or simulated settlement evidence returns null. Green requires an owner decision on default-on and an owner-signed receipt-first upgrade per proof.claim_upgrade_receipts.v1.',
+          'Yellow covers the live wiring behind CHAT_WORLD_PAYMENTS: chat-world-subscriptions.ts backfills and streams public activity-timeline events into GotChatWorldPaymentParticle, update.ts stores the bounded active set, view.ts composes modelChatWorldParticles through withChatWorldPaymentLayer, and chat-world-visualization.ts turns each accepted particle into clickable beam/burst endpoint evidence. PAYMENT_EVENT_KINDS remains exactly {real_bitcoin_moved, settlement_recorded}; realBitcoinMoved:true and sourceRefs are required, so an event with no sourceRef or simulated settlement evidence returns null. The 2026-06-29 #7030 decision keeps this intentionally flag-gated instead of default-on until a fresh owner-approved rollout receipt exists. Green requires a default-on/staged-rollout receipt or an owner-signed green-scope decision per proof.claim_upgrade_receipts.v1.',
         authorityBoundary:
           'Visualizing a Bitcoin settlement grants no payment authority, no spend, no payout, and no settlement authority. The particle is a clickable projection of an already-public receipt or event; it never moves money and never asserts a settlement that the underlying receipt does not.',
       },
@@ -4061,7 +4065,7 @@ export const publicProductPromisesDocument = () => {
         claim:
           'A Pylon visibly grows in the agent world — crystal scale, facets, and brightness step up by tier — as it earns cumulative settled sats.',
         safeCopy:
-          'Pylon growth tiers are merged and live-wired behind the chat-world flags: public per-Pylon cumulative settled sats map to a monotonic growth tier that the scene adapter turns into crystal scale/status brightness and facet metadata, with tier 0 an honest still crystal for a Pylon that has not settled any earnings yet. It rides the same default-off CHAT_WORLD_SCENE / CHAT_WORLD_PAYMENTS flags and is not on by default.',
+          'Pylon growth tiers are merged and live-wired behind the intentionally flag-gated chat-world flags: public per-Pylon cumulative settled sats map to a monotonic growth tier that the scene adapter turns into crystal scale/status brightness and facet metadata, with tier 0 an honest still crystal for a Pylon that has not settled any earnings yet. The 2026-06-29 #7030 decision keeps it off by default until a fresh owner-approved rollout receipt exists.',
         unsafeCopy:
           'Do not say Pylon growth is live for all users by default, that growth reflects anything other than real settled sats, or that a larger crystal implies any new earning, payout, or settlement capability.',
         evidenceRefs: [
@@ -4073,14 +4077,15 @@ export const publicProductPromisesDocument = () => {
           'apps/autopilot-desktop/src/shared/chat-world-scene.ts',
           'apps/autopilot-desktop/src/shared/chat-world-scene.test.ts',
           'apps/autopilot-desktop/src/ui/pylon-network-visualization.ts',
+          'docs/promises/2026-06-29-autopilot-world-visualization-gate-decision.md',
           'promise:autopilot.agent_world_scene.v1',
           'promise:autopilot.bitcoin_payment_visualization.v1',
         ],
         blockerRefs: [
-          'blocker.product_promises.pylon_growth_flag_default_off',
+          'blocker.product_promises.pylon_growth_intentionally_flag_gated',
         ],
         verification:
-          'Yellow now covers the live scene wiring behind CHAT_WORLD_SCENE / CHAT_WORLD_PAYMENTS: PublicRecentPylon preserves public cumulativeSettledSats when present, projectChatWorldPylonScene computes each node growth descriptor from that value, liveChatWorldNetworkScene carries the descriptor into PylonNetworkNode, and pylonNetworkVisualizationOptions maps tiers onto the pinned three-effect renderer knobs (larger role geometry, brighter status, and facet/sats detail). Tier 0 remains the 0-sat still crystal. Green still requires an owner decision on default-on and an owner-signed receipt-first upgrade per proof.claim_upgrade_receipts.v1.',
+          'Yellow now covers the live scene wiring behind CHAT_WORLD_SCENE / CHAT_WORLD_PAYMENTS: PublicRecentPylon preserves public cumulativeSettledSats when present, projectChatWorldPylonScene computes each node growth descriptor from that value, liveChatWorldNetworkScene carries the descriptor into PylonNetworkNode, and pylonNetworkVisualizationOptions maps tiers onto the pinned three-effect renderer knobs (larger role geometry, brighter status, and facet/sats detail). Tier 0 remains the 0-sat still crystal. The 2026-06-29 #7030 decision keeps this intentionally flag-gated instead of default-on until a fresh owner-approved rollout receipt exists. Green still requires a default-on/staged-rollout receipt or an owner-signed green-scope decision per proof.claim_upgrade_receipts.v1.',
         authorityBoundary:
           'Pylon growth visualization is a presentational projection of already-public settled-sats data. It grants no earning, spend, payout, or settlement authority, and a crystal tier never asserts earnings the underlying settlement receipts do not.',
       },

--- a/docs/promises/2026-06-29-autopilot-world-visualization-gate-decision.md
+++ b/docs/promises/2026-06-29-autopilot-world-visualization-gate-decision.md
@@ -1,0 +1,43 @@
+# Autopilot World Visualization Gate Decision
+
+Date: 2026-06-29
+
+Issue: #7030
+
+## Decision
+
+Keep the Autopilot world visualizations intentionally flag-gated for now:
+
+- `autopilot.agent_world_scene.v1` stays behind `CHAT_WORLD_SCENE`.
+- `autopilot.bitcoin_payment_visualization.v1` stays behind `CHAT_WORLD_PAYMENTS`.
+- `autopilot.pylon_growth_visualization.v1` rides the same chat-world flags and is not default-on.
+
+This records the conservative product decision for the current registry. The
+source-level and live in-app wiring remain valid evidence, but there is no new
+default-on, staged-rollout, or broad shipped-feature claim without a fresh
+owner-approved rollout receipt.
+
+## Scope
+
+This decision only covers public product-promise copy and blocker wording for
+the three visual-scene promises. It does not change runtime flags, desktop app
+defaults, payment logic, Pylon earning logic, multiplayer authority, payout
+authority, or settlement authority.
+
+## Registry Effect
+
+The three promises remain yellow. Their blockers are intentional gate blockers,
+not stale wiring blockers:
+
+- `blocker.product_promises.agent_world_scene_intentionally_flag_gated`
+- `blocker.product_promises.payment_visualization_intentionally_flag_gated`
+- `blocker.product_promises.pylon_growth_intentionally_flag_gated`
+
+Green still requires a default-on or staged-rollout receipt, or an owner-signed
+green-scope decision recorded through the receipt-first product-promise process.
+
+## Safety Notes
+
+The scene is presentational. Payment particles must stay bound to public payment
+or settlement evidence and stale beams must expire. Growth tiers must remain a
+visualization of public settled-sats data only.


### PR DESCRIPTION
## Summary

- records the #7030 product decision to keep the Autopilot world scene, payment particles, and Pylon growth visualizations intentionally flag-gated for now
- bumps the product-promises registry to `2026-06-29.3` and replaces stale default-off blocker wording with explicit intentional-gate blockers
- adds regression coverage so the three promises stay yellow, cite the decision record, and do not drift into default-on copy

Closes #7030.

## Verification

- `bun test apps/openagents.com/workers/api/src/product-promises.test.ts`
- `bun test tests/verse-launch-checklist.test.ts tests/chat-world-subscriptions.test.ts tests/chat-world-scene.test.ts tests/chat-world-visualization.test.ts` from `apps/autopilot-desktop`
- `true` for `command.public.pylon_khala.verify.b5bea41b6c623f7c09f1bf24`
