### PR TITLE
Harden non-code fanout plan ids

### DIFF
--- a/apps/openagents.com/INVARIANTS.md
+++ b/apps/openagents.com/INVARIANTS.md
@@ -2460,25 +2460,24 @@ check:architecture` inside `check:deploy`) discovers `/api/public/...`
     (`generatedAt`, `live_at_read` contract). The surface is flag-gated
     (`SELF_SERVE_FANOUT_ENABLED`, default off => empty store) and the payload
     always reports `inert: true` / `promiseState: 'yellow'` / `selfServe: true`
-    / `workClass: 'code_task'`, surfacing the cleared self-serve blocker and the
-    still-uncleared plugin-marketplace blocker. It models a customer-initiated
-    single-action fanout plan (the lane-C gate decision plus the linked market
-    work-request the fanout would list) over the existing server-side lane-C
-    gate. The dispatch seam (`dispatchSelfServeFanout`) is flag-gated INERT and
-    is unreachable from this read-only route; the surface lists nothing on the
-    market and moves no money.
+    / `workClass: 'code_task'`, surfacing the cleared self-serve blocker and
+    the plugin-marketplace-beyond-code-task planner blocker. It models a
+    customer-initiated single-action fanout plan (the lane-C gate decision plus
+    the linked market work-request the fanout would list) over the existing
+    server-side lane-C gate. The dispatch seam (`dispatchSelfServeFanout`) is
+    flag-gated INERT and is unreachable from this read-only route; the surface
+    lists nothing on the market and moves no money.
   - `GET /api/public/autopilot/marketplace-work-classes` — live at read over the
     in-module marketplace work-class catalog (promise
     `autopilot.control_center_fanout_marketplace.v1`, yellow) — compliant
     (`generatedAt`, `live_at_read` contract). Read-only registry view: it lists
-    every registered work class with its `status`, names the single live class
-    (`code_task`), and always reports `pluginMarketplaceBeyondCodeTaskLive: false`
-    with the still-uncleared plugin-marketplace-beyond-code_task blocker in
-    `unclearedBlockerRefs`. Optional `?workClass=` narrows to one class. No flag
-    and no store: `assertCatalogInvariants` (inside the projection) throws rather
-    than let any plugin class silently flip live, so the surface can never
-    over-claim a live plugin marketplace; it lists nothing executable and moves no
-    money.
+    every registered work class with its `status`, names the live classes
+    (`code_task` and `data_labeling`), and reports
+    `pluginMarketplaceBeyondCodeTaskLive: true` at the planner contract level.
+    Optional `?workClass=` narrows to one class. No flag and no store:
+    `assertCatalogInvariants` (inside the projection) throws rather than let the
+    catalog silently lose its non-code live class; the surface moves no money and
+    does not claim settled broad marketplace execution.
   - `GET /api/public/markets/signature-monetization/metering` — live at read
     over the INERT signature usage-metering store (promise
     `marketplace.signature_monetization.v1`, red) — compliant (`generatedAt`,

--- a/apps/openagents.com/workers/api/src/config.ts
+++ b/apps/openagents.com/workers/api/src/config.ts
@@ -29,11 +29,9 @@ export type OpenAgentsWorkerConfigEnv = Readonly<{
   // store) and the dispatch seam (dispatchSelfServeFanout) lists nothing. Set
   // "true"/"1"/"on" to arm the (still yellow/inert) surface. The plan makes no
   // broad-live-marketplace claim and the promise stays yellow regardless; the
-  // capability clears only blocker.product_promises.self_serve_fanout_missing
-  // (a customer-initiated single-action fanout planner/route exists), while
-  // blocker.product_promises.plugin_marketplace_beyond_code_task_missing stays
-  // uncleared (code_task work class only). A green flip stays receipt-first and
-  // owner-signed with a dereferenceable settlement receipt.
+  // capability clears the self-serve planner/route blocker and the
+  // plugin-marketplace-beyond-code-task planner blocker. A green flip stays
+  // receipt-first and owner-signed with a dereferenceable settlement receipt.
   SELF_SERVE_FANOUT_ENABLED?: string | undefined
   // Labor self-serve earning payout flag (promise
   // provider.compliant_usage_labor.v1, yellow). Default OFF: the

--- a/apps/openagents.com/workers/api/src/marketplace-work-class-catalog-routes.ts
+++ b/apps/openagents.com/workers/api/src/marketplace-work-class-catalog-routes.ts
@@ -2,13 +2,11 @@
 // (promise autopilot.control_center_fanout_marketplace.v1, yellow).
 //
 // HONESTY / SCOPE: this route exposes the catalog projection unchanged. It is
-// ALWAYS honest: `inert: true`, `promiseState: 'yellow'`, the single live work
-// class (`code_task`), and the still-uncleared plugin-marketplace-beyond-code_task
-// blocker. There is NO flag and NO store to arm here because the catalog makes no
-// live claim of its own — `code_task` is the only live class and
-// `assertCatalogInvariants` (called inside the projection) throws rather than let
-// any plugin class silently flip live. This route lists nothing executable; it is
-// purely a read-only registry view. Read-only (GET only).
+// ALWAYS honest: `inert: false`, `promiseState: 'yellow'`, the live work classes,
+// and whether at least one non-code class is live at the planner contract level.
+// There is NO flag and NO store to arm here because the catalog makes no
+// settlement claim of its own. This route moves no money; it is purely a
+// read-only registry view. Read-only (GET only).
 
 import { Effect } from 'effect'
 

--- a/apps/openagents.com/workers/api/src/marketplace-work-class-catalog.ts
+++ b/apps/openagents.com/workers/api/src/marketplace-work-class-catalog.ts
@@ -41,8 +41,8 @@ export const MARKETPLACE_WORK_CLASS_CATALOG_SCHEMA =
 export const MARKETPLACE_WORK_CLASS_CATALOG_PROMISE =
   'autopilot.control_center_fanout_marketplace.v1' as const
 
-// The ONE work class that is actually live on the market today — the same class
-// the self-serve fanout lists and #4783 settled under.
+// The original live work class — the same class the self-serve fanout defaults
+// to and #4783 settled under.
 export const MARKETPLACE_LIVE_WORK_CLASS = 'code_task' as const
 
 export const MARKETPLACE_DATA_LABELING_WORK_CLASS = 'data_labeling' as const

--- a/apps/openagents.com/workers/api/src/self-serve-fanout.test.ts
+++ b/apps/openagents.com/workers/api/src/self-serve-fanout.test.ts
@@ -93,6 +93,8 @@ describe('buildSelfServeFanoutPlan', () => {
     if (!result.ok) return
     const plan = result.plan
     expect(plan.workClass).toBe('data_labeling')
+    expect(plan.planId).toBe(selfServeFanoutPlanId('wo-1', 'data_labeling'))
+    expect(plan.planId).not.toBe(selfServeFanoutPlanId('wo-1'))
     expect(plan.readyForMarket).toBe(true)
     expect(plan.marketWorkRequest).toMatchObject({
       requiredCapabilityRefs: ['capability.market.data_labeling'],

--- a/apps/openagents.com/workers/api/src/self-serve-fanout.ts
+++ b/apps/openagents.com/workers/api/src/self-serve-fanout.ts
@@ -182,9 +182,18 @@ const isNonEmpty = (value: string): boolean => value.trim().length > 0
 const isWholeNonNegative = (value: number): boolean =>
   Number.isInteger(value) && value >= 0
 
-/** Stable, public-safe plan id derived from a work order ref. */
-export const selfServeFanoutPlanId = (workOrderRef: string): string =>
-  `self_serve_fanout.${workOrderRef.replace(/[^a-z0-9._-]+/giu, '_')}`
+/** Stable, public-safe plan id derived from a work order ref and work class. */
+export const selfServeFanoutPlanId = (
+  workOrderRef: string,
+  workClass: MarketplaceWorkClassId = SELF_SERVE_FANOUT_WORK_CLASS,
+): string => {
+  const safeWorkOrderRef = workOrderRef.replace(/[^a-z0-9._-]+/giu, '_')
+  if (workClass === SELF_SERVE_FANOUT_WORK_CLASS) {
+    return `self_serve_fanout.${safeWorkOrderRef}`
+  }
+  const safeWorkClass = workClass.replace(/[^a-z0-9._-]+/giu, '_')
+  return `self_serve_fanout.${safeWorkOrderRef}.${safeWorkClass}`
+}
 
 /** Public-safe deadline ref for a self-serve fanout market job. */
 export const SELF_SERVE_FANOUT_DEADLINE_REF =
@@ -284,7 +293,7 @@ export const buildSelfServeFanoutPlan = (
     ok: true,
     plan: {
       schema: SELF_SERVE_FANOUT_SCHEMA,
-      planId: selfServeFanoutPlanId(input.workOrderRef),
+      planId: selfServeFanoutPlanId(input.workOrderRef, workClass),
       workOrderRef: input.workOrderRef,
       customerRef: input.customerRef,
       selfServe: true,


### PR DESCRIPTION
## Summary
- make self-serve fanout plan ids include the marketplace work class for non-code live classes while preserving the existing `code_task` id shape
- lock the non-code `data_labeling` path with a plan-id assertion
- align public projection/invariant comments with the existing live non-code planner contract without claiming green/settled marketplace execution

Closes #6893.

## Verification
- `bun test ./src/self-serve-fanout.test.ts ./src/marketplace-work-class-catalog.test.ts ./src/marketplace-work-class-catalog-routes.test.ts ./src/autopilot-work-routes.test.ts` from `apps/openagents.com/workers/api`
- `true` for `command.public.pylon_khala.verify.b5bea41b6c623f7c09f1bf24`
- `bun run --cwd apps/openagents.com check:deploy`
