### PR TITLE
promise: clarify business paid receipt blockers

### DIFF
--- a/apps/openagents.com/workers/api/src/product-promises.test.ts
+++ b/apps/openagents.com/workers/api/src/product-promises.test.ts
@@ -84,6 +84,56 @@ const ProductPromisesDocument = S.Struct({
 })
 
 describe('public product promises document', () => {
+  test('keeps business quick-win paid receipt blockers exact for issue 7025', () => {
+    const decoded = S.decodeUnknownSync(ProductPromisesDocument)(
+      publicProductPromisesDocument(),
+    )
+    const promiseById = new Map(
+      decoded.promises.map(promise => [promise.promiseId, promise]),
+    )
+
+    expect(
+      promiseById.get('business.intake_quick_win_offering.v1'),
+    ).toMatchObject({
+      state: 'yellow',
+      blockerRefs: expect.arrayContaining([
+        'blocker.product_promises.business_quick_win_self_serve_delivery_missing',
+        'blocker.product_promises.business_first_paid_quick_win_receipt_missing',
+      ]),
+    })
+    expect(promiseById.get('business.coding_quick_win.v1')).toMatchObject({
+      state: 'yellow',
+      blockerRefs: expect.arrayContaining([
+        'blocker.product_promises.business_coding_quick_win_self_serve_missing',
+        'blocker.product_promises.business_coding_quick_win_paid_receipt_missing',
+      ]),
+    })
+    expect(
+      promiseById.get('business.ecommerce_workspace_pack.v1'),
+    ).toMatchObject({
+      state: 'yellow',
+      blockerRefs: [
+        'blocker.product_promises.ecommerce_pack_first_paid_delivery_receipt_missing',
+      ],
+    })
+    expect(promiseById.get('business.legal_workspace_pack.v1')).toMatchObject({
+      state: 'yellow',
+      blockerRefs: expect.arrayContaining([
+        'blocker.product_promises.legal_pack_self_serve_missing',
+        'blocker.product_promises.legal_pack_first_paid_delivery_receipt_missing',
+      ]),
+    })
+    expect(
+      promiseById.get('business.marketing_agency_workspace_pack.v1'),
+    ).toMatchObject({
+      state: 'yellow',
+      blockerRefs: expect.arrayContaining([
+        'blocker.product_promises.marketing_agency_pack_self_serve_missing',
+        'blocker.product_promises.marketing_agency_pack_first_paid_delivery_receipt_missing',
+      ]),
+    })
+  })
+
   test('matches the browser-facing schema', () => {
     const decoded = S.decodeUnknownSync(ProductPromisesDocument)(
       publicProductPromisesDocument(),

--- a/apps/openagents.com/workers/api/src/product-promises.ts
+++ b/apps/openagents.com/workers/api/src/product-promises.ts
@@ -4,7 +4,7 @@ import { currentIsoTimestamp } from './runtime-primitives'
 export const PublicProductPromisesEndpoint = '/api/public/product-promises'
 export const PublicProductPromisesSchemaVersion =
   'openagents.product_promises.v1'
-export const PublicProductPromisesVersion = '2026-06-29.2'
+export const PublicProductPromisesVersion = '2026-06-29.3'
 
 const reportPath = 'https://openagents.com/forum/f/product-promises'
 
@@ -4350,6 +4350,10 @@ export const publicProductPromisesDocument = () => {
           'docs/blitz/forge/2026-06-16-marketing-agency-prefilled-workspace.md',
           'apps/openagents.com/workers/api/src/prefilled-workspace-vertical-templates.ts',
           'apps/openagents.com/workers/api/src/prefilled-workspace-vertical-templates.test.ts',
+          'apps/openagents.com/workers/api/src/marketing-agency-delivery-receipt.ts',
+          'apps/openagents.com/workers/api/src/marketing-agency-delivery-receipt.test.ts',
+          'apps/openagents.com/workers/api/src/marketing-agency-claim-upgrade.ts',
+          'apps/openagents.com/workers/api/src/marketing-agency-receipt-public-routes.ts',
           'https://github.com/OpenAgentsInc/openagents/issues/5102',
           'promise:autopilot_sites.site_build_and_host.v1',
           'promise:autopilot_sites.native_email_sequences.v1',
@@ -4357,6 +4361,7 @@ export const publicProductPromisesDocument = () => {
         ],
         blockerRefs: [
           'blocker.product_promises.marketing_agency_pack_self_serve_missing',
+          'blocker.product_promises.marketing_agency_pack_first_paid_delivery_receipt_missing',
         ],
         verification:
           'Yellow is the shipped, tested prefilled marketing-agency template (forge.template.marketing_agency.white_label_launch.v1) seeding a white-label landing-page + email workspace (prefilled-workspace-vertical-templates.ts, .test.ts), composed with the yellow Autopilot Sites records (site build/host, custom hostnames, native email sequences). True today: an operator can stand up the seeded workspace and draft pages/emails under a review gate. Green requires a self-serve vertical pack with proven send/publish deliverability and a dereferenceable first paid agency work-item delivery receipt, with a receipt-first upgrade per proof.claim_upgrade_receipts.v1.',


### PR DESCRIPTION
## Summary

- make the marketing-agency workspace pack expose its existing first-paid delivery receipt blocker in the public product-promise registry
- add the existing marketing-agency receipt/claim route machinery as evidence refs without promoting the promise green or claiming a real paid delivery
- add a focused registry test covering the five business quick-win promises from #7025 so paid receipt blockers stay exact

Closes #7025.

## Verification

- `bun install --frozen-lockfile`
- `bun run --cwd apps/openagents.com/workers/api test -- src/product-promises.test.ts`
- `bun run --cwd apps/openagents.com/workers/api test -- src/product-promises.test.ts src/marketing-agency-delivery-receipt.test.ts src/marketing-agency-claim-upgrade.test.ts src/marketing-agency-receipt-public-routes.test.ts`

Note: the task supplied opaque verification ref `command.public.pylon_khala.verify.b5bea41b6c623f7c09f1bf24`, but this bounded checkout and local Pylon metadata did not contain a command-ref-to-argv mapping for that hash. I searched the checkout and local `.pylon-fable` state and ran the relevant focused verification directly.
