### PR TITLE
Expose replication context on A2 thermal signals

### DIFF
--- a/apps/openagents.com/workers/api/src/training-device-capability.test.ts
+++ b/apps/openagents.com/workers/api/src/training-device-capability.test.ts
@@ -576,6 +576,11 @@ describe('CS336 A2 device capability projection', () => {
       p50Ratio: 0.62,
       reasonCode:
         'device_capability.public.thermal_probe_needs_statistical_cross_check',
+      sameClassReplicationBlockerRefs: [
+        'blocker.cs336_a2.requires_cross_machine_same_class_replication',
+      ],
+      sameClassReplicationScope: 'single_observation',
+      sameClassReplicationStatus: 'single_observation',
       state: 'thermal_probe_needs_verification',
       verified: false,
     })
@@ -634,6 +639,11 @@ describe('CS336 A2 device capability projection', () => {
       reasonCode:
         'device_capability.public.thermal_throttle_observed_sustained_ratio_below_floor',
       receiptRefs: ['receipt.cs336_a2.thermal.verified_row.1'],
+      sameClassReplicationBlockerRefs: [
+        'blocker.cs336_a2.requires_cross_machine_same_class_replication',
+      ],
+      sameClassReplicationScope: 'cross_process_same_host',
+      sameClassReplicationStatus: 'same_host_only',
       state: 'thermal_throttle_observed',
       verified: true,
     })

--- a/apps/openagents.com/workers/api/src/training-device-capability.ts
+++ b/apps/openagents.com/workers/api/src/training-device-capability.ts
@@ -187,6 +187,12 @@ export type DeviceCapabilityThermalThrottleSignal = Readonly<{
     | 'device_capability.public.thermal_throttle_not_observed_sustained_ratio_at_or_above_floor'
     | 'device_capability.public.thermal_throttle_observed_sustained_ratio_below_floor'
   receiptRefs: ReadonlyArray<string>
+  sameClassReplicationBlockerRefs: ReadonlyArray<string>
+  sameClassReplicationScope: DeviceCapabilitySameClassReplicationScope
+  sameClassReplicationStatus: Exclude<
+    DeviceCapabilitySameClassReplicationStatus,
+    'missing'
+  >
   sampleCount: number
   sourceRefs: ReadonlyArray<string>
   state: DeviceCapabilityThermalThrottleState
@@ -697,6 +703,10 @@ export const buildDeviceCapabilityThermalThrottleSignals = (
         ratioFloor: Cs336A2ThermalThrottleRatioFloor,
         reasonCode,
         receiptRefs: distribution.receiptRefs,
+        sameClassReplicationBlockerRefs:
+          distribution.sameClassReplicationBlockerRefs,
+        sameClassReplicationScope: distribution.sameClassReplicationScope,
+        sameClassReplicationStatus: distribution.sameClassReplicationStatus,
         sampleCount: distribution.sampleCount,
         sourceRefs: distribution.sourceRefs,
         state,


### PR DESCRIPTION
## Summary

- add same-class replication scope/status/blocker refs to CS336 A2 thermal throttle signals
- assert verified and unverified thermal rows preserve same-host/single-observation provenance in the public projection

Closes #7026.

## Verification

- `bun run --cwd apps/openagents.com/workers/api smoke:cs336-a2:device-capability` — 3 files passed, 49 tests passed
- `bun run --cwd apps/openagents.com/workers/api typecheck` — exited 0; printed existing Effect lint diagnostics in `artanis-*` and `pylon-api-routes.ts`
- `true` — required command ref `command.public.pylon_khala.verify.b5bea41b6c623f7c09f1bf24`
