### PR TITLE
fix(forge): require verification receipts for promotion

### DIFF
--- a/apps/openagents.com/workers/api/src/forge-control-plane-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/forge-control-plane-routes.test.ts
@@ -145,6 +145,52 @@ const makeHarness = () => {
   return { canonicalStore, run, store: coordinationStore }
 }
 
+const forgeVerificationReceipt = (overrides: Record<string, unknown> = {}) => ({
+  schema: 'openagents.forge.verification.receipt.v0.1',
+  tenant_ref: 'tenant.openagents',
+  verification_ref: 'verification.forge.6770',
+  change_ref: 'change.forge.6770',
+  repository_ref: 'repo:OpenAgentsInc/openagents',
+  base_ref: 'refs/heads/main',
+  base_head: '8e0c9b2eaf84c821caf555cae233a0d27e94d4ab',
+  head_ref: 'refs/heads/forge-6770',
+  head_head: '9e0c9b2eaf84c821caf555cae233a0d27e94d4ac',
+  packfile_ref: 'packfile.forge.6770',
+  packfile_sha256: 'sha256:verification',
+  executor_identity_ref: 'agent.public.forge',
+  command_ref: 'cmd.test',
+  command_args: ['bun', 'test'],
+  exit_code: 0,
+  verdict: 'passed',
+  started_at: now,
+  completed_at: '2026-06-28T17:02:00.000Z',
+  artifact_refs: ['artifact:test-log'],
+  log_sha256: 'sha256:log',
+  source_refs: ['github:OpenAgentsInc/openagents#6770'],
+  redacted: true,
+  ...overrides,
+})
+
+const forgePromotionDecision = (overrides: Record<string, unknown> = {}) => ({
+  schema: 'openagents.forge.promotion.decision.v0.1',
+  tenant_ref: 'tenant.openagents',
+  promotion_ref: 'promotion.forge.6770',
+  queue_ref: 'queue.forge.main',
+  change_ref: 'change.forge.6770',
+  decision: 'approved',
+  base_head: '8e0c9b2eaf84c821caf555cae233a0d27e94d4ab',
+  candidate_head: '9e0c9b2eaf84c821caf555cae233a0d27e94d4ac',
+  promoted_head: '9e0c9b2eaf84c821caf555cae233a0d27e94d4ac',
+  verification_ref: 'verification.forge.6770',
+  gate_refs: ['gate.tests'],
+  blocker_refs: [],
+  decided_by_ref: 'agent.public.forge',
+  decided_at: '2026-06-28T17:03:00.000Z',
+  source_refs: ['github:OpenAgentsInc/openagents#6770'],
+  redacted: true,
+  ...overrides,
+})
+
 describe('Forge control-plane routes', () => {
   test('rejects Forge smart-Git tokens on control-plane routes', async () => {
     const { run } = makeHarness()
@@ -312,30 +358,7 @@ describe('Forge control-plane routes', () => {
 
     const verificationResponse = await run(
       requestJson('/api/forge/verification-receipts', {
-        json: {
-          schema: 'openagents.forge.verification.receipt.v0.1',
-          tenant_ref: 'tenant.openagents',
-          verification_ref: 'verification.forge.6770',
-          change_ref: 'change.forge.6770',
-          repository_ref: 'repo:OpenAgentsInc/openagents',
-          base_ref: 'refs/heads/main',
-          base_head: '8e0c9b2eaf84c821caf555cae233a0d27e94d4ab',
-          head_ref: 'refs/heads/forge-6770',
-          head_head: '9e0c9b2eaf84c821caf555cae233a0d27e94d4ac',
-          packfile_ref: 'packfile.forge.6770',
-          packfile_sha256: 'sha256:verification',
-          executor_identity_ref: 'agent.public.forge',
-          command_ref: 'cmd.test',
-          command_args: ['bun', 'test'],
-          exit_code: 0,
-          verdict: 'passed',
-          started_at: now,
-          completed_at: '2026-06-28T17:02:00.000Z',
-          artifact_refs: ['artifact:test-log'],
-          log_sha256: 'sha256:log',
-          source_refs: ['github:OpenAgentsInc/openagents#6770'],
-          redacted: true,
-        },
+        json: forgeVerificationReceipt(),
         headers: authHeaders(scopes),
         method: 'POST',
       }),
@@ -344,24 +367,7 @@ describe('Forge control-plane routes', () => {
 
     const promotionResponse = await run(
       requestJson('/api/forge/promotion-decisions', {
-        json: {
-          schema: 'openagents.forge.promotion.decision.v0.1',
-          tenant_ref: 'tenant.openagents',
-          promotion_ref: 'promotion.forge.6770',
-          queue_ref: 'queue.forge.main',
-          change_ref: 'change.forge.6770',
-          decision: 'approved',
-          base_head: '8e0c9b2eaf84c821caf555cae233a0d27e94d4ab',
-          candidate_head: '9e0c9b2eaf84c821caf555cae233a0d27e94d4ac',
-          promoted_head: '9e0c9b2eaf84c821caf555cae233a0d27e94d4ac',
-          verification_ref: 'verification.forge.6770',
-          gate_refs: ['gate.tests'],
-          blocker_refs: [],
-          decided_by_ref: 'agent.public.forge',
-          decided_at: '2026-06-28T17:03:00.000Z',
-          source_refs: ['github:OpenAgentsInc/openagents#6770'],
-          redacted: true,
-        },
+        json: forgePromotionDecision(),
         headers: authHeaders(scopes),
         method: 'POST',
       }),
@@ -389,6 +395,50 @@ describe('Forge control-plane routes', () => {
       promotionDecisions: ReadonlyArray<unknown>
     }
     expect(decisionsBody.promotionDecisions).toHaveLength(1)
+  })
+
+  test('fails closed when approved promotion lacks a recorded verification receipt', async () => {
+    const { run } = makeHarness()
+    const response = await run(
+      requestJson('/api/forge/promotion-decisions', {
+        json: forgePromotionDecision(),
+        headers: authHeaders('forge:promotion:decide'),
+        method: 'POST',
+      }),
+    )
+    const body = (await response.json()) as { error: string; reason: string }
+
+    expect(response.status).toBe(409)
+    expect(body.error).toBe('forge_promotion_verification_receipt_missing')
+    expect(body.reason).toContain('recorded verification receipt')
+  })
+
+  test('fails closed when approved promotion verification receipt is stale or failing', async () => {
+    const { run } = makeHarness()
+    const scopes = 'forge:receipt:write forge:promotion:decide'
+    const verificationResponse = await run(
+      requestJson('/api/forge/verification-receipts', {
+        json: forgeVerificationReceipt({
+          head_head: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+        }),
+        headers: authHeaders(scopes),
+        method: 'POST',
+      }),
+    )
+    expect(verificationResponse.status).toBe(201)
+
+    const response = await run(
+      requestJson('/api/forge/promotion-decisions', {
+        json: forgePromotionDecision(),
+        headers: authHeaders(scopes),
+        method: 'POST',
+      }),
+    )
+    const body = (await response.json()) as { error: string; reason: string }
+
+    expect(response.status).toBe(409)
+    expect(body.error).toBe('forge_promotion_verification_receipt_mismatch')
+    expect(body.reason).toContain('passing')
   })
 
   test('imports the public OpenAgents main ref into canonical refs idempotently', async () => {

--- a/apps/openagents.com/workers/api/src/forge-control-plane-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/forge-control-plane-routes.test.ts
@@ -441,6 +441,52 @@ describe('Forge control-plane routes', () => {
     expect(body.reason).toContain('passing')
   })
 
+  test('accepts approved promotion when matching receipt is outside list window', async () => {
+    const { run } = makeHarness()
+    const scopes = 'forge:receipt:write forge:promotion:decide'
+    const verificationResponse = await run(
+      requestJson('/api/forge/verification-receipts', {
+        json: forgeVerificationReceipt({
+          completed_at: '2026-06-28T17:01:00.000Z',
+        }),
+        headers: authHeaders(scopes),
+        method: 'POST',
+      }),
+    )
+    expect(verificationResponse.status).toBe(201)
+
+    await Array.from({ length: 101 }).reduce<Promise<void>>(
+      (previous, _, index) =>
+        previous.then(async () => {
+          const response = await run(
+            requestJson('/api/forge/verification-receipts', {
+              json: forgeVerificationReceipt({
+                verification_ref: `verification.forge.noise.${index}`,
+                completed_at: `2026-06-28T18:${String(Math.floor(index / 60)).padStart(
+                  2,
+                  '0',
+                )}:${String(index % 60).padStart(2, '0')}.000Z`,
+              }),
+              headers: authHeaders(scopes),
+              method: 'POST',
+            }),
+          )
+          expect(response.status).toBe(201)
+        }),
+      Promise.resolve(),
+    )
+
+    const promotionResponse = await run(
+      requestJson('/api/forge/promotion-decisions', {
+        json: forgePromotionDecision(),
+        headers: authHeaders(scopes),
+        method: 'POST',
+      }),
+    )
+
+    expect(promotionResponse.status).toBe(201)
+  })
+
   test('imports the public OpenAgents main ref into canonical refs idempotently', async () => {
     const { canonicalStore, run } = makeHarness()
     const headers = authHeaders('forge:admin forge:change:read')

--- a/apps/openagents.com/workers/api/src/forge-control-plane-routes.ts
+++ b/apps/openagents.com/workers/api/src/forge-control-plane-routes.ts
@@ -628,9 +628,10 @@ const assertApprovedPromotionHasPassingVerificationReceipt = async (
     )
   }
 
-  const verificationReceipt = (
-    await store.listVerificationReceipts(receipt.tenant_ref, 100, receipt.change_ref)
-  ).find(candidate => candidate.verification_ref === receipt.verification_ref)
+  const verificationReceipt = await store.readVerificationReceipt(
+    receipt.tenant_ref,
+    receipt.verification_ref,
+  )
 
   if (verificationReceipt === undefined) {
     throw new ForgeControlPlaneHttpError(
@@ -643,6 +644,7 @@ const assertApprovedPromotionHasPassingVerificationReceipt = async (
   if (
     verificationReceipt.verdict !== 'passed' ||
     verificationReceipt.exit_code !== 0 ||
+    verificationReceipt.change_ref !== receipt.change_ref ||
     verificationReceipt.base_head !== receipt.base_head ||
     verificationReceipt.head_head !== receipt.candidate_head
   ) {

--- a/apps/openagents.com/workers/api/src/forge-control-plane-routes.ts
+++ b/apps/openagents.com/workers/api/src/forge-control-plane-routes.ts
@@ -612,6 +612,48 @@ const routeVerificationReceipts = async <Bindings>(
   return noStoreJsonResponse({ verificationReceipt }, { status: 201 })
 }
 
+const assertApprovedPromotionHasPassingVerificationReceipt = async (
+  store: ForgeCoordinationStore,
+  receipt: typeof ForgePromotionDecisionReceipt.Type,
+) => {
+  if (receipt.decision !== 'approved') {
+    return
+  }
+
+  if (receipt.verification_ref === null) {
+    throw new ForgeControlPlaneHttpError(
+      409,
+      'forge_promotion_verification_receipt_required',
+      'Approved Forge promotions require a passing verification receipt for the exact change/base/head.',
+    )
+  }
+
+  const verificationReceipt = (
+    await store.listVerificationReceipts(receipt.tenant_ref, 100, receipt.change_ref)
+  ).find(candidate => candidate.verification_ref === receipt.verification_ref)
+
+  if (verificationReceipt === undefined) {
+    throw new ForgeControlPlaneHttpError(
+      409,
+      'forge_promotion_verification_receipt_missing',
+      'Approved Forge promotion verification_ref does not name a recorded verification receipt for this change.',
+    )
+  }
+
+  if (
+    verificationReceipt.verdict !== 'passed' ||
+    verificationReceipt.exit_code !== 0 ||
+    verificationReceipt.base_head !== receipt.base_head ||
+    verificationReceipt.head_head !== receipt.candidate_head
+  ) {
+    throw new ForgeControlPlaneHttpError(
+      409,
+      'forge_promotion_verification_receipt_mismatch',
+      'Approved Forge promotion verification receipt must be passing and match the promotion change/base/head.',
+    )
+  }
+}
+
 const routePromotionDecisions = async <Bindings>(
   dependencies: ForgeControlPlaneRouteDependencies<Bindings>,
   request: Request,
@@ -647,6 +689,7 @@ const routePromotionDecisions = async <Bindings>(
     'forge:promotion:decide',
     receipt.tenant_ref,
   )
+  await assertApprovedPromotionHasPassingVerificationReceipt(store, receipt)
   const promotionDecision = await store.recordPromotionDecisionReceipt(
     receipt,
     routeNowIso(dependencies),

--- a/apps/openagents.com/workers/api/src/forge-coordination-store.ts
+++ b/apps/openagents.com/workers/api/src/forge-coordination-store.ts
@@ -124,6 +124,10 @@ export type ForgeCoordinationStore = Readonly<{
     receipt: ForgeVerificationReceipt,
     createdAt: string,
   ) => Promise<ForgeVerificationReceipt>
+  readVerificationReceipt: (
+    tenantRef: string,
+    verificationRef: string,
+  ) => Promise<ForgeVerificationReceipt | undefined>
   listVerificationReceipts: (
     tenantRef: string,
     limit: number,
@@ -854,6 +858,21 @@ export const makeD1ForgeCoordinationStore = (
             .all<ForgeVerificationReceiptRow>()
 
     return rows.results.map(verificationReceiptFromRow)
+  },
+
+  async readVerificationReceipt(tenantRef, verificationRef) {
+    const row = await db
+      .prepare(
+        `
+          SELECT *
+          FROM forge_verification_receipts
+          WHERE tenant_ref = ? AND verification_ref = ?
+        `,
+      )
+      .bind(tenantRef, verificationRef)
+      .first<ForgeVerificationReceiptRow>()
+
+    return row === null ? undefined : verificationReceiptFromRow(row)
   },
 
   async recordPromotionDecisionReceipt(receipt, createdAt) {


### PR DESCRIPTION
## Summary
- Require approved Forge promotion decisions to cite a recorded verification receipt for the same change.
- Fail closed when the receipt is missing, failing, non-zero, or for a stale/wrong base or head.
- Add Forge control-plane route coverage for missing and stale verification receipts.

Closes #6795

## Verification
- bun run --cwd apps/openagents.com/workers/api test -- src/forge-control-plane-routes.test.ts src/forge-coordination-store.test.ts
- bun run --cwd apps/openagents.com check:deploy

Note: the requested command ref command.public.pylon_khala.verify.b5bea41b6c623f7c09f1bf24 was not recoverable to argv from local task metadata; the issue acceptance verifier check:deploy was run successfully.