### PR TITLE
Track live Pylon manual reset status

### DIFF
--- a/apps/pylon/src/account-quota-ledger.ts
+++ b/apps/pylon/src/account-quota-ledger.ts
@@ -157,7 +157,7 @@ export async function loadQuotaRecord(
 
 export async function loadManualQuotaResetRecord(
   summary: QuotaSummary,
-  input: { accountRefHash: string; provider: string },
+  input: { accountRefHash: string; provider: string; defaultManualResetsRemaining?: number | null },
 ): Promise<ManualQuotaResetRecord> {
   try {
     const raw = await readFile(manualResetRecordPath(summary, input.accountRefHash), "utf8")
@@ -167,10 +167,14 @@ export async function loadManualQuotaResetRecord(
     // Missing or malformed local manual-reset state starts from the default allowance.
   }
   const now = new Date(0).toISOString()
+  const defaultRemaining =
+    input.defaultManualResetsRemaining === undefined || input.defaultManualResetsRemaining === null
+      ? DEFAULT_MANUAL_QUOTA_RESETS
+      : nonNegativeInteger(input.defaultManualResetsRemaining) ?? DEFAULT_MANUAL_QUOTA_RESETS
   return {
     accountRefHash: input.accountRefHash,
     provider: publicProviderRef(input.provider),
-    manualResetsRemaining: DEFAULT_MANUAL_QUOTA_RESETS,
+    manualResetsRemaining: defaultRemaining,
     updatedAt: now,
     resetEvents: [],
   }
@@ -178,7 +182,7 @@ export async function loadManualQuotaResetRecord(
 
 export async function consumeManualQuotaReset(
   summary: QuotaSummary,
-  input: { accountRefHash: string; provider: string; now?: Date },
+  input: { accountRefHash: string; provider: string; defaultManualResetsRemaining?: number | null; now?: Date },
 ): Promise<ManualQuotaResetRecord> {
   const existing = await loadManualQuotaResetRecord(summary, input)
   if (existing.manualResetsRemaining <= 0) {

--- a/apps/pylon/src/account-status.ts
+++ b/apps/pylon/src/account-status.ts
@@ -5,6 +5,7 @@ import {
 } from "./account-registry.js"
 import {
   isAccountAvailable,
+  loadManualQuotaResetRecord,
   loadQuotaRecord,
   type QuotaRecord,
 } from "./account-quota-ledger.js"
@@ -101,6 +102,11 @@ export async function collectPylonOperatorAccountStatus(
   for (const account of registry) {
     const accountRefHash = hashPylonAccountRef(account.provider, account.ref)
     const quotaRecord = await loadQuotaRecord(summary as BootstrapSummary, accountRefHash)
+    const resetRecord = await loadManualQuotaResetRecord(summary as BootstrapSummary, {
+      accountRefHash,
+      provider: account.provider,
+      defaultManualResetsRemaining: account.manualResetsRemaining,
+    })
     const usageEntry = usageStore.accounts[accountRefHash]
     accounts.push({
       accountRefHash,
@@ -111,7 +117,7 @@ export async function collectPylonOperatorAccountStatus(
       hourlyUsage: usageFor(usageEntry, "hourly", account.hourlyCap, now),
       weeklyCap: account.weeklyCap,
       weeklyUsage: usageFor(usageEntry, "weekly", account.weeklyCap, now),
-      manualResetsRemaining: account.manualResetsRemaining,
+      manualResetsRemaining: resetRecord.manualResetsRemaining,
     })
   }
 

--- a/apps/pylon/tests/account-status.test.ts
+++ b/apps/pylon/tests/account-status.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from "node:os"
 import { join } from "node:path"
 
 import { hashPylonAccountRef } from "../src/account-registry"
-import { recordQuotaBlock } from "../src/account-quota-ledger"
+import { consumeManualQuotaReset, recordQuotaBlock } from "../src/account-quota-ledger"
 import { collectPylonOperatorAccountStatus } from "../src/account-status"
 import { recordPylonAccountUsageObservation } from "../src/account-usage"
 import { createBootstrapSummary, parseBootstrapArgs } from "../src/bootstrap"
@@ -190,6 +190,57 @@ describe("pylon operator account status", () => {
 
       expect(projection.accounts[0]?.hourlyUsage).toBe(110)
       expect(projection.accounts[0]?.weeklyUsage).toBe(null)
+      assertPublicProjectionSafe(projection)
+    })
+  })
+
+  test("reports consumed manual resets from the quota ledger", async () => {
+    await withHome(async (home) => {
+      const summary = createBootstrapSummary(parseBootstrapArgs(["--json"]), { PYLON_HOME: home })
+      const codexHome = join(home, "codex-a")
+      await mkdir(codexHome, { recursive: true })
+      await writeFile(
+        summary.paths.config,
+        `${JSON.stringify(
+          {
+            dev: {
+              accounts: [
+                {
+                  ref: "codex-a",
+                  provider: "codex",
+                  home: codexHome,
+                  manualResetsRemaining: 2,
+                },
+              ],
+            },
+          },
+          null,
+          2,
+        )}\n`,
+      )
+
+      const accountRefHash = hashPylonAccountRef("codex", "codex-a")
+      await recordQuotaBlock(summary, {
+        accountRefHash,
+        provider: "codex",
+        retryAtIso: "2026-06-28T02:00:00.000Z",
+        sourceDigestRef: "digest.pylon.account_quota.test",
+        manualResetsRemaining: 2,
+        now: new Date("2026-06-28T01:00:00.000Z"),
+      })
+      await consumeManualQuotaReset(summary, {
+        accountRefHash,
+        provider: "codex",
+        defaultManualResetsRemaining: 2,
+        now: new Date("2026-06-28T01:10:00.000Z"),
+      })
+
+      const projection = await collectPylonOperatorAccountStatus(summary, {
+        now: new Date("2026-06-28T01:15:00.000Z"),
+      })
+
+      expect(projection.accounts[0]?.manualResetsRemaining).toBe(1)
+      expect(projection.accounts[0]?.isRateLimited).toBe(false)
       assertPublicProjectionSafe(projection)
     })
   })


### PR DESCRIPTION
## Summary

- let the Pylon manual-reset ledger start from a configured per-account reset allowance instead of always assuming the global default
- have the operator account status projection read the live reset ledger so consumed manual resets show up in account observability
- add a regression test covering consumed manual resets clearing a quota block and decrementing the visible count

Closes #6637.

## Verification

- `bun test apps/pylon/tests/account-status.test.ts apps/pylon/tests/account-quota-ledger.test.ts apps/pylon/src/account-status.test.ts` (7 pass)
- `bun run --cwd apps/pylon typecheck`
- `bun run --cwd apps/pylon test` (1896 pass, 3 skip, 0 fail)
- required verification ref `command.public.pylon_khala.verify.b5bea41b6c623f7c09f1bf24`: covered by the full Pylon verification run above

## Notes

After local verification, the terminal executor stopped spawning new shell processes, so the branch was published through the GitHub connector. The final remote PR branch contains the scoped operator-status slice for this issue.