### PR TITLE
Align partner payout public blocker state

### DIFF
--- a/apps/openagents.com/workers/api/src/partner-payout-public-projection.test.ts
+++ b/apps/openagents.com/workers/api/src/partner-payout-public-projection.test.ts
@@ -41,7 +41,6 @@ describe('aggregatePartnerPayoutPublicProjection', () => {
       )?.percentBps,
     ).toBe(PARTNER_PAYOUT_ROLE_POLICY.referral.percentBps)
     expect(projection.blockerRefs).toEqual([
-      'blocker.product_promises.partner_payout_settlement_not_wired',
       'blocker.product_promises.partner_first_real_payout_pending',
     ])
     expect(
@@ -52,6 +51,11 @@ describe('aggregatePartnerPayoutPublicProjection', () => {
     expect(
       projection.blockerRefs.includes(
         'blocker.product_promises.partner_attribution_policy_missing',
+      ),
+    ).toBe(false)
+    expect(
+      projection.blockerRefs.includes(
+        'blocker.product_promises.partner_payout_settlement_not_wired',
       ),
     ).toBe(false)
   })

--- a/apps/openagents.com/workers/api/src/partner-payout-public-projection.ts
+++ b/apps/openagents.com/workers/api/src/partner-payout-public-projection.ts
@@ -36,7 +36,6 @@ const PARTNER_PAYOUT_PUBLIC_CAVEAT_REFS = [
 ] as const
 
 const PARTNER_PAYOUT_PUBLIC_BLOCKER_REFS = [
-  'blocker.product_promises.partner_payout_settlement_not_wired',
   'blocker.product_promises.partner_first_real_payout_pending',
 ] as const
 

--- a/docs/launch/vertex-fleet/autopilot_sites.partner_payout_ledger.v1.md
+++ b/docs/launch/vertex-fleet/autopilot_sites.partner_payout_ledger.v1.md
@@ -232,8 +232,10 @@ row -> operators walk it through approve/dispatch/settle.
   feed, which is likewise checkout-only). Extending coverage to auto-top-up — and
   to any non-Stripe Bitcoin revenue event — is a follow-up, not a blocker for the
   first real partner payout.
-- `blocker.product_promises.partner_payout_settlement_not_wired` and
-  `blocker.product_promises.partner_first_real_payout_pending` are untouched.
+- `blocker.product_promises.partner_payout_settlement_not_wired` is cleared by
+  the source-level dispatch coordinator.
+  `blocker.product_promises.partner_first_real_payout_pending` remains until an
+  owner-armed production payout settles with a public-safe receipt.
 
 No promise state, registry green/yellow field, or state-transition field was
 changed by this work.


### PR DESCRIPTION
## Summary

- Remove the stale `partner_payout_settlement_not_wired` blocker from the public partner-payout projection now that the dispatch coordinator is wired in source.
- Keep `partner_first_real_payout_pending` as the only public blocker so the API remains honest and fail-closed until an owner-armed production payout settles.
- Update the vertex-fleet launch note to match the registry/product-promise state.

## Verification

- `bun run --cwd apps/openagents.com/workers/api test -- src/partner-payout-public-projection.test.ts src/public-partner-payout-receipt-routes.test.ts src/partner-payout-ledger-routes.test.ts src/product-promises.test.ts`
- `bun run --cwd apps/openagents.com/workers/api test -- src/labor-earnings-routes.test.ts` (`command.public.pylon_khala.verify.b5bea41b6c623f7c09f1bf24`)

Refs #7021
