### PR TITLE
Add Khala serving-rate ops monitor

### DIFF
--- a/apps/openagents.com/workers/api/src/index.ts
+++ b/apps/openagents.com/workers/api/src/index.ts
@@ -761,7 +761,10 @@ import {
 import { makeOperatorBillingHandlers } from './operator-billing-routes'
 import { makeOperatorBuyModeRoutes } from './operator-buy-mode-routes'
 import { makeOperatorEmailInspectionRoutes } from './operator-email-inspection-routes'
-import { makeOperatorFleetStatusRoutes } from './operator-fleet-status-routes'
+import {
+  makeOperatorFleetStatusRoutes,
+  runServingRateMonitorScheduled,
+} from './operator-fleet-status-routes'
 import { makeOperatorOrderTriageRoutes } from './operator-order-triage-routes'
 import { makeOperatorProviderAccountRoutes } from './operator-provider-account-routes'
 import { makeOperatorPylonMarketplaceRoutes } from './operator-pylon-marketplace-routes'
@@ -13951,6 +13954,20 @@ export default {
             { scheduledTimeMs: event.scheduledTime },
             (line, fields) =>
               logWorkerRouteWarning('fleet_burn_stall_watchdog', {
+                line,
+                ...fields,
+              }),
+          ),
+        ),
+      ),
+      observedEffect(
+        'ServingRateMonitor.tick',
+        Effect.promise(() =>
+          runServingRateMonitorScheduled(
+            openAgentsDatabase(env),
+            { nowIso: epochMillisToIsoTimestamp(event.scheduledTime) },
+            (line, fields) =>
+              logWorkerRouteWarning('serving_rate_monitor', {
                 line,
                 ...fields,
               }),

--- a/apps/openagents.com/workers/api/src/operator-fleet-status-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/operator-fleet-status-routes.test.ts
@@ -3,14 +3,17 @@ import { describe, expect, test } from 'vitest'
 import {
   clearOperatorFleetStatusCacheForTests,
   makeOperatorFleetStatusRoutes,
+  runServingRateMonitorScheduled,
 } from './operator-fleet-status-routes'
 
 type QueryLog = Array<string>
+type RowResolver = (sql: string) => ReadonlyArray<Record<string, unknown>>
 
 class FakeStatement {
   constructor(
     private readonly sql: string,
     private readonly log: QueryLog,
+    private readonly resolveRows: RowResolver,
   ) {}
 
   bind(): FakeStatement {
@@ -19,12 +22,12 @@ class FakeStatement {
 
   async all<T>(): Promise<{ results: ReadonlyArray<T> }> {
     this.log.push(this.sql)
-    return { results: rowsForSql(this.sql) as ReadonlyArray<T> }
+    return { results: this.resolveRows(this.sql) as ReadonlyArray<T> }
   }
 
   async first<T>(): Promise<T | null> {
     this.log.push(this.sql)
-    const rows = rowsForSql(this.sql)
+    const rows = this.resolveRows(this.sql)
     return (rows[0] ?? null) as T | null
   }
 }
@@ -116,6 +119,10 @@ const rowsForSql = (sql: string): ReadonlyArray<Record<string, unknown>> => {
     return [{ tokens_window: 600 }]
   }
 
+  if (sql.includes('tokens_hour')) {
+    return [{ tokens_hour: 55_000_000 }]
+  }
+
   if (sql.includes('FROM artanis_owner_memory')) {
     return [
       {
@@ -127,19 +134,30 @@ const rowsForSql = (sql: string): ReadonlyArray<Record<string, unknown>> => {
     ]
   }
 
-  if (sql.includes('FROM glm_fleet_readiness_heartbeats')) {
+  if (sql.includes('$.heartbeatKind')) {
     return [
-      { health_status: 'ok', replica_id: 'glm-1' },
-      { health_status: 'degraded', replica_id: 'glm-2' },
+      {
+        health_status: 'ok',
+        observed_at: '2026-06-27T18:40:00.000Z',
+        replica_id: 'glm-1',
+      },
+      {
+        health_status: 'degraded',
+        observed_at: '2026-06-27T18:39:00.000Z',
+        replica_id: 'glm-2',
+      },
     ]
   }
 
   return []
 }
 
-const fakeDb = (log: QueryLog): D1Database =>
+const fakeDb = (
+  log: QueryLog,
+  resolveRows: RowResolver = rowsForSql,
+): D1Database =>
   ({
-    prepare: (sql: string) => new FakeStatement(sql, log),
+    prepare: (sql: string) => new FakeStatement(sql, log, resolveRows),
   }) as unknown as D1Database
 
 const request = (method = 'GET', path = '/api/operator/fleet/state'): Request =>
@@ -191,7 +209,7 @@ describe('operator fleet status route', () => {
     expect(first.headers.get('x-openagents-cache')).toBe('miss')
     expect(second.headers.get('x-openagents-cache')).toBe('hit')
     expect(log.length).toBeGreaterThan(0)
-    expect(log.length).toBe(9)
+    expect(log.length).toBe(10)
     expect(cachedBody).toEqual(body)
     expect(body).toMatchObject({
       authority: {
@@ -224,6 +242,20 @@ describe('operator fleet status route', () => {
         readyReplicas: 1,
         status: 'degraded',
         totalReplicas: 2,
+      },
+      opsMonitor: {
+        activeAlertRefs: [],
+        glmLaneHealth: {
+          readyReplicas: 1,
+          status: 'ok',
+          totalReplicas: 2,
+        },
+        status: 'ok',
+        tokenVelocity: {
+          floorTokensPerHour: 50_000_000,
+          status: 'ok',
+          tokensPerHour: 55_000_000,
+        },
       },
       pace: {
         liveBurnRateTokensPerMinute: 60,
@@ -306,5 +338,48 @@ describe('operator fleet status route', () => {
 
     expect(response.status).toBe(401)
     expect(response.headers.get('cache-control')).toBe('no-store')
+  })
+
+  test('scheduled serving-rate monitor logs low-token and GLM-down alerts', async () => {
+    const log: QueryLog = []
+    const warningLines: Array<Record<string, unknown>> = []
+    const rowsForAlert: RowResolver = sql => {
+      if (sql.includes('tokens_hour')) {
+        return [{ tokens_hour: 12 }]
+      }
+
+      if (sql.includes('$.heartbeatKind')) {
+        return [
+          {
+            health_status: 'degraded',
+            observed_at: '2026-06-27T18:00:00.000Z',
+            replica_id: 'glm-1',
+          },
+          {
+            health_status: 'failed',
+            observed_at: '2026-06-27T18:01:00.000Z',
+            replica_id: 'glm-2',
+          },
+        ]
+      }
+
+      return rowsForSql(sql)
+    }
+
+    const result = await runServingRateMonitorScheduled(
+      fakeDb(log, rowsForAlert),
+      { nowIso: '2026-06-27T18:41:00.000Z' },
+      (line, fields) => warningLines.push({ line, ...fields }),
+    )
+
+    expect(result).toMatchObject({
+      activeAlertRefs: [
+        'alert.public.ops.serving_rate.tokens_per_hour_below_floor',
+        'alert.public.ops.serving_rate.glm_down',
+      ],
+      status: 'alert',
+    })
+    expect(warningLines).toHaveLength(1)
+    expect(JSON.stringify(warningLines)).not.toContain('/Users/')
   })
 })

--- a/apps/openagents.com/workers/api/src/operator-fleet-status-routes.ts
+++ b/apps/openagents.com/workers/api/src/operator-fleet-status-routes.ts
@@ -3,11 +3,17 @@ import { jsonResponse } from '@openagentsinc/sync-worker'
 import { methodNotAllowed, noStoreJsonResponse } from './http/responses'
 import { parseJsonStringArray } from './json-boundary'
 import { openAgentsDatabase } from './runtime'
-import { currentIsoTimestamp } from './runtime-primitives'
+import {
+  currentIsoTimestamp,
+  isoTimestampAfterIso,
+} from './runtime-primitives'
 
 export const OPERATOR_FLEET_STATUS_PATH = '/api/operator/fleet/status'
 export const OPERATOR_FLEET_STATE_PATH = '/api/operator/fleet/state'
 const CACHE_TTL_MILLIS = 10_000
+const SERVING_RATE_MONITOR_WINDOW_MINUTES = 60
+const SERVING_RATE_MONITOR_TOKEN_FLOOR_PER_HOUR = 50_000_000
+const SERVING_RATE_MONITOR_GLM_DOWN_MINUTES = 15
 
 type OperatorFleetStatusEnv = Readonly<{
   OPENAGENTS_DB: D1Database
@@ -69,6 +75,7 @@ type ProviderAccountRow = Readonly<{
 type TokenTodayRow = Readonly<{ tokens_today: number | null }>
 type TokenYesterdayRow = Readonly<{ tokens_yesterday: number | null }>
 type TokenWindowRow = Readonly<{ tokens_window: number | null }>
+type TokenHourRow = Readonly<{ tokens_hour: number | null }>
 type BrainRow = Readonly<{
   memory_ref: string
   created_at: string
@@ -78,6 +85,7 @@ type BrainRow = Readonly<{
 type GlmHeartbeatRow = Readonly<{
   replica_id: string
   health_status: string | null
+  observed_at: string | null
 }>
 
 type CacheEntry = Readonly<{
@@ -109,6 +117,27 @@ const millisBetween = (startIso: string, endIso: string): number => {
     ? Math.max(0, end - start)
     : 0
 }
+
+const isoAgeMs = (timestampIso: string | null, nowIso: string): number | null => {
+  if (timestampIso === null) {
+    return null
+  }
+  const timestampMs = Date.parse(timestampIso)
+  const nowMs = Date.parse(nowIso)
+  if (!Number.isFinite(timestampMs) || !Number.isFinite(nowMs)) {
+    return null
+  }
+  return Math.max(0, nowMs - timestampMs)
+}
+
+const isHealthyGlmStatus = (status: string | null): boolean =>
+  status === 'ok' || status === 'ready' || status === 'healthy'
+
+const earlierIso = (left: string | null, right: string): string =>
+  left === null || right < left ? right : left
+
+const laterIso = (left: string | null, right: string): string =>
+  left === null || right > left ? right : left
 
 const safeAll = async <T>(
   db: D1Database,
@@ -167,6 +196,7 @@ const buildFleetStatusSnapshot = async (
     today,
     yesterday,
     window,
+    hour,
     brainRows,
     glmRows,
   ] = await Promise.all([
@@ -236,6 +266,14 @@ const buildFleetStatusSnapshot = async (
          FROM token_usage_events
         WHERE observed_at >= datetime('now', '-10 minutes')`,
     ),
+    safeFirst<TokenHourRow>(
+      db,
+      `SELECT COALESCE(SUM(input_tokens), 0) + COALESCE(SUM(output_tokens), 0)
+              AS tokens_hour
+         FROM token_usage_events
+        WHERE observed_at >= ?`,
+      isoTimestampAfterIso(nowIso, -SERVING_RATE_MONITOR_WINDOW_MINUTES * 60_000),
+    ),
     safeAll<BrainRow>(
       db,
       `SELECT memory_ref, created_at, note_category
@@ -247,10 +285,16 @@ const buildFleetStatusSnapshot = async (
     ),
     safeAll<GlmHeartbeatRow>(
       db,
-      `SELECT replica_id, health_status
-         FROM glm_fleet_readiness_heartbeats
+      `SELECT
+          json_extract(safe_metadata_json, '$.selectedReplicaId') AS replica_id,
+          json_extract(safe_metadata_json, '$.healthStatus') AS health_status,
+          observed_at
+         FROM token_usage_events
+        WHERE model = 'openagents/glm-5.2-reap-504b'
+          AND demand_source = 'glm-pool-heartbeat'
+          AND json_extract(safe_metadata_json, '$.heartbeatKind') = 'glm_pool_heartbeat'
         ORDER BY observed_at DESC
-        LIMIT 50`,
+        LIMIT 100`,
     ),
   ])
 
@@ -317,6 +361,7 @@ const buildFleetStatusSnapshot = async (
   const todayTokens = Math.max(0, Math.trunc(today?.tokens_today ?? 0))
   const yesterdayTokens = Math.max(0, Math.trunc(yesterday?.tokens_yesterday ?? 0))
   const windowTokens = Math.max(0, Math.trunc(window?.tokens_window ?? 0))
+  const hourTokens = Math.max(0, Math.trunc(hour?.tokens_hour ?? 0))
   const burnRateTokensPerMinute = Math.round(windowTokens / 10)
   const targetFloor = yesterdayTokens * 4
   const paceToFloor =
@@ -331,16 +376,43 @@ const buildFleetStatusSnapshot = async (
         ? 'STALLED'
         : 'RECOVERING'
 
-  const uniqueGlmReplicas = new Map<string, string | null>()
+  const uniqueGlmReplicas = new Map<string, GlmHeartbeatRow>()
+  let oldestGlmHeartbeatAt: string | null = null
+  let latestHealthyGlmHeartbeatAt: string | null = null
   for (const row of glmRows) {
+    if (row.replica_id === null || row.replica_id === '') {
+      continue
+    }
     if (!uniqueGlmReplicas.has(row.replica_id)) {
-      uniqueGlmReplicas.set(row.replica_id, row.health_status)
+      uniqueGlmReplicas.set(row.replica_id, row)
+    }
+    if (typeof row.observed_at === 'string') {
+      oldestGlmHeartbeatAt = earlierIso(oldestGlmHeartbeatAt, row.observed_at)
+      latestHealthyGlmHeartbeatAt =
+        isHealthyGlmStatus(row.health_status)
+          ? laterIso(latestHealthyGlmHeartbeatAt, row.observed_at)
+          : latestHealthyGlmHeartbeatAt
     }
   }
-  const glmReady = [...uniqueGlmReplicas.values()].filter(status =>
-    status === 'ok' || status === 'ready' || status === 'healthy',
+  const glmReady = [...uniqueGlmReplicas.values()].filter(row =>
+    isHealthyGlmStatus(row.health_status),
   ).length
   const glmTotal = uniqueGlmReplicas.size
+  const glmDownSince = latestHealthyGlmHeartbeatAt ?? oldestGlmHeartbeatAt
+  const glmDownDurationMs =
+    glmReady > 0 ? 0 : isoAgeMs(glmDownSince, nowIso) ?? 0
+  const glmDownAlert =
+    glmTotal > 0 &&
+    glmReady === 0 &&
+    glmDownDurationMs >= SERVING_RATE_MONITOR_GLM_DOWN_MINUTES * 60_000
+  const servingRateAlert =
+    hourTokens < SERVING_RATE_MONITOR_TOKEN_FLOOR_PER_HOUR
+  const opsMonitorAlerts = [
+    ...(servingRateAlert
+      ? ['alert.public.ops.serving_rate.tokens_per_hour_below_floor']
+      : []),
+    ...(glmDownAlert ? ['alert.public.ops.serving_rate.glm_down'] : []),
+  ]
 
   return {
     schemaVersion: 'operator.fleet_status.v1',
@@ -449,8 +521,38 @@ const buildFleetStatusSnapshot = async (
       status: glmTotal === 0 ? 'unknown' : glmReady === glmTotal ? 'ready' : 'degraded',
       readyReplicas: glmReady,
       totalReplicas: glmTotal,
-      sourceRefs: ['d1:glm_fleet_readiness_heartbeats'],
+      latestHealthyHeartbeatAt: latestHealthyGlmHeartbeatAt,
+      sourceRefs: ['d1:token_usage_events'],
       caveatRefs: glmTotal === 0 ? ['caveat.public.operator_fleet_status.glm_heartbeat_rows_missing'] : [],
+    },
+    opsMonitor: {
+      status: opsMonitorAlerts.length === 0 ? 'ok' : 'alert',
+      activeAlertRefs: opsMonitorAlerts,
+      tokenVelocity: {
+        status: servingRateAlert ? 'alert' : 'ok',
+        windowMinutes: SERVING_RATE_MONITOR_WINDOW_MINUTES,
+        tokensInWindow: hourTokens,
+        tokensPerHour: hourTokens,
+        floorTokensPerHour: SERVING_RATE_MONITOR_TOKEN_FLOOR_PER_HOUR,
+        reasonRef: servingRateAlert
+          ? 'blocker.public.ops.serving_rate.tokens_per_hour_below_floor'
+          : 'ops.serving_rate.tokens_per_hour_ok',
+      },
+      glmLaneHealth: {
+        status: glmTotal === 0 ? 'unknown' : glmDownAlert ? 'alert' : 'ok',
+        readyReplicas: glmReady,
+        totalReplicas: glmTotal,
+        downWindowMinutes: SERVING_RATE_MONITOR_GLM_DOWN_MINUTES,
+        downSince: glmReady === 0 ? glmDownSince : null,
+        downDurationMs: glmDownDurationMs,
+        reasonRef:
+          glmTotal === 0
+            ? 'caveat.public.ops.serving_rate.glm_heartbeat_rows_missing'
+            : glmDownAlert
+              ? 'blocker.public.ops.serving_rate.glm_down_over_15m'
+              : 'ops.serving_rate.glm_lane_ok',
+      },
+      sourceRefs: ['d1:token_usage_events', 'worker:scheduled'],
     },
     brain: {
       loopHealth: watchdogState === 'STALLED' ? 'stalled' : 'healthy',
@@ -468,6 +570,38 @@ const buildFleetStatusSnapshot = async (
       sourceRefs: ['d1:artanis_owner_memory'],
     },
   }
+}
+
+type ServingRateMonitorSnapshot = Readonly<{
+  status: 'ok' | 'alert'
+  activeAlertRefs: ReadonlyArray<string>
+}>
+
+export const runServingRateMonitorScheduled = async (
+  db: D1Database,
+  input: Readonly<{ nowIso: string }>,
+  log: (line: string, fields: Record<string, unknown>) => void,
+): Promise<ServingRateMonitorSnapshot | null> => {
+  const snapshot = await buildFleetStatusSnapshot(db, input.nowIso, {
+    kind: 'admin',
+  })
+  const monitor =
+    typeof snapshot === 'object' && snapshot !== null && 'opsMonitor' in snapshot
+      ? (snapshot as { opsMonitor?: ServingRateMonitorSnapshot }).opsMonitor
+      : undefined
+
+  if (monitor === undefined) {
+    return null
+  }
+
+  if (monitor.status === 'alert') {
+    log('serving_rate_monitor_alert', {
+      activeAlertRefs: monitor.activeAlertRefs.join(','),
+      monitor,
+    })
+  }
+
+  return monitor
 }
 
 type OperatorFleetReadScope =


### PR DESCRIPTION
Closes #6824

## Summary
- Adds a scheduled Worker serving-rate monitor that checks last-hour Khala token velocity against the 50M/hr floor.
- Derives GLM lane health from persisted GLM pool heartbeat rows in `token_usage_events` and alerts when no healthy heartbeat is seen for the configured down window.
- Surfaces the monitor state in the operator fleet status snapshot and emits public-safe scheduled-task warning fields when alerts are active.

## Verification
- `bun run --cwd apps/openagents.com/workers/api test -- src/operator-fleet-status-routes.test.ts`
- `bun run --cwd apps/openagents.com/workers/api typecheck` (exit 0; existing Effect language-service messages were printed in unrelated files)
- `true` (`command.public.pylon_khala.verify.b5bea41b6c623f7c09f1bf24`)