### PR TITLE
Audit Hosted Gemini production receipt state

### DIFF
--- a/apps/openagents.com/workers/api/src/product-promises.test.ts
+++ b/apps/openagents.com/workers/api/src/product-promises.test.ts
@@ -1614,6 +1614,35 @@ describe('public product promises document', () => {
     )
   })
 
+  test('keeps Hosted Gemini yellow after the production receipt audit until the Gemini path succeeds', () => {
+    const decoded = S.decodeUnknownSync(ProductPromisesDocument)(
+      publicProductPromisesDocument(),
+    )
+    const hostedGeminiPromise = decoded.promises.find(
+      promise => promise.promiseId === 'api.hosted_gemini.v1',
+    )
+
+    expect(hostedGeminiPromise).toMatchObject({
+      state: 'yellow',
+      blockerRefs: [
+        'blocker.product_promises.hosted_gemini_production_receipt_pending',
+        'blocker.product_promises.hosted_gemini_owner_upgrade_signoff_pending',
+      ],
+    })
+    expect(hostedGeminiPromise?.evidenceRefs).toContain(
+      'docs/inference/2026-06-29-hosted-gemini-production-receipt-audit.md',
+    )
+    expect(hostedGeminiPromise?.safeCopy).toContain(
+      'direct gemini-3.5-flash returned model_unavailable',
+    )
+    expect(hostedGeminiPromise?.safeCopy).toContain(
+      'Hosted Gemini production receipt remains pending',
+    )
+    expect(hostedGeminiPromise?.unsafeCopy).toContain(
+      'without a real production receipt',
+    )
+  })
+
   test('keeps kernel optimization planned while exposing code-backed dispatch and parity receipt machinery', () => {
     const decoded = S.decodeUnknownSync(ProductPromisesDocument)(
       publicProductPromisesDocument(),

--- a/apps/openagents.com/workers/api/src/product-promises.ts
+++ b/apps/openagents.com/workers/api/src/product-promises.ts
@@ -4,7 +4,7 @@ import { currentIsoTimestamp } from './runtime-primitives'
 export const PublicProductPromisesEndpoint = '/api/public/product-promises'
 export const PublicProductPromisesSchemaVersion =
   'openagents.product_promises.v1'
-export const PublicProductPromisesVersion = '2026-06-29.2'
+export const PublicProductPromisesVersion = '2026-06-29.3'
 
 const reportPath = 'https://openagents.com/forum/f/product-promises'
 
@@ -54,6 +54,7 @@ const sourceRefs = [
   'docs/transcripts/243.md',
   'docs/transcripts/244.md',
   'docs/inference/2026-06-25-khala-inference-gtm-push.md',
+  'docs/inference/2026-06-29-hosted-gemini-production-receipt-audit.md',
   'docs/khala/2026-06-25-pylon-linked-coding-capacity-routing-spec.md',
   'docs/afteraction/2026-06-26-khala-pylon-codex-delegation-afteraction.md',
   'docs/traces/2026-06-27-pylon-codex-live-trace-status-audit.md',
@@ -1311,7 +1312,7 @@ export const publicProductPromisesDocument = () => {
         claim:
           'OpenAgents is API-driven and may offer hosted Gemini through an OpenAgents API surface.',
         safeCopy:
-          'OpenAgents has route-covered hosted Gemini execution through the env-gated Vertex binding and the OpenAI-compatible Khala gateway enforces account credits, entitlement/free-quota gates, metering, and served-token rows. The promise stays yellow until a real production receipt and owner-approved upgrade evidence are attached.',
+          'OpenAgents has route-covered hosted Gemini execution through the env-gated Vertex binding and the OpenAI-compatible Khala gateway enforces account credits, entitlement/free-quota gates, metering, and served-token rows. A 2026-06-29 production audit found the authenticated public gateway live for openagents/khala with public-safe usage metadata, but direct gemini-3.5-flash returned model_unavailable, so the Hosted Gemini production receipt remains pending. The promise stays yellow until a successful Hosted Gemini production receipt and owner-approved upgrade evidence are attached.',
         unsafeCopy:
           'Do not claim hosted Gemini is green, settled, broadly resale-ready, or owner-approved without a real production receipt.',
         evidenceRefs: [
@@ -1323,6 +1324,7 @@ export const publicProductPromisesDocument = () => {
           'apps/openagents.com/workers/api/src/inference/chat-completions-routes.test.ts',
           'apps/openagents.com/workers/api/src/autopilot-hosted-gemini-executor-env.ts',
           'apps/openagents.com/workers/api/src/inference/served-tokens-recorder.ts',
+          'docs/inference/2026-06-29-hosted-gemini-production-receipt-audit.md',
           'docs/autopilot-coder/2026-06-09-probe-autopilot-sites-agent-api-audit.md',
         ],
         blockerRefs: [

--- a/docs/inference/2026-06-29-hosted-gemini-production-receipt-audit.md
+++ b/docs/inference/2026-06-29-hosted-gemini-production-receipt-audit.md
@@ -1,0 +1,50 @@
+# Hosted Gemini production receipt audit
+
+Date: 2026-06-29. Issue: #7017.
+
+## Result
+
+The production OpenAI-compatible Khala endpoint is live for the authenticated
+public model path, but the direct Hosted Gemini selector is not currently a
+successful production user/agent path.
+
+Audited path:
+
+- `POST https://openagents.com/api/v1/chat/completions`
+- Auth: OpenAgents bearer token, not recorded here.
+- Direct Hosted Gemini request model: `gemini-3.5-flash`
+- Production result: HTTP `400`, `error: "model_unavailable"`
+
+The public model catalog for the same token listed only `openagents/khala`.
+
+Control request against `openagents/khala` returned HTTP `200` and a normal
+OpenAI-compatible completion shape with non-empty usage:
+
+- response object: `chat.completion`
+- public response model: `openagents/khala`
+- `usage.prompt_tokens`: present
+- `usage.completion_tokens`: present
+- `usage.total_tokens`: present
+- `openagents.requested_model`: `openagents/khala`
+- `openagents.served_model`: `accounts/fireworks/models/deepseek-v4-flash`
+- `openagents.supply_lane`: `fireworks`
+- `openagents.billing.mode`: `no_debit`
+
+This is deliberately not a Hosted Gemini success receipt. It proves the
+authenticated production gateway and public-safe usage metadata are reachable,
+while the direct Hosted Gemini production receipt remains pending.
+
+## Promise impact
+
+`api.hosted_gemini.v1` stays yellow.
+
+Do not clear:
+
+- `blocker.product_promises.hosted_gemini_production_receipt_pending`
+- `blocker.product_promises.hosted_gemini_owner_upgrade_signoff_pending`
+
+Green still requires a successful production Hosted Gemini request through the
+intended public/authenticated path plus owner-signed upgrade evidence. The
+successful `openagents/khala` control request is not paid-credit evidence and
+does not imply a Hosted Gemini lane, paid resale, settlement, or owner-approved
+green claim.


### PR DESCRIPTION
## Summary

- Records a public-safe 2026-06-29 production audit for `api.hosted_gemini.v1`.
- Wires the audit into `/api/public/product-promises` evidence and bumps the registry version to `2026-06-29.3`.
- Adds a focused registry test proving Hosted Gemini stays yellow and keeps both blockers until the direct production Gemini path succeeds and owner signoff exists.

## Live audit result

- `POST https://openagents.com/api/v1/chat/completions` with `model: gemini-3.5-flash` returned HTTP `400` / `model_unavailable`.
- `GET https://openagents.com/api/v1/models` listed only `openagents/khala` for the same token.
- Control request to `openagents/khala` returned HTTP `200` with normal completion shape and non-empty usage metadata, served by the Fireworks lane with `billing.mode: no_debit`.

This intentionally does not clear `hosted_gemini_production_receipt_pending` or `hosted_gemini_owner_upgrade_signoff_pending`; it makes the current production state dereferenceable and prevents accidental green overclaim.

## Verification

- `bun test src/product-promises.test.ts` from `apps/openagents.com/workers/api` — 11 pass / 0 fail.
- `command.public.pylon_khala.verify.b5bea41b6c623f7c09f1bf24` resolved to `true` and passed.

Closes #7017.
