### PR TITLE
Expose Artanis responder readiness blockers

### DIFF
--- a/apps/openagents.com/workers/api/src/artanis-responder-provenance.test.ts
+++ b/apps/openagents.com/workers/api/src/artanis-responder-provenance.test.ts
@@ -1,6 +1,14 @@
 import { describe, expect, test } from 'vitest'
 
 import {
+  artanisResponderTickRef,
+  projectArtanisResponderTickReadiness,
+  type ArtanisResponderTickActionRow,
+  type ArtanisResponderTickRow,
+} from './artanis-responder-ticks'
+import {
+  ARTANIS_RESPONDER_EXTERNAL_FLOW_BLOCKER,
+  ARTANIS_RESPONDER_TEN_TICKS_BLOCKER,
   boundedResponderSupportLimit,
   classifyAskerProvenance,
   projectArtanisResponderSupport,
@@ -23,6 +31,38 @@ const row = (
   tip_receipt_ref: null,
   topic_id: 'topic-1',
   ...overrides,
+})
+
+const tickAt = (hour: number): string =>
+  `2026-06-20T${String(hour).padStart(2, '0')}:00:00.000Z`
+
+const tickRow = (hour: number): ArtanisResponderTickRow => {
+  const scheduledAt = tickAt(hour)
+  return {
+    compose_blocked: 0,
+    compose_considered: 1,
+    compose_responded: 1,
+    compose_skipped_reason: null,
+    compose_state: 'ran',
+    compose_tipped: 0,
+    scan_blocked: 0,
+    scan_proposed: 1,
+    scan_scanned: 1,
+    scan_skipped: 0,
+    scan_skipped_reason: null,
+    scan_state: 'ran',
+    scheduled_at: scheduledAt,
+    tick_ref: artanisResponderTickRef(scheduledAt),
+  }
+}
+
+const tickActionRow = (hour: number): ArtanisResponderTickActionRow => ({
+  asker_provenance: 'external_contributor',
+  id: `tick-action-${hour}`,
+  replied_at: `2026-06-20T${String(hour).padStart(2, '0')}:15:00.000Z`,
+  reply_post_id: `post.public.forum.artanis.tick.${hour}`,
+  state: 'responded',
+  topic_id: `topic-${hour}`,
 })
 
 describe('classifyAskerProvenance', () => {
@@ -72,6 +112,16 @@ describe('projectArtanisResponderSupport', () => {
     expect(projection.publicSafe).toBe(true)
     expect(projection.staleness.contractVersion).toBe('projection_staleness.v1')
     expect(projection.staleness.composition).toBe('live_at_read')
+    expect(projection.blockerRefs).toEqual([
+      ARTANIS_RESPONDER_EXTERNAL_FLOW_BLOCKER,
+      ARTANIS_RESPONDER_TEN_TICKS_BLOCKER,
+    ])
+    expect(projection.activeBlockerRefs).toEqual([
+      ARTANIS_RESPONDER_EXTERNAL_FLOW_BLOCKER,
+      ARTANIS_RESPONDER_TEN_TICKS_BLOCKER,
+    ])
+    expect(projection.clearedBlockerRefs).toEqual([])
+    expect(projection.greenGateMet).toBe(false)
     expect(projection.externalContributorAnsweredCount).toBe(1)
     expect(projection.externalContributorFlowProven).toBe(true)
     expect(projection.externalInteractions).toHaveLength(1)
@@ -160,6 +210,62 @@ describe('projectArtanisResponderSupport', () => {
     )
     expect(projection.externalContributorAnsweredCount).toBe(0)
     expect(projection.ownerOperatorAnsweredCount).toBe(0)
+  })
+
+  test('clears both responder blockers when external flow and ten tick receipts are proven', () => {
+    const tickReadiness = projectArtanisResponderTickReadiness(
+      Array.from({ length: 10 }, (_, index) => tickRow(index + 1)),
+      Array.from({ length: 10 }, (_, index) => tickActionRow(index + 1)),
+    )
+    const projection = projectArtanisResponderSupport(
+      [
+        row({
+          replied_at: '2026-06-19T23:45:00.000Z',
+        }),
+      ],
+      nowIso,
+      tickReadiness,
+    )
+
+    expect(projection.tickReadiness?.unattendedResponderTicksProven).toBe(true)
+    expect(
+      projection.tickReadiness?.externalContributorAnsweredWithinTickWindow,
+    ).toBe(true)
+    expect(projection.activeBlockerRefs).toEqual([])
+    expect(projection.clearedBlockerRefs).toEqual([
+      ARTANIS_RESPONDER_EXTERNAL_FLOW_BLOCKER,
+      ARTANIS_RESPONDER_TEN_TICKS_BLOCKER,
+    ])
+    expect(projection.greenGateMet).toBe(true)
+  })
+
+  test('keeps the external-flow blocker active when the external answer is not in a scheduled tick window', () => {
+    const tickReadiness = projectArtanisResponderTickReadiness(
+      Array.from({ length: 10 }, (_, index) => tickRow(index + 1)),
+      Array.from({ length: 10 }, (_, index) =>
+        tickActionRow(index + 1),
+      ).map(action => ({
+        ...action,
+        asker_provenance: 'owner_operator',
+      })),
+    )
+    const projection = projectArtanisResponderSupport(
+      [row({})],
+      nowIso,
+      tickReadiness,
+    )
+
+    expect(projection.externalContributorFlowProven).toBe(true)
+    expect(
+      projection.tickReadiness?.externalContributorAnsweredWithinTickWindow,
+    ).toBe(false)
+    expect(projection.activeBlockerRefs).toEqual([
+      ARTANIS_RESPONDER_EXTERNAL_FLOW_BLOCKER,
+    ])
+    expect(projection.clearedBlockerRefs).toEqual([
+      ARTANIS_RESPONDER_TEN_TICKS_BLOCKER,
+    ])
+    expect(projection.greenGateMet).toBe(false)
   })
 })
 

--- a/apps/openagents.com/workers/api/src/artanis-responder-provenance.ts
+++ b/apps/openagents.com/workers/api/src/artanis-responder-provenance.ts
@@ -41,6 +41,11 @@ export const ARTANIS_RESPONDER_SUPPORT_STALENESS: PublicProjectionStalenessContr
     'artanis_responder_actions.update',
   ])
 
+export const ARTANIS_RESPONDER_EXTERNAL_FLOW_BLOCKER =
+  'blocker.product_promises.external_contributor_flow_unproven'
+export const ARTANIS_RESPONDER_TEN_TICKS_BLOCKER =
+  'blocker.product_promises.ten_unattended_responder_ticks_unaccrued'
+
 // The bounded asker-provenance enum. external_contributor is the only class
 // the green gate cares about; the others exist so the classifier is total
 // and the projection can honestly say WHY a given interaction does not count.
@@ -127,6 +132,9 @@ export type ArtanisResponderSupportProjection = Readonly<{
   publicSafe: true
   authorityBoundary: string
   staleness: PublicProjectionStalenessContract
+  blockerRefs: ReadonlyArray<string>
+  clearedBlockerRefs: ReadonlyArray<string>
+  activeBlockerRefs: ReadonlyArray<string>
   // Counts over the projected window, split by provenance honesty.
   externalContributorAnsweredCount: number
   externalContributorTippedCount: number
@@ -138,6 +146,7 @@ export type ArtanisResponderSupportProjection = Readonly<{
   // dereferenceable reply-post ref.
   externalInteractions: ReadonlyArray<ArtanisExternalSupportInteraction>
   tickReadiness?: ArtanisResponderTickReadinessProjection
+  greenGateMet: boolean
   generatedAt: string
   notes: ReadonlyArray<string>
 }>
@@ -224,20 +233,50 @@ export const projectArtanisResponderSupport = (
   const externalContributorFlowProven = externalInteractions.some(
     interaction => interaction.replyPostRef !== null,
   )
+  const externalContributorTickFlowProven =
+    externalContributorFlowProven &&
+    (tickReadiness?.externalContributorAnsweredWithinTickWindow ?? false)
+  const unattendedResponderTicksProven =
+    tickReadiness?.unattendedResponderTicksProven ?? false
+  const clearedBlockerRefs = [
+    ...(externalContributorTickFlowProven
+      ? [ARTANIS_RESPONDER_EXTERNAL_FLOW_BLOCKER]
+      : []),
+    ...(unattendedResponderTicksProven
+      ? [ARTANIS_RESPONDER_TEN_TICKS_BLOCKER]
+      : []),
+  ]
+  const activeBlockerRefs = [
+    ...(externalContributorTickFlowProven
+      ? []
+      : [ARTANIS_RESPONDER_EXTERNAL_FLOW_BLOCKER]),
+    ...(unattendedResponderTicksProven
+      ? []
+      : [ARTANIS_RESPONDER_TEN_TICKS_BLOCKER]),
+  ]
 
   return {
+    activeBlockerRefs,
     authorityBoundary:
       'Read-only projection over the Artanis responder-action ledger. Grants no dispatch, spend, assignment, settlement, moderation, or registry authority and cannot create an interaction, a reply, or a tip. Asker provenance is a bounded identity-field classification (operator/owner/agent/user prefix plus known internal Artanis/admin refs); the mind still owns the question-class decision.',
+    blockerRefs: [
+      ARTANIS_RESPONDER_EXTERNAL_FLOW_BLOCKER,
+      ARTANIS_RESPONDER_TEN_TICKS_BLOCKER,
+    ],
+    clearedBlockerRefs,
     externalContributorAnsweredCount,
     externalContributorFlowProven,
     externalContributorTippedCount,
     externalInteractions,
     generatedAt: nowIso,
+    greenGateMet:
+      externalContributorTickFlowProven && unattendedResponderTicksProven,
     kind: 'artanis_pylon_support_responder_external_flow',
     notes: [
       'An external contributor is a registered non-owner, non-operator, non-Artanis identity (a user: actor or a non-internal agent: actor). Operator/owner test articles are classified owner_operator and never satisfy the external-contributor gate.',
       'externalContributorFlowProven becomes true only when at least one external contributor has been answered end to end with a dereferenceable reply post (state responded or tipped); the reply post is fetchable at the publicUrl.',
       'A tipped interaction additionally proves the budget-gated economic leg (reliable-tips ladder) on a real external post.',
+      'greenGateMet is the mechanical receipt-evidence predicate only: an external contributor must be answered inside a scheduled tick window and the ten qualifying unattended responder tick target must be met. activeBlockerRefs names any missing blocker explicitly; the yellow->green flip still requires the separate owner-signed promise transition.',
     ],
     ownerOperatorAnsweredCount,
     publicSafe: true,


### PR DESCRIPTION
## Summary

- Add named Artanis responder blocker refs to the public responder-support projection.
- Report `activeBlockerRefs`, `clearedBlockerRefs`, and `greenGateMet` so `/api/public/artanis/responder-support` explicitly shows whether the external-contributor tick-flow and ten unattended responder tick gates are satisfied.
- Cover the combined readiness gate and partial-evidence behavior in focused tests.

Closes #7024

## Verification

- `bun run --cwd apps/openagents.com/workers/api test src/artanis-responder-provenance.test.ts src/artanis-responder-ticks.test.ts src/artanis-labor-green-readiness.test.ts src/artanis-labor-receipt-routes.test.ts src/product-promises.test.ts` (46 passed)
- `bun run --cwd apps/openagents.com/workers/api typecheck` (exit 0; emits existing Effect language-service diagnostics in unrelated files: `artanis-activity-routes.ts`, `artanis-operator-tools.ts`, `artanis-public-report-routes.ts`, `pylon-api-routes.ts`)