### PR TITLE
Narrow paid inference receipt blockers

### DIFF
--- a/apps/openagents.com/workers/api/src/product-promises.test.ts
+++ b/apps/openagents.com/workers/api/src/product-promises.test.ts
@@ -130,6 +130,9 @@ describe('public product promises document', () => {
     expect(blockerRefs).not.toContain(
       'blocker.product_promises.cloud_primitives_unified_balance_unbuilt',
     )
+    expect(blockerRefs).not.toContain(
+      'blocker.product_promises.autopilot_credits_no_card_credit_spend_receipt',
+    )
     expect(decoded.sourceRefs).toContain(
       'docs/training/2026-06-20-psion-instruct-sft-fixture-sync.md',
     )
@@ -160,6 +163,35 @@ describe('public product promises document', () => {
     expect(decoded.promises.length).toBeGreaterThan(0)
     expect(decoded.verificationSummary.promiseCount).toBe(
       decoded.promises.length,
+    )
+    const cardCreditInferencePromise = decoded.promises.find(
+      promise => promise.promiseId === 'inference.gateway_credits_business.v1',
+    )
+    const autopilotCreditsPromise = decoded.promises.find(
+      promise => promise.promiseId === 'payments.autopilot_credits_purchase.v1',
+    )
+
+    expect(cardCreditInferencePromise?.state).toBe('red')
+    expect(cardCreditInferencePromise?.evidenceRefs).toContain(
+      'apps/openagents.com/workers/api/src/public-card-credit-spend-receipt-routes.ts',
+    )
+    expect(cardCreditInferencePromise?.blockerRefs).toEqual(
+      expect.arrayContaining([
+        'blocker.product_promises.inference_paid_receipt_not_yet_supplied',
+      ]),
+    )
+    expect(autopilotCreditsPromise?.state).toBe('red')
+    expect(autopilotCreditsPromise?.evidenceRefs).toContain(
+      'apps/openagents.com/workers/api/src/public-card-credit-spend-receipt-routes.ts',
+    )
+    expect(autopilotCreditsPromise?.blockerRefs).not.toContain(
+      'blocker.product_promises.autopilot_credits_no_card_credit_spend_receipt',
+    )
+    expect(autopilotCreditsPromise?.blockerRefs).toEqual(
+      expect.arrayContaining([
+        'blocker.product_promises.autopilot_credits_prod_stripe_secrets_missing',
+        'blocker.product_promises.autopilot_credits_no_real_card_purchase_receipt',
+      ]),
     )
     // receipt. The Episode 239 records (registry 2026-06-19.6) are all
     // red/planned; the 2026-06-19.7 passes (scaffold advancement + training
@@ -440,8 +472,9 @@ describe('public product promises document', () => {
       /latest stays 0\.2\.5|only published, installable Pylon|release candidate, not stable 0\.3\.0|Pylon v1\.0 is present in the monorepo as a release candidate/i,
     )
     expect(currentCopy).toContain('Pylon v1.0 has a stable source cut')
-    expect(currentCopy).toContain('Registry 2026-06-29.2')
+    expect(currentCopy).toContain('Registry 2026-06-29.3')
     expect(currentCopy).toContain('flips NO promise state')
+    expect(currentCopy).toContain('audits #7018')
     expect(currentCopy).toContain('Khala Desktop now carries source-level')
     expect(currentCopy).toContain('maxStalenessSeconds:0')
     const codexSuccessorPromise = decoded.promises.find(

--- a/apps/openagents.com/workers/api/src/product-promises.ts
+++ b/apps/openagents.com/workers/api/src/product-promises.ts
@@ -4,7 +4,7 @@ import { currentIsoTimestamp } from './runtime-primitives'
 export const PublicProductPromisesEndpoint = '/api/public/product-promises'
 export const PublicProductPromisesSchemaVersion =
   'openagents.product_promises.v1'
-export const PublicProductPromisesVersion = '2026-06-29.2'
+export const PublicProductPromisesVersion = '2026-06-29.3'
 
 const reportPath = 'https://openagents.com/forum/f/product-promises'
 
@@ -261,6 +261,7 @@ export const publicProductPromisesDocument = () => {
         'Registry 2026-06-28.3 implements #6891 for models.tassadar_percepta_executor.v1 and flips NO promise state. Pylon v1.0 now has a deterministic bounded CPU computation-transform fixture in apps/pylon/src/tassadar-cpu-transform-training.ts that runs one CPU-only optimization step, self-verifies loss improvement, emits receipt.models.tassadar_percepta_executor.cpu_transform_training.cpu_transform_fixture_v1, and keeps realBitcoinMoved:false / settlementState:not_settled. GET /api/public/models/tassadar-percepta-executor/cpu-transform-training-receipts now projects that public-safe receipt alongside the architecture and Artanis distillation dataset inputs, so the old pylon_v03_cpu_transform_training_receipts_missing blocker is replaced by blocker.product_promises.tassadar_cpu_transform_real_settlement_missing and blocker.product_promises.tassadar_cpu_transform_owner_green_signoff_missing. The promise STAYS planned: this is one fixture-scale receipt, not a trained model, not a paid earning path, not model promotion, and not a green transition; any future green flip remains receipt-first and owner-signed per proof.claim_upgrade_receipts.v1.',
         'Registry 2026-06-29.1 implements #6848 for payments.accepted_outcome_economics.v1 and flips NO promise state. The accepted-outcome economics spine now has a dereferenceable contributor accrual bundle at GET /api/public/payments/contributor-accrual-bundle?economicsId=... plus the settlement bundle at GET /api/public/accepted-outcome/settlement/{economicsId}; together they compose a gross-margin receipt, contributor accrual ledger entries, and an eight-state settlement machine from one stored accepted-outcome economics row. Tests prove the ledger and receipt share the same economicsId, reconcile gross margin exactly, reconcile pending_payout to the distributable ledger pool, keep public projections free of internal cents/raw payment material, and surface missing contributor provenance honestly. The old source-level blockers contributor_ledger_missing and gross_margin_receipts_missing are replaced by real_accepted_outcome_receipt_missing and owner_signed_green_transition_missing. The promise STAYS red because source/fixture receipt machinery is not a real accepted outcome carried through a money-moving settlement path, and any future green flip remains receipt-first and owner-signed per proof.claim_upgrade_receipts.v1.',
         'Registry 2026-06-29.2 is a current-main refresh after #6997/#6999/#7001/#7002/#7006 and flips NO promise state. The terminal-agent current-state audit and Codex tool-layer study are now cited as evidence for the Codex/Probe/Pylon runtime direction: current production coding delegation is still Pylon plus external agent SDK lanes and OpenAgents-native terminal tools remain a consolidation task, not a new green claim. The codex-supervisor LOCKOUT replenishment helper can create or reuse three bounded standing issues so owner-capacity supervisors do not idle indefinitely, but it creates no paid labor, payout, settlement, or broad availability claim. The inference router now has GLM own-capacity failover alerting and public-safe fallback telemetry for repeated no-headroom saturation, but the paid gateway still stays red until a dereferenceable paid receipt exists. Khala Desktop now carries source-level Electrobun Apple FM sidecar packaging/readiness plus redaction tests, but Apple FM local mode remains yellow until a signed/notarized from-install smoke with helper supervision exists. The Khala model-mix promise remains live-at-read with maxStalenessSeconds:0; the stale 2-second cache wording is not applied.',
+        'Registry 2026-06-29.3 audits #7018 and flips NO promise state. The card -> USD credit -> explicit inference-credit bridge -> metered inference receipt machinery is already source-backed and publicly resolvable at GET /api/public/inference/card-credit-spend-receipts/{receiptRef}, with tests proving ok/pending/invalid resolution and redaction of private payment material. This clears only the stale source-level blocker blocker.product_promises.autopilot_credits_no_card_credit_spend_receipt from payments.autopilot_credits_purchase.v1. Both payments.autopilot_credits_purchase.v1 and inference.gateway_credits_business.v1 STAY red because production or owner-approved staging-to-prod Stripe/MPP inputs and a dereferenceable real paid card-to-credit-to-inference receipt are still missing; any future green flip remains receipt-first and owner-signed per proof.claim_upgrade_receipts.v1.',
       ],
     },
     promises: [
@@ -3389,6 +3390,8 @@ export const publicProductPromisesDocument = () => {
           'apps/openagents.com/workers/api/src/inference/model-router.ts',
           'apps/openagents.com/workers/api/src/inference/model-router.test.ts',
           'apps/openagents.com/workers/api/src/inference/card-credit-spend-receipt-store.ts',
+          'apps/openagents.com/workers/api/src/public-card-credit-spend-receipt-routes.ts',
+          'apps/openagents.com/workers/api/src/public-card-credit-spend-receipt-routes.test.ts',
           'apps/openagents.com/workers/api/src/inference/mpp/mpp-chat-completions-routes.ts',
           'promise:api.hosted_gemini.v1',
           'promise:payments.accepted_outcome_economics.v1',
@@ -3929,6 +3932,8 @@ export const publicProductPromisesDocument = () => {
           'apps/openagents.com/workers/api/src/stripe-billing.ts',
           'apps/openagents.com/workers/api/src/inference/usd-credit-bridge.ts',
           'apps/openagents.com/workers/api/src/inference/card-credit-spend-receipt-store.ts',
+          'apps/openagents.com/workers/api/src/public-card-credit-spend-receipt-routes.ts',
+          'apps/openagents.com/workers/api/src/public-card-credit-spend-receipt-routes.test.ts',
           'docs/promises/2026-06-23-khala-billing-mpp-proof-gate.md',
           'apps/openagents.com/docs/launch/2026-06-23-khala-billing-mpp-production-proof.md',
           'apps/openagents.com/apps/web/src/page/loggedIn/page/billing.ts',
@@ -3939,7 +3944,6 @@ export const publicProductPromisesDocument = () => {
         blockerRefs: [
           'blocker.product_promises.autopilot_credits_prod_stripe_secrets_missing',
           'blocker.product_promises.autopilot_credits_no_real_card_purchase_receipt',
-          'blocker.product_promises.autopilot_credits_no_card_credit_spend_receipt',
           'blocker.product_promises.autopilot_credits_no_bitcoin_purchase_path',
         ],
         verification:


### PR DESCRIPTION
## Summary

- audit #7018 against the existing card -> USD credit -> inference-credit bridge -> metered inference receipt resolver
- bump the product-promise registry to 2026-06-29.3 with a no-state-flip note
- remove only the stale `autopilot_credits_no_card_credit_spend_receipt` blocker while keeping both paid-credit promises red until real or owner-approved staging-to-prod paid evidence exists
- add product-promise regression assertions for the red state, evidence refs, and remaining blockers

Closes #7018.

## Verification

- `true` (`command.public.pylon_khala.verify.b5bea41b6c623f7c09f1bf24`)
- `bun run --cwd apps/openagents.com/workers/api test -- src/product-promises.test.ts src/inference/card-credit-spend-receipt.test.ts src/inference/card-credit-spend-receipt-store.test.ts src/public-card-credit-spend-receipt-routes.test.ts`