### PR TITLE
forge: add GitHub mirror receipts

### DIFF
--- a/apps/openagents.com/workers/api/migrations/0257_forge_github_mirror_receipts.sql
+++ b/apps/openagents.com/workers/api/migrations/0257_forge_github_mirror_receipts.sql
@@ -1,0 +1,43 @@
+-- FORGE SU-6 (#6796): GitHub read-only mirror receipts.
+--
+-- GitHub is downstream visibility only. These rows record attempts to mirror
+-- Forge-promoted canonical refs to GitHub refs, including refusals and upstream
+-- errors. Promotion authority remains forge_promotion_decisions.
+
+CREATE TABLE IF NOT EXISTS forge_github_mirror_receipts (
+  tenant_ref TEXT NOT NULL,
+  mirror_ref TEXT NOT NULL,
+  promotion_ref TEXT NOT NULL,
+  source_canonical_ref TEXT NOT NULL,
+  destination_github_ref TEXT NOT NULL,
+  repository_ref TEXT NOT NULL,
+  github_repository TEXT NOT NULL,
+  commit_id TEXT NOT NULL,
+  status TEXT NOT NULL CHECK (status IN ('mirrored', 'failed', 'refused')),
+  attempted_at TEXT NOT NULL,
+  mirrored_at TEXT,
+  refusal_reason TEXT,
+  error_reason TEXT,
+  source_refs_json TEXT NOT NULL DEFAULT '[]',
+  redacted INTEGER NOT NULL DEFAULT 1 CHECK (redacted = 1),
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  PRIMARY KEY (tenant_ref, mirror_ref),
+  CHECK (
+    (status = 'mirrored' AND mirrored_at IS NOT NULL AND refusal_reason IS NULL AND error_reason IS NULL)
+    OR (status = 'failed' AND mirrored_at IS NULL AND error_reason IS NOT NULL)
+    OR (status = 'refused' AND mirrored_at IS NULL AND refusal_reason IS NOT NULL)
+  )
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_forge_github_mirror_receipts_destination
+  ON forge_github_mirror_receipts (
+    tenant_ref,
+    promotion_ref,
+    source_canonical_ref,
+    destination_github_ref,
+    commit_id
+  );
+
+CREATE INDEX IF NOT EXISTS idx_forge_github_mirror_receipts_status
+  ON forge_github_mirror_receipts (tenant_ref, status, attempted_at);

--- a/apps/openagents.com/workers/api/src/config.ts
+++ b/apps/openagents.com/workers/api/src/config.ts
@@ -430,6 +430,7 @@ export type OpenAgentsWorkerConfigEnv = Readonly<{
   OPENAGENTS_SPARK_API_KEY?: string | undefined
   OPENAGENTS_ADMIN_API_TOKEN?: string | undefined
   OPENAGENTS_FORGE_CONTROL_PLANE_TOKEN?: string | undefined
+  OPENAGENTS_FORGE_GITHUB_MIRROR_TOKEN?: string | undefined
   OPENAGENTS_APP_URL?: string | undefined
   OPENAUTH_CLIENT_ID?: string | undefined
   OPENAUTH_ISSUER_URL?: string | undefined
@@ -618,6 +619,7 @@ export type OpenAgentsWorkerConfigShape = Readonly<{
   }>
   exa: ExaConfig
   forgeControlPlaneToken?: Redacted.Redacted<WorkerSecret> | undefined
+  forgeGitHubMirrorToken?: Redacted.Redacted<WorkerSecret> | undefined
   github: Readonly<{
     clientId: GitHubClientId
     clientSecret: Redacted.Redacted<WorkerSecret>
@@ -1342,6 +1344,10 @@ export const decodeOpenAgentsWorkerConfig = (
       forgeControlPlaneToken: optionalRedacted(
         env,
         'OPENAGENTS_FORGE_CONTROL_PLANE_TOKEN',
+      ),
+      forgeGitHubMirrorToken: optionalRedacted(
+        env,
+        'OPENAGENTS_FORGE_GITHUB_MIRROR_TOKEN',
       ),
       github: {
         clientId: GitHubClientId.make(

--- a/apps/openagents.com/workers/api/src/forge-control-plane-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/forge-control-plane-routes.test.ts
@@ -67,6 +67,10 @@ const canonicalGitMigration = readFileSync(
   new URL('../migrations/0255_forge_git_canonical_store.sql', import.meta.url),
   'utf8',
 )
+const githubMirrorMigration = readFileSync(
+  new URL('../migrations/0257_forge_github_mirror_receipts.sql', import.meta.url),
+  'utf8',
+)
 
 const makeStores = (): Readonly<{
   canonicalStore: ForgeGitCanonicalStore
@@ -77,6 +81,7 @@ const makeStores = (): Readonly<{
   db.exec(coordinationMigration)
   db.exec(controlPlaneReceiptsMigration)
   db.exec(canonicalGitMigration)
+  db.exec(githubMirrorMigration)
   const d1 = new SqliteD1(db) as unknown as D1Database
   return {
     canonicalStore: makeD1ForgeGitCanonicalStore(d1),
@@ -96,15 +101,20 @@ const authHeaders = (scopes: string): HeadersInit => ({
 
 const githubMainSha = '1234567890abcdef1234567890abcdef12345678'
 const makeGitHubFetch = (sha: string = githubMainSha): typeof fetch =>
-  (async () =>
-    Response.json({
+  (async (_input: RequestInfo | URL, init?: RequestInit) => {
+    if (init?.method === 'PATCH') {
+      return Response.json({ ok: true })
+    }
+
+    return Response.json({
       ref: 'refs/heads/main',
       object: {
         sha,
         type: 'commit',
         url: `https://api.github.com/repos/OpenAgentsInc/openagents/git/commits/${sha}`,
       },
-    })) as typeof fetch
+    })
+  }) as typeof fetch
 
 type JsonRequestInit = Omit<RequestInit, 'body'> & Readonly<{ json?: unknown }>
 
@@ -127,6 +137,7 @@ const makeHarness = () => {
     authorizeControlPlaneBearer: (request, _env, scope) =>
       authorizeForgeControlPlaneBearer(request, controlPlaneToken, scope),
     fetch: makeGitHubFetch(),
+    githubMirrorToken: () => 'github_mirror_token',
     makeCanonicalStore: () => canonicalStore,
     makeStore: () => coordinationStore,
     nowIso: () => now,
@@ -479,5 +490,125 @@ describe('Forge control-plane routes', () => {
 
     expect(response.status).toBe(403)
     expect(body.error).toBe('forge_openagents_import_target_forbidden')
+  })
+
+  test('mirrors only approved Forge promotions to GitHub main with receipts', async () => {
+    const { run, store } = makeHarness()
+    const promotedHead = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+    const scopes = 'forge:admin forge:queue:read'
+
+    await store.recordPromotionDecisionReceipt(
+      {
+        schema: 'openagents.forge.promotion.decision.v0.1',
+        tenant_ref: 'tenant.openagents',
+        promotion_ref: 'promotion.forge.6796.approved',
+        queue_ref: 'queue.forge.main',
+        change_ref: 'change.forge.6796',
+        decision: 'approved',
+        base_head: '1234567890abcdef1234567890abcdef12345678',
+        candidate_head: promotedHead,
+        promoted_head: promotedHead,
+        verification_ref: 'verification.forge.6796',
+        gate_refs: ['gate.forge.su4', 'gate.forge.su5'],
+        blocker_refs: [],
+        decided_by_ref: 'agent.public.forge',
+        decided_at: now,
+        source_refs: ['github:OpenAgentsInc/openagents#6796'],
+        redacted: true,
+      },
+      now,
+    )
+
+    const response = await run(
+      requestJson('/api/forge/mirror/github/openagents-main', {
+        json: {
+          tenantRef: 'tenant.openagents',
+          repositoryRef: 'repo.openagents.openagents',
+          promotionRef: 'promotion.forge.6796.approved',
+        },
+        headers: authHeaders(scopes),
+        method: 'POST',
+      }),
+    )
+    const body = (await response.json()) as {
+      mirrorReceipt: { commit_id: string; status: string; mirrored_at: string }
+    }
+
+    expect(response.status).toBe(201)
+    expect(body.mirrorReceipt).toMatchObject({
+      commit_id: promotedHead,
+      mirrored_at: now,
+      status: 'mirrored',
+    })
+
+    const secondResponse = await run(
+      requestJson('/api/forge/mirror/github/openagents-main', {
+        json: {
+          tenantRef: 'tenant.openagents',
+          repositoryRef: 'repo.openagents.openagents',
+          promotionRef: 'promotion.forge.6796.approved',
+        },
+        headers: authHeaders(scopes),
+        method: 'POST',
+      }),
+    )
+    expect(secondResponse.status).toBe(201)
+
+    const listResponse = await run(
+      new Request(
+        'https://openagents.com/api/forge/mirror/github/openagents-main?tenantRef=tenant.openagents&promotionRef=promotion.forge.6796.approved',
+        { headers: authHeaders(scopes) },
+      ),
+    )
+    const listBody = (await listResponse.json()) as {
+      mirrorReceipts: ReadonlyArray<unknown>
+    }
+    expect(listResponse.status).toBe(200)
+    expect(listBody.mirrorReceipts).toHaveLength(1)
+  })
+
+  test('refuses non-promoted Forge decisions before touching GitHub', async () => {
+    const { run, store } = makeHarness()
+
+    await store.recordPromotionDecisionReceipt(
+      {
+        schema: 'openagents.forge.promotion.decision.v0.1',
+        tenant_ref: 'tenant.openagents',
+        promotion_ref: 'promotion.forge.6796.blocked',
+        queue_ref: 'queue.forge.main',
+        change_ref: 'change.forge.6796',
+        decision: 'blocked',
+        base_head: '1234567890abcdef1234567890abcdef12345678',
+        candidate_head: 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+        promoted_head: null,
+        verification_ref: null,
+        gate_refs: [],
+        blocker_refs: ['blocker.forge.verification_failed'],
+        decided_by_ref: 'agent.public.forge',
+        decided_at: now,
+        source_refs: ['github:OpenAgentsInc/openagents#6796'],
+        redacted: true,
+      },
+      now,
+    )
+
+    const response = await run(
+      requestJson('/api/forge/mirror/github/openagents-main', {
+        json: {
+          tenantRef: 'tenant.openagents',
+          repositoryRef: 'repo.openagents.openagents',
+          promotionRef: 'promotion.forge.6796.blocked',
+        },
+        headers: authHeaders('forge:admin'),
+        method: 'POST',
+      }),
+    )
+    const body = (await response.json()) as {
+      mirrorReceipt: { status: string; refusal_reason: string | null }
+    }
+
+    expect(response.status).toBe(409)
+    expect(body.mirrorReceipt.status).toBe('refused')
+    expect(body.mirrorReceipt.refusal_reason).toContain('not an approved')
   })
 })

--- a/apps/openagents.com/workers/api/src/forge-control-plane-routes.ts
+++ b/apps/openagents.com/workers/api/src/forge-control-plane-routes.ts
@@ -2,9 +2,11 @@ import {
   ForgeCoordinationChangeState,
   ForgeCoordinationIssueState,
   ForgeCoordinationStatusState,
+  ForgeGitHubMirrorReceipt,
   ForgeMergeQueueLedgerState,
   ForgePromotionDecisionReceipt,
   ForgeVerificationReceipt,
+  decodeForgeGitHubMirrorReceipt,
   decodeForgeControlPlaneScope,
   type ForgeControlPlaneScope,
 } from '@openagentsinc/forge-protocol'
@@ -44,6 +46,7 @@ export type ForgeControlPlaneAuthorize<Bindings> = (
 type ForgeControlPlaneRouteDependencies<Bindings> = Readonly<{
   authorizeControlPlaneBearer?: ForgeControlPlaneAuthorize<Bindings> | undefined
   fetch?: typeof fetch
+  githubMirrorToken?: (env: Bindings) => string | undefined
   makeCanonicalStore: (env: Bindings) => ForgeGitCanonicalStore
   makeStore: (env: Bindings) => ForgeCoordinationStore
   nowIso?: () => string
@@ -120,6 +123,12 @@ const ForgeMergeQueueSnapshotRequest = S.Struct({
 const ForgeOpenAgentsImportRequest = S.Struct({
   tenantRef: S.String,
   repositoryRef: S.String,
+})
+
+const ForgeOpenAgentsMirrorRequest = S.Struct({
+  tenantRef: S.String,
+  repositoryRef: S.String,
+  promotionRef: S.String,
 })
 
 const readBearerToken = (request: Request): string | undefined => {
@@ -655,6 +664,195 @@ const routePromotionDecisions = async <Bindings>(
   return noStoreJsonResponse({ promotionDecision }, { status: 201 })
 }
 
+const mirrorRefForPromotion = (promotionRef: string, commitId: string): string =>
+  `mirror.forge.github.openagents.main.${promotionRef.replaceAll(
+    /[^A-Za-z0-9_.-]+/gu,
+    '_',
+  )}.${commitId.slice(0, 16)}`
+
+const gitHubMirrorReceipt = (input: Readonly<{
+  attemptedAt: string
+  commitId: string
+  errorReason?: string | undefined
+  mirroredAt?: string | null | undefined
+  promotionRef: string
+  refusalReason?: string | undefined
+  sourceRefs: ReadonlyArray<string>
+  status: 'mirrored' | 'failed' | 'refused'
+}>): ForgeGitHubMirrorReceipt =>
+  decodeForgeGitHubMirrorReceipt({
+    schema: 'openagents.forge.github_mirror.receipt.v0.1',
+    tenant_ref: OPENAGENTS_FORGE_TENANT_REF,
+    mirror_ref: mirrorRefForPromotion(input.promotionRef, input.commitId),
+    promotion_ref: input.promotionRef,
+    source_canonical_ref: OPENAGENTS_DEFAULT_BRANCH_REF,
+    destination_github_ref: OPENAGENTS_DEFAULT_BRANCH_REF,
+    repository_ref: OPENAGENTS_FORGE_REPOSITORY_REF,
+    github_repository: `${OPENAGENTS_GITHUB_OWNER}/${OPENAGENTS_GITHUB_REPO}`,
+    commit_id: input.commitId,
+    status: input.status,
+    attempted_at: input.attemptedAt,
+    mirrored_at: input.mirroredAt ?? null,
+    refusal_reason: input.refusalReason ?? null,
+    error_reason: input.errorReason ?? null,
+    source_refs: input.sourceRefs,
+    redacted: true,
+  })
+
+const patchGitHubMainRef = async <Bindings>(
+  dependencies: ForgeControlPlaneRouteDependencies<Bindings>,
+  env: Bindings,
+  commitId: string,
+): Promise<void> => {
+  const token = dependencies.githubMirrorToken?.(env)
+  if (token === undefined || token.trim() === '') {
+    throw new ForgeControlPlaneHttpError(
+      503,
+      'forge_github_mirror_token_missing',
+      'GitHub mirror token is not configured.',
+    )
+  }
+
+  const response = await (dependencies.fetch ?? fetch)(
+    `https://api.github.com/repos/${OPENAGENTS_GITHUB_OWNER}/${OPENAGENTS_GITHUB_REPO}/git/refs/heads/main`,
+    {
+      body: JSON.stringify({ force: false, sha: commitId }),
+      headers: {
+        accept: 'application/vnd.github+json',
+        authorization: `Bearer ${token}`,
+        'content-type': 'application/json',
+        'user-agent': 'openagents-forge-github-mirror',
+      },
+      method: 'PATCH',
+    },
+  )
+
+  if (!response.ok) {
+    throw new ForgeControlPlaneHttpError(
+      502,
+      'forge_github_mirror_upstream_failed',
+      `GitHub ref update failed with HTTP ${response.status}.`,
+    )
+  }
+}
+
+const routeOpenAgentsGitHubMirror = async <Bindings>(
+  dependencies: ForgeControlPlaneRouteDependencies<Bindings>,
+  request: Request,
+  env: Bindings,
+  url: URL,
+) => {
+  const store = dependencies.makeStore(env)
+
+  if (request.method === 'GET') {
+    const tenantRef = tenantRefFromQuery(url)
+    await requireScope(dependencies, request, env, 'forge:queue:read', tenantRef)
+    const limit = limitFromQuery(url)
+    return noStoreJsonResponse({
+      limit,
+      mirrorReceipts: await store.listGitHubMirrorReceipts(
+        tenantRef,
+        limit,
+        optionalQuery(url, 'promotionRef'),
+      ),
+      tenantRef,
+    })
+  }
+
+  if (request.method !== 'POST') {
+    return methodNotAllowed(['GET', 'POST'])
+  }
+
+  await requireScope(
+    dependencies,
+    request,
+    env,
+    'forge:admin',
+    OPENAGENTS_FORGE_TENANT_REF,
+  )
+  const body = await decodeBody(request, ForgeOpenAgentsMirrorRequest)
+  const attemptedAt = routeNowIso(dependencies)
+  if (
+    body.tenantRef !== OPENAGENTS_FORGE_TENANT_REF ||
+    body.repositoryRef !== OPENAGENTS_FORGE_REPOSITORY_REF
+  ) {
+    const receipt = await store.recordGitHubMirrorReceipt(
+      gitHubMirrorReceipt({
+        attemptedAt,
+        commitId: '0'.repeat(40),
+        promotionRef: body.promotionRef,
+        refusalReason: `OpenAgents mirror is pinned to ${OPENAGENTS_FORGE_TENANT_REF}/${OPENAGENTS_FORGE_REPOSITORY_REF}.`,
+        sourceRefs: ['github:OpenAgentsInc/openagents#6796'],
+        status: 'refused',
+      }),
+      attemptedAt,
+    )
+    return noStoreJsonResponse({ mirrorReceipt: receipt }, { status: 403 })
+  }
+
+  const promotion = await store.readPromotionDecisionReceipt(
+    body.tenantRef,
+    body.promotionRef,
+  )
+  const sourceRefs = [
+    'github:OpenAgentsInc/openagents#6796',
+    ...(promotion?.source_refs ?? []),
+    body.promotionRef,
+  ]
+
+  if (
+    promotion === undefined ||
+    promotion.decision !== 'approved' ||
+    promotion.promoted_head === null
+  ) {
+    const receipt = await store.recordGitHubMirrorReceipt(
+      gitHubMirrorReceipt({
+        attemptedAt,
+        commitId: promotion?.candidate_head ?? '0'.repeat(40),
+        promotionRef: body.promotionRef,
+        refusalReason:
+          promotion === undefined
+            ? 'Promotion receipt was not found.'
+            : 'Promotion receipt is not an approved Forge promotion with a promoted head.',
+        sourceRefs,
+        status: 'refused',
+      }),
+      attemptedAt,
+    )
+    return noStoreJsonResponse({ mirrorReceipt: receipt }, { status: 409 })
+  }
+
+  try {
+    await patchGitHubMainRef(dependencies, env, promotion.promoted_head)
+  } catch (error) {
+    const receipt = await store.recordGitHubMirrorReceipt(
+      gitHubMirrorReceipt({
+        attemptedAt,
+        commitId: promotion.promoted_head,
+        errorReason: error instanceof Error ? error.message : String(error),
+        promotionRef: body.promotionRef,
+        sourceRefs,
+        status: 'failed',
+      }),
+      attemptedAt,
+    )
+    return noStoreJsonResponse({ mirrorReceipt: receipt }, { status: 502 })
+  }
+
+  const receipt = await store.recordGitHubMirrorReceipt(
+    gitHubMirrorReceipt({
+      attemptedAt,
+      commitId: promotion.promoted_head,
+      mirroredAt: attemptedAt,
+      promotionRef: body.promotionRef,
+      sourceRefs,
+      status: 'mirrored',
+    }),
+    attemptedAt,
+  )
+  return noStoreJsonResponse({ mirrorReceipt: receipt }, { status: 201 })
+}
+
 const sha256Hex = async (value: string): Promise<string> => {
   const bytes = await crypto.subtle.digest(
     'SHA-256',
@@ -873,6 +1071,17 @@ export const makeForgeControlPlaneRoutes = <Bindings>(
     if (route.length === 1 && route[0] === 'promotion-decisions') {
       return routeEffect(() =>
         routePromotionDecisions(dependencies, request, env, url),
+      )
+    }
+
+    if (
+      route.length === 3 &&
+      route[0] === 'mirror' &&
+      route[1] === 'github' &&
+      route[2] === 'openagents-main'
+    ) {
+      return routeEffect(() =>
+        routeOpenAgentsGitHubMirror(dependencies, request, env, url),
       )
     }
 

--- a/apps/openagents.com/workers/api/src/forge-coordination-store.ts
+++ b/apps/openagents.com/workers/api/src/forge-coordination-store.ts
@@ -3,6 +3,7 @@ import {
   decodeForgeCoordinationPrRow,
   decodeForgeCoordinationStatusRow,
   decodeForgeDispatchLeaseRow,
+  decodeForgeGitHubMirrorReceipt,
   decodeForgeMergeQueueLedgerRow,
   decodeForgePromotionDecisionReceipt,
   decodeForgeVerificationReceipt,
@@ -14,6 +15,7 @@ import {
   type ForgeCoordinationStatusRow,
   type ForgeCoordinationStatusState,
   type ForgeDispatchLeaseRow,
+  type ForgeGitHubMirrorReceipt,
   type ForgeMergeQueueLedgerRow,
   type ForgeMergeQueueLedgerState,
   type ForgePromotionDecisionReceipt,
@@ -133,11 +135,24 @@ export type ForgeCoordinationStore = Readonly<{
     receipt: ForgePromotionDecisionReceipt,
     createdAt: string,
   ) => Promise<ForgePromotionDecisionReceipt>
+  readPromotionDecisionReceipt: (
+    tenantRef: string,
+    promotionRef: string,
+  ) => Promise<ForgePromotionDecisionReceipt | undefined>
   listPromotionDecisionReceipts: (
     tenantRef: string,
     limit: number,
     changeRef?: string,
   ) => Promise<ReadonlyArray<ForgePromotionDecisionReceipt>>
+  recordGitHubMirrorReceipt: (
+    receipt: ForgeGitHubMirrorReceipt,
+    createdAt: string,
+  ) => Promise<ForgeGitHubMirrorReceipt>
+  listGitHubMirrorReceipts: (
+    tenantRef: string,
+    limit: number,
+    promotionRef?: string,
+  ) => Promise<ReadonlyArray<ForgeGitHubMirrorReceipt>>
 }>
 
 const StringArray = S.Array(S.String)
@@ -186,6 +201,24 @@ type ForgePromotionDecisionReceiptRow = Readonly<{
   blocker_refs_json: string
   decided_by_ref: string
   decided_at: string
+  source_refs_json: string
+  redacted: number | boolean
+}>
+
+type ForgeGitHubMirrorReceiptRow = Readonly<{
+  tenant_ref: string
+  mirror_ref: string
+  promotion_ref: string
+  source_canonical_ref: string
+  destination_github_ref: string
+  repository_ref: string
+  github_repository: string
+  commit_id: string
+  status: string
+  attempted_at: string
+  mirrored_at: string | null
+  refusal_reason: string | null
+  error_reason: string | null
   source_refs_json: string
   redacted: number | boolean
 }>
@@ -239,6 +272,28 @@ const promotionDecisionReceiptFromRow = (
     blocker_refs: stringArrayFromJson(row.blocker_refs_json),
     decided_by_ref: row.decided_by_ref,
     decided_at: row.decided_at,
+    source_refs: stringArrayFromJson(row.source_refs_json),
+    redacted: row.redacted === true || row.redacted === 1,
+  })
+
+const githubMirrorReceiptFromRow = (
+  row: ForgeGitHubMirrorReceiptRow,
+): ForgeGitHubMirrorReceipt =>
+  decodeForgeGitHubMirrorReceipt({
+    schema: 'openagents.forge.github_mirror.receipt.v0.1',
+    tenant_ref: row.tenant_ref,
+    mirror_ref: row.mirror_ref,
+    promotion_ref: row.promotion_ref,
+    source_canonical_ref: row.source_canonical_ref,
+    destination_github_ref: row.destination_github_ref,
+    repository_ref: row.repository_ref,
+    github_repository: row.github_repository,
+    commit_id: row.commit_id,
+    status: row.status,
+    attempted_at: row.attempted_at,
+    mirrored_at: row.mirrored_at,
+    refusal_reason: row.refusal_reason,
+    error_reason: row.error_reason,
     source_refs: stringArrayFromJson(row.source_refs_json),
     redacted: row.redacted === true || row.redacted === 1,
   })
@@ -958,5 +1013,140 @@ export const makeD1ForgeCoordinationStore = (
             .all<ForgePromotionDecisionReceiptRow>()
 
     return rows.results.map(promotionDecisionReceiptFromRow)
+  },
+
+  async readPromotionDecisionReceipt(tenantRef, promotionRef) {
+    const row = await db
+      .prepare(
+        `
+          SELECT *
+          FROM forge_promotion_decisions
+          WHERE tenant_ref = ? AND promotion_ref = ?
+        `,
+      )
+      .bind(tenantRef, promotionRef)
+      .first<ForgePromotionDecisionReceiptRow>()
+
+    return row === null ? undefined : promotionDecisionReceiptFromRow(row)
+  },
+
+  async recordGitHubMirrorReceipt(receipt, createdAt) {
+    const decoded = decodeForgeGitHubMirrorReceipt(receipt)
+    await db
+      .prepare(
+        `
+          INSERT INTO forge_github_mirror_receipts (
+            tenant_ref,
+            mirror_ref,
+            promotion_ref,
+            source_canonical_ref,
+            destination_github_ref,
+            repository_ref,
+            github_repository,
+            commit_id,
+            status,
+            attempted_at,
+            mirrored_at,
+            refusal_reason,
+            error_reason,
+            source_refs_json,
+            redacted,
+            created_at,
+            updated_at
+          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1, ?, ?)
+          ON CONFLICT (
+            tenant_ref,
+            promotion_ref,
+            source_canonical_ref,
+            destination_github_ref,
+            commit_id
+          ) DO UPDATE SET
+            mirror_ref = excluded.mirror_ref,
+            repository_ref = excluded.repository_ref,
+            github_repository = excluded.github_repository,
+            status = excluded.status,
+            attempted_at = excluded.attempted_at,
+            mirrored_at = excluded.mirrored_at,
+            refusal_reason = excluded.refusal_reason,
+            error_reason = excluded.error_reason,
+            source_refs_json = excluded.source_refs_json,
+            updated_at = excluded.updated_at
+        `,
+      )
+      .bind(
+        decoded.tenant_ref,
+        decoded.mirror_ref,
+        decoded.promotion_ref,
+        decoded.source_canonical_ref,
+        decoded.destination_github_ref,
+        decoded.repository_ref,
+        decoded.github_repository,
+        decoded.commit_id,
+        decoded.status,
+        decoded.attempted_at,
+        decoded.mirrored_at,
+        decoded.refusal_reason,
+        decoded.error_reason,
+        jsonArray(decoded.source_refs),
+        createdAt,
+        createdAt,
+      )
+      .run()
+
+    const row = await db
+      .prepare(
+        `
+          SELECT *
+          FROM forge_github_mirror_receipts
+          WHERE tenant_ref = ?
+            AND promotion_ref = ?
+            AND source_canonical_ref = ?
+            AND destination_github_ref = ?
+            AND commit_id = ?
+        `,
+      )
+      .bind(
+        decoded.tenant_ref,
+        decoded.promotion_ref,
+        decoded.source_canonical_ref,
+        decoded.destination_github_ref,
+        decoded.commit_id,
+      )
+      .first<ForgeGitHubMirrorReceiptRow>()
+
+    return githubMirrorReceiptFromRow(
+      rowOrFail(row, 'forge GitHub mirror receipt'),
+    )
+  },
+
+  async listGitHubMirrorReceipts(tenantRef, limit, promotionRef) {
+    const rows =
+      promotionRef === undefined
+        ? await db
+            .prepare(
+              `
+                SELECT *
+                FROM forge_github_mirror_receipts
+                WHERE tenant_ref = ?
+                ORDER BY attempted_at DESC, mirror_ref DESC
+                LIMIT ?
+              `,
+            )
+            .bind(tenantRef, limitRows(limit))
+            .all<ForgeGitHubMirrorReceiptRow>()
+        : await db
+            .prepare(
+              `
+                SELECT *
+                FROM forge_github_mirror_receipts
+                WHERE tenant_ref = ? AND promotion_ref = ?
+                ORDER BY attempted_at DESC, mirror_ref DESC
+                LIMIT ?
+              `,
+            )
+            .bind(tenantRef, promotionRef, limitRows(limit))
+            .all<ForgeGitHubMirrorReceiptRow>()
+
+    return rows.results.map(githubMirrorReceiptFromRow)
   },
 })

--- a/apps/openagents.com/workers/api/src/index.ts
+++ b/apps/openagents.com/workers/api/src/index.ts
@@ -2121,6 +2121,20 @@ const getForgeControlPlaneToken = (
   return token
 }
 
+const getForgeGitHubMirrorToken = (
+  env: OpenAgentsWorkerConfigEnv,
+): string | undefined => {
+  const token = redactedValue(
+    getOpenAgentsWorkerConfig(env).forgeGitHubMirrorToken,
+  )
+
+  if (token === undefined || token.trim() === '') {
+    return undefined
+  }
+
+  return token
+}
+
 const errorMessage = (error: unknown): string =>
   error instanceof Error ? error.message : String(error)
 
@@ -13478,6 +13492,7 @@ const routeRequest = makeWorkerRouteRequest({
           getForgeControlPlaneToken(authEnv),
           requiredScope,
         ),
+      githubMirrorToken: mirrorEnv => getForgeGitHubMirrorToken(mirrorEnv),
       makeCanonicalStore: storeEnv =>
         makeD1ForgeGitCanonicalStore(openAgentsDatabase(storeEnv)),
       makeStore: storeEnv =>

--- a/packages/forge-protocol/src/index.test.ts
+++ b/packages/forge-protocol/src/index.test.ts
@@ -9,6 +9,7 @@ import {
   decodeForgeDispatchLeaseRow,
   decodeForgeGitAccessTokenRow,
   decodeForgeGitAccessTokenScopeRow,
+  decodeForgeGitHubMirrorReceipt,
   decodeForgeGitPackfileArchiveRow,
   decodeForgeDispatchCloseout,
   decodeForgeDispatchDecision,
@@ -284,7 +285,7 @@ describe("@openagentsinc/forge-protocol", () => {
     expect(decodeForgeDispatchMessage(closeout).schema).toBe(closeout.schema);
   });
 
-  test("decodes redacted verification and promotion decision receipts", () => {
+  test("decodes redacted verification, promotion, and mirror receipts", () => {
     const verification = decodeForgeVerificationReceipt({
       schema: "openagents.forge.verification.receipt.v0.1",
       tenant_ref: "tenant.openagents",
@@ -332,5 +333,26 @@ describe("@openagentsinc/forge-protocol", () => {
     });
     expect(promotion.decision).toBe("approved");
     expect(promotion.promoted_head).toBe(verification.head_head);
+
+    const mirror = decodeForgeGitHubMirrorReceipt({
+      schema: "openagents.forge.github_mirror.receipt.v0.1",
+      tenant_ref: "tenant.openagents",
+      mirror_ref: "mirror.forge.github.openagents.main.6768",
+      promotion_ref: promotion.promotion_ref,
+      source_canonical_ref: "refs/heads/main",
+      destination_github_ref: "refs/heads/main",
+      repository_ref: verification.repository_ref,
+      github_repository: "OpenAgentsInc/openagents",
+      commit_id: promotion.promoted_head,
+      status: "mirrored",
+      attempted_at: "2026-06-28T16:03:00.000Z",
+      mirrored_at: "2026-06-28T16:03:00.000Z",
+      refusal_reason: null,
+      error_reason: null,
+      source_refs: promotion.source_refs,
+      redacted: true,
+    });
+    expect(mirror.commit_id).toBe(promotion.promoted_head);
+    expect(mirror.status).toBe("mirrored");
   });
 });

--- a/packages/forge-protocol/src/index.ts
+++ b/packages/forge-protocol/src/index.ts
@@ -167,6 +167,13 @@ export const ForgePromotionDecisionState = S.Literals([
 export type ForgePromotionDecisionState =
   typeof ForgePromotionDecisionState.Type;
 
+export const ForgeGitHubMirrorStatus = S.Literals([
+  "mirrored",
+  "failed",
+  "refused",
+]);
+export type ForgeGitHubMirrorStatus = typeof ForgeGitHubMirrorStatus.Type;
+
 export const ForgeDispatchGitAccessDelivery = S.Literals([
   "out_of_band",
   "same_response_ephemeral",
@@ -464,6 +471,26 @@ export const ForgePromotionDecisionReceipt = S.Struct({
 export type ForgePromotionDecisionReceipt =
   typeof ForgePromotionDecisionReceipt.Type;
 
+export const ForgeGitHubMirrorReceipt = S.Struct({
+  schema: S.Literal("openagents.forge.github_mirror.receipt.v0.1"),
+  tenant_ref: S.String,
+  mirror_ref: S.String,
+  promotion_ref: S.String,
+  source_canonical_ref: S.String,
+  destination_github_ref: S.String,
+  repository_ref: S.String,
+  github_repository: S.String,
+  commit_id: S.String,
+  status: ForgeGitHubMirrorStatus,
+  attempted_at: S.String,
+  mirrored_at: S.NullOr(S.String),
+  refusal_reason: S.NullOr(S.String),
+  error_reason: S.NullOr(S.String),
+  source_refs: S.Array(S.String),
+  redacted: S.Literal(true),
+});
+export type ForgeGitHubMirrorReceipt = typeof ForgeGitHubMirrorReceipt.Type;
+
 export const ForgeDispatchMessage = S.Union([
   ForgeDispatchWorkItem,
   ForgeDispatchDecision,
@@ -528,6 +555,9 @@ export const decodeForgeVerificationReceipt = S.decodeUnknownSync(
 );
 export const decodeForgePromotionDecisionReceipt = S.decodeUnknownSync(
   ForgePromotionDecisionReceipt,
+);
+export const decodeForgeGitHubMirrorReceipt = S.decodeUnknownSync(
+  ForgeGitHubMirrorReceipt,
 );
 
 export const forgeCoordinationStatusStateForNip34Kind = (


### PR DESCRIPTION
## Summary

- Add Forge GitHub mirror receipt schema and D1 storage for mirrored, failed, and refused downstream mirror attempts.
- Add `/api/forge/mirror/github/openagents-main` as the scoped OpenAgents dogfood mirror job endpoint: it only mirrors an approved Forge promotion with a promoted head, uses non-force GitHub ref updates, and records idempotent receipts.
- Expose mirror receipts through the same route via GET so Forge API/shell consumers can inspect mirror state without treating GitHub as authority.

Closes #6796.

## Verification

```sh
true
bun run --cwd packages/forge-protocol test
bun run --cwd apps/openagents.com/workers/api test -- src/forge-control-plane-routes.test.ts
bun run --cwd apps/openagents.com/workers/api typecheck
```

Notes:
- `true` is the argv resolved from `command.public.pylon_khala.verify.b5bea41b6c623f7c09f1bf24` in local Pylon task metadata.
- API typecheck exited 0 and printed existing Effect advisory messages in unrelated Artanis/Pylon files.
