### PR TITLE
refactor(pylon): add scoped runtime timeout pattern

### DIFF
--- a/apps/pylon/src/codex-agent-executor.ts
+++ b/apps/pylon/src/codex-agent-executor.ts
@@ -1,6 +1,7 @@
 import { access, lstat, mkdir, readFile, readlink, rename, rm, symlink, writeFile } from "node:fs/promises"
 import { dirname, isAbsolute, join, relative, resolve } from "node:path"
 import { createHash, randomUUID } from "node:crypto"
+import { Effect } from "effect"
 import {
   CODEX_AGENT_SDK_PACKAGE,
   loadCodexAgentConfig,
@@ -30,6 +31,7 @@ import {
 } from "./codex-pr-publisher.js"
 import { runCodexComposerStream } from "./codex-composer.js"
 import type { CodexAgentConfig } from "./codex-agent.js"
+import { scopedTimeout } from "./effect-runtime-patterns.js"
 import {
   createPylonCodexEventChunkReporter,
   createPylonCodexTurnReporter,
@@ -1118,21 +1120,23 @@ async function runCodexAgentWithOuterDeadline(
   runner: CodexAgentRunner,
   input: CodexAgentRunInput,
 ): Promise<CodexAgentRunResult> {
-  let timeout: ReturnType<typeof setTimeout> | undefined
-  const runnerPromise = runner(input)
-  runnerPromise.catch(() => undefined)
-  const timeoutPromise = new Promise<CodexAgentRunResult>((resolve) => {
-    timeout = setTimeout(
-      () => resolve(deadlineBudgetExceededResult()),
-      Math.max(0, input.timeoutMs),
-    )
-  })
-
-  try {
-    return await Promise.race([runnerPromise, timeoutPromise])
-  } finally {
-    if (timeout !== undefined) clearTimeout(timeout)
-  }
+  return Effect.runPromise(
+    Effect.scoped(
+      Effect.gen(function* () {
+        const runnerPromise = runner(input)
+        runnerPromise.catch(() => undefined)
+        let resolveDeadline!: (result: CodexAgentRunResult) => void
+        const timeoutPromise = new Promise<CodexAgentRunResult>((resolve) => {
+          resolveDeadline = resolve
+        })
+        yield* scopedTimeout({
+          delayMs: input.timeoutMs,
+          onTimeout: () => resolveDeadline(deadlineBudgetExceededResult()),
+        })
+        return yield* Effect.promise(() => Promise.race([runnerPromise, timeoutPromise]))
+      }),
+    ),
+  )
 }
 
 function refusalRecord(input: {

--- a/apps/pylon/src/effect-runtime-patterns.ts
+++ b/apps/pylon/src/effect-runtime-patterns.ts
@@ -1,0 +1,32 @@
+import { Effect, Schedule } from "effect"
+
+/**
+ * Shared Pylon runtime patterns for Effect-backed resource lifecycles.
+ *
+ * Use `Effect.acquireRelease` for resources that must be cleaned up when the
+ * owning fiber completes, fails, or is interrupted: subprocess handles,
+ * WebSocket clients, workspace/file locks, temporary worktrees, and assignment
+ * runner timers. Keep the acquire step small and make release idempotent.
+ */
+export function scopedTimeout(input: {
+  delayMs: number
+  onTimeout: () => void
+  setTimeout?: typeof setTimeout
+  clearTimeout?: typeof clearTimeout
+}) {
+  const scheduleTimeout = input.setTimeout ?? setTimeout
+  const clearScheduledTimeout = input.clearTimeout ?? clearTimeout
+  return Effect.acquireRelease(
+    Effect.sync(() => scheduleTimeout(input.onTimeout, Math.max(0, input.delayMs))),
+    (timer) => Effect.sync(() => clearScheduledTimeout(timer)),
+  )
+}
+
+export const PylonRuntimeRetrySchedules = {
+  externalHttpProviderCall: Schedule.recurs(3),
+  durableObjectCall: Schedule.recurs(2),
+  walletAdjacentCall: Schedule.recurs(2),
+  gitGithubOperation: Schedule.recurs(3),
+  d1TransientFailure: Schedule.recurs(3),
+  publicProjectionSync: Schedule.recurs(2),
+} as const

--- a/apps/pylon/tests/codex-agent-executor.test.ts
+++ b/apps/pylon/tests/codex-agent-executor.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, mock, test } from "bun:test"
+import { Deferred, Effect, Fiber } from "effect"
 import { existsSync } from "node:fs"
 import { lstat, mkdir, mkdtemp, readdir, readFile, readlink, rm, writeFile } from "node:fs/promises"
 import { join, relative } from "node:path"
@@ -25,6 +26,10 @@ import {
   WorkspaceCheckoutError,
   workspaceLeaseRecordFor,
 } from "../src/workspace-materializer"
+import {
+  PylonRuntimeRetrySchedules,
+  scopedTimeout,
+} from "../src/effect-runtime-patterns"
 
 const now = new Date("2026-06-11T22:00:00.000Z")
 
@@ -240,6 +245,53 @@ describe("codex agent task recognition", () => {
       )
       assertPublicProjectionSafe(record)
     })
+  })
+
+  test("scoped deadline timers are released when the owning fiber is interrupted", async () => {
+    const events: string[] = []
+
+    await Effect.runPromise(
+      Effect.scoped(
+        Effect.gen(function* () {
+          const acquired = yield* Deferred.make<void>()
+          const fiber = yield* Effect.forkScoped(
+            Effect.scoped(
+              Effect.gen(function* () {
+                yield* scopedTimeout({
+                  delayMs: 10_000,
+                  onTimeout: () => events.push("timeout-fired"),
+                  setTimeout: (() => {
+                    events.push("timeout-scheduled")
+                    return 42 as unknown as ReturnType<typeof setTimeout>
+                  }) as typeof setTimeout,
+                  clearTimeout: ((timer) => {
+                    events.push(`timeout-cleared:${String(timer)}`)
+                  }) as typeof clearTimeout,
+                })
+                yield* Deferred.succeed(acquired, undefined)
+                yield* Effect.never
+              }),
+            ),
+          )
+
+          yield* Deferred.await(acquired)
+          yield* Fiber.interrupt(fiber)
+        }),
+      ),
+    )
+
+    expect(events).toEqual(["timeout-scheduled", "timeout-cleared:42"])
+  })
+
+  test("Pylon retry schedules expose named Effect schedules for shared runtime paths", () => {
+    expect(Object.keys(PylonRuntimeRetrySchedules).sort()).toEqual([
+      "d1TransientFailure",
+      "durableObjectCall",
+      "externalHttpProviderCall",
+      "gitGithubOperation",
+      "publicProjectionSync",
+      "walletAdjacentCall",
+    ])
   })
 
   test("redaction: unsafe-shaped digests are rejected before any POST", async () => {


### PR DESCRIPTION
## Summary
- add a small Pylon Effect runtime-pattern helper for scoped timeout resources and named retry schedules
- migrate the Codex agent outer deadline timer to the scoped timeout helper
- add interruption cleanup coverage for the scoped timer plus a named retry schedule guard

Closes #7013

## Verification
- bun test apps/pylon/tests/codex-agent-executor.test.ts
- bun run --cwd apps/pylon typecheck
- true (required command ref command.public.pylon_khala.verify.b5bea41b6c623f7c09f1bf24)
