### PR TITLE
docs(promises): audit world-first claim gates

### DIFF
--- a/apps/openagents.com/workers/api/src/product-promises.test.ts
+++ b/apps/openagents.com/workers/api/src/product-promises.test.ts
@@ -1,4 +1,5 @@
 import { Schema as S } from 'effect'
+import { existsSync } from 'node:fs'
 import { describe, expect, test } from 'vitest'
 
 import {
@@ -82,6 +83,9 @@ const ProductPromisesDocument = S.Struct({
   }),
   version: S.String,
 })
+
+const repoFile = (relPath: string): URL =>
+  new URL(`../../../../../${relPath}`, import.meta.url)
 
 describe('public product promises document', () => {
   test('matches the browser-facing schema', () => {
@@ -1293,6 +1297,77 @@ describe('public product promises document', () => {
     expect(externalRepoStudyPromise?.authorityBoundary).toContain(
       'no private repo ingestion authority',
     )
+  })
+
+  test('world-first and largest-force claims stay gated by the #7027 dated audit', () => {
+    const auditDoc = 'docs/promises/2026-06-29-world-first-claims-7027-audit.md'
+    expect(existsSync(repoFile(auditDoc))).toBe(true)
+
+    const document = publicProductPromisesDocument()
+    const byId = new Map(
+      document.promises.map(promise => [promise.promiseId, promise]),
+    )
+
+    const paidBitcoin = byId.get(
+      'claims.world_first_ai_training_paid_bitcoin.v1',
+    )
+    expect(paidBitcoin).toMatchObject({
+      state: 'red',
+      blockerRefs: expect.arrayContaining([
+        'blocker.product_promises.world_first_evidence_pack_missing',
+        'blocker.product_promises.world_first_owner_signed_upgrade_missing',
+      ]),
+      evidenceRefs: expect.arrayContaining([auditDoc]),
+    })
+    expect(paidBitcoin?.safeCopy).toContain('full qualifiers')
+    expect(paidBitcoin?.unsafeCopy).toContain('bare "world first"')
+    expect(paidBitcoin?.verification).toContain('#7027 dated audit')
+
+    const llmComputer = byId.get(
+      'claims.world_first_public_llm_computer_training_run.v1',
+    )
+    expect(llmComputer).toMatchObject({
+      state: 'red',
+      blockerRefs: [
+        'blocker.product_promises.world_first_owner_signed_upgrade_missing',
+      ],
+      evidenceRefs: expect.arrayContaining([auditDoc]),
+    })
+    expect(llmComputer?.safeCopy).toContain('Percepta')
+    expect(llmComputer?.unsafeCopy).toContain('bare "world first"')
+    expect(llmComputer?.verification).toContain('#7027 dated audit')
+
+    const agenticSalesForce = byId.get(
+      'claims.pursued_world_first_largest_agentic_sales_force.v1',
+    )
+    expect(agenticSalesForce).toMatchObject({
+      state: 'planned',
+      blockerRefs: expect.arrayContaining([
+        'blocker.product_promises.world_first_agentic_sales_force_not_achieved',
+        'blocker.product_promises.world_first_agentic_sales_force_no_sized_verifiable_force',
+        'blocker.product_promises.world_first_owner_signed_upgrade_missing',
+      ]),
+      evidenceRefs: expect.arrayContaining([auditDoc]),
+    })
+    expect(agenticSalesForce?.safeCopy).toContain('PURSUED')
+    expect(agenticSalesForce?.unsafeCopy).toContain('OpenAgents HAS')
+    expect(agenticSalesForce?.verification).toContain('#7027 dated audit')
+
+    const largestSalesForce = byId.get(
+      'claims.pursued_world_first_largest_sales_force.v1',
+    )
+    expect(largestSalesForce).toMatchObject({
+      state: 'planned',
+      blockerRefs: expect.arrayContaining([
+        'blocker.product_promises.world_first_largest_sales_force_not_achieved',
+        'blocker.product_promises.world_first_largest_sales_force_seven_million_bar_unmet',
+        'blocker.product_promises.world_first_owner_signed_upgrade_missing',
+      ]),
+      evidenceRefs: expect.arrayContaining([auditDoc]),
+    })
+    expect(largestSalesForce?.safeCopy).toContain('NOT achieved')
+    expect(largestSalesForce?.unsafeCopy).toContain('~7M-agent bar')
+    expect(largestSalesForce?.verification).toContain('#7027 dated audit')
   })
 
   test('weekend pylon promise assault attaches evidence without flipping any state', () => {

--- a/apps/openagents.com/workers/api/src/product-promises.ts
+++ b/apps/openagents.com/workers/api/src/product-promises.ts
@@ -4,7 +4,7 @@ import { currentIsoTimestamp } from './runtime-primitives'
 export const PublicProductPromisesEndpoint = '/api/public/product-promises'
 export const PublicProductPromisesSchemaVersion =
   'openagents.product_promises.v1'
-export const PublicProductPromisesVersion = '2026-06-29.2'
+export const PublicProductPromisesVersion = '2026-06-29.3'
 
 const reportPath = 'https://openagents.com/forum/f/product-promises'
 
@@ -75,6 +75,7 @@ const sourceRefs = [
   'docs/promises/2026-06-14-registry-reality-reconciliation-audit.md',
   'docs/promises/2026-06-17-training-monday-simulation-settlement-policy.md',
   'docs/promises/2026-06-18-training-monday-real-settlement-gate-met.md',
+  'docs/promises/2026-06-29-world-first-claims-7027-audit.md',
   'docs/launch/2026-06-19-autostream-settlement-visibility-capture.md',
   'docs/launch/2026-06-19-autostream-settlement-clip-manifest.json',
   'docs/launch/2026-06-18-autopilot-desktop-availability-audit.md',
@@ -261,6 +262,7 @@ export const publicProductPromisesDocument = () => {
         'Registry 2026-06-28.3 implements #6891 for models.tassadar_percepta_executor.v1 and flips NO promise state. Pylon v1.0 now has a deterministic bounded CPU computation-transform fixture in apps/pylon/src/tassadar-cpu-transform-training.ts that runs one CPU-only optimization step, self-verifies loss improvement, emits receipt.models.tassadar_percepta_executor.cpu_transform_training.cpu_transform_fixture_v1, and keeps realBitcoinMoved:false / settlementState:not_settled. GET /api/public/models/tassadar-percepta-executor/cpu-transform-training-receipts now projects that public-safe receipt alongside the architecture and Artanis distillation dataset inputs, so the old pylon_v03_cpu_transform_training_receipts_missing blocker is replaced by blocker.product_promises.tassadar_cpu_transform_real_settlement_missing and blocker.product_promises.tassadar_cpu_transform_owner_green_signoff_missing. The promise STAYS planned: this is one fixture-scale receipt, not a trained model, not a paid earning path, not model promotion, and not a green transition; any future green flip remains receipt-first and owner-signed per proof.claim_upgrade_receipts.v1.',
         'Registry 2026-06-29.1 implements #6848 for payments.accepted_outcome_economics.v1 and flips NO promise state. The accepted-outcome economics spine now has a dereferenceable contributor accrual bundle at GET /api/public/payments/contributor-accrual-bundle?economicsId=... plus the settlement bundle at GET /api/public/accepted-outcome/settlement/{economicsId}; together they compose a gross-margin receipt, contributor accrual ledger entries, and an eight-state settlement machine from one stored accepted-outcome economics row. Tests prove the ledger and receipt share the same economicsId, reconcile gross margin exactly, reconcile pending_payout to the distributable ledger pool, keep public projections free of internal cents/raw payment material, and surface missing contributor provenance honestly. The old source-level blockers contributor_ledger_missing and gross_margin_receipts_missing are replaced by real_accepted_outcome_receipt_missing and owner_signed_green_transition_missing. The promise STAYS red because source/fixture receipt machinery is not a real accepted outcome carried through a money-moving settlement path, and any future green flip remains receipt-first and owner-signed per proof.claim_upgrade_receipts.v1.',
         'Registry 2026-06-29.2 is a current-main refresh after #6997/#6999/#7001/#7002/#7006 and flips NO promise state. The terminal-agent current-state audit and Codex tool-layer study are now cited as evidence for the Codex/Probe/Pylon runtime direction: current production coding delegation is still Pylon plus external agent SDK lanes and OpenAgents-native terminal tools remain a consolidation task, not a new green claim. The codex-supervisor LOCKOUT replenishment helper can create or reuse three bounded standing issues so owner-capacity supervisors do not idle indefinitely, but it creates no paid labor, payout, settlement, or broad availability claim. The inference router now has GLM own-capacity failover alerting and public-safe fallback telemetry for repeated no-headroom saturation, but the paid gateway still stays red until a dereferenceable paid receipt exists. Khala Desktop now carries source-level Electrobun Apple FM sidecar packaging/readiness plus redaction tests, but Apple FM local mode remains yellow until a signed/notarized from-install smoke with helper supervision exists. The Khala model-mix promise remains live-at-read with maxStalenessSeconds:0; the stale 2-second cache wording is not applied.',
+        'Registry 2026-06-29.3 implements #7027 for the world-first / largest-force promise audit and flips NO promise state. docs/promises/2026-06-29-world-first-claims-7027-audit.md is now load-bearing evidence for claims.world_first_ai_training_paid_bitcoin.v1, claims.world_first_public_llm_computer_training_run.v1, claims.pursued_world_first_largest_agentic_sales_force.v1, and claims.pursued_world_first_largest_sales_force.v1. The audit records exact allowed wording, refuse-list wording, prior-art caveats, receipt refs, and dated blocker notes. The two world-first claims stay red; the two largest-force records stay planned pursuits; no owner-signed transition receipt, record-holder status, green claim, payout, settlement, or marketing-claim authority is created.',
       ],
     },
     promises: [
@@ -697,6 +699,7 @@ export const publicProductPromisesDocument = () => {
           'docs/transcripts/238.md',
           'docs/launch/2026-06-18-pylon-v1-launch-readiness-audit.md',
           'docs/launch/2026-06-18-world-firsts-verification.md',
+          'docs/promises/2026-06-29-world-first-claims-7027-audit.md',
           'promise:training.decentralized_training_launch.v1',
           'promise:promises.registry.v1',
           'promise:proof.claim_upgrade_receipts.v1',
@@ -706,7 +709,7 @@ export const publicProductPromisesDocument = () => {
           'blocker.product_promises.world_first_owner_signed_upgrade_missing',
         ],
         verification:
-          'An independent prior-art/competing-claim search now exists (docs/launch/2026-06-18-world-firsts-verification.md; prior art checked includes Spirit of Satoshi, Bittensor/Templar, Gensyn, Prime Intellect, Nous/Psyche, Salad, Percepta, Tracr) with a defensible narrowed wording. Green still requires (1) a dereferenceable evidence pack tying the qualified world-first to the live run receipts and (2) an owner-signed receipt-first upgrade per proof.claim_upgrade_receipts.v1. Until then this stays red and any public use must carry the full qualifiers.',
+          'An independent prior-art/competing-claim search now exists (docs/launch/2026-06-18-world-firsts-verification.md; prior art checked includes Spirit of Satoshi, Bittensor/Templar, Gensyn, Prime Intellect, Nous/Psyche, Salad, Percepta, Tracr) with a defensible narrowed wording. The #7027 dated audit (docs/promises/2026-06-29-world-first-claims-7027-audit.md) keeps this red because the prior-art review is not yet a single dereferenceable evidence pack tying each qualifier to live receipts, and no owner-signed transition receipt exists. Green still requires (1) a dereferenceable evidence pack tying the qualified world-first to the live run receipts and (2) an owner-signed receipt-first upgrade per proof.claim_upgrade_receipts.v1. Until then this stays red and any public use must carry the full qualifiers.',
         authorityBoundary:
           'A launch transcript does not establish a world-first. The bounded real settlements prove payment to two contributors, not a first-in-the-world claim, and grant no network-scale or comparison authority.',
       },
@@ -728,6 +731,7 @@ export const publicProductPromisesDocument = () => {
           'docs/launch/2026-06-18-world-firsts-verification.md',
           'docs/launch/2026-06-20-llm-computer-training-run-definition.md',
           'docs/launch/2026-06-20-world-first-llm-computer-evidence-pack.md',
+          'docs/promises/2026-06-29-world-first-claims-7027-audit.md',
           'apps/openagents.com/workers/api/src/world-first-llm-computer-evidence-pack.test.ts',
           'promise:compute.tassadar_executor_poc.v1',
           'promise:models.tassadar_percepta_executor.v1',
@@ -738,7 +742,7 @@ export const publicProductPromisesDocument = () => {
           'blocker.product_promises.world_first_owner_signed_upgrade_missing',
         ],
         verification:
-          'An independent prior-art/competing-claim search now exists (docs/launch/2026-06-18-world-firsts-verification.md) with a defensible narrowed wording crediting Percepta as the paradigm originator. A precise definition of "LLM-computer training run" now exists (docs/launch/2026-06-20-llm-computer-training-run-definition.md): it pins the phrase to the executor-construction / exact-trace sense (sense B), distinguishes it from gradient-descent model training (sense A), credits Percepta, and enumerates the refuse-list so the phrase cannot overclaim against the no-gradient-descent executor PoC. A focused, dereferenceable evidence pack now exists (docs/launch/2026-06-20-world-first-llm-computer-evidence-pack.md): it ties the qualified Claim-2 world-first to the live-run receipts qualifier-by-qualifier (public/open-contributor paid loop -> run summary + two contributor settlement receipts; Percepta paradigm credit -> Percepta blog/transformer-vm + prior-art search; executor/exact-trace/replay-verified -> verified+rejected replay pairs and a Verified challenge), with a skeptic-runnable verification recipe and a refuse-list. A regression guard (apps/openagents.com/workers/api/src/world-first-llm-computer-evidence-pack.test.ts) now machine-enforces that the pack and definition stay dereferenceable: every repo-relative doc they cite resolves on disk, every promise: evidence ref resolves to a real registry promiseId, the cleared definition/evidence-pack blockers stay cleared without flipping state, and the refuse-list plus Percepta credit stay in the copy. Green still requires an owner-signed receipt-first upgrade per proof.claim_upgrade_receipts.v1, and the underlying public paid loop remains bounded (two contributors, not at scale).',
+          'An independent prior-art/competing-claim search now exists (docs/launch/2026-06-18-world-firsts-verification.md) with a defensible narrowed wording crediting Percepta as the paradigm originator. A precise definition of "LLM-computer training run" now exists (docs/launch/2026-06-20-llm-computer-training-run-definition.md): it pins the phrase to the executor-construction / exact-trace sense (sense B), distinguishes it from gradient-descent model training (sense A), credits Percepta, and enumerates the refuse-list so the phrase cannot overclaim against the no-gradient-descent executor PoC. A focused, dereferenceable evidence pack now exists (docs/launch/2026-06-20-world-first-llm-computer-evidence-pack.md): it ties the qualified Claim-2 world-first to the live-run receipts qualifier-by-qualifier (public/open-contributor paid loop -> run summary + two contributor settlement receipts; Percepta paradigm credit -> Percepta blog/transformer-vm + prior-art search; executor/exact-trace/replay-verified -> verified+rejected replay pairs and a Verified challenge), with a skeptic-runnable verification recipe and a refuse-list. The #7027 dated audit (docs/promises/2026-06-29-world-first-claims-7027-audit.md) records that only the owner-signed transition blocker remains. A regression guard (apps/openagents.com/workers/api/src/world-first-llm-computer-evidence-pack.test.ts) now machine-enforces that the pack and definition stay dereferenceable: every repo-relative doc they cite resolves on disk, every promise: evidence ref resolves to a real registry promiseId, the cleared definition/evidence-pack blockers stay cleared without flipping state, and the refuse-list plus Percepta credit stay in the copy. Green still requires an owner-signed receipt-first upgrade per proof.claim_upgrade_receipts.v1, and the underlying public paid loop remains bounded (two contributors, not at scale).',
         authorityBoundary:
           'A bounded exact-trace executor proof of concept grants no general LLM-computer capability claim and no world-first claim. The Tassadar research publication gates stay closed for everything beyond the scoped compute.tassadar_executor_poc.v1 promise.',
       },
@@ -3870,6 +3874,7 @@ export const publicProductPromisesDocument = () => {
         evidenceRefs: [
           'docs/transcripts/239.md',
           'docs/promises/2026-06-19-episode-239-lets-make-money-registry-reconciliation.md',
+          'docs/promises/2026-06-29-world-first-claims-7027-audit.md',
           'promise:referral.refer_once_earn_forever.v1',
           'promise:claims.world_first_ai_training_paid_bitcoin.v1',
         ],
@@ -3879,7 +3884,7 @@ export const publicProductPromisesDocument = () => {
           'blocker.product_promises.world_first_owner_signed_upgrade_missing',
         ],
         verification:
-          'This record is intentionally never green from aspiration. Any future non-aspirational claim would require a real, sized, independently-countable agentic sales force, an independent prior-art / record review, a dereferenceable evidence pack, and an owner-signed receipt-first upgrade per proof.claim_upgrade_receipts.v1. Until then it stays a labeled pursuit.',
+          'This record is intentionally never green from aspiration. The #7027 dated audit (docs/promises/2026-06-29-world-first-claims-7027-audit.md) keeps the blockers explicit: there is no real, sized, independently countable agentic sales force, no record review, and no owner-signed upgrade. Any future non-aspirational claim would require a real, sized, independently-countable agentic sales force, an independent prior-art / record review, a dereferenceable evidence pack, and an owner-signed receipt-first upgrade per proof.claim_upgrade_receipts.v1. Until then it stays a labeled pursuit.',
         authorityBoundary:
           'A pursued world first grants no record-holder status, no marketing-claim authority, and no sales, payout, or settlement authority. Aspiration is not achievement.',
       },
@@ -3898,6 +3903,7 @@ export const publicProductPromisesDocument = () => {
         evidenceRefs: [
           'docs/transcripts/239.md',
           'docs/promises/2026-06-19-episode-239-lets-make-money-registry-reconciliation.md',
+          'docs/promises/2026-06-29-world-first-claims-7027-audit.md',
           'promise:claims.pursued_world_first_largest_agentic_sales_force.v1',
           'promise:claims.world_first_public_llm_computer_training_run.v1',
         ],
@@ -3907,7 +3913,7 @@ export const publicProductPromisesDocument = () => {
           'blocker.product_promises.world_first_owner_signed_upgrade_missing',
         ],
         verification:
-          'This record is intentionally never green from aspiration. Any future non-aspirational claim would require independently verified counts crossing the stated bar, an independent prior-art / record review (with the comparison figure independently sourced, not ChatGPT-attributed), a dereferenceable evidence pack, and an owner-signed receipt-first upgrade per proof.claim_upgrade_receipts.v1.',
+          'This record is intentionally never green from aspiration. The #7027 dated audit (docs/promises/2026-06-29-world-first-claims-7027-audit.md) keeps the blockers explicit: no independently verified count crosses the stated bar, no independently sourced comparison pack exists, and no owner-signed upgrade exists. Any future non-aspirational claim would require independently verified counts crossing the stated bar, an independent prior-art / record review (with the comparison figure independently sourced, not ChatGPT-attributed), a dereferenceable evidence pack, and an owner-signed receipt-first upgrade per proof.claim_upgrade_receipts.v1.',
         authorityBoundary:
           'A pursued world first grants no record-holder status, no marketing-claim authority, and no sales, payout, or settlement authority. Aspiration is not achievement.',
       },

--- a/docs/promises/2026-06-29-world-first-claims-7027-audit.md
+++ b/docs/promises/2026-06-29-world-first-claims-7027-audit.md
@@ -1,0 +1,29 @@
+# World-First Claims #7027 Audit
+
+- Date: 2026-06-29
+- Scope: public issue #7027, covering the four `claims.world_first_*` and
+  `claims.pursued_world_first_*largest*_sales_force.v1` product-promise records.
+- Result: no state upgrades. The two world-first claims stay red; the two
+  largest-force claims stay planned pursuits.
+
+## Claim Gates
+
+| Promise | State | Allowed wording | Refuse-list wording | Current dated blocker |
+| --- | --- | --- | --- | --- |
+| `claims.world_first_ai_training_paid_bitcoin.v1` | red | Only the fully qualified formulation from `docs/launch/2026-06-18-world-firsts-verification.md`: first AI model training run that pays independent contributors in Bitcoin for replay-verified training compute on their own consumer devices. | Bare "world first", "first AI training run paid in Bitcoin", "first to pay Bitcoin for AI", network-scale paid-training claims, or any copy that drops Bitcoin, replay verification, training compute, or own consumer devices. | `blocker.product_promises.world_first_evidence_pack_missing` remains because the prior-art review is not yet a single dereferenceable evidence pack tying each qualifier to live receipts; `blocker.product_promises.world_first_owner_signed_upgrade_missing` remains because no owner-signed transition receipt exists. |
+| `claims.world_first_public_llm_computer_training_run.v1` | red | Only the qualified public/open-contributor LLM-computer training-run wording, with Percepta credited as the paradigm originator and "training run" limited to executor construction / exact-trace work. | Bare "world first", "we invented the LLM-computer", gradient-descent model-training claims, general LLM-computer capability, performance parity, or transformers-as-a-served-product claims. | The definition and evidence-pack blockers are cleared by `docs/launch/2026-06-20-llm-computer-training-run-definition.md` and `docs/launch/2026-06-20-world-first-llm-computer-evidence-pack.md`; `blocker.product_promises.world_first_owner_signed_upgrade_missing` remains because no owner-signed transition receipt exists. |
+| `claims.pursued_world_first_largest_agentic_sales_force.v1` | planned | Only a clearly labeled pursuit/aspiration to build the largest agentic sales force. | "OpenAgents has the largest agentic sales force", "record held", "achieved", "verified", or copy implying a sized agentic sales force already exists. | `blocker.product_promises.world_first_agentic_sales_force_not_achieved`, `blocker.product_promises.world_first_agentic_sales_force_no_sized_verifiable_force`, and `blocker.product_promises.world_first_owner_signed_upgrade_missing` remain because there is no real, sized, independently countable agentic sales force, no record review, and no owner-signed upgrade. |
+| `claims.pursued_world_first_largest_sales_force.v1` | planned | Only a clearly labeled pursuit/aspiration toward a roughly seven-million selling-or-sell-equipped-agent bar. | "OpenAgents has the largest sales force", "~7M bar met", "world record held/achieved/verified", or copy treating the cited Avon comparison as OpenAgents-verified. | `blocker.product_promises.world_first_largest_sales_force_not_achieved`, `blocker.product_promises.world_first_largest_sales_force_seven_million_bar_unmet`, and `blocker.product_promises.world_first_owner_signed_upgrade_missing` remain because no independently verified count crosses the stated bar, no independently sourced comparison pack exists, and no owner-signed upgrade exists. |
+
+## Receipt Discipline
+
+The current receipt refs support only bounded underlying facts: a scoped
+decentralized training launch, exact-trace executor proof-of-concept work, and
+the dated prior-art/evidence documents already named in the registry. They do
+not authorize bare world-first wording, record-holder wording, largest-force
+wording, network-scale paid-training copy, payout/settlement authority, or any
+green product-promise transition.
+
+Public and operator copy must continue to use the registry `safeCopy` and
+`unsafeCopy` fields as the copy gate until a future owner-signed
+`proof.claim_upgrade_receipts.v1` transition lands for the exact claim wording.


### PR DESCRIPTION
## Summary

- Adds a dated #7027 audit note for the four world-first / largest-force product-promise records.
- Wires the audit into the product-promise registry, keeps all affected promises red/planned, and bumps the registry version to 2026-06-29.3.
- Adds a regression test that the four records retain the audit evidence, blockers, and refuse-list copy gates.

Closes #7027.

## Verification

- `bun run --cwd apps/openagents.com/workers/api test -- src/product-promises.test.ts src/world-first-llm-computer-evidence-pack.test.ts`
- `git diff --check`
- `rg -n "\\b(world first|world-first|largest agentic sales force|largest sales force|largest sales force in the world)\\b" apps/openagents.com docs/promises docs/launch packages -S`

Note: local Pylon lease metadata did not include argv for `command.public.pylon_khala.verify.b5bea41b6c623f7c09f1bf24`; the focused product-promise verification above was run directly in this checkout.
