### PR TITLE
fix(khala-desktop): verify Apple FM helper after build

### DIFF
--- a/clients/khala-desktop/package.json
+++ b/clients/khala-desktop/package.json
@@ -8,7 +8,7 @@
     "prepare:apple-fm-bridge": "bash scripts/prepare-apple-fm-bridge.sh",
     "verify:apple-fm-bridge": "bun scripts/verify-packaged-apple-fm-bridge.ts",
     "build:ui": "bun build src/ui/main.ts --outdir resources/ui --target browser",
-    "build": "bun run prepare:apple-fm-bridge && bun run build:ui && electrobun build",
+    "build": "bun run prepare:apple-fm-bridge && bun run build:ui && electrobun build && bun run verify:apple-fm-bridge",
     "typecheck": "tsc -p tsconfig.typecheck.json --noEmit",
     "test": "bun test tests/*.test.ts",
     "verify": "bun run typecheck && bun test tests/*.test.ts && bun run build:ui && bun build src/bun/index.ts --outdir /tmp/khala-desktop-bun-build --target bun"

--- a/clients/khala-desktop/tests/apple-fm-packaging.test.ts
+++ b/clients/khala-desktop/tests/apple-fm-packaging.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, test } from "bun:test"
+import { readFileSync } from "node:fs"
+import { join } from "node:path"
 
 import {
   APPLE_FM_BRIDGE_ELECTROBUN_COPY_DEST,
@@ -29,6 +31,19 @@ describe("khala desktop Apple FM packaging", () => {
   test("packaged helper path stays inside the Khala app bundle", () => {
     expect(packagedAppleFmBridgePath("build/stable-macos-arm64/Khala.app")).toBe(
       "build/stable-macos-arm64/Khala.app/Contents/Resources/app/apple-fm-bridge/foundation-bridge",
+    )
+  })
+
+  test("build script verifies the packaged helper after electrobun build", () => {
+    const packageJson = JSON.parse(
+      readFileSync(join(import.meta.dir, "..", "package.json"), "utf8"),
+    ) as { scripts?: Record<string, string> }
+    const buildScript = packageJson.scripts?.build ?? ""
+
+    expect(buildScript).toContain("electrobun build")
+    expect(buildScript).toContain("bun run verify:apple-fm-bridge")
+    expect(buildScript.indexOf("electrobun build")).toBeLessThan(
+      buildScript.indexOf("bun run verify:apple-fm-bridge"),
     )
   })
 


### PR DESCRIPTION
## Summary
- run the Khala Desktop packaged Apple FM helper verifier after `electrobun build`
- add a focused packaging test so the build script keeps the pre-signing verifier in place

Closes #6978

## Verification
- `bun run --cwd clients/khala-desktop verify`
- `true` (command.public.pylon_khala.verify.b5bea41b6c623f7c09f1bf24)