### PR TITLE
fix(codex-supervisor): GC orphan claims and fast-retry gate refusals

### DIFF
--- a/apps/pylon/scripts/codex-supervisor/backoff-policy.sh
+++ b/apps/pylon/scripts/codex-supervisor/backoff-policy.sh
@@ -16,6 +16,7 @@
 : "${SUP_CODEX_REFUSAL_TUNE_THRESHOLD:=3}"
 : "${SUP_CLAIMED_DEEP_BACKLOG_SLEEP_SECS:=1}"
 : "${SUP_FAILURE_BACKOFF_ESCALATE_THRESHOLD:=2}"
+: "${SUP_TRANSIENT_REFUSAL_RETRY_SECS:=2}"
 
 sup_backoff_policy_dir() {
   local d="${SUP_BACKOFF_POLICY_DIR:-$SUP_STATE_DIR/backoff-policy}"
@@ -143,6 +144,9 @@ sup_should_escalate_failure_backoff() {
   local sig="$1"
   local repeated="$2"
   if [ "$sig" = "codex_agent_execution_refused" ]; then
+    return 1
+  fi
+  if [ "$sig" = "refused" ]; then
     return 1
   fi
   [ "$repeated" -ge "$SUP_FAILURE_BACKOFF_ESCALATE_THRESHOLD" ] 2>/dev/null

--- a/apps/pylon/scripts/codex-supervisor/backoff-policy.test.sh
+++ b/apps/pylon/scripts/codex-supervisor/backoff-policy.test.sh
@@ -21,6 +21,7 @@ export SUP_MAX_SLOTS=8
 export SUP_CODEX_REFUSAL_TUNE_THRESHOLD=3
 export SUP_CLAIMED_DEEP_BACKLOG_SLEEP_SECS=1
 export SUP_FAILURE_BACKOFF_ESCALATE_THRESHOLD=2
+export SUP_TRANSIENT_REFUSAL_RETRY_SECS=2
 mkdir -p "$SUP_STATE_DIR" "$SUP_BACKOFF_POLICY_DIR"
 
 # shellcheck source=backoff-policy.sh
@@ -103,16 +104,22 @@ else
   bad "shallow backlog should keep normal backoff"
 fi
 
-if sup_should_escalate_failure_backoff refused 1; then
-  bad "first genuine refusal should not escalate backoff"
+if [ "$SUP_TRANSIENT_REFUSAL_RETRY_SECS" = "2" ]; then
+  ok "transient gate refusal retry is fast"
 else
-  ok "first genuine refusal does not escalate backoff"
+  bad "transient gate refusal retry should be 2s, got $SUP_TRANSIENT_REFUSAL_RETRY_SECS"
+fi
+
+if sup_should_escalate_failure_backoff refused 1; then
+  bad "first gate refusal should not escalate backoff"
+else
+  ok "first gate refusal does not escalate backoff"
 fi
 
 if sup_should_escalate_failure_backoff refused 2; then
-  ok "repeated genuine refusal escalates backoff"
+  bad "repeated gate refusal should stay fast-retry"
 else
-  bad "repeated genuine refusal should escalate backoff"
+  ok "repeated gate refusal stays fast-retry"
 fi
 
 if sup_should_escalate_failure_backoff codex_agent_execution_refused 9; then

--- a/apps/pylon/scripts/codex-supervisor/claim-dispatch.test.sh
+++ b/apps/pylon/scripts/codex-supervisor/claim-dispatch.test.sh
@@ -16,6 +16,8 @@
 #   * sup_release_claim frees a claim immediately.
 #   * sup_gc_stale_claims removes only entries past SUP_CLAIM_TTL_SECS.
 #   * sup_gc_orphan_claims removes fresh claims whose owner process is gone.
+#   * background workers stamp claims with their own process PID, not the
+#     top-level supervisor shell PID.
 #   * sup_refresh_claim renews a claim's TTL window.
 #   * epics/standing-tasks are never claimed for dispatch.
 #   * pick_and_claim_unlocked_issue returns DISTINCT issues on repeated calls,
@@ -110,6 +112,34 @@ sup_gc_orphan_claims
 if sup_claim_is_active 704; then bad "orphan #704 should be GC'd on startup cleanup"; else ok "orphan #704 GC'd by sup_gc_orphan_claims"; fi
 if sup_claim_is_active 705; then ok "live-owner #705 survives orphan GC"; else bad "live-owner #705 should survive orphan GC"; fi
 sup_release_claim 705
+
+# --- background workers own claims by their worker PID ----------------------
+(
+  sup_try_claim_issue 706 >/dev/null
+  sup_claim_owner_pid "$(sup_claims_dir)/claim.706" > "$WORK/owner.706"
+  if [ -n "${BASHPID:-}" ]; then
+    printf '%s' "$BASHPID" > "$WORK/workerpid.706"
+  else
+    sh -c 'printf %s "$PPID"' > "$WORK/workerpid.706"
+  fi
+  sleep 1
+) &
+worker_pid=$!
+for _ in $(seq 1 20); do
+  [ -s "$WORK/owner.706" ] && [ -s "$WORK/workerpid.706" ] && break
+  sleep 0.05
+done
+owner_pid="$(cat "$WORK/owner.706" 2>/dev/null || true)"
+worker_actual_pid="$(cat "$WORK/workerpid.706" 2>/dev/null || true)"
+if [ "$owner_pid" = "$worker_actual_pid" ] && [ "$owner_pid" != "$$" ]; then
+  ok "background claim owner uses worker PID"
+else
+  bad "background claim owner should be worker PID (owner=$owner_pid worker=$worker_actual_pid parent=$$)"
+fi
+sup_gc_orphan_claims
+if sup_claim_is_active 706; then ok "live background-worker #706 survives orphan GC"; else bad "live background-worker #706 should survive orphan GC"; fi
+wait "$worker_pid"
+sup_release_claim 706
 
 # --- sup_refresh_claim renews TTL ------------------------------------------
 sup_try_claim_issue 703 >/dev/null

--- a/apps/pylon/scripts/codex-supervisor/claim-dispatch.test.sh
+++ b/apps/pylon/scripts/codex-supervisor/claim-dispatch.test.sh
@@ -15,7 +15,9 @@
 #   * sup_claim_is_active reflects held vs released vs stale claims.
 #   * sup_release_claim frees a claim immediately.
 #   * sup_gc_stale_claims removes only entries past SUP_CLAIM_TTL_SECS.
+#   * sup_gc_orphan_claims removes fresh claims whose owner process is gone.
 #   * sup_refresh_claim renews a claim's TTL window.
+#   * epics/standing-tasks are never claimed for dispatch.
 #   * pick_and_claim_unlocked_issue returns DISTINCT issues on repeated calls,
 #     still honors the CLOSED/open-PR lockout, and reports rc 1 when nothing
 #     distinct+unlocked remains.
@@ -101,6 +103,14 @@ if sup_claim_is_active 701; then bad "stale #701 should be GC'd"; else ok "stale
 if sup_claim_is_active 702; then ok "fresh #702 survives GC"; else bad "fresh #702 should survive GC"; fi
 sup_release_claim 702
 
+# --- sup_gc_orphan_claims ---------------------------------------------------
+sup_try_claim_issue 704 99999999 >/dev/null
+sup_try_claim_issue 705 $$ >/dev/null
+sup_gc_orphan_claims
+if sup_claim_is_active 704; then bad "orphan #704 should be GC'd on startup cleanup"; else ok "orphan #704 GC'd by sup_gc_orphan_claims"; fi
+if sup_claim_is_active 705; then ok "live-owner #705 survives orphan GC"; else bad "live-owner #705 should survive orphan GC"; fi
+sup_release_claim 705
+
 # --- sup_refresh_claim renews TTL ------------------------------------------
 sup_try_claim_issue 703 >/dev/null
 touch -t 200001010000 "$(sup_claims_dir)/claim.703" 2>/dev/null || true
@@ -132,6 +142,19 @@ sup_release_claim 710; sup_release_claim 711; sup_release_claim 712
 picked=$(pick_and_claim_unlocked_issue 0 799 713)
 if [ "$picked" = "713" ]; then ok "pick_and_claim skips CLOSED #799 -> #713"; else bad "expected 713, got '$picked'"; fi
 sup_release_claim 713
+
+# --- pick_and_claim never claims epics / standing tasks ---------------------
+sup_labels_for_issue() {
+  case "$1" in
+    714) printf 'epic' ;;
+    715) printf 'standing-task' ;;
+    *) printf '' ;;
+  esac
+}
+picked=$(pick_and_claim_unlocked_issue 0 714 715 716)
+if [ "$picked" = "716" ]; then ok "pick_and_claim skips epic/standing-task issues -> #716"; else bad "expected 716 after epic/standing-task skip, got '$picked'"; fi
+sup_release_claim 716
+unset -f sup_labels_for_issue
 
 # --- CONCURRENCY: N slots, same pool -> all DISTINCT, no duplicates ---------
 # This is the core regression assertion for the duplicate-dispatch bug.

--- a/apps/pylon/scripts/codex-supervisor/codex-supervisor.sh
+++ b/apps/pylon/scripts/codex-supervisor/codex-supervisor.sh
@@ -513,6 +513,9 @@ worker_loop() {
     if [ "$sig" = "codex_agent_execution_refused" ]; then
       failure_sleep="$SUP_CLAIMED_DEEP_BACKLOG_SLEEP_SECS"
       escalate_backoff=0
+    elif [ "$sig" = "refused" ]; then
+      failure_sleep="$SUP_TRANSIENT_REFUSAL_RETRY_SECS"
+      escalate_backoff=0
     elif ! sup_should_escalate_failure_backoff "$sig" "$failure_repeat"; then
       escalate_backoff=0
     fi
@@ -542,6 +545,7 @@ echo $$ > "$SUP_STATE_DIR/supervisor.pid"
 # Seed last_dispatch_time at startup so the liveness check has a baseline and the
 # fresh process is not flagged wedged before its first dispatch (#6646).
 record_dispatch_attempt
+sup_gc_orphan_claims
 log "=== codex-supervisor START pid=$$ repo=$REPO_ROOT pylon=$SUP_PYLON_REF per_account=$SUP_PER_ACCOUNT max_slots=$SUP_MAX_SLOTS account_refs=${SUP_ACCOUNT_REFS:-all} ==="
 
 sup_run_timeout "$SUP_PYLON_TIMEOUT_SECS" "${PYLON[@]}" provider go-online >> "$SUP_LOG" 2>&1 || log "provider go-online nonzero (continuing)"

--- a/apps/pylon/scripts/codex-supervisor/lockout.sh
+++ b/apps/pylon/scripts/codex-supervisor/lockout.sh
@@ -303,6 +303,17 @@ sup_claim_owner_pid() {
   awk 'NR==1 {print $1; exit}' "$claim/meta" 2>/dev/null
 }
 
+sup_set_current_pid_var() {
+  local __var="$1"
+  if [ -n "${BASHPID:-}" ]; then
+    printf -v "$__var" '%s' "$BASHPID"
+  else
+    # macOS ships Bash 3.2, which has no BASHPID. A directly spawned shell sees
+    # this shell as its parent, so PPID gives us the current background worker.
+    printf -v "$__var" '%s' "$(sh -c 'printf %s "$PPID"')"
+  fi
+}
+
 sup_pid_is_alive() {
   local pid="$1"
   [ "$pid" -ge 1 ] 2>/dev/null || return 1
@@ -346,8 +357,9 @@ sup_claim_is_active() {
 #   rc 1 if another slot already holds a fresh claim. Relies on the caller (or a
 #   preceding sup_gc_stale_claims) to have cleared expired claims first.
 sup_try_claim_issue() {
-  local issue="$1"; local owner="${2:-$$}"
+  local issue="$1"; local owner="${2:-}"
   [ -n "$issue" ] || return 1
+  [ -n "$owner" ] || sup_set_current_pid_var owner
   local dir; dir="$(sup_claims_dir)"
   local claim="$dir/claim.$issue"
   if mkdir "$claim" 2>/dev/null; then
@@ -363,13 +375,15 @@ sup_try_claim_issue() {
 #   the claim does not exist.
 sup_refresh_claim() {
   local issue="$1"; [ -n "$issue" ] || return 0
+  local owner="${2:-}"
+  [ -n "$owner" ] || sup_set_current_pid_var owner
   local claim; claim="$(sup_claims_dir)/claim.$issue"
   [ -e "$claim" ] || return 0
   # Bump the claim DIRECTORY's mtime (the value sup_claim_is_active /
   # sup_gc_stale_claims read); overwriting an existing inner file does not
   # reliably update the directory mtime on all filesystems.
   touch "$claim" 2>/dev/null || true
-  printf '%s %s\n' "${2:-$$}" "$(date +%s)" > "$claim/meta" 2>/dev/null || true
+  printf '%s %s\n' "$owner" "$(date +%s)" > "$claim/meta" 2>/dev/null || true
 }
 
 # sup_release_claim <issue>

--- a/apps/pylon/scripts/codex-supervisor/lockout.sh
+++ b/apps/pylon/scripts/codex-supervisor/lockout.sh
@@ -298,6 +298,35 @@ sup_gc_stale_claims() {
   done
 }
 
+sup_claim_owner_pid() {
+  local claim="$1"
+  awk 'NR==1 {print $1; exit}' "$claim/meta" 2>/dev/null
+}
+
+sup_pid_is_alive() {
+  local pid="$1"
+  [ "$pid" -ge 1 ] 2>/dev/null || return 1
+  kill -0 "$pid" 2>/dev/null
+}
+
+# sup_gc_orphan_claims
+#   Startup/restart cleanup for fresh claim dirs left behind by a SIGKILLed
+#   supervisor. TTL-only GC is not enough here: a recently killed process can
+#   leave fresh claims that block every slot until the full dispatch timeout.
+#   Claims with no live owner PID are removed; claims owned by a still-running
+#   process are preserved.
+sup_gc_orphan_claims() {
+  local dir; dir="$(sup_claims_dir)"
+  local claim owner
+  for claim in "$dir"/claim.*; do
+    [ -e "$claim" ] || continue
+    owner="$(sup_claim_owner_pid "$claim")"
+    if ! sup_pid_is_alive "$owner"; then
+      rm -rf "$claim" 2>/dev/null || true
+    fi
+  done
+}
+
 # sup_claim_is_active <issue>
 #   rc 0 if a FRESH claim is held for the issue (reserved by some slot), rc 1
 #   otherwise. Does not mutate; GC of stale entries is sup_gc_stale_claims's job.
@@ -352,6 +381,17 @@ sup_release_claim() {
   rm -rf "$(sup_claims_dir)/claim.$issue" 2>/dev/null || true
 }
 
+sup_issue_is_claim_excluded() {
+  local issue="$1"
+  [ -n "$issue" ] || return 1
+  if command -v sup_labels_for_issue >/dev/null 2>&1; then
+    case ",$(sup_labels_for_issue "$issue")," in
+      *,epic,*|*,standing-task,*) return 0 ;;
+    esac
+  fi
+  return 1
+}
+
 # pick_and_claim_unlocked_issue <start_index> <issue...>
 #   Like pick_unlocked_issue, but additionally enforces cross-slot distinctness:
 #   it GCs stale claims, then scans the rotation skipping issues that are CLOSED,
@@ -370,6 +410,11 @@ pick_and_claim_unlocked_issue() {
   for (( k=0; k<n; k++ )); do
     i=$(( (start + k) % n ))
     issue="${arr[$i]}"
+    # Epics and standing tasks are backlog steering containers, not dispatch
+    # units; claiming them wedges the real work queue behind non-actionable rows.
+    if sup_issue_is_claim_excluded "$issue"; then
+      continue
+    fi
     # Already reserved by another slot this window -> spread to a distinct issue.
     if sup_claim_is_active "$issue"; then
       continue


### PR DESCRIPTION
## Summary
- GC fresh orphan claim dirs on supervisor startup when their owner PID is gone
- skip epic and standing-task issues before claiming dispatch work
- treat transient dispatch-gate refusals as fast retry instead of escalating normal backoff

Closes #6987

## Verification
- bash apps/pylon/scripts/codex-supervisor/claim-dispatch.test.sh
- bash apps/pylon/scripts/codex-supervisor/backoff-policy.test.sh

Note: the requested public verification ref `command.public.pylon_khala.verify.b5bea41b6c623f7c09f1bf24` was not resolvable to argv from this bounded checkout/local Pylon state; direct Pylon CLI lookup is unavailable because this checkout is missing linked dependencies for `apps/pylon/src/index.ts` (`effect`).