### PR TITLE
Gate referral payout receipts by live rail

### DIFF
--- a/apps/openagents.com/workers/api/src/public-site-referral-payout-receipt-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/public-site-referral-payout-receipt-routes.test.ts
@@ -20,6 +20,16 @@ const projection = (
     receiptRef,
   ],
   generatedAt: '2026-06-20T00:01:00.000Z',
+  promiseGate: {
+    broaderReferralPromiseIdsNotSatisfied: [
+      'referral.refer_once_earn_forever.v1',
+      'inference.referral_on_all_inference.v1',
+      'marketplace.monetize_any_layer_with_referral.v1',
+    ],
+    livePurchaseToBitcoinPayoutReceipt: true,
+    requiredSettlementRail: 'hosted_mdk',
+    scopedPromiseId: 'sites.referral_bitcoin_stream.v1',
+  },
   policyRefs: ['policy.site_referral_payout.v1'],
   qualifyingEventKind: 'inference_paid_request',
   receiptRef,
@@ -89,6 +99,16 @@ describe('public Site referral payout receipt routes', () => {
     expect(body.receipt).toMatchObject({
       attributionLinked: true,
       generatedAt: '2026-06-20T00:01:00.000Z',
+      promiseGate: {
+        broaderReferralPromiseIdsNotSatisfied: [
+          'referral.refer_once_earn_forever.v1',
+          'inference.referral_on_all_inference.v1',
+          'marketplace.monetize_any_layer_with_referral.v1',
+        ],
+        livePurchaseToBitcoinPayoutReceipt: true,
+        requiredSettlementRail: 'hosted_mdk',
+        scopedPromiseId: 'sites.referral_bitcoin_stream.v1',
+      },
       qualifyingEventKind: 'inference_paid_request',
       receiptRef,
       resolution: {

--- a/apps/openagents.com/workers/api/src/site-referral-payout-receipt-loop.test.ts
+++ b/apps/openagents.com/workers/api/src/site-referral-payout-receipt-loop.test.ts
@@ -355,6 +355,16 @@ describe('RL-1 staging-test settlement-receipt closed loop (#5524)', () => {
     expect(receipt).toMatchObject({
       amountSats: fed.entry.amountSats,
       attributionLinked: true,
+      promiseGate: {
+        broaderReferralPromiseIdsNotSatisfied: [
+          'referral.refer_once_earn_forever.v1',
+          'inference.referral_on_all_inference.v1',
+          'marketplace.monetize_any_layer_with_referral.v1',
+        ],
+        livePurchaseToBitcoinPayoutReceipt: false,
+        requiredSettlementRail: 'hosted_mdk',
+        scopedPromiseId: 'sites.referral_bitcoin_stream.v1',
+      },
       qualifyingEventKind: 'forum_tip_paid',
       receiptRef: outcome.receiptRef,
       resolution: {
@@ -426,6 +436,59 @@ describe('RL-1 staging-test settlement-receipt closed loop (#5524)', () => {
 
     expect(receipt?.resolution.state).toBe('settled')
     expect(receipt?.receiptRef).toBe(expectedReceiptRef)
+  })
+
+  test('hosted-MDK receipts satisfy the live purchase-to-Bitcoin payout receipt gate', async () => {
+    const store = new LoopStore()
+    const db = loopDb(store)
+    const receiptRef = 'receipt.site_referral_payout.hosted_mdk.live123'
+
+    store.rows.push({
+      amount_sats: 125,
+      archived_at: null,
+      caveat_refs_json: JSON.stringify([
+        'caveat.site_referral_payout.settlement_evidence_required',
+      ]),
+      created_at: '2026-06-22T12:05:00.000Z',
+      evidence_refs_json: JSON.stringify([
+        'evidence.site_referral_payout.adapter.hosted_mdk',
+        receiptRef,
+      ]),
+      id: 'site_referral_payout_entry_live',
+      idempotency_key: 'site_referral_payout.live.hosted_mdk',
+      payout_ref: 'site_referral_payout_live_hosted_mdk',
+      period_key: '2026-06',
+      policy_refs_json: JSON.stringify(['policy.site_referral_payout.v1']),
+      previous_entry_id: null,
+      qualifying_amount_sats: 2500,
+      qualifying_event_kind: 'forum_tip_paid',
+      qualifying_event_ref: 'evidence.btc_paid.live.hosted_mdk',
+      referred_user_id: 'github:live-buyer',
+      referral_attribution_id: 'referral_attribution_live',
+      referral_invite_id: null,
+      referral_source_id: 'site_referral_source_live',
+      referrer_user_id: 'github:live-referrer',
+      reversal_of_entry_id: null,
+      state: 'settled',
+      state_reason_ref:
+        'reason.public.site_referral_payout.settled_with_adapter_receipt',
+    })
+
+    const receipt = await makeD1SiteReferralPayoutReceiptStore(
+      db,
+    ).readSiteReferralPayoutReceipt(receiptRef, '2026-06-22T12:06:00.000Z')
+
+    expect(receipt?.resolution.settlementRail).toBe('hosted_mdk')
+    expect(receipt?.promiseGate).toEqual({
+      broaderReferralPromiseIdsNotSatisfied: [
+        'referral.refer_once_earn_forever.v1',
+        'inference.referral_on_all_inference.v1',
+        'marketplace.monetize_any_layer_with_referral.v1',
+      ],
+      livePurchaseToBitcoinPayoutReceipt: true,
+      requiredSettlementRail: 'hosted_mdk',
+      scopedPromiseId: 'sites.referral_bitcoin_stream.v1',
+    })
   })
 
   test('fail-safe: a DISABLED staging adapter never settles and records no settled state (no receipt to dereference)', async () => {

--- a/apps/openagents.com/workers/api/src/site-referral-payout-receipts.ts
+++ b/apps/openagents.com/workers/api/src/site-referral-payout-receipts.ts
@@ -20,6 +20,15 @@ export type PublicSiteReferralPayoutReceiptProjection = Readonly<{
   caveatRefs: ReadonlyArray<string>
   evidenceRefs: ReadonlyArray<string>
   generatedAt: string
+  promiseGate: Readonly<{
+    broaderReferralPromiseIdsNotSatisfied: ReadonlyArray<string>
+    livePurchaseToBitcoinPayoutReceipt: boolean
+    requiredSettlementRail: Extract<
+      SiteReferralPayoutReceiptSettlementRail,
+      'hosted_mdk'
+    >
+    scopedPromiseId: 'sites.referral_bitcoin_stream.v1'
+  }>
   policyRefs: ReadonlyArray<string>
   qualifyingEventKind: string
   receiptRef: string
@@ -66,6 +75,12 @@ const settlementRailForReceipt = (
       ? 'staging_test'
       : 'public_safe_adapter'
 
+const BROADER_REFERRAL_PROMISE_IDS_NOT_SATISFIED = [
+  'referral.refer_once_earn_forever.v1',
+  'inference.referral_on_all_inference.v1',
+  'marketplace.monetize_any_layer_with_referral.v1',
+] as const
+
 const publicProjection = (
   row: SettledReceiptRow,
   receiptRef: string,
@@ -74,6 +89,7 @@ const publicProjection = (
   const evidenceRefs = parseJsonStringArray(row.evidence_refs_json).filter(ref =>
     isPublicSafeRef(ref),
   )
+  const settlementRail = settlementRailForReceipt(receiptRef)
 
   return {
     amountSats: Number(row.amount_sats),
@@ -83,11 +99,18 @@ const publicProjection = (
     caveatRefs: parseJsonStringArray(row.caveat_refs_json),
     evidenceRefs,
     generatedAt,
+    promiseGate: {
+      broaderReferralPromiseIdsNotSatisfied:
+        BROADER_REFERRAL_PROMISE_IDS_NOT_SATISFIED,
+      livePurchaseToBitcoinPayoutReceipt: settlementRail === 'hosted_mdk',
+      requiredSettlementRail: 'hosted_mdk',
+      scopedPromiseId: 'sites.referral_bitcoin_stream.v1',
+    },
     policyRefs: parseJsonStringArray(row.policy_refs_json),
     qualifyingEventKind: row.qualifying_event_kind,
     receiptRef,
     resolution: {
-      settlementRail: settlementRailForReceipt(receiptRef),
+      settlementRail,
       state: 'settled',
       status: 'ok',
     },


### PR DESCRIPTION
## Summary

- Add a public `promiseGate` block to Site referral payout receipts so only `hosted_mdk` receipts satisfy the live purchase-to-Bitcoin payout receipt gate.
- Keep staging-test receipts dereferenceable while explicitly marking them as not live payout proof.
- Record that the receipt scope is `sites.referral_bitcoin_stream.v1` and does not satisfy broader referral/inference/marketplace referral promises.

Closes #7020

## Verification

- `bun run --cwd apps/openagents.com/workers/api test -- src/site-referral-payout-receipt-loop.test.ts src/public-site-referral-payout-receipt-routes.test.ts src/site-referral-payout-public-projection.test.ts src/product-promises.test.ts` passed locally: 4 files, 25 tests.

Note: I could not resolve or rerun `command.public.pylon_khala.verify.b5bea41b6c623f7c09f1bf24` after the local process runner began rejecting new shell spawns at the OS spawn layer; the focused command above was completed before that failure.