### PR TITLE
test(khala-desktop): harden Apple FM packaging guard

### DIFF
--- a/clients/khala-desktop/tests/apple-fm-packaging.test.ts
+++ b/clients/khala-desktop/tests/apple-fm-packaging.test.ts
@@ -38,6 +38,19 @@ describe("khala desktop Apple FM packaging", () => {
     expect(result.verifiedPath).toContain("Khala-dev.app")
   })
 
+  test("verifier picks the first candidate that ships a usable helper", () => {
+    const stableOnly: AppleFmBridgeProbe = (helperPath) =>
+      helperPath.includes("stable-macos-arm64")
+        ? { exists: true, nonEmpty: true, executable: true }
+        : { exists: false, nonEmpty: false, executable: false }
+
+    const result = verifyPackagedAppleFmBridge({ probe: stableOnly })
+
+    expect(result.ok).toBe(true)
+    expect(result.verifiedEnv).toBe("stable")
+    expect(result.verifiedPath).toContain("Khala.app")
+  })
+
   test("verifier rejects missing, empty, and non-executable helpers", () => {
     const missing = verifyPackagedAppleFmBridge({
       probe: () => ({ exists: false, nonEmpty: false, executable: false }),
@@ -59,5 +72,18 @@ describe("khala desktop Apple FM packaging", () => {
     expect(
       nonExecutable.failures.every((failure) => failure.reason === "helper not executable"),
     ).toBe(true)
+  })
+
+  test("failure reasons carry only structural bundle diagnostics", () => {
+    const result = verifyPackagedAppleFmBridge({
+      probe: () => ({ exists: false, nonEmpty: false, executable: false }),
+    })
+
+    expect(result.ok).toBe(false)
+    for (const failure of result.failures) {
+      expect(failure.bundleDir.startsWith("build/")).toBe(true)
+      expect(failure.reason.includes("/")).toBe(false)
+      expect(failure.reason).not.toContain("foundation-bridge")
+    }
   })
 })


### PR DESCRIPTION
## Summary
- add Khala Desktop Apple FM packaging coverage for selecting a later usable app bundle candidate
- assert verifier failure diagnostics stay structural and public-safe

Closes #6973.

## Verification
- bun run --cwd clients/khala-desktop verify
- bun run --cwd apps/openagents.com check:deploy
