### PR TITLE
refactor(effect): add authority boundary scan

### DIFF
--- a/docs/adr/0008-effect-authority-boundary-checklist.md
+++ b/docs/adr/0008-effect-authority-boundary-checklist.md
@@ -1,0 +1,80 @@
+# ADR 0008: Effect Authority-Boundary Checklist
+
+## Status
+
+Accepted.
+
+## Context
+
+OpenAgents authority paths decide payment, settlement, assignment, public proof,
+product-promise, auth, and routing state. Those paths need typed failure,
+validated inputs, and explicit runtime dependencies instead of incidental
+platform calls hidden inside business logic.
+
+The Effect usage audits from 2026-06-28 and 2026-06-29 found good local
+examples, but the repository still depends on review discipline to prevent new
+raw `JSON.parse`, direct environment reads, bare `catch {}`, raw `fetch`, and
+incidental `Effect.runPromise` bridges from entering authority code.
+
+## Decision
+
+Authority-bearing TypeScript should default to functions that return
+`Effect<Success, DomainError, R>` or pure typed values. Raw async/platform code is
+allowed only at named entry edges and adapters, where it immediately converts
+platform data into schema-validated values, typed service dependencies, or
+domain errors.
+
+Use this checklist when changing authority paths:
+
+- Runtime entrypoints may call `Effect.runPromise`, read Worker bindings, or
+  adapt HTTP/platform requests. Deeper modules should return `Effect` values and
+  leave execution to the entrypoint.
+- External JSON must be decoded with Effect Schema or a local typed boundary
+  helper before it affects auth, routing, payment, settlement, proof, or public
+  claims. `JSON.parse(...) as Type` is migration inventory unless it is isolated
+  behind an explicitly documented compatibility boundary.
+- Environment and binding reads belong in runtime layering, config loaders, or
+  deployment scripts. Authority logic should receive configuration through typed
+  services or arguments.
+- Network calls should go through provider/domain clients that model retry,
+  timeout, response decoding, and tagged errors. A raw `fetch` in authority code
+  must be an adapter edge with an allowlist reason.
+- Empty `catch {}` blocks are not acceptable in authority logic. Expected
+  failures should become typed errors, diagnostic refs, or deliberately ignored
+  cleanup errors with a comment and allowlist entry.
+- Public projection and product-promise code must preserve public-safe data
+  boundaries: private prompts, raw provider payloads, wallet material, local
+  paths, and private repo content stay out of public traces and counters.
+
+## Local Examples To Follow
+
+- Worker runtime layering in `apps/openagents.com/workers/api` keeps request
+  adapters and deployment composition near the Worker edge.
+- Provider-account code uses tagged errors and typed account state instead of
+  throwing unstructured platform exceptions.
+- OpenRouter integration code demonstrates retry/config/error discipline around
+  provider calls rather than scattering raw fetches through call sites.
+- `packages/world-contract` centralizes public-safe world command, row, delta,
+  and cursor schemas with Effect Schema.
+- ATIF redaction service code models scrubbed trace shape before trace data can
+  become public-safe evidence.
+
+## Guardrail
+
+Run the report-only scanner:
+
+```sh
+bun run scan:effect-authority-boundaries
+```
+
+The scanner inventories suspicious raw boundary operations in declared authority
+directories. It does not fail the build yet; existing findings are migration
+inventory for follow-up issues. Intentional raw edges must be listed in
+`scripts/effect-authority-boundary-allowlist.ts` with a reason explaining the
+boundary and why a typed Effect adapter is not the right shape there yet.
+
+## Consequences
+
+This ADR does not require one large migration. It creates a common checklist and
+an actionable local report so future work can migrate module-by-module while
+keeping new authority code inside the intended Effect model.

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "test:qa-async-gce-trigger": "bun test scripts/qa-async-gce-trigger.test.ts",
     "test:github-issue-triage": "bun test scripts/github-issue-triage.test.ts",
     "triage:issues": "bun run scripts/github-issue-triage.ts",
+    "scan:effect-authority-boundaries": "bun run scripts/effect-authority-boundary-scan.ts",
     "check:deploy": "bun run --cwd apps/openagents.com check:deploy",
     "typecheck": "bun run typecheck:forge && bun run typecheck:forum && bun run typecheck:nostr-relay && bun run typecheck:openagents-world && bun run typecheck:khala-cli && bun run typecheck:khala-macos && bun run typecheck:openagents-desktop && bun run typecheck:nip90 && bun run typecheck:proof-replay && bun run typecheck:public-activity-timeline && bun run typecheck:input-bindings && bun run typecheck:design-tokens && bun run typecheck:replay-clips && bun run typecheck:ui && bun run typecheck:agent-runtime-schema && bun run typecheck:provider-account-schema && bun run typecheck:blueprint-contracts && bun run typecheck:mcp-contract && bun run typecheck:forge-protocol && bun run typecheck:world-contract && bun run typecheck:world-client && bun run typecheck:autopilot-ui && bun run typecheck:durable-stream",
     "typecheck:forge": "bun run --cwd apps/forge typecheck",

--- a/scripts/effect-authority-boundary-allowlist.ts
+++ b/scripts/effect-authority-boundary-allowlist.ts
@@ -1,0 +1,35 @@
+export type EffectAuthorityBoundaryAllowlistEntry = {
+  readonly category:
+    | "json-parse-cast"
+    | "direct-env-read"
+    | "bare-catch"
+    | "raw-fetch"
+    | "effect-run-promise"
+  readonly path: string
+  readonly pattern: string
+  readonly reason: string
+}
+
+export const effectAuthorityBoundaryAllowlist = [
+  {
+    category: "effect-run-promise",
+    path: "apps/openagents.com/workers/api/src/index.ts",
+    pattern: "Effect.runPromise",
+    reason:
+      "Worker request entrypoint executes the already-layered Effect program at the platform edge.",
+  },
+  {
+    category: "direct-env-read",
+    path: "apps/pylon/src/index.ts",
+    pattern: "Bun.env",
+    reason:
+      "CLI process entrypoint reads local process configuration before passing typed options into command handlers.",
+  },
+  {
+    category: "direct-env-read",
+    path: "apps/pylon/src/index.ts",
+    pattern: "process.env",
+    reason:
+      "CLI process entrypoint reads local process configuration before passing typed options into command handlers.",
+  },
+] satisfies readonly EffectAuthorityBoundaryAllowlistEntry[]

--- a/scripts/effect-authority-boundary-scan.test.ts
+++ b/scripts/effect-authority-boundary-scan.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, test } from "bun:test"
+
+describe("effect authority-boundary scan", () => {
+  test("runs report-only and emits line-addressed findings", async () => {
+    const proc = Bun.spawn([process.execPath, "run", "scan:effect-authority-boundaries"], {
+      cwd: process.cwd(),
+      stderr: "pipe",
+      stdout: "pipe",
+    })
+
+    const [stdout, _stderr, exitCode] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ])
+
+    expect(exitCode).toBe(0)
+    expect(stdout).toContain("Effect authority-boundary scan")
+    expect(stdout).toContain("mode: report-only")
+    expect(stdout).toMatch(/MIGRATE .+:\d+ /)
+  })
+})

--- a/scripts/effect-authority-boundary-scan.ts
+++ b/scripts/effect-authority-boundary-scan.ts
@@ -1,0 +1,259 @@
+import { effectAuthorityBoundaryAllowlist } from "./effect-authority-boundary-allowlist"
+
+type Category =
+  | "json-parse-cast"
+  | "direct-env-read"
+  | "bare-catch"
+  | "raw-fetch"
+  | "effect-run-promise"
+
+type Finding = {
+  readonly category: Category
+  readonly path: string
+  readonly line: number
+  readonly snippet: string
+  readonly allowedReason?: string
+}
+
+const authorityRoots = [
+  "apps/openagents.com/workers/api",
+  "apps/pylon/src",
+  "packages/atif",
+  "packages/mcp-contract",
+  "packages/nip90",
+  "packages/proof-replay",
+  "packages/provider-account-schema",
+  "packages/world-client",
+  "packages/world-contract",
+] as const
+
+const sourceExtensions = new Set([
+  ".cjs",
+  ".cts",
+  ".js",
+  ".jsx",
+  ".mjs",
+  ".mts",
+  ".ts",
+  ".tsx",
+])
+
+const ignoredPathParts = new Set([
+  ".git",
+  ".wrangler",
+  "dist",
+  "node_modules",
+  "coverage",
+  "scripts",
+])
+
+const categoryLabels = {
+  "json-parse-cast": "JSON.parse followed by cast/manual narrowing",
+  "direct-env-read": "direct process.env/Bun.env read",
+  "bare-catch": "bare catch block",
+  "raw-fetch": "raw fetch call",
+  "effect-run-promise": "Effect.runPromise bridge",
+} satisfies Record<Category, string>
+
+const relativePath = (path: string): string =>
+  path.startsWith(`${process.cwd()}/`) ? path.slice(process.cwd().length + 1) : path
+
+const hasSourceExtension = (path: string): boolean => {
+  const dot = path.lastIndexOf(".")
+  return dot >= 0 && sourceExtensions.has(path.slice(dot))
+}
+
+const isProductionSource = (path: string): boolean =>
+  !/\.(test|spec)\.[cm]?[tj]sx?$/.test(path) &&
+  !path.includes("/__tests__/") &&
+  !path.includes("/fixtures/") &&
+  !path.includes("/generated/")
+
+const walk = async (root: string): Promise<readonly string[]> => {
+  const files: string[] = []
+
+  const visit = async (dir: string): Promise<void> => {
+    let entries: string[]
+    try {
+      entries = await Array.fromAsync(new Bun.Glob("*").scan({ cwd: dir, onlyFiles: false }))
+    } catch {
+      return
+    }
+
+    for (const entry of entries) {
+      if (ignoredPathParts.has(entry)) {
+        continue
+      }
+
+      const path = `${dir}/${entry}`
+      const stat = await Bun.file(path).stat()
+      if (stat.isDirectory()) {
+        await visit(path)
+      } else if (stat.isFile() && hasSourceExtension(path) && isProductionSource(path)) {
+        files.push(path)
+      }
+    }
+  }
+
+  await visit(root)
+  return files
+}
+
+const isCommentLine = (line: string): boolean => {
+  const trimmed = line.trim()
+  return (
+    trimmed.startsWith("//") ||
+    trimmed.startsWith("*") ||
+    trimmed.startsWith("/*") ||
+    trimmed.startsWith("#")
+  )
+}
+
+const normalizeSnippet = (line: string): string => line.trim().replace(/\s+/g, " ")
+
+const allowlistReason = (finding: Omit<Finding, "allowedReason">): string | undefined => {
+  const entry = effectAuthorityBoundaryAllowlist.find(
+    (candidate) =>
+      candidate.category === finding.category &&
+      candidate.path === finding.path &&
+      finding.snippet.includes(candidate.pattern),
+  )
+
+  return entry?.reason
+}
+
+const findJsonParseCast = (
+  lines: readonly string[],
+  path: string,
+  index: number,
+): Finding | undefined => {
+  const line = lines[index] ?? ""
+  if (isCommentLine(line) || !line.includes("JSON.parse")) {
+    return undefined
+  }
+
+  const windowText = lines.slice(index, index + 4).join("\n")
+  const suspiciousCast =
+    /\)\s+as\s+[A-Za-z_{]/.test(windowText) ||
+    /\bas\s+(Record|unknown|any|Readonly|Array|[A-Z][A-Za-z0-9_]+)/.test(windowText) ||
+    /:\s*(Record|unknown|any|Readonly|Array|[A-Z][A-Za-z0-9_]+)\s*=/.test(windowText)
+
+  if (!suspiciousCast) {
+    return undefined
+  }
+
+  return {
+    category: "json-parse-cast",
+    path,
+    line: index + 1,
+    snippet: normalizeSnippet(line),
+  }
+}
+
+const findLineFindings = (
+  lines: readonly string[],
+  path: string,
+  index: number,
+): readonly Finding[] => {
+  const line = lines[index] ?? ""
+  if (isCommentLine(line)) {
+    return []
+  }
+
+  const findings: Finding[] = []
+  const snippet = normalizeSnippet(line)
+
+  if (/\b(process\.env|Bun\.env)\b/.test(line)) {
+    findings.push({ category: "direct-env-read", path, line: index + 1, snippet })
+  }
+
+  if (/catch\s*\{\s*\}/.test(line) || /catch\s*\{\s*$/.test(line)) {
+    const nextMeaningful = lines
+      .slice(index + 1, index + 5)
+      .map((candidate) => candidate.trim())
+      .find((candidate) => candidate.length > 0 && !candidate.startsWith("//"))
+    if (nextMeaningful === "}" || /catch\s*\{\s*\}/.test(line)) {
+      findings.push({ category: "bare-catch", path, line: index + 1, snippet })
+    }
+  }
+
+  if (/\bfetch\s*\(/.test(line)) {
+    findings.push({ category: "raw-fetch", path, line: index + 1, snippet })
+  }
+
+  if (/\bEffect\.runPromise\s*\(/.test(line)) {
+    findings.push({ category: "effect-run-promise", path, line: index + 1, snippet })
+  }
+
+  const jsonParseCast = findJsonParseCast(lines, path, index)
+  if (jsonParseCast) {
+    findings.push(jsonParseCast)
+  }
+
+  return findings
+}
+
+const collectFindings = async (): Promise<readonly Finding[]> => {
+  const findings: Finding[] = []
+
+  for (const root of authorityRoots) {
+    for (const absolutePath of await walk(root)) {
+      const path = relativePath(absolutePath)
+      const text = await Bun.file(absolutePath).text()
+      const lines = text.split(/\r?\n/)
+
+      for (let index = 0; index < lines.length; index += 1) {
+        for (const finding of findLineFindings(lines, path, index)) {
+          findings.push({
+            ...finding,
+            allowedReason: allowlistReason(finding),
+          })
+        }
+      }
+    }
+  }
+
+  return findings
+}
+
+const printReport = (findings: readonly Finding[]): void => {
+  const byCategory = new Map<Category, readonly Finding[]>()
+  for (const category of Object.keys(categoryLabels) as readonly Category[]) {
+    byCategory.set(
+      category,
+      findings.filter((finding) => finding.category === category),
+    )
+  }
+
+  console.log("Effect authority-boundary scan")
+  console.log("mode: report-only")
+  console.log(`scanned roots: ${authorityRoots.join(", ")}`)
+  console.log(`findings: ${findings.length}`)
+
+  for (const [category, categoryFindings] of byCategory) {
+    if (categoryFindings.length === 0) {
+      continue
+    }
+
+    const allowed = categoryFindings.filter((finding) => finding.allowedReason).length
+    console.log("")
+    console.log(`${categoryLabels[category]}: ${categoryFindings.length} (${allowed} allowed)`)
+
+    for (const finding of categoryFindings) {
+      const marker = finding.allowedReason ? "ALLOWLISTED" : "MIGRATE"
+      console.log(
+        `${marker} ${finding.path}:${finding.line} ${finding.snippet}`,
+      )
+      if (finding.allowedReason) {
+        console.log(`  reason: ${finding.allowedReason}`)
+      }
+    }
+  }
+
+  if (findings.length === 0) {
+    console.log("No suspicious authority-boundary operations found.")
+  }
+}
+
+const findings = await collectFindings()
+printReport(findings)


### PR DESCRIPTION
## Summary
- add ADR 0008 with the Effect authority-boundary checklist for raw platform/async edges
- add a report-only `bun run scan:effect-authority-boundaries` scanner over authority-bearing source roots
- add a TypeScript allowlist with documented reasons for intentional raw edges and a focused scanner smoke test

## Scan summary
`bun run scan:effect-authority-boundaries` is report-only and currently reports 582 production-source findings across the declared authority roots, including JSON.parse casts, direct env reads, bare catches, raw fetches, and Effect.runPromise bridges. Existing findings are migration inventory, not failures.

## Verification
- `true` (required command ref `command.public.pylon_khala.verify.b5bea41b6c623f7c09f1bf24`)
- `bun run scan:effect-authority-boundaries`
- `bun test scripts/effect-authority-boundary-scan.test.ts`
- `bun run check:deploy`

Closes #7009