### PR TITLE
test(khala): guard data privacy promise alignment

### DIFF
--- a/apps/openagents.com/workers/api/src/free-key-mint-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/free-key-mint-routes.test.ts
@@ -8,6 +8,7 @@ import {
   type AgentRegistrationStore,
 } from './agent-registration'
 import { type Env, handleFreeKeyMint } from './index'
+import { freeTierDataSharingDisclosure } from './inference/free-tier-data-sharing-disclosure'
 import { FREE_KEY_MAX_MINTS_PER_IP_PER_DAY } from './inference/inference-free-tier-key'
 
 // In-memory agent registration store so minting reuses the real registration
@@ -164,12 +165,7 @@ describe('POST /api/keys/free (issue #6228)', () => {
     expect(body.quota.maxRequestsPerDay).toBeGreaterThan(0)
     // DISCLOSURE (#6296): the honest free-tier data-sharing terms ride along on
     // the mint response so a caller is told the deal at key-mint time.
-    expect(body.dataSharing.promiseId).toBe(
-      'data.free_tier_capture_disclosure.v1',
-    )
-    expect(body.dataSharing.terms.length).toBeGreaterThan(0)
-    expect(body.dataSharing.policy.capturedByDefault).toBe(true)
-    expect(body.dataSharing.policy.paidPrivacyOptOut).toBe(true)
+    expect(body.dataSharing).toEqual(freeTierDataSharingDisclosure())
     // The minted account is now marked free-tier in D1.
     const row = await db
       .prepare(

--- a/apps/openagents.com/workers/api/src/product-promises.test.ts
+++ b/apps/openagents.com/workers/api/src/product-promises.test.ts
@@ -6,6 +6,7 @@ import {
   publicProductPromisesAnnouncementReadiness,
   publicProductPromisesDocument,
 } from './product-promises'
+import { FREE_TIER_DATA_SHARING_PROMISE_ID } from './inference/free-tier-data-sharing-disclosure'
 
 const ProductPromiseState = S.Literals([
   'degraded',
@@ -1650,6 +1651,66 @@ describe('public product promises document', () => {
     )
     expect(kernelPromise?.verification).toContain(
       'Green still requires a real live market-dispatched optimized kernel',
+    )
+  })
+
+  test('keeps Khala data/privacy capture promises aligned and explicitly gated (#7019)', () => {
+    const decoded = S.decodeUnknownSync(ProductPromisesDocument)(
+      publicProductPromisesDocument(),
+    )
+    const byId = (promiseId: string) =>
+      decoded.promises.find(promise => promise.promiseId === promiseId)
+
+    const disclosurePromise = byId(FREE_TIER_DATA_SHARING_PROMISE_ID)
+    expect(disclosurePromise).toMatchObject({
+      state: 'yellow',
+      blockerRefs: [
+        'blocker.product_promises.free_tier_capture_default_owner_gated',
+        'blocker.product_promises.disclosure_copy_owner_signoff_pending',
+      ],
+    })
+    expect(disclosurePromise?.safeCopy).toContain(
+      'GET /api/public/free-tier-data-sharing',
+    )
+    expect(disclosurePromise?.safeCopy).toContain(
+      'POST /api/keys/free mint response',
+    )
+    expect(disclosurePromise?.safeCopy).toContain(
+      'Pay for privacy, or run confidential compute, to opt out of capture',
+    )
+    expect(disclosurePromise?.authorityBoundary).toContain(
+      'does not change capture behavior',
+    )
+
+    const capturePromise = byId('data.khala_free_tier_trace_capture.v1')
+    expect(capturePromise).toMatchObject({
+      state: 'yellow',
+      blockerRefs: [
+        'blocker.product_promises.free_tier_capture_default_owner_gated',
+        'blocker.product_promises.trace_capture_public_disclosure_alignment_required',
+        'blocker.product_promises.trace_capture_reward_marker_inert',
+      ],
+    })
+    expect(capturePromise?.safeCopy).toContain(
+      'captured traces are owner_only',
+    )
+    expect(capturePromise?.unsafeCopy).toContain(
+      'do not claim capture pays users or contributors',
+    )
+
+    const privacyPromise = byId('privacy.khala_paid_capture_optout.v1')
+    expect(privacyPromise).toMatchObject({
+      state: 'yellow',
+      blockerRefs: [
+        'blocker.product_promises.paid_privacy_owner_signoff_pending',
+        'blocker.product_promises.paid_khala_business_loop_not_green',
+      ],
+    })
+    expect(privacyPromise?.safeCopy).toContain(
+      'fails closed to not-captured',
+    )
+    expect(privacyPromise?.unsafeCopy).toContain(
+      'Do not claim paid privacy, confidential compute, or privacy-preserving paid Khala is broadly green',
     )
   })
 


### PR DESCRIPTION
## Summary

- Tighten the free-key mint test so `dataSharing` must equal the canonical free-tier disclosure object.
- Add a focused product-promise registry regression for #7019 covering the disclosure, trace-capture, and paid/privacy opt-out records.
- Keep the records explicitly yellow/gated and assert the owner-gated, paid opt-out, and inert reward boundaries stay visible.

Closes #7019.

## Verification

- `bun run --cwd apps/openagents.com/workers/api test -- src/free-key-mint-routes.test.ts src/inference/free-tier-data-sharing-disclosure.test.ts src/inference/inference-privacy-entitlement.test.ts src/inference/inference-privacy-receipt-routes.test.ts src/product-promises.test.ts`
- `bun run --cwd apps/openagents.com check:deploy`
