### PR TITLE
docs(adr): record missing architecture decisions

### DIFF
--- a/docs/adr/0008-declare-public-projection-staleness.md
+++ b/docs/adr/0008-declare-public-projection-staleness.md
@@ -1,0 +1,81 @@
+---
+status: "accepted"
+date: 2026-06-29
+decision-makers: OpenAgents maintainers
+consulted: Root INVARIANTS.md, apps/openagents.com/INVARIANTS.md, docs/systems/README.md
+informed: OpenAgents contributors and agents
+---
+
+# Declare public projection staleness
+
+## Context and Problem Statement
+
+OpenAgents exposes public product, proof, stats, promise, Forum, Site, and
+world projection surfaces. Many of those surfaces are backed by D1 rows or
+composed live from D1 state, while others are generated records. Contributors
+and agents need a settled rule for whether a public projection is current,
+generated, stale, or intentionally live at read.
+
+## Decision Drivers
+
+* Prevent stale public data from being presented as current.
+* Keep public surfaces explicit about freshness and rebuild behavior.
+* Preserve Worker/D1 authority for public product truth while allowing
+  Cloudflare world projections to own only public-safe world state.
+* Make missing staleness contracts reviewable and checkable.
+
+## Considered Options
+
+* Public projection staleness declarations
+* Implicit freshness based on route behavior
+* Ad hoc comments near individual routes
+
+## Decision Outcome
+
+Chosen option: "Public projection staleness declarations", because the root
+and app invariant ledgers already require each public projection to carry a
+`generatedAt` value or equivalent rebuild timestamp plus a declared staleness
+contract, and the OpenAgents.com architecture guard tracks route coverage in a
+projection-surface ledger.
+
+### Consequences
+
+* Good, because consumers can distinguish live-at-read projections from
+  generated or potentially stale records.
+* Good, because public projection changes have a shared review vocabulary.
+* Bad, because new public routes must be added to the projection ledger instead
+  of relying only on local route tests.
+
+### Confirmation
+
+Compliance is confirmed by invariant review, the public projection inventory in
+`apps/openagents.com/INVARIANTS.md`, route and projection tests, and
+`apps/openagents.com/scripts/check-zero-debt-architecture.mjs`, which fails
+missing projection-surface declarations as part of `check:deploy`.
+
+## Pros and Cons of the Options
+
+### Public projection staleness declarations
+
+* Good, because the freshness contract is visible outside individual route
+  implementations.
+* Good, because stale or generated data can be described honestly in API
+  payloads and docs.
+* Bad, because the ledger must stay synchronized with route additions.
+
+### Implicit freshness based on route behavior
+
+* Good, because it avoids a separate inventory.
+* Bad, because readers and agents would need to infer freshness from code.
+
+### Ad hoc comments near individual routes
+
+* Good, because the comment can be close to the implementation.
+* Bad, because comments are hard to audit across all public routes.
+
+## More Information
+
+* `INVARIANTS.md` ("Public Projection Staleness")
+* `apps/openagents.com/INVARIANTS.md` ("Public Projection Staleness Declaration")
+* `apps/openagents.com/scripts/check-zero-debt-architecture.mjs`
+* `docs/systems/README.md` ("D1 / projections / projection-surface ledger")

--- a/docs/adr/0009-count-served-tokens-from-exact-usage-ledger-rows.md
+++ b/docs/adr/0009-count-served-tokens-from-exact-usage-ledger-rows.md
@@ -77,7 +77,7 @@ against exact rows before accepting counter projection movement.
 ## More Information
 
 * `AGENTS.md` ("Confirm exact downstream Codex token rows and private traces")
-* `apps/openagents.com/INVARIANTS.md` ("Khala Token Usage Truth Split")
+* `apps/openagents.com/INVARIANTS.md` ("Canonical Token Usage Ledger")
 * `apps/openagents.com/workers/api/migrations/0137_token_usage_events.sql`
 * `apps/openagents.com/workers/api/src/token-usage-ledger-routes.test.ts`
 * `apps/openagents.com/workers/api/src/public-khala-tokens-served-routes.test.ts`

--- a/docs/adr/0009-count-served-tokens-from-exact-usage-ledger-rows.md
+++ b/docs/adr/0009-count-served-tokens-from-exact-usage-ledger-rows.md
@@ -1,0 +1,84 @@
+---
+status: "accepted"
+date: 2026-06-29
+decision-makers: OpenAgents maintainers
+consulted: Root AGENTS.md, apps/openagents.com/INVARIANTS.md, docs/systems/README.md
+informed: OpenAgents contributors, agents, and Pylon operators
+---
+
+# Count served tokens from exact usage ledger rows
+
+## Context and Problem Statement
+
+Khala, Pylon/Codex own-capacity delegation, BYOK inference, model mix stats, and
+public tokens-served counters all need token usage accounting. The repository
+already distinguishes exact downstream usage rows from projections, private
+traces, raw event chunks, and public counters. Counter movement alone is not
+accepted proof of delegated coding work.
+
+## Decision Drivers
+
+* Use exact provider or SDK usage records as accounting truth.
+* Keep public counters aggregate-only and derived from the canonical ledger.
+* Preserve demand attribution through bounded `demand_kind` and
+  `demand_source` fields.
+* Avoid synthetic burn, estimated usage, or raw private trace material in public
+  counters.
+
+## Considered Options
+
+* Exact `token_usage_events` ledger rows as usage truth
+* Public counter deltas as usage truth
+* Synthetic or estimated token burn when exact usage is unavailable
+
+## Decision Outcome
+
+Chosen option: "Exact `token_usage_events` ledger rows as usage truth", because
+the Worker and Pylon delegation contracts require exact rows with stable
+idempotency, demand attribution, provider/model identity, and usage truth before
+public counters or closeout proof can be treated as complete.
+
+### Consequences
+
+* Good, because usage accounting can be reconciled from public counters back to
+  durable D1 rows.
+* Good, because reasoning, cache-read, input, and output tokens can be retained
+  separately while still producing public aggregates.
+* Bad, because integrations that cannot provide exact usage must not invent
+  accounting rows to make counters move.
+
+### Confirmation
+
+Compliance is confirmed by the `token_usage_events` D1 migrations, token usage
+ledger routes and tests, Khala tokens-served routes and tests, Pylon/Codex turn
+ingest checks, and the Khala/Pylon runbook steps that reconcile closeout proof
+against exact rows before accepting counter projection movement.
+
+## Pros and Cons of the Options
+
+### Exact `token_usage_events` ledger rows as usage truth
+
+* Good, because it gives one canonical source for served-token accounting.
+* Good, because idempotency and demand attribution are recorded with the event.
+* Bad, because callers must debug missing ingest rather than paper over it with
+  counter-only evidence.
+
+### Public counter deltas as usage truth
+
+* Good, because they are easy to observe.
+* Bad, because other traffic can move the counter and aggregates do not prove a
+  specific assignment or request.
+
+### Synthetic or estimated token burn when exact usage is unavailable
+
+* Good, because it could make progress visible when providers omit usage.
+* Bad, because it would undermine billing, proof, and public counter integrity.
+
+## More Information
+
+* `AGENTS.md` ("Confirm exact downstream Codex token rows and private traces")
+* `apps/openagents.com/INVARIANTS.md` ("Khala Token Usage Truth Split")
+* `apps/openagents.com/workers/api/migrations/0137_token_usage_events.sql`
+* `apps/openagents.com/workers/api/src/token-usage-ledger-routes.test.ts`
+* `apps/openagents.com/workers/api/src/public-khala-tokens-served-routes.test.ts`
+* `docs/systems/README.md` ("Token accounting / served counters")

--- a/docs/adr/0010-separate-spark-agent-payments-from-mdk-checkouts.md
+++ b/docs/adr/0010-separate-spark-agent-payments-from-mdk-checkouts.md
@@ -1,0 +1,83 @@
+---
+status: "accepted"
+date: 2026-06-29
+decision-makers: OpenAgents maintainers
+consulted: apps/openagents.com/INVARIANTS.md, docs/mpp/README.md, docs/payments/
+informed: OpenAgents contributors, agents, and payment operators
+---
+
+# Separate Spark agent payments from MDK checkouts
+
+## Context and Problem Statement
+
+OpenAgents has agent payments, Machine Payments Protocol inference, Forum
+tips/checkouts, payout readiness, and settlement projections. Earlier payment
+work mixed Spark and MDK responsibilities. The settled architecture now makes
+Spark the primary rail for agent and MPP payments, while MDK remains a checkout
+surface and explicit fallback where documented.
+
+## Decision Drivers
+
+* Agent and MPP payments need Spark's offline receive capability.
+* Checkout flows and agent settlement flows have different authority and
+  readiness requirements.
+* Lightning MPP invoice issuance should prefer Spark and only fall back to MDK
+  when Spark is unavailable or unconfigured.
+* Public payment claims must stay receipt-backed and explicit about unsettled,
+  rejected, unpaid, credited, and settled states.
+
+## Considered Options
+
+* Spark primary for agent and MPP payments, MDK for checkouts and fallback
+* MDK as the default agent and MPP payment rail
+* A single generic payment abstraction with no rail separation
+
+## Decision Outcome
+
+Chosen option: "Spark primary for agent and MPP payments, MDK for checkouts and
+fallback", because the OpenAgents.com invariant ledger records Spark as the
+primary rail for all agent payments and MPP, with MDK limited to checkout flows
+and explicit fallback Lightning issuance.
+
+### Consequences
+
+* Good, because agent receives and payouts use the rail designed for the needed
+  offline receive behavior.
+* Good, because checkout-specific MDK state cannot be mistaken for agent
+  settlement authority.
+* Bad, because payment code and runbooks must preserve multiple rail-specific
+  readiness checks instead of collapsing them into one status.
+
+### Confirmation
+
+Compliance is confirmed by the payment rail invariant, MPP Lightning issuer
+selection code and tests, Spark payout target registration records, payment
+runbooks, receipt-backed public projection checks, and deployment review.
+
+## Pros and Cons of the Options
+
+### Spark primary for agent and MPP payments, MDK for checkouts and fallback
+
+* Good, because it matches the current production rail split.
+* Good, because fallback behavior is explicit and bounded.
+* Bad, because operators must understand which rail a surface is proving.
+
+### MDK as the default agent and MPP payment rail
+
+* Good, because checkout and agent flows would appear simpler.
+* Bad, because the invariant ledger states MDK does not satisfy the primary
+  agent-payment requirement.
+
+### A single generic payment abstraction with no rail separation
+
+* Good, because UI copy could be simpler.
+* Bad, because it would hide materially different readiness, receipt, and
+  settlement boundaries.
+
+## More Information
+
+* `apps/openagents.com/INVARIANTS.md` ("Payment Rail Separation")
+* `docs/mpp/README.md`
+* `docs/payments/`
+* `apps/openagents.com/workers/api/src/inference/mpp/mpp-lightning-invoice-spark.ts`
+* `apps/openagents.com/workers/api/src/inference/mpp/mpp-lightning-invoice-mdk.ts`

--- a/docs/adr/0011-ship-khala-mobile-as-native-swiftui-with-local-apple-tooling.md
+++ b/docs/adr/0011-ship-khala-mobile-as-native-swiftui-with-local-apple-tooling.md
@@ -1,0 +1,80 @@
+---
+status: "accepted"
+date: 2026-06-29
+decision-makers: OpenAgents maintainers
+consulted: Root AGENTS.md, docs/DEPLOYMENT.md, docs/mobile/2026-06-26-khala-voice-app-spec.md, docs/mobile/2026-06-26-autopilot-remote-control-retirement.md
+informed: OpenAgents contributors, agents, and release operators
+---
+
+# Ship Khala mobile as native SwiftUI with local Apple tooling
+
+## Context and Problem Statement
+
+The repository previously carried an Expo React Native mobile surface for
+remote control. That surface was retired. The current Khala iOS client is the
+native SwiftUI app under `clients/khala-ios/Khala`, and mobile release
+instructions require local Xcode tooling and Apple-native upload paths.
+
+## Decision Drivers
+
+* Keep mobile builds on owner-controlled local tooling.
+* Avoid Expo/EAS cloud build, submit, or update paths.
+* Make native SwiftUI the current Khala iOS implementation boundary.
+* Prevent OTA assumptions from leaking into a native app that has no Expo
+  update path.
+
+## Considered Options
+
+* Native SwiftUI Khala iOS app with local Xcode and Apple upload tooling
+* Revive the retired Expo React Native app
+* Use Expo/EAS cloud for native build, submit, or OTA updates
+
+## Decision Outcome
+
+Chosen option: "Native SwiftUI Khala iOS app with local Xcode and Apple upload
+tooling", because root instructions and mobile docs settle the mobile product
+boundary on `clients/khala-ios/Khala`, local `xcodebuild`, and Apple-native
+TestFlight upload, with no Expo/EAS cloud path.
+
+### Consequences
+
+* Good, because the mobile build and signing chain stays on local controlled
+  infrastructure.
+* Good, because contributors do not need to reason about Expo prebuild or OTA
+  behavior for the current Khala iOS app.
+* Bad, because JavaScript-only OTA release techniques do not apply to native
+  SwiftUI app changes.
+
+### Confirmation
+
+Compliance is confirmed by root mobile policy, the Khala voice app spec, the
+Autopilot Remote Control retirement record, the TestFlight release runbook, and
+code review rejecting `eas build`, `eas submit`, or `eas update` for current
+mobile release work.
+
+## Pros and Cons of the Options
+
+### Native SwiftUI Khala iOS app with local Xcode and Apple upload tooling
+
+* Good, because it matches the current repository app and release policy.
+* Good, because it avoids cloud build dependency for mobile releases.
+* Bad, because release operators must have the local Apple signing environment.
+
+### Revive the retired Expo React Native app
+
+* Good, because Expo can be fast for JavaScript UI iteration.
+* Bad, because the retired app is no longer the current product boundary.
+
+### Use Expo/EAS cloud for native build, submit, or OTA updates
+
+* Good, because hosted build and OTA flows are convenient.
+* Bad, because root policy explicitly forbids Expo/EAS cloud for the current
+  mobile app.
+
+## More Information
+
+* `AGENTS.md` ("Mobile build/ship policy")
+* `docs/DEPLOYMENT.md`
+* `docs/mobile/2026-06-26-khala-voice-app-spec.md`
+* `docs/mobile/2026-06-26-autopilot-remote-control-retirement.md`
+* `docs/mobile/2026-06-26-khala-testflight-release-runbook.md`

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -30,3 +30,7 @@ records. They provide a stable decision log that links those sources together.
 * [ADR-0005: Land through PR review and the `check:deploy` gate](0005-land-through-pr-review-and-check-deploy.md)
 * [ADR-0006: Route Khala coding delegation through owner-local Pylon capacity](0006-route-khala-coding-delegation-through-owner-local-pylon-capacity.md)
 * [ADR-0007: Gate public product claims through product promises](0007-gate-public-product-claims-through-product-promises.md)
+* [ADR-0008: Declare public projection staleness](0008-declare-public-projection-staleness.md)
+* [ADR-0009: Count served tokens from exact usage ledger rows](0009-count-served-tokens-from-exact-usage-ledger-rows.md)
+* [ADR-0010: Separate Spark agent payments from MDK checkouts](0010-separate-spark-agent-payments-from-mdk-checkouts.md)
+* [ADR-0011: Ship Khala mobile as native SwiftUI with local Apple tooling](0011-ship-khala-mobile-as-native-swiftui-with-local-apple-tooling.md)


### PR DESCRIPTION
## Summary

- Add ADR-0008 for public projection staleness declarations and the projection-surface ledger.
- Add ADR-0009 for exact `token_usage_events` as served-token truth.
- Add ADR-0010 for Spark-primary agent/MPP payments with MDK checkout/fallback boundaries.
- Add ADR-0011 for native SwiftUI Khala mobile shipping with local Apple tooling and no Expo/EAS.
- Update the ADR index.

## Verification

- `bun install` to hydrate this bounded checkout's dependencies; lockfile content unchanged.
- `bun run --cwd apps/openagents.com check:deploy` passed (exit 0).

Closes #6971
