### PR TITLE
Align Tassadar CPU-transform receipt projection

### DIFF
--- a/apps/openagents.com/workers/api/src/index.ts
+++ b/apps/openagents.com/workers/api/src/index.ts
@@ -10687,9 +10687,10 @@ const exactRouteRegistry = makeExactRouteRegistry<Env>([
   {
     // Tassadar Percepta executor architecture receipts (#5523 / DE-5 #5528;
     // promise models.tassadar_percepta_executor.v1, planned). Read-only refs and
-    // digest projection: clears only the architecture-receipt blocker while
-    // Pylon CPU-transform training receipts remain missing. No trained model,
-    // inference endpoint, spend, settlement, promotion, or green claim.
+    // digest projection: architecture receipts and a separate bounded
+    // CPU-transform fixture receipt are available while settlement and owner
+    // green sign-off remain missing. No trained model, inference endpoint,
+    // spend, settlement, promotion, or green claim.
     path: TassadarPerceptaArchitectureReceiptsEndpoint,
     handler: request => handleTassadarPerceptaArchitectureReceiptsApi(request),
   },
@@ -10697,7 +10698,8 @@ const exactRouteRegistry = makeExactRouteRegistry<Env>([
     // Tassadar Percepta CPU-transform training receipt status (#5523 / DE-5
     // #5528; promise models.tassadar_percepta_executor.v1, planned). Read-only
     // status projection: exposes the architecture and Artanis dataset inputs
-    // while every real training receipt gate remains false.
+    // plus one bounded fixture receipt while settlement and green gates remain
+    // false.
     path: TassadarPerceptaCpuTransformTrainingReceiptsEndpoint,
     handler: request =>
       handleTassadarPerceptaCpuTransformTrainingReceiptsApi(request),

--- a/apps/openagents.com/workers/api/src/openagents-openapi.ts
+++ b/apps/openagents.com/workers/api/src/openagents-openapi.ts
@@ -434,7 +434,7 @@ export const TassadarPerceptaArchitectureReceiptsEnvelope: JsonSchema = {
   type: 'object',
   additionalProperties: true,
   description:
-    'Public-safe architecture-receipts projection for models.tassadar_percepta_executor.v1. Carries generatedAt, a live_at_read staleness contract, one architecture receipt bundle with compiled-executor, learned-interface, verifier, and artifact-lineage components, plus explicit gate fields showing architectureReceiptsAvailable=true, pylonCpuTransformTrainingReceiptsAvailable=false, and greenGateSatisfied=false. It exposes refs and digests only: no raw traces, private runner logs, provider payloads, wallet material, payment material, trained-model claim, inference endpoint, model promotion, or CPU-transform training claim.',
+    'Public-safe architecture-receipts projection for models.tassadar_percepta_executor.v1. Carries generatedAt, a live_at_read staleness contract, one architecture receipt bundle with compiled-executor, learned-interface, verifier, and artifact-lineage components, plus explicit gate fields showing architectureReceiptsAvailable=true, pylonCpuTransformTrainingReceiptsAvailable=true for the separate bounded fixture receipt, and greenGateSatisfied=false. It exposes refs and digests only: no raw traces, private runner logs, provider payloads, wallet material, payment material, trained-model claim, inference endpoint, model promotion, or broad CPU-transform training claim.',
   required: [
     'authorityBoundary',
     'endpoint',
@@ -7833,7 +7833,7 @@ const paths = (): JsonSchema => ({
       operationId: 'getTassadarPerceptaArchitectureReceipts',
       summary: 'Read Tassadar Percepta executor architecture receipts',
       description:
-        'Returns the public-safe architecture-receipts projection for models.tassadar_percepta_executor.v1. The receipt bundle ties the public model profile to compiled/frozen executor refs, learned-interface refs, artifact-lineage hashes, and verifier refs. It clears only the architecture-receipt blocker; Pylon CPU-transform training receipts remain missing and greenGateSatisfied remains false. Read-only; grants no training dispatch, spend, settlement, model promotion, inference endpoint, CPU-transform training claim, or green product-promise authority.',
+        'Returns the public-safe architecture-receipts projection for models.tassadar_percepta_executor.v1. The receipt bundle ties the public model profile to compiled/frozen executor refs, learned-interface refs, artifact-lineage hashes, and verifier refs. The separate bounded CPU-transform fixture receipt is now available, while real settlement and greenGateSatisfied remain false. Read-only; grants no training dispatch, spend, settlement, model promotion, inference endpoint, broad CPU-transform training claim, or green product-promise authority.',
       tags: ['Training', 'Public Proof'],
       security: publicRead,
       responses: {

--- a/apps/openagents.com/workers/api/src/tassadar-percepta-architecture-receipts.test.ts
+++ b/apps/openagents.com/workers/api/src/tassadar-percepta-architecture-receipts.test.ts
@@ -6,7 +6,8 @@ import {
   TassadarPerceptaArchitectureReceiptsEndpoint,
   TassadarPerceptaArchitectureReceiptsProjection,
   TassadarPerceptaArchitectureReceiptRef,
-  TassadarPerceptaCpuTransformTrainingReceiptBlocker,
+  TassadarPerceptaCpuTransformOwnerGreenSignoffBlocker,
+  TassadarPerceptaCpuTransformRealSettlementBlocker,
   projectTassadarPerceptaArchitectureReceipts,
 } from './tassadar-percepta-architecture-receipts'
 import { handleTassadarPerceptaArchitectureReceiptsApi } from './tassadar-percepta-architecture-receipts-routes'
@@ -49,10 +50,11 @@ describe('Tassadar Percepta architecture receipts projection', () => {
       architectureReceiptsAvailable: true,
       clearsBlockerRefs: [TassadarPerceptaArchitectureReceiptBlocker],
       greenGateSatisfied: false,
-      pylonCpuTransformTrainingReceiptsAvailable: false,
+      pylonCpuTransformTrainingReceiptsAvailable: true,
       publicProjectionAvailable: true,
       remainingBlockerRefs: [
-        TassadarPerceptaCpuTransformTrainingReceiptBlocker,
+        TassadarPerceptaCpuTransformRealSettlementBlocker,
+        TassadarPerceptaCpuTransformOwnerGreenSignoffBlocker,
       ],
     })
     expect(projection.receiptSummary).toMatchObject({
@@ -131,7 +133,7 @@ describe('Tassadar Percepta architecture receipts projection', () => {
     )
     expect(body.promiseState).toBe('planned')
     expect(body.gate.architectureReceiptsAvailable).toBe(true)
-    expect(body.gate.pylonCpuTransformTrainingReceiptsAvailable).toBe(false)
+    expect(body.gate.pylonCpuTransformTrainingReceiptsAvailable).toBe(true)
     expect(body.gate.greenGateSatisfied).toBe(false)
   })
 

--- a/apps/openagents.com/workers/api/src/tassadar-percepta-architecture-receipts.ts
+++ b/apps/openagents.com/workers/api/src/tassadar-percepta-architecture-receipts.ts
@@ -22,6 +22,10 @@ export const TassadarPerceptaArchitectureReceiptBlocker =
   'blocker.product_promises.percepta_executor_architecture_receipts_missing'
 export const TassadarPerceptaCpuTransformTrainingReceiptBlocker =
   'blocker.product_promises.pylon_v03_cpu_transform_training_receipts_missing'
+export const TassadarPerceptaCpuTransformRealSettlementBlocker =
+  'blocker.product_promises.tassadar_cpu_transform_real_settlement_missing'
+export const TassadarPerceptaCpuTransformOwnerGreenSignoffBlocker =
+  'blocker.product_promises.tassadar_cpu_transform_owner_green_signoff_missing'
 
 const unsafePublicMaterialPattern =
   /(\"?(deviceId|deviceRef|nodeId|nodeRef|ownerId|ownerRef|pylonId|pylonRef|wallet[A-Za-z0-9_-]*|mnemonic|payment[A-Za-z0-9_-]*|preimage|invoice|bolt11|bolt12|lno1|secret[A-Za-z0-9_-]*|private[A-Za-z0-9_-]*)\"?\s*:|\/Users\/|\/home\/|api[_-]?key|bearer|lnbc|lntb|lno1|mnemonic|payment[_-]?(hash|preimage)|preimage|raw[_-]?(dataset|invoice|payment|payload|prompt|runner)|seed[_-]?phrase|sk-[a-z0-9]|wallet[_-]?(home|path|seed|mnemonic|private))/i
@@ -323,7 +327,7 @@ const buildArchitectureReceipt = (): TassadarPerceptaArchitectureReceipt => {
     receiptState: 'available',
     sourceRefs: entryRefs(components.flatMap(component => component.sourceRefs)),
     unsafeCopy:
-      'Do not claim a trained Tassadar model exists, that Pylon CPU-transform training has run, that public contributors trained this model, that an inference endpoint exists, or that this architecture receipt makes the planned promise green.',
+      'Do not claim a trained Tassadar model exists, that this architecture receipt is the CPU-transform training receipt, that public contributors trained this model, that an inference endpoint exists, or that this architecture receipt makes the planned promise green.',
   })
 
   assertPublicSafeValue('Tassadar Percepta architecture receipt', receipt)
@@ -348,10 +352,11 @@ export const projectTassadarPerceptaArchitectureReceipts = (
       architectureReceiptsAvailable: true,
       clearsBlockerRefs: [TassadarPerceptaArchitectureReceiptBlocker],
       greenGateSatisfied: false,
-      pylonCpuTransformTrainingReceiptsAvailable: false,
+      pylonCpuTransformTrainingReceiptsAvailable: true,
       publicProjectionAvailable: true,
       remainingBlockerRefs: [
-        TassadarPerceptaCpuTransformTrainingReceiptBlocker,
+        TassadarPerceptaCpuTransformRealSettlementBlocker,
+        TassadarPerceptaCpuTransformOwnerGreenSignoffBlocker,
       ],
     },
     generatedAt: input.generatedAt ?? currentIsoTimestamp(),
@@ -381,7 +386,7 @@ export const projectTassadarPerceptaArchitectureReceipts = (
     staleness: TassadarPerceptaArchitectureReceiptsStaleness,
     status: 'architecture_receipts_available',
     statusLabel:
-      'Tassadar Percepta executor architecture receipts are available; Pylon CPU-transform training receipts remain missing.',
+      'Tassadar Percepta executor architecture receipts and one bounded Pylon CPU-transform training fixture receipt are available; real settlement and owner green sign-off remain missing.',
     unsafeCopy:
       'Do not claim a trained Tassadar Percepta model, public contributor CPU-transform training, an inference endpoint, settlement, model promotion, or a green promise. This projection clears only the architecture-receipt blocker.',
   })


### PR DESCRIPTION
## Summary
- align the existing Tassadar Percepta architecture projection with the now-live bounded CPU-transform fixture receipt
- keep the promise planned by preserving false green/settlement gates and naming the remaining settlement + owner sign-off blockers
- refresh matching route/OpenAPI copy and architecture projection tests

Closes #6891.

## Verification
- `bun test apps/pylon/tests/tassadar-cpu-transform-training.test.ts`
- `bun run --cwd apps/openagents.com/workers/api test -- src/tassadar-percepta-architecture-receipts.test.ts src/tassadar-percepta-cpu-transform-training-receipts.test.ts src/product-promises.test.ts src/openagents-openapi-routes.test.ts`
- `bun run --cwd apps/openagents.com check:deploy` (`command.public.pylon_khala.verify.b5bea41b6c623f7c09f1bf24`)
