### PR TITLE
refactor(pylon): scope workspace materialization cleanup

### DIFF
--- a/apps/pylon/src/workspace-materializer.ts
+++ b/apps/pylon/src/workspace-materializer.ts
@@ -45,6 +45,7 @@ export type GitCheckoutWorkspace = {
 export type WorkspaceCheckoutRunner = (
   workingDirectory: string,
   checkout: GitCheckoutWorkspace,
+  signal?: AbortSignal,
 ) => Promise<void>
 
 export type MaterializedWorkspace = {
@@ -641,16 +642,60 @@ export async function materializeGitCheckoutWorkspace(input: {
   leaseRef: string
   refPrefix: string
 }): Promise<MaterializedWorkspace> {
+  return Effect.runPromise(Effect.scoped(materializeGitCheckoutWorkspaceEffect(input)))
+}
+
+/**
+ * Effect-native workspace materialization pattern (#7013): acquire the local
+ * workspace directory in Scope, run the checkout with an AbortSignal, and keep
+ * the finalizer armed until checkout has fully completed. Interruption or a
+ * checkout failure removes the partially-created assignment directory.
+ */
+export function materializeGitCheckoutWorkspaceEffect(input: {
+  cacheRoot: string
+  checkout: GitCheckoutWorkspace
+  checkoutRunner?: WorkspaceCheckoutRunner
+  leaseRef: string
+  refPrefix: string
+}) {
   const workspaceRef = stableRef(input.refPrefix, input.leaseRef)
   const workingDirectory = join(input.cacheRoot, workspaceRef)
-  await mkdir(input.cacheRoot, { recursive: true })
-  await (input.checkoutRunner ?? defaultGitCheckoutRunner)(workingDirectory, input.checkout)
-  return {
+  const materialized = {
     cleanupRef: stableRef("cleanup.pylon.workspace", workspaceRef),
     sourceRef: checkoutSourceRef(input.checkout),
     workingDirectory,
     workspaceRef,
   }
+  let checkoutCompleted = false
+
+  return Effect.gen(function* () {
+    yield* Effect.acquireRelease(
+      Effect.tryPromise({
+        try: () => mkdir(input.cacheRoot, { recursive: true }).then(() => materialized),
+        catch: (error) => error,
+      }),
+      (workspace) =>
+        checkoutCompleted
+          ? Effect.void
+          : Effect.promise(() =>
+              removeMaterializedWorkspace({
+                cacheRoot: input.cacheRoot,
+                workingDirectory: workspace.workingDirectory,
+              }).catch(() => undefined),
+            ),
+    )
+    yield* Effect.tryPromise({
+      try: (signal) =>
+        (input.checkoutRunner ?? defaultGitCheckoutRunner)(
+          workingDirectory,
+          input.checkout,
+          signal,
+        ),
+      catch: (error) => error,
+    })
+    checkoutCompleted = true
+    return materialized
+  })
 }
 
 /**

--- a/apps/pylon/src/workspace-materializer.ts
+++ b/apps/pylon/src/workspace-materializer.ts
@@ -224,14 +224,25 @@ function isTransientGitLockStderr(stderr: string): boolean {
 async function spawnGitCommand(
   args: string[],
   cwd: string,
+  signal?: AbortSignal,
 ): Promise<{ exitCode: number; stdout: string; stderr: string }> {
   const proc = Bun.spawn(args, { cwd, stderr: "pipe", stdout: "pipe" })
-  const [stdout, stderr, exitCode] = await Promise.all([
-    new Response(proc.stdout).text(),
-    new Response(proc.stderr).text(),
-    proc.exited,
-  ])
-  return { exitCode, stdout, stderr }
+  const abort = () => proc.kill()
+  if (signal?.aborted) {
+    abort()
+  } else {
+    signal?.addEventListener("abort", abort, { once: true })
+  }
+  try {
+    const [stdout, stderr, exitCode] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ])
+    return { exitCode, stdout, stderr }
+  } finally {
+    signal?.removeEventListener("abort", abort)
+  }
 }
 
 /**
@@ -243,19 +254,20 @@ async function spawnGitCommand(
 async function runGitCommand(
   args: string[],
   cwd: string,
+  signal?: AbortSignal,
 ): Promise<{ exitCode: number; stdout: string; stderr: string }> {
-  let result = await spawnGitCommand(args, cwd)
+  let result = await spawnGitCommand(args, cwd, signal)
   for (let attempt = 1; attempt < gitCommandMaxAttempts; attempt += 1) {
     if (result.exitCode === 0 || !isTransientGitLockStderr(result.stderr)) return result
     const backoff = Math.min(gitCommandRetryBaseMs * 2 ** (attempt - 1), gitCommandRetryMaxMs)
     await sleep(backoff + Math.floor(Math.random() * gitCommandRetryBaseMs))
-    result = await spawnGitCommand(args, cwd)
+    result = await spawnGitCommand(args, cwd, signal)
   }
   return result
 }
 
-async function runQuietCommand(args: string[], cwd: string): Promise<number> {
-  return (await runGitCommand(args, cwd)).exitCode
+async function runQuietCommand(args: string[], cwd: string, signal?: AbortSignal): Promise<number> {
+  return (await runGitCommand(args, cwd, signal)).exitCode
 }
 
 async function runTextCommand(args: string[], cwd: string): Promise<{ exitCode: number; stdout: string }> {
@@ -277,8 +289,13 @@ export function workspaceCheckoutFailureReasonRef(error: unknown): string | null
   return error instanceof WorkspaceCheckoutError ? error.reasonRef : null
 }
 
-async function runCheckedCommand(args: string[], cwd: string, reasonRef?: string): Promise<void> {
-  const exitCode = await runQuietCommand(args, cwd)
+async function runCheckedCommand(
+  args: string[],
+  cwd: string,
+  reasonRef?: string,
+  signal?: AbortSignal,
+): Promise<void> {
+  const exitCode = await runQuietCommand(args, cwd, signal)
   if (exitCode !== 0) {
     if (reasonRef !== undefined) throw new WorkspaceCheckoutError(reasonRef)
     throw new Error(`command failed: ${args[0] ?? "unknown"}`)
@@ -586,14 +603,15 @@ export function detectInFlightVirtualBranchConflicts(
 export const defaultGitCheckoutRunner: WorkspaceCheckoutRunner = async (
   workingDirectory,
   checkout,
+  signal,
 ) => {
   const baseCommitSha = checkoutBaseCommitSha(checkout)
   await rm(workingDirectory, { recursive: true, force: true })
   await mkdir(workingDirectory, { recursive: true })
-  await runCheckedCommand(["git", "init"], workingDirectory, "reason.workspace_checkout.init_failed")
+  await runCheckedCommand(["git", "init"], workingDirectory, "reason.workspace_checkout.init_failed", signal)
   // Each detached checkout is isolated, but disabling auto maintenance keeps a
   // background `git gc` from ever racing a concurrent sibling materialization.
-  await disableGitAutoMaintenance(workingDirectory)
+  await disableGitAutoMaintenance(workingDirectory, signal)
   await runCheckedCommand(
     [
       "git",
@@ -604,16 +622,19 @@ export const defaultGitCheckoutRunner: WorkspaceCheckoutRunner = async (
     ],
     workingDirectory,
     "reason.workspace_checkout.remote_add_failed",
+    signal,
   )
   await runCheckedCommand(
     ["git", "fetch", "--depth", "1", "origin", baseCommitSha],
     workingDirectory,
     "reason.workspace_checkout.fetch_failed",
+    signal,
   )
   await runCheckedCommand(
     ["git", "checkout", "--detach", baseCommitSha],
     workingDirectory,
     "reason.workspace_checkout.checkout_failed",
+    signal,
   )
 }
 
@@ -624,9 +645,9 @@ export const defaultGitCheckoutRunner: WorkspaceCheckoutRunner = async (
  * sibling materialization on the shared object store. Best-effort: a failure
  * to set config never fails the checkout.
  */
-async function disableGitAutoMaintenance(gitDirectory: string): Promise<void> {
-  await runQuietCommand(["git", "config", "gc.auto", "0"], gitDirectory)
-  await runQuietCommand(["git", "config", "maintenance.auto", "false"], gitDirectory)
+async function disableGitAutoMaintenance(gitDirectory: string, signal?: AbortSignal): Promise<void> {
+  await runQuietCommand(["git", "config", "gc.auto", "0"], gitDirectory, signal)
+  await runQuietCommand(["git", "config", "maintenance.auto", "false"], gitDirectory, signal)
 }
 
 /**

--- a/apps/pylon/tests/workspace-materializer.test.ts
+++ b/apps/pylon/tests/workspace-materializer.test.ts
@@ -1,14 +1,16 @@
 import { describe, expect, test } from "bun:test"
 import { existsSync } from "node:fs"
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises"
+import { mkdir, mkdtemp, readdir, rm, writeFile } from "node:fs/promises"
 import { join } from "node:path"
 import { tmpdir } from "node:os"
+import { Effect, Fiber } from "effect"
 import {
   checkoutBaseCommitSha,
   checkoutSourceRef,
   cleanupOldestMaterializedWorkspaces,
   gitCheckoutWorkspaceFrom,
   materializeGitCheckoutWorkspace,
+  materializeGitCheckoutWorkspaceEffect,
   materializeGitCheckoutWorkspaceWithLease,
   removeMaterializedWorkspace,
   type GitCheckoutWorkspace,
@@ -260,6 +262,55 @@ describe("materializeGitCheckoutWorkspace", () => {
       expect(first.workingDirectory).not.toBe(second.workingDirectory)
       expect(existsSync(first.workingDirectory)).toBe(true)
       expect(existsSync(second.workingDirectory)).toBe(true)
+    } finally {
+      await rm(cacheRoot, { recursive: true, force: true })
+    }
+  })
+
+  test("Effect-scoped materialization removes a partial workspace on interruption", async () => {
+    const cacheRoot = await mkdtemp(join(tmpdir(), "pylon-workspace-cache-"))
+    let releaseStarted: (() => void) | undefined
+    const started = new Promise<void>((resolve) => {
+      releaseStarted = resolve
+    })
+    let abortObserved = false
+    const interruptedRunner: WorkspaceCheckoutRunner = async (workingDirectory, _checkout, signal) => {
+      await mkdir(workingDirectory, { recursive: true })
+      await writeFile(join(workingDirectory, "partial"), "started\n")
+      releaseStarted?.()
+      await new Promise<void>((_resolve, reject) => {
+        signal?.addEventListener(
+          "abort",
+          () => {
+            abortObserved = true
+            reject(new Error("checkout interrupted"))
+          },
+          { once: true },
+        )
+      })
+    }
+
+    try {
+      await Effect.runPromise(
+        Effect.scoped(
+          Effect.gen(function* () {
+            const fiber = yield* Effect.forkScoped(
+              materializeGitCheckoutWorkspaceEffect({
+                cacheRoot,
+                checkout: validCheckout,
+                checkoutRunner: interruptedRunner,
+                leaseRef: "lease.public.workspace.interrupted",
+                refPrefix: "workspace.pylon.codex_agent_task",
+              }),
+            )
+            yield* Effect.promise(() => started)
+            yield* Fiber.interrupt(fiber)
+          }),
+        ),
+      )
+
+      expect(abortObserved).toBe(true)
+      expect((await readdir(cacheRoot)).filter((entry) => entry.startsWith("workspace.pylon."))).toEqual([])
     } finally {
       await rm(cacheRoot, { recursive: true, force: true })
     }


### PR DESCRIPTION
## Summary

- add an Effect-scoped workspace materialization helper that cleans partial workspace directories on checkout failure or fiber interruption
- keep the existing Promise API as a wrapper over the scoped Effect path
- add interruption coverage for partial workspace cleanup

Closes #7013.

## Verification

- `bun test tests/workspace-materializer.test.ts tests/workspace-worktree.test.ts` (in `apps/pylon`)
- `bun run typecheck` (in `apps/pylon`)

Note: the requested command ref `command.public.pylon_khala.verify.b5bea41b6c623f7c09f1bf24` was not resolvable to argv from local checkout metadata or the Pylon CLI command catalog, so I ran the focused public verifier for the touched Pylon workspace materializer path directly.