### PR TITLE
fix(glm): admit internal stress on idle GLM headroom

### DIFF
--- a/apps/openagents.com/workers/api/src/index.ts
+++ b/apps/openagents.com/workers/api/src/index.ts
@@ -10384,7 +10384,7 @@ const dispatchFailureTelemetry = makeBoundedDispatchFailureTelemetry({
 const glmOwnCapacityFailover = makeGlmOwnCapacityFailover({
   failureThreshold: 3,
   isRecovered: () =>
-    latestHydraliskGlm52RouteAdmission?.reservedExternalHeadroomAvailable ===
+    latestHydraliskGlm52RouteAdmission?.internalStressHeadroomAvailable ===
     true,
   onAlert: event => {
     logWorkerRouteWarning('glm_own_capacity_failover_alert', {

--- a/apps/openagents.com/workers/api/src/inference/chat-completions-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/chat-completions-routes.test.ts
@@ -3285,6 +3285,7 @@ describe('POST /v1/chat/completions', () => {
           lanePlan: () => ['primary'],
           registry,
           routeAdmission: {
+            internalStressHeadroomAvailable: false,
             reason: 'glm_reserved_external_headroom_unavailable',
             reservedExternalHeadroomAvailable: false,
           },
@@ -3299,6 +3300,41 @@ describe('POST /v1/chat/completions', () => {
       },
     })
     expect(registerCalls).toBe(0)
+  })
+
+  test('admits internal_stress when GLM has an idle slot but external reserve is unavailable', async () => {
+    let dispatched = false
+    const registry = new InferenceProviderRegistry()
+    registry.register({
+      ...echoAdapter('primary'),
+      complete: request => {
+        dispatched = true
+        return stubEchoAdapter.complete(request)
+      },
+    })
+
+    const response = await run(
+      handleChatCompletions(
+        chatRequest(helloBody, {
+          headers: {
+            [INFERENCE_DEMAND_KIND_HEADER]: 'internal_stress',
+            [INFERENCE_DEMAND_SOURCE_HEADER]: 'glm-saturation',
+          },
+        }),
+        baseDeps({
+          lanePlan: () => ['primary'],
+          registry,
+          routeAdmission: {
+            internalStressHeadroomAvailable: true,
+            reason: 'glm_reserved_external_headroom_unavailable',
+            reservedExternalHeadroomAvailable: false,
+          },
+        }),
+      ),
+    )
+
+    expect(response.status).toBe(200)
+    expect(dispatched).toBe(true)
   })
 
   test('wired GLM saturation proof: internal_stress yields while external overflows and records exact served tokens', async () => {

--- a/apps/openagents.com/workers/api/src/inference/chat-completions-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/chat-completions-routes.test.ts
@@ -3304,6 +3304,18 @@ describe('POST /v1/chat/completions', () => {
 
   test('admits internal_stress when GLM has an idle slot but external reserve is unavailable', async () => {
     let dispatched = false
+    let registerCalls = 0
+    let releaseCalls = 0
+    const coordinator: InternalStressPreemptionCoordinator = {
+      preempt: async () => undefined,
+      register: async () => {
+        registerCalls += 1
+        return async () => {
+          releaseCalls += 1
+        }
+      },
+      snapshot: async () => ({ activeStressCount: 0 }),
+    }
     const registry = new InferenceProviderRegistry()
     registry.register({
       ...echoAdapter('primary'),
@@ -3322,6 +3334,7 @@ describe('POST /v1/chat/completions', () => {
           },
         }),
         baseDeps({
+          internalStressCoordinator: coordinator,
           lanePlan: () => ['primary'],
           registry,
           routeAdmission: {
@@ -3335,6 +3348,8 @@ describe('POST /v1/chat/completions', () => {
 
     expect(response.status).toBe(200)
     expect(dispatched).toBe(true)
+    expect(registerCalls).toBe(1)
+    expect(releaseCalls).toBe(1)
   })
 
   test('wired GLM saturation proof: internal_stress yields while external overflows and records exact served tokens', async () => {

--- a/apps/openagents.com/workers/api/src/inference/chat-completions-routes.ts
+++ b/apps/openagents.com/workers/api/src/inference/chat-completions-routes.ts
@@ -3122,7 +3122,10 @@ export const handleChatCompletions = (
     const internalStressRouteAdmissionRejected =
       routeDemandClass === 'internal_stress' &&
       deps.routeAdmission !== undefined &&
-      deps.routeAdmission.reservedExternalHeadroomAvailable === false
+      !(
+        deps.routeAdmission.internalStressHeadroomAvailable ??
+        deps.routeAdmission.reservedExternalHeadroomAvailable
+      )
     const preemptionAbortController =
       routeDemandClass === 'internal_stress' &&
       !internalStressRouteAdmissionRejected &&

--- a/apps/openagents.com/workers/api/src/inference/hydralisk-adapter.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/hydralisk-adapter.test.ts
@@ -328,6 +328,7 @@ describe('hydralisk vLLM adapter', () => {
     })
 
     expect(runtime.routeAdmission()).toEqual({
+      internalStressHeadroomAvailable: true,
       reason: 'glm_reserved_external_headroom_available',
       reservedExternalHeadroomAvailable: true,
     })
@@ -336,20 +337,22 @@ describe('hydralisk vLLM adapter', () => {
     await startedFetchPromise
 
     expect(runtime.routeAdmission()).toEqual({
-      reason: 'glm_reserved_external_headroom_available',
-      reservedExternalHeadroomAvailable: true,
+      internalStressHeadroomAvailable: true,
+      reason: 'glm_reserved_external_headroom_unavailable',
+      reservedExternalHeadroomAvailable: false,
     })
 
     releaseFetch?.()
     await pending
 
     expect(runtime.routeAdmission()).toEqual({
+      internalStressHeadroomAvailable: true,
       reason: 'glm_reserved_external_headroom_available',
       reservedExternalHeadroomAvailable: true,
     })
   })
 
-  it('rejects route admission only when eligible GLM headroom is exhausted', () => {
+  it('admits internal stress on one idle GLM slot while preserving external reserve state', () => {
     const config = {
       id: GLM_POOL_ADAPTER_ID,
       replicas: [
@@ -361,12 +364,14 @@ describe('hydralisk vLLM adapter', () => {
     }
 
     expect(readHydraliskPoolRouteAdmission(config)).toEqual({
-      reason: 'glm_reserved_external_headroom_available',
-      reservedExternalHeadroomAvailable: true,
+      internalStressHeadroomAvailable: true,
+      reason: 'glm_reserved_external_headroom_unavailable',
+      reservedExternalHeadroomAvailable: false,
     })
     expect(
       readHydraliskPoolRouteAdmission(config, new Map([['primary', 1]])),
     ).toEqual({
+      internalStressHeadroomAvailable: false,
       reason: 'glm_aggregate_external_headroom_zero',
       reservedExternalHeadroomAvailable: false,
     })
@@ -403,6 +408,7 @@ describe('hydralisk vLLM adapter', () => {
     })
 
     expect(runtime.routeAdmission()).toEqual({
+      internalStressHeadroomAvailable: true,
       reason: 'glm_reserved_external_headroom_available',
       reservedExternalHeadroomAvailable: true,
     })
@@ -411,14 +417,16 @@ describe('hydralisk vLLM adapter', () => {
     await startedFetchPromise
 
     expect(runtime.routeAdmission()).toEqual({
-      reason: 'glm_reserved_external_headroom_available',
-      reservedExternalHeadroomAvailable: true,
+      internalStressHeadroomAvailable: true,
+      reason: 'glm_reserved_external_headroom_unavailable',
+      reservedExternalHeadroomAvailable: false,
     })
 
     releaseFetch?.()
     await pending
 
     expect(runtime.routeAdmission()).toEqual({
+      internalStressHeadroomAvailable: true,
       reason: 'glm_reserved_external_headroom_available',
       reservedExternalHeadroomAvailable: true,
     })

--- a/apps/openagents.com/workers/api/src/inference/hydralisk-adapter.ts
+++ b/apps/openagents.com/workers/api/src/inference/hydralisk-adapter.ts
@@ -117,6 +117,7 @@ export type HydraliskPoolAdapterConfig = Readonly<{
 }>
 
 export type HydraliskPoolRouteAdmissionSnapshot = Readonly<{
+  internalStressHeadroomAvailable: boolean
   reason: string
   reservedExternalHeadroomAvailable: boolean
 }>
@@ -957,19 +958,25 @@ const routeAdmissionForHeadroom = (
 ): HydraliskPoolRouteAdmissionSnapshot => {
   if (headroom.aggregateMaxInflight <= 0) {
     return {
+      internalStressHeadroomAvailable: false,
       reason: 'glm_pool_no_external_capacity',
       reservedExternalHeadroomAvailable: false,
     }
   }
   if (headroom.aggregateExternalHeadroom <= 0) {
     return {
+      internalStressHeadroomAvailable: false,
       reason: 'glm_aggregate_external_headroom_zero',
       reservedExternalHeadroomAvailable: false,
     }
   }
   return {
-    reason: 'glm_reserved_external_headroom_available',
-    reservedExternalHeadroomAvailable: true,
+    internalStressHeadroomAvailable: true,
+    reason:
+      headroom.aggregateExternalHeadroom > 1
+        ? 'glm_reserved_external_headroom_available'
+        : 'glm_reserved_external_headroom_unavailable',
+    reservedExternalHeadroomAvailable: headroom.aggregateExternalHeadroom > 1,
   }
 }
 

--- a/apps/openagents.com/workers/api/src/inference/model-router.ts
+++ b/apps/openagents.com/workers/api/src/inference/model-router.ts
@@ -631,6 +631,7 @@ export type DispatchLoadSheddingPolicy = Readonly<{
 
 export type DispatchRouteAdmissionPolicy = Readonly<{
   demandClass: InferenceDemandClass
+  internalStressHeadroomAvailable?: boolean | undefined
   reservedExternalHeadroomAvailable: boolean
   reason: string
 }>
@@ -907,7 +908,10 @@ const shouldRejectAdmission = (
 ): boolean =>
   admission !== undefined &&
   admission.demandClass === 'internal_stress' &&
-  !admission.reservedExternalHeadroomAvailable
+  !(
+    admission.internalStressHeadroomAvailable ??
+    admission.reservedExternalHeadroomAvailable
+  )
 
 const admissionError = (
   admission: DispatchRouteAdmissionPolicy,


### PR DESCRIPTION
## Summary
- Split GLM route admission into `internalStressHeadroomAvailable` and `reservedExternalHeadroomAvailable`.
- Allow `internal_stress` / `glm-saturation` traffic to dispatch when one real GLM slot is idle, while keeping external reserve state false so external demand can still preempt/yield stress.
- Clear the GLM own-capacity failover breaker when any real GLM slot is back, not only when more-than-reserved external headroom is available.

Closes #6963

## Verification
- `bun run --cwd apps/openagents.com/workers/api test -- src/inference/hydralisk-adapter.test.ts src/inference/chat-completions-routes.test.ts src/inference/model-router.test.ts`
- `true` (requested verifier ref `command.public.pylon_khala.verify.b5bea41b6c623f7c09f1bf24`)
- `bun run --cwd apps/openagents.com/workers/api typecheck` (exit 0; existing Effect language-service messages only)

## Live probe note
A bounded production `internal_stress` / `glm-saturation` probe from this checkout timed out with zero response bytes before this patch is deployed, so it is diagnostic only and not post-fix proof.
