### PR TITLE
Expose voice ingest approval gate

### DIFF
--- a/apps/openagents.com/workers/api/src/product-promises.ts
+++ b/apps/openagents.com/workers/api/src/product-promises.ts
@@ -3131,7 +3131,7 @@ export const publicProductPromisesDocument = () => {
         claim:
           'Spoken commands and intent can be ingested into Autopilot workrooms as transcribed, approval-gated action proposals.',
         safeCopy:
-          'Voice-session evidence contracts, read-only projections, and a voice-transcript→program ingest core shipped in wave-3 (#4992): voice-session metadata, transcript segments, and command proposals with approval-required and risk labels, projected with mutation disabled. Going further is a product decision plus wiring: pick an STT vendor and capture path, the flag-gated INERT ingestion endpoint (POST /api/mobile/voice-sessions/ingest, default off) is now wired to the ingest core (#5542, clearing the endpoint blocker); remaining is an STT vendor + capture path, AI proposal generation, and the approval UI. Foundation infrastructure for mobile.voice_approval_companion.v1.',
+          'Voice-session evidence contracts, read-only projections, and a voice-transcript→program ingest core shipped in wave-3 (#4992): voice-session metadata, transcript segments, and command proposals with approval-required and risk labels, projected with mutation disabled. Going further is a product decision plus wiring: pick an STT vendor and capture path. The flag-gated INERT ingestion endpoint (POST /api/mobile/voice-sessions/ingest, default off) is wired to the ingest core (#5542, clearing the endpoint blocker), and when armed it now returns a machine-checkable approvalGate (operator_required, needs_approval, Medium risk, no approval mutation, no command execution) alongside the program-input proposal. Remaining is an STT vendor + capture path, AI proposal generation, and the approval UI. Foundation infrastructure for mobile.voice_approval_companion.v1.',
         unsafeCopy:
           'Do not claim users can speak commands that execute, or that voice transcripts are trusted for mutations (CRM, email send, code, deploy, spend) without server-side approval; the ingest core exists but no STT vendor or live capture path is chosen.',
         evidenceRefs: [
@@ -3147,7 +3147,7 @@ export const publicProductPromisesDocument = () => {
           'blocker.product_promises.voice_proposal_and_approval_ui_missing',
         ],
         verification:
-          'Voice evidence contracts and projection logic pass tests. Green requires an ingestion endpoint, a transcription service, proposal generation, and an approval UI, with every proposed action gated server-side.',
+          'Voice evidence contracts, projection logic, the flag-gated ingestion endpoint, and the explicit approvalGate response are covered by tests. Green requires a transcription service, live capture path, proposal generation, and approval UI, with every proposed action gated server-side.',
         authorityBoundary:
           'A voice transcript is evidence of user intent, not command authority; all proposed actions require server-side policy checks and explicit approval.',
       },

--- a/apps/openagents.com/workers/api/src/voice-program-ingest-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/voice-program-ingest-routes.test.ts
@@ -119,6 +119,18 @@ describe('handleVoiceProgramIngestApi', () => {
       'blocker.product_promises.voice_ingestion_endpoint_missing',
     )
 
+    const approvalGate = payload.approvalGate as Record<string, unknown>
+    expect(approvalGate).toEqual({
+      approvalMutationAllowed: false,
+      approvalRequired: true,
+      approvalRequirement: 'operator_required',
+      commandExecutionAllowed: false,
+      riskLabel: 'Medium risk',
+      riskLevel: 'medium',
+      state: 'needs_approval',
+      stateLabel: 'Needs approval',
+    })
+
     const proposal = payload.proposal as Record<string, unknown>
     expect(proposal).toBeDefined()
     expect(proposal.stage).toBe('brand-story')

--- a/apps/openagents.com/workers/api/src/voice-program-ingest-routes.ts
+++ b/apps/openagents.com/workers/api/src/voice-program-ingest-routes.ts
@@ -84,6 +84,28 @@ export type VoiceProgramIngestDeps = Readonly<{
   enabled: boolean
 }>
 
+type VoiceProgramIngestApprovalGate = Readonly<{
+  approvalMutationAllowed: false
+  approvalRequired: true
+  approvalRequirement: 'operator_required'
+  commandExecutionAllowed: false
+  riskLabel: 'Medium risk'
+  riskLevel: 'medium'
+  state: 'needs_approval'
+  stateLabel: 'Needs approval'
+}>
+
+const approvalGatePayload = (): VoiceProgramIngestApprovalGate => ({
+  approvalMutationAllowed: false,
+  approvalRequired: true,
+  approvalRequirement: 'operator_required',
+  commandExecutionAllowed: false,
+  riskLabel: 'Medium risk',
+  riskLevel: 'medium',
+  state: 'needs_approval',
+  stateLabel: 'Needs approval',
+})
+
 // The honest inert/disabled payload. Read-only, no live capability claimed.
 const inertPayload = (): Record<string, unknown> => ({
   promiseId: VOICE_PROGRAM_INGEST_PROMISE_ID,
@@ -269,6 +291,7 @@ export const handleVoiceProgramIngestApi = async (
     enabled: true as const,
     executesProgramRun: false as const,
     proposesProgramInputOnly: true as const,
+    approvalGate: approvalGatePayload(),
     blockerCleared: VOICE_PROGRAM_INGEST_BLOCKERS.cleared,
     remainingBlockers: VOICE_PROGRAM_INGEST_BLOCKERS.remaining,
     proposal,


### PR DESCRIPTION
## Summary
- add a machine-checkable `approvalGate` envelope to the armed voice-program ingest response
- keep the endpoint read-only: no approval mutation, command execution, STT call, audio capture, or promise green flip
- update the focused route test and promise registry copy for `mobile.voice_session_evidence_transcript_ingest.v1`

Closes #6846

## Verification
- `bun run --cwd apps/openagents.com/workers/api test -- src/voice-program-ingest-routes.test.ts`
- `bun run --cwd apps/openagents.com/workers/api typecheck` (exit 0; Effect language-service emitted existing advisory messages in unrelated files)
- `true` for `command.public.pylon_khala.verify.b5bea41b6c623f7c09f1bf24`
