### PR TITLE
feat(operator): surface fleet assignment progress

### DIFF
--- a/apps/openagents.com/workers/api/src/operator-fleet-status-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/operator-fleet-status-routes.test.ts
@@ -50,6 +50,44 @@ const rowsForSql = (sql: string): ReadonlyArray<Record<string, unknown>> => {
     ]
   }
 
+  if (sql.includes('FROM pylon_api_events')) {
+    const rows = [
+      {
+        assignment_ref: 'assignment.public.issue_6427',
+        created_at: '2026-06-27T18:40:50.000Z',
+        event_body_json: JSON.stringify({
+          artifactRefs: ['artifact.public.assignment.testing'],
+        }),
+        event_kind: 'artifact_proof_metadata',
+        event_ref: 'event.public.assignment.issue_6427.artifact.testing',
+        status: 'submitted',
+      },
+      {
+        assignment_ref: 'assignment.public.issue_6427',
+        created_at: '2026-06-27T18:40:30.000Z',
+        event_body_json: JSON.stringify({
+          progressPercent: 65,
+          progressRefs: ['progress.public.assignment.testing'],
+        }),
+        event_kind: 'assignment_progress',
+        event_ref: 'event.public.assignment.issue_6427.progress.testing',
+        status: 'ok',
+      },
+    ]
+    return sql.includes("event_kind = 'assignment_progress'")
+      ? rows.filter(row => row.event_kind === 'assignment_progress')
+      : rows
+  }
+
+  if (sql.includes('FROM token_usage_events') && sql.includes('task_ref')) {
+    return [
+      {
+        task_ref: 'assignment.public.issue_6427',
+        total_tokens: 4096,
+      },
+    ]
+  }
+
   if (sql.includes('FROM pylon_api_assignments')) {
     return [
       {
@@ -191,7 +229,7 @@ describe('operator fleet status route', () => {
     expect(first.headers.get('x-openagents-cache')).toBe('miss')
     expect(second.headers.get('x-openagents-cache')).toBe('hit')
     expect(log.length).toBeGreaterThan(0)
-    expect(log.length).toBe(9)
+    expect(log.length).toBe(11)
     expect(cachedBody).toEqual(body)
     expect(body).toMatchObject({
       authority: {
@@ -209,9 +247,16 @@ describe('operator fleet status route', () => {
           {
             assignmentRef: 'assignment.public.issue_6427',
             elapsedMs: 660000,
-            lastProgressEvent: null,
+            lastProgressEvent: {
+              eventKind: 'assignment_progress',
+              eventRef: 'event.public.assignment.issue_6427.progress.testing',
+              observedAt: '2026-06-27T18:40:30.000Z',
+              progressPercent: 65,
+              progressRefs: ['progress.public.assignment.testing'],
+              status: 'ok',
+            },
             phase: 'running',
-            tokensSoFar: null,
+            tokensSoFar: 4096,
           },
         ],
         activeSlots: 3,
@@ -287,8 +332,15 @@ describe('operator fleet status route', () => {
 
     expect(response.status).toBe(200)
     expect(body.fleet.sourceRefs).toContain('d1:pylon_api_registrations')
+    expect(body.fleet.sourceRefs).toContain('d1:pylon_api_events')
+    expect(body.fleet.sourceRefs).toContain('d1:token_usage_events')
     expect(log.some(sql => sql.includes('owner_agent_user_id = ?'))).toBe(true)
     expect(log.some(sql => sql.includes('AND user_id = ?'))).toBe(true)
+    expect(log.some(sql => sql.includes('AND actor_user_id = ?'))).toBe(true)
+    expect(log.some(sql => sql.includes("event_kind = 'assignment_progress'"))).toBe(true)
+    expect(log.some(sql => sql.includes('assignment_ref IN ('))).toBe(true)
+    expect(log.some(sql => sql.includes('task_ref IN ('))).toBe(true)
+    expect(log.some(sql => sql.includes("usage_truth = 'exact'"))).toBe(true)
   })
 
   test('keeps the legacy fleet status path admin-token only', async () => {

--- a/apps/openagents.com/workers/api/src/operator-fleet-status-routes.ts
+++ b/apps/openagents.com/workers/api/src/operator-fleet-status-routes.ts
@@ -1,7 +1,7 @@
 import { jsonResponse } from '@openagentsinc/sync-worker'
 
 import { methodNotAllowed, noStoreJsonResponse } from './http/responses'
-import { parseJsonStringArray } from './json-boundary'
+import { parseJsonRecord, parseJsonStringArray } from './json-boundary'
 import { openAgentsDatabase } from './runtime'
 import { currentIsoTimestamp } from './runtime-primitives'
 
@@ -43,6 +43,20 @@ type AssignmentRow = Readonly<{
   created_at: string
   updated_at: string
   lease_expires_at: string
+}>
+
+type AssignmentProgressEventRow = Readonly<{
+  assignment_ref: string
+  created_at: string
+  event_body_json: string
+  event_kind: string
+  event_ref: string
+  status: string
+}>
+
+type AssignmentTokenRow = Readonly<{
+  task_ref: string
+  total_tokens: number | null
 }>
 
 type AlertRow = Readonly<{
@@ -110,6 +124,21 @@ const millisBetween = (startIso: string, endIso: string): number => {
     : 0
 }
 
+const optionalNumber = (value: unknown): number | null =>
+  typeof value === 'number' && Number.isFinite(value) ? value : null
+
+const progressEventFromRow = (row: AssignmentProgressEventRow) => {
+  const body = parseJsonRecord(row.event_body_json) ?? {}
+  return {
+    eventKind: row.event_kind,
+    eventRef: row.event_ref,
+    observedAt: row.created_at,
+    progressPercent: optionalNumber(body.progressPercent),
+    progressRefs: parseJsonStringArray(JSON.stringify(body.progressRefs ?? [])),
+    status: row.status,
+  }
+}
+
 const safeAll = async <T>(
   db: D1Database,
   sql: string,
@@ -159,10 +188,14 @@ const buildFleetStatusSnapshot = async (
       : ''
   const accountOwnerClause = scope.kind === 'agent' ? 'AND user_id = ?' : ''
   const ownerBindings = scope.kind === 'agent' ? [scope.userId] : []
+  const repeatedOwnerBindings =
+    scope.kind === 'agent' ? [scope.userId, scope.userId] : []
   const [
     registrations,
     assignments,
     providerAccounts,
+    progressEvents,
+    assignmentTokenRows,
     latestAlert,
     today,
     yesterday,
@@ -208,6 +241,49 @@ const buildFleetStatusSnapshot = async (
           provider_account_ref ASC
         LIMIT 100`,
       ...ownerBindings,
+    ),
+    safeAll<AssignmentProgressEventRow>(
+      db,
+      `SELECT assignment_ref, created_at, event_body_json, event_kind,
+              event_ref, status
+         FROM pylon_api_events
+        WHERE archived_at IS NULL
+          AND assignment_ref IS NOT NULL
+          AND event_kind = 'assignment_progress'
+          ${scope.kind === 'agent' ? 'AND owner_agent_user_id = ?' : ''}
+          AND assignment_ref IN (
+            SELECT assignment_ref
+              FROM pylon_api_assignments
+             WHERE archived_at IS NULL
+               ${assignmentOwnerClause}
+               AND state IN ('offered','accepted','running','proof_submitted')
+          )
+        ORDER BY created_at DESC
+        LIMIT 100`,
+      ...repeatedOwnerBindings,
+    ),
+    safeAll<AssignmentTokenRow>(
+      db,
+      `SELECT task_ref, COALESCE(SUM(total_tokens), 0) AS total_tokens
+         FROM token_usage_events
+        WHERE task_ref IS NOT NULL
+          AND provider = 'pylon-codex-own-capacity'
+          AND model = 'openagents/pylon-codex'
+          AND usage_truth = 'exact'
+          AND demand_kind = 'own_capacity'
+          AND demand_source = 'khala_coding_delegation'
+          ${scope.kind === 'agent' ? 'AND actor_user_id = ?' : ''}
+          AND task_ref IN (
+            SELECT assignment_ref
+              FROM pylon_api_assignments
+             WHERE archived_at IS NULL
+               ${assignmentOwnerClause}
+               AND state IN ('offered','accepted','running','proof_submitted')
+          )
+        GROUP BY task_ref
+        ORDER BY MAX(observed_at) DESC
+        LIMIT 200`,
+      ...repeatedOwnerBindings,
     ),
     safeFirst<AlertRow>(
       db,
@@ -284,6 +360,19 @@ const buildFleetStatusSnapshot = async (
   const activeAssignments = assignments.filter(row =>
     row.state === 'accepted' || row.state === 'running' || row.state === 'proof_submitted',
   )
+  const latestProgressByAssignment = new Map<
+    string,
+    ReturnType<typeof progressEventFromRow>
+  >()
+  for (const row of progressEvents) {
+    if (!latestProgressByAssignment.has(row.assignment_ref)) {
+      latestProgressByAssignment.set(row.assignment_ref, progressEventFromRow(row))
+    }
+  }
+  const tokensByAssignment = new Map<string, number>()
+  for (const row of assignmentTokenRows) {
+    tokensByAssignment.set(row.task_ref, Math.max(0, Math.trunc(row.total_tokens ?? 0)))
+  }
   const accountLedger = providerAccounts.map(row => {
     const cooldownExpiresAt =
       row.cooldown_until !== null && row.cooldown_until > nowIso
@@ -369,24 +458,27 @@ const buildFleetStatusSnapshot = async (
       busySlots,
       queuedSlots,
       spread: fleetAccounts,
-      activeAssignments: assignments.map(row => ({
-        assignmentRef: row.assignment_ref,
-        pylonRef: row.pylon_ref,
-        jobKind: row.job_kind,
-        state: row.state,
-        elapsedMs: millisBetween(row.created_at, nowIso),
-        phase:
-          row.state === 'proof_submitted'
-            ? 'proof'
-            : row.state === 'running' || row.state === 'accepted'
-              ? 'running'
-              : 'queued',
-        tokensSoFar: null,
-        lastProgressEvent: null,
-        lastLog: null,
-        updatedAt: row.updated_at,
-        leaseExpiresAt: row.lease_expires_at,
-      })),
+      activeAssignments: assignments.map(row => {
+        const progressEvent = latestProgressByAssignment.get(row.assignment_ref) ?? null
+        return {
+          assignmentRef: row.assignment_ref,
+          pylonRef: row.pylon_ref,
+          jobKind: row.job_kind,
+          state: row.state,
+          elapsedMs: millisBetween(row.created_at, nowIso),
+          phase:
+            row.state === 'proof_submitted'
+              ? 'proof'
+              : row.state === 'running' || row.state === 'accepted'
+                ? 'running'
+                : 'queued',
+          tokensSoFar: tokensByAssignment.get(row.assignment_ref) ?? 0,
+          lastProgressEvent: progressEvent,
+          lastLog: null,
+          updatedAt: row.updated_at,
+          leaseExpiresAt: row.lease_expires_at,
+        }
+      }),
       inFlightAssignments: assignments.map(row => ({
         assignmentRef: row.assignment_ref,
         pylonRef: row.pylon_ref,
@@ -397,7 +489,12 @@ const buildFleetStatusSnapshot = async (
         leaseExpiresAt: row.lease_expires_at,
       })),
       activeAssignmentCount: activeAssignments.length,
-      sourceRefs: ['d1:pylon_api_registrations', 'd1:pylon_api_assignments'],
+      sourceRefs: [
+        'd1:pylon_api_registrations',
+        'd1:pylon_api_assignments',
+        'd1:pylon_api_events',
+        'd1:token_usage_events',
+      ],
     },
     accounts: {
       status: accountLedger,


### PR DESCRIPTION
Addresses #7230.

### Changes
- Enrich `/api/operator/fleet/state` active assignments with the latest public-safe `assignment_progress` event.
- Add exact own-capacity token totals per active assignment from `token_usage_events`.
- Preserve owner-scoped reads for agent-token access and keep the legacy `/api/operator/fleet/status` path admin-token only.

### Verification
- `bun run --cwd apps/openagents.com/workers/api test -- src/operator-fleet-status-routes.test.ts` - passed
- `bun run --cwd apps/openagents.com/workers/api typecheck --pretty false` - passed with existing Effect diagnostic messages only
- `true` (`command.public.pylon_khala.verify.b5bea41b6c623f7c09f1bf24`) - passed
