### PR TITLE
fix(khala): expose free-tier capture gate blockers

### DIFF
--- a/apps/openagents.com/apps/web/public/AGENTS.md
+++ b/apps/openagents.com/apps/web/public/AGENTS.md
@@ -70,12 +70,16 @@ or wait for the UTC reset. Full quickstart (curl + Python + JS, limits, errors):
 `docs/faq/khala-inference-quickstart.md`.
 
 **Free-tier data sharing (read this).** When you use the free Khala API without
-paying for privacy, your traffic is **captured by default** as a **redacted,
-private-by-default (`owner_only`)** trace and **may be used to improve and train**
-OpenAgents models. **Pay for privacy** (or run confidential compute) to opt out of
-capture entirely. A captured trace is shared **publicly only if its owner opts it
-in**. Capture grants **no payout or settlement** (the data-market reward marker is
-inert and owner-gated). The full canonical terms are agent-readable at
+paying for privacy and the owner-gated production capture flag is armed, your
+traffic is **captured by default** as a **redacted, private-by-default
+(`owner_only`)** trace and **may be used to improve and train** OpenAgents
+models. Default-on production capture remains owner-gated by
+`KHALA_FREE_TIER_TRACE_CAPTURE_DEFAULT`; until that gate is armed, only
+explicitly opted-in trace emission is captured. **Pay for privacy** (or run
+confidential compute) to opt out of capture entirely. A captured trace is shared
+**publicly only if its owner opts it in**. Capture grants **no payout or
+settlement** (the data-market reward marker is inert and owner-gated). The full
+canonical terms are agent-readable at
 `GET https://openagents.com/api/public/free-tier-data-sharing` (also embedded in
 the `POST /api/keys/free` mint response as `dataSharing`), and tracked as the
 `data.free_tier_capture_disclosure.v1` product promise.

--- a/apps/openagents.com/workers/api/src/free-key-mint-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/free-key-mint-routes.test.ts
@@ -155,7 +155,17 @@ describe('POST /api/keys/free (issue #6228)', () => {
       dataSharing: {
         promiseId: string
         terms: ReadonlyArray<string>
-        policy: { capturedByDefault: boolean; paidPrivacyOptOut: boolean }
+        policy: {
+          capturedByDefault: boolean
+          defaultCaptureGate: string
+          paidPrivacyOptOut: boolean
+        }
+        gates: {
+          defaultCapture: { state: string }
+          paidPrivacyOptOut: { failClosed: boolean }
+          traceRewards: { payoutClaimAllowed: boolean }
+        }
+        blockerRefs: ReadonlyArray<string>
       }
     }
     expect(body.tier).toBe('free')
@@ -169,7 +179,14 @@ describe('POST /api/keys/free (issue #6228)', () => {
     )
     expect(body.dataSharing.terms.length).toBeGreaterThan(0)
     expect(body.dataSharing.policy.capturedByDefault).toBe(true)
+    expect(body.dataSharing.policy.defaultCaptureGate).toBe('owner_gated')
     expect(body.dataSharing.policy.paidPrivacyOptOut).toBe(true)
+    expect(body.dataSharing.gates.defaultCapture.state).toBe('owner_gated')
+    expect(body.dataSharing.gates.paidPrivacyOptOut.failClosed).toBe(true)
+    expect(body.dataSharing.gates.traceRewards.payoutClaimAllowed).toBe(false)
+    expect(body.dataSharing.blockerRefs).toContain(
+      'blocker.product_promises.paid_khala_business_loop_not_green',
+    )
     // The minted account is now marked free-tier in D1.
     const row = await db
       .prepare(

--- a/apps/openagents.com/workers/api/src/inference/free-tier-data-sharing-disclosure.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/free-tier-data-sharing-disclosure.test.ts
@@ -17,6 +17,7 @@ describe('free-tier data-sharing disclosure (#6296)', () => {
     // The bounded policy facts mirror the runtime capture seams.
     expect(disclosure.policy).toEqual({
       capturedByDefault: true,
+      defaultCaptureGate: 'owner_gated',
       redacted: true,
       defaultVisibility: 'owner_only',
       mayTrain: true,
@@ -25,6 +26,34 @@ describe('free-tier data-sharing disclosure (#6296)', () => {
       rewardInert: true,
     })
     expect(disclosure.reportPath).toContain('forum/f/product-promises')
+    expect(disclosure.blockerRefs).toEqual([
+      'blocker.product_promises.free_tier_capture_default_owner_gated',
+      'blocker.product_promises.disclosure_copy_owner_signoff_pending',
+      'blocker.product_promises.trace_capture_public_disclosure_alignment_required',
+      'blocker.product_promises.trace_capture_reward_marker_inert',
+      'blocker.product_promises.paid_privacy_owner_signoff_pending',
+      'blocker.product_promises.paid_khala_business_loop_not_green',
+    ])
+    expect(disclosure.gates.defaultCapture).toEqual({
+      state: 'owner_gated',
+      envFlag: 'KHALA_FREE_TIER_TRACE_CAPTURE_DEFAULT',
+      blockerRef:
+        'blocker.product_promises.free_tier_capture_default_owner_gated',
+    })
+    expect(disclosure.gates.paidPrivacyOptOut).toEqual({
+      state: 'wired_yellow',
+      failClosed: true,
+      blockerRefs: [
+        'blocker.product_promises.paid_privacy_owner_signoff_pending',
+        'blocker.product_promises.paid_khala_business_loop_not_green',
+      ],
+    })
+    expect(disclosure.gates.traceRewards).toEqual({
+      state: 'inert',
+      payoutClaimAllowed: false,
+      blockerRef:
+        'blocker.product_promises.trace_capture_reward_marker_inert',
+    })
   })
 
   test('terms cover the four honest clauses without overclaiming', () => {
@@ -33,6 +62,8 @@ describe('free-tier data-sharing disclosure (#6296)', () => {
       .toLowerCase()
     // captured by default, redacted, private
     expect(text).toContain('captured by default')
+    expect(text).toContain('owner-gated')
+    expect(text).toContain('khala_free_tier_trace_capture_default')
     expect(text).toContain('redacted')
     expect(text).toContain('owner_only')
     // may improve/train
@@ -53,8 +84,16 @@ describe('free-tier data-sharing disclosure (#6296)', () => {
       ),
     )
     expect(ok.status).toBe(200)
-    const body = (await ok.json()) as { promiseId: string }
+    const body = (await ok.json()) as {
+      promiseId: string
+      gates: { defaultCapture: { state: string } }
+      blockerRefs: ReadonlyArray<string>
+    }
     expect(body.promiseId).toBe(FREE_TIER_DATA_SHARING_PROMISE_ID)
+    expect(body.gates.defaultCapture.state).toBe('owner_gated')
+    expect(body.blockerRefs).toContain(
+      'blocker.product_promises.free_tier_capture_default_owner_gated',
+    )
 
     const denied = await Effect.runPromise(
       handleFreeTierDataSharingDisclosureApi(

--- a/apps/openagents.com/workers/api/src/inference/free-tier-data-sharing-disclosure.ts
+++ b/apps/openagents.com/workers/api/src/inference/free-tier-data-sharing-disclosure.ts
@@ -36,20 +36,22 @@ export const FREE_TIER_DATA_SHARING_PROMISE_ID =
 
 // Disclosure version. Bump when the TERMS text changes (not on unrelated copy
 // edits). Surfaces echo this so a caller/agent can pin which terms they saw.
-export const FREE_TIER_DATA_SHARING_DISCLOSURE_VERSION = '2026-06-25.1' as const
+export const FREE_TIER_DATA_SHARING_DISCLOSURE_VERSION = '2026-06-29.1' as const
 
 // Public, human-readable summary line. Intentionally short and quotable; the
 // full clause list carries the precise terms.
 export const FREE_TIER_DATA_SHARING_SUMMARY: string =
-  'Free API usage is captured by default as redacted, private-by-default traces ' +
-  'that may be used to improve and train OpenAgents models. Pay for privacy ' +
-  '(or use confidential compute) to opt out of capture. Public sharing of a ' +
-  'captured trace is opt-in only.'
+  'Free API usage is captured by default when the owner-gated production ' +
+  'capture flag is armed, as redacted, private-by-default traces that may be ' +
+  'used to improve and train OpenAgents models. Pay for privacy (or use ' +
+  'confidential compute) to opt out of capture. Public sharing of a captured ' +
+  'trace is opt-in only.'
 
 // The precise, code-accurate terms, one bounded clause each. Public-safe: no
 // secrets, no account material, no prompts.
 export const FREE_TIER_DATA_SHARING_TERMS: ReadonlyArray<string> = [
-  'Free tier: when you use the free Khala API (openagents/khala) without paying for privacy, your request/response traffic is captured by default.',
+  'Free tier: when you use the free Khala API (openagents/khala) without paying for privacy and the owner-gated production capture flag is armed, your request/response traffic is captured by default.',
+  'Current gate: default-on production capture remains owner-gated by KHALA_FREE_TIER_TRACE_CAPTURE_DEFAULT; until that gate is armed, only explicitly opted-in trace emission is captured.',
   'Redacted: captured traffic is scrubbed for secrets, credentials, wallet/payment material, and personal data before storage, with a public-safety backstop that drops anything residual.',
   'Private by default: an auto-captured trace is stored owner_only — it is not in any public feed and is not reachable by link until you explicitly choose to share it.',
   'May be used to improve/train: captured free-tier data may be used to improve and train the next generation of OpenAgents models.',
@@ -64,6 +66,9 @@ export type FreeTierDataSharingPolicy = Readonly<{
   // Free-tier traffic is captured by default (subject to the deployment's
   // capture flag being armed; the POLICY default is capture-on for free tier).
   capturedByDefault: true
+  // The production default-capture flip is still owner-gated while the promise
+  // remains yellow.
+  defaultCaptureGate: 'owner_gated'
   // Captured traffic is redacted before storage.
   redacted: true
   // Default stored visibility of an auto-captured trace.
@@ -80,6 +85,7 @@ export type FreeTierDataSharingPolicy = Readonly<{
 
 export const FREE_TIER_DATA_SHARING_POLICY: FreeTierDataSharingPolicy = {
   capturedByDefault: true,
+  defaultCaptureGate: 'owner_gated',
   redacted: true,
   defaultVisibility: 'owner_only',
   mayTrain: true,
@@ -87,6 +93,15 @@ export const FREE_TIER_DATA_SHARING_POLICY: FreeTierDataSharingPolicy = {
   publicSharingOptIn: true,
   rewardInert: true,
 }
+
+export const FREE_TIER_DATA_SHARING_BLOCKER_REFS: ReadonlyArray<string> = [
+  'blocker.product_promises.free_tier_capture_default_owner_gated',
+  'blocker.product_promises.disclosure_copy_owner_signoff_pending',
+  'blocker.product_promises.trace_capture_public_disclosure_alignment_required',
+  'blocker.product_promises.trace_capture_reward_marker_inert',
+  'blocker.product_promises.paid_privacy_owner_signoff_pending',
+  'blocker.product_promises.paid_khala_business_loop_not_green',
+] as const
 
 // The canonical disclosure object surfaced to humans and agents. Stable shape:
 // version + summary + ordered terms + bounded policy facts + reference links.
@@ -102,6 +117,30 @@ export type FreeTierDataSharingDisclosure = Readonly<{
   publicSharing: string
   // Where to report a disclosure mismatch (Forum-first, per repo policy).
   reportPath: string
+  // Explicit blockers that keep the related data/privacy promises yellow.
+  blockerRefs: ReadonlyArray<string>
+  // Public-safe gate summary so agents do not infer green/live behavior from
+  // the policy terms alone.
+  gates: Readonly<{
+    defaultCapture: Readonly<{
+      state: 'owner_gated'
+      envFlag: 'KHALA_FREE_TIER_TRACE_CAPTURE_DEFAULT'
+      blockerRef: 'blocker.product_promises.free_tier_capture_default_owner_gated'
+    }>
+    paidPrivacyOptOut: Readonly<{
+      state: 'wired_yellow'
+      failClosed: true
+      blockerRefs: ReadonlyArray<
+        | 'blocker.product_promises.paid_privacy_owner_signoff_pending'
+        | 'blocker.product_promises.paid_khala_business_loop_not_green'
+      >
+    }>
+    traceRewards: Readonly<{
+      state: 'inert'
+      payoutClaimAllowed: false
+      blockerRef: 'blocker.product_promises.trace_capture_reward_marker_inert'
+    }>
+  }>
   // Public references for the policy and its source.
   references: ReadonlyArray<string>
 }>
@@ -122,6 +161,29 @@ export const freeTierDataSharingDisclosure =
     publicSharing:
       'Auto-captured traces are private (owner_only). A trace is shared publicly only when its owner explicitly opts it into public visibility.',
     reportPath: FREE_TIER_DATA_SHARING_REPORT_PATH,
+    blockerRefs: FREE_TIER_DATA_SHARING_BLOCKER_REFS,
+    gates: {
+      defaultCapture: {
+        state: 'owner_gated',
+        envFlag: 'KHALA_FREE_TIER_TRACE_CAPTURE_DEFAULT',
+        blockerRef:
+          'blocker.product_promises.free_tier_capture_default_owner_gated',
+      },
+      paidPrivacyOptOut: {
+        state: 'wired_yellow',
+        failClosed: true,
+        blockerRefs: [
+          'blocker.product_promises.paid_privacy_owner_signoff_pending',
+          'blocker.product_promises.paid_khala_business_loop_not_green',
+        ],
+      },
+      traceRewards: {
+        state: 'inert',
+        payoutClaimAllowed: false,
+        blockerRef:
+          'blocker.product_promises.trace_capture_reward_marker_inert',
+      },
+    },
     references: [
       'https://openagents.com/docs/product-promises',
       'https://openagents.com/api/public/product-promises',

--- a/apps/openagents.com/workers/api/src/openagents-openapi.ts
+++ b/apps/openagents.com/workers/api/src/openagents-openapi.ts
@@ -4098,10 +4098,12 @@ const requestSchemas = (): JsonSchema => ({
       'optOut',
       'publicSharing',
       'reportPath',
+      'blockerRefs',
+      'gates',
       'references',
     ],
     description:
-      'Canonical, code-accurate data-sharing terms for the free Khala API (#6296). Public-safe: terms text + bounded policy facts only — no secrets, account, or payment material.',
+      'Canonical, code-accurate data-sharing terms for the free Khala API (#6296/#7019). Public-safe: terms text, bounded policy facts, and explicit blocker/gate refs only — no secrets, account, prompt, trace, or payment material.',
     properties: {
       promiseId: {
         type: 'string',
@@ -4123,6 +4125,7 @@ const requestSchemas = (): JsonSchema => ({
         additionalProperties: false,
         required: [
           'capturedByDefault',
+          'defaultCaptureGate',
           'redacted',
           'defaultVisibility',
           'mayTrain',
@@ -4134,6 +4137,7 @@ const requestSchemas = (): JsonSchema => ({
           'Machine-checkable policy facts mirroring the runtime capture seams.',
         properties: {
           capturedByDefault: { type: 'boolean' },
+          defaultCaptureGate: { type: 'string', enum: ['owner_gated'] },
           redacted: { type: 'boolean' },
           defaultVisibility: { type: 'string', enum: ['owner_only'] },
           mayTrain: { type: 'boolean' },
@@ -4145,6 +4149,54 @@ const requestSchemas = (): JsonSchema => ({
       optOut: { type: 'string' },
       publicSharing: { type: 'string' },
       reportPath: { type: 'string' },
+      blockerRefs: {
+        type: 'array',
+        items: { type: 'string' },
+        description:
+          'Public-safe blocker refs that keep the related data/privacy promises yellow.',
+      },
+      gates: {
+        type: 'object',
+        additionalProperties: false,
+        required: ['defaultCapture', 'paidPrivacyOptOut', 'traceRewards'],
+        description:
+          'Public-safe gate summary so agents do not infer green/live behavior from policy terms alone.',
+        properties: {
+          defaultCapture: {
+            type: 'object',
+            additionalProperties: false,
+            required: ['state', 'envFlag', 'blockerRef'],
+            properties: {
+              state: { type: 'string', enum: ['owner_gated'] },
+              envFlag: {
+                type: 'string',
+                enum: ['KHALA_FREE_TIER_TRACE_CAPTURE_DEFAULT'],
+              },
+              blockerRef: { type: 'string' },
+            },
+          },
+          paidPrivacyOptOut: {
+            type: 'object',
+            additionalProperties: false,
+            required: ['state', 'failClosed', 'blockerRefs'],
+            properties: {
+              state: { type: 'string', enum: ['wired_yellow'] },
+              failClosed: { type: 'boolean' },
+              blockerRefs: { type: 'array', items: { type: 'string' } },
+            },
+          },
+          traceRewards: {
+            type: 'object',
+            additionalProperties: false,
+            required: ['state', 'payoutClaimAllowed', 'blockerRef'],
+            properties: {
+              state: { type: 'string', enum: ['inert'] },
+              payoutClaimAllowed: { type: 'boolean' },
+              blockerRef: { type: 'string' },
+            },
+          },
+        },
+      },
       references: { type: 'array', items: { type: 'string' } },
     },
   },
@@ -5606,7 +5658,7 @@ const paths = (): JsonSchema => ({
       operationId: 'getFreeTierDataSharingDisclosure',
       summary: 'Read free-API data-sharing terms',
       description:
-        'Returns the canonical, code-accurate data-sharing terms for the free Khala API so agents and users can discover them over the API surface, not only in human UI. The honest terms: free API usage is captured by default as REDACTED, PRIVATE (owner_only) traces that may be used to improve and train OpenAgents models; paying for privacy (or running confidential compute) opts you OUT of capture (fail-closed to not-captured); public sharing of a captured trace is owner opt-in only; and being captured grants NO payout or settlement (the data-market reward marker is inert and owner-gated). The same disclosure object is embedded in the POST /api/keys/free mint response. Read-only, no auth, no secrets.',
+        'Returns the canonical, code-accurate data-sharing terms for the free Khala API so agents and users can discover them over the API surface, not only in human UI. The honest terms: free API usage is captured by default when the owner-gated production capture flag is armed, as REDACTED, PRIVATE (owner_only) traces that may be used to improve and train OpenAgents models; paying for privacy (or running confidential compute) opts you OUT of capture (fail-closed to not-captured); public sharing of a captured trace is owner opt-in only; and being captured grants NO payout or settlement (the data-market reward marker is inert and owner-gated). The same disclosure object is embedded in the POST /api/keys/free mint response. Read-only, no auth, no secrets.',
       tags: ['Public Proof', 'Agents'],
       security: publicRead,
       responses: {

--- a/apps/openagents.com/workers/api/src/product-promises.ts
+++ b/apps/openagents.com/workers/api/src/product-promises.ts
@@ -1026,9 +1026,9 @@ export const publicProductPromisesDocument = () => {
         audience: ['user', 'agent', 'contributor', 'public'],
         state: 'yellow',
         claim:
-          'Free Khala API usage is captured by default as redacted, private traces that may be used to improve and train models; pay for privacy to opt out; public sharing is opt-in only.',
+          'Free Khala API usage is captured by default when the owner-gated production capture flag is armed, as redacted, private traces that may be used to improve and train models; pay for privacy to opt out; public sharing is opt-in only.',
         safeCopy:
-          'Free tier: when you use the free Khala API without paying for privacy, your traffic is captured by default as a redacted, private-by-default (owner_only) trace and may be used to improve and train OpenAgents models. Pay for privacy, or run confidential compute, to opt out of capture (fail-closed to not-captured). A captured trace is shared publicly only if its owner explicitly opts it into public visibility. Capture grants no payout or settlement — the data-market reward marker is inert and owner-gated. The canonical terms are served at GET /api/public/free-tier-data-sharing and embedded in the POST /api/keys/free mint response.',
+          'Free tier: when you use the free Khala API without paying for privacy, your traffic is captured by default when the owner-gated production capture flag is armed, as a redacted, private-by-default (owner_only) trace and may be used to improve and train OpenAgents models. Pay for privacy, or run confidential compute, to opt out of capture (fail-closed to not-captured). A captured trace is shared publicly only if its owner explicitly opts it into public visibility. Capture grants no payout or settlement — the data-market reward marker is inert and owner-gated. The canonical terms are served at GET /api/public/free-tier-data-sharing and embedded in the POST /api/keys/free mint response with explicit blocker/gate refs.',
         unsafeCopy:
           'Do not claim free traffic is never captured, do not claim captured traces are public by default, do not claim paid-privacy callers are captured, and do not claim capture earns the user a payout, reward, or settlement.',
         evidenceRefs: [
@@ -1045,9 +1045,13 @@ export const publicProductPromisesDocument = () => {
         blockerRefs: [
           'blocker.product_promises.free_tier_capture_default_owner_gated',
           'blocker.product_promises.disclosure_copy_owner_signoff_pending',
+          'blocker.product_promises.trace_capture_public_disclosure_alignment_required',
+          'blocker.product_promises.trace_capture_reward_marker_inert',
+          'blocker.product_promises.paid_privacy_owner_signoff_pending',
+          'blocker.product_promises.paid_khala_business_loop_not_green',
         ],
         verification:
-          'GET /api/public/free-tier-data-sharing returns the canonical disclosure (version, summary, ordered terms, bounded policy facts) and the POST /api/keys/free mint response embeds the same dataSharing object. The terms must stay accurate to the capture seams: auto-capture is redacted and owner_only (khala-chat-trace-emitter.ts), paid-privacy is excluded fail-closed (inference-privacy-entitlement.ts), public is owner opt-in only, and the reward marker stays inert (#6221). Green requires the default-on capture flip armed in prod (KHALA_FREE_TIER_TRACE_CAPTURE_DEFAULT) and owner-approved public copy.',
+          'GET /api/public/free-tier-data-sharing returns the canonical disclosure (version, summary, ordered terms, bounded policy facts, blocker refs, and gate summary) and the POST /api/keys/free mint response embeds the same dataSharing object. The terms must stay accurate to the capture seams: auto-capture is redacted and owner_only (khala-chat-trace-emitter.ts), default-on production capture is owner-gated by KHALA_FREE_TIER_TRACE_CAPTURE_DEFAULT, paid-privacy is excluded fail-closed (inference-privacy-entitlement.ts), public is owner opt-in only, and the reward marker stays inert (#6221). Green requires the default-on capture flip armed in prod and owner-approved public copy.',
         authorityBoundary:
           'A disclosure grants no spend, payout, settlement, training-consent, or capture authority. It describes policy only; it does not change capture behavior or move money.',
       },

--- a/docs/promises/2026-06-25-free-tier-data-sharing-disclosure.md
+++ b/docs/promises/2026-06-25-free-tier-data-sharing-disclosure.md
@@ -1,6 +1,6 @@
 # Free-API data-sharing terms / consent disclosure (promise record)
 
-> **Status: 2026-06-25.** Disclosure-only. This record documents the honest
+> **Status: 2026-06-29.** Disclosure-only. This record documents the honest
 > free-tier data-sharing terms that back default-on trace capture (#6293). It
 > ships NO capture behavior, NO authority, and moves NO money. It is the policy
 > half of capture going live; the storage/exclusion halves are #6293/#6294/#6295.
@@ -14,14 +14,14 @@
 
 Default-on capture (#6293) must be backed by an honest, discoverable disclosure.
 As of capture going live, free-tier `/api/v1/chat/completions` traffic is
-captured by default as **redacted, private (`owner_only`) ATIF traces** and **may
-be used to improve and train** OpenAgents models. Capturing free traffic for
-training without a clearly disclosed term is not acceptable. Users and agents
-must be told, in plain terms:
+captured by default when the owner-gated production capture flag is armed, as
+**redacted, private (`owner_only`) ATIF traces** and **may be used to improve and
+train** OpenAgents models. Capturing free traffic for training without a clearly
+disclosed term is not acceptable. Users and agents must be told, in plain terms:
 
-> Use the free API and we capture your traffic (redacted, private by default) and
-> may use it to improve/train. Pay for privacy to opt out. Public sharing is
-> opt-in only.
+> Use the free API and, when the owner-gated production capture flag is armed, we
+> capture your traffic (redacted, private by default) and may use it to
+> improve/train. Pay for privacy to opt out. Public sharing is opt-in only.
 
 ## Promise record
 
@@ -31,17 +31,18 @@ productArea: data
 audience: [user, agent, contributor, public]
 state: yellow
 claim: >
-  Free Khala API usage is captured by default as redacted, private traces that
-  may be used to improve and train models; pay for privacy to opt out; public
-  sharing is opt-in only.
+  Free Khala API usage is captured by default when the owner-gated production
+  capture flag is armed, as redacted, private traces that may be used to improve
+  and train models; pay for privacy to opt out; public sharing is opt-in only.
 safeCopy: >
   Free tier: when you use the free Khala API without paying for privacy, your
-  traffic is captured by default as a redacted, private-by-default (owner_only)
-  trace and may be used to improve and train OpenAgents models. Pay for privacy,
-  or run confidential compute, to opt out of capture (fail-closed to
-  not-captured). A captured trace is shared publicly only if its owner explicitly
-  opts it into public visibility. Capture grants no payout or settlement — the
-  data-market reward marker is inert and owner-gated.
+  traffic is captured by default when the owner-gated production capture flag is
+  armed, as a redacted, private-by-default (owner_only) trace and may be used to
+  improve and train OpenAgents models. Pay for privacy, or run confidential
+  compute, to opt out of capture (fail-closed to not-captured). A captured trace
+  is shared publicly only if its owner explicitly opts it into public visibility.
+  Capture grants no payout or settlement — the data-market reward marker is
+  inert and owner-gated.
 unsafeCopy: >
   Do not claim free traffic is never captured, do not claim captured traces are
   public by default, do not claim paid-privacy callers are captured, and do not
@@ -58,6 +59,10 @@ evidenceRefs:
 blockerRefs:
   - blocker.product_promises.free_tier_capture_default_owner_gated
   - blocker.product_promises.disclosure_copy_owner_signoff_pending
+  - blocker.product_promises.trace_capture_public_disclosure_alignment_required
+  - blocker.product_promises.trace_capture_reward_marker_inert
+  - blocker.product_promises.paid_privacy_owner_signoff_pending
+  - blocker.product_promises.paid_khala_business_loop_not_green
 verification: >
   GET /api/public/free-tier-data-sharing returns the canonical disclosure
   (version, summary, ordered terms, bounded policy facts) and POST /api/keys/free
@@ -76,7 +81,7 @@ Every clause maps to a real seam so the disclosure can never overclaim:
 
 | Clause | Backing code |
 | --- | --- |
-| Free tier traffic is **captured by default** | `khala-chat-trace-emitter.ts` (default-on capture flag `KHALA_FREE_TIER_TRACE_CAPTURE_DEFAULT`) |
+| Free tier traffic is **captured by default when the owner-gated production flag is armed** | `khala-chat-trace-emitter.ts` (default-on capture flag `KHALA_FREE_TIER_TRACE_CAPTURE_DEFAULT`) |
 | Captured traffic is **redacted** | `redactTraceValue` scrub + `atifTraceTripwire` fail-closed backstop |
 | **Private by default** (`owner_only`) | `KHALA_AUTO_CAPTURE_VISIBILITY = 'owner_only'` |
 | **May be used to improve/train** | Episode 243 thesis; data market EPIC #6206 |
@@ -103,13 +108,22 @@ Every clause maps to a real seam so the disclosure can never overclaim:
 
 ## Why YELLOW (not green)
 
-The disclosure text is implemented and discoverable, but two gates remain:
+The disclosure text is implemented and discoverable, but these gates remain:
 
 - `free_tier_capture_default_owner_gated`: the default-on capture flip
   (`KHALA_FREE_TIER_TRACE_CAPTURE_DEFAULT`) is owner-gated in prod.
 - `disclosure_copy_owner_signoff_pending`: the user-facing copy is owner-approval
   gated per the audit (the keystone "drafts the terms for the owner to approve;
   the keystone does not ship copy").
+- `trace_capture_public_disclosure_alignment_required`: capture behavior,
+  `AGENTS.md`, the free-key mint response, and
+  `GET /api/public/free-tier-data-sharing` must continue to describe the same
+  gate state.
+- `trace_capture_reward_marker_inert`: trace reward/payout markers remain inert
+  unless a separate paid data-market promise becomes green.
+- `paid_privacy_owner_signoff_pending` and `paid_khala_business_loop_not_green`:
+  paid/confidential opt-out receipts exist, but broad paid privacy copy waits on
+  owner sign-off and the paid Khala business loop.
 
 The terms are written to be true *whether or not* the flip is armed (they
 describe the policy that applies when it is), so they are safe to publish now and

--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/Users/christopherdavid/.pylon-fable/cache/codex-agent-tasks-node-modules-shared/20075bf07df76717d12f16b6/__root__/node_modules


### PR DESCRIPTION
Addresses #7269.

### Changes
- Updates generated dependency contents under `node_modules`.

### Verification
- `true` - passed (exit 0)