### PR TITLE
Improve desktop Codex timeline rendering

### DIFF
--- a/clients/openagents-desktop/src/shared/coding-status.ts
+++ b/clients/openagents-desktop/src/shared/coding-status.ts
@@ -41,10 +41,14 @@ export type CodingTranscriptRole =
   | "user"
 
 export type CodingTranscriptMessage = {
+  readonly detail: string | null
   readonly kind: string
+  readonly label: string
   readonly role: CodingTranscriptRole
+  readonly status: "active" | "completed" | "error" | "info"
   readonly text: string
   readonly timestamp: string | null
+  readonly title: string | null
 }
 
 export type CodingCodexSession = {
@@ -389,6 +393,28 @@ const textFromUnknown = (value: unknown): string | null => {
   )
 }
 
+const compactJsonFromUnknown = (value: unknown): string | null => {
+  if (value === undefined || value === null) return null
+  if (typeof value === "string") return value.trim() === "" ? null : value
+  try {
+    return JSON.stringify(value, null, 2)
+  } catch {
+    return null
+  }
+}
+
+const normalizeToolArguments = (value: unknown): string | null => {
+  const text = compactJsonFromUnknown(value)
+  if (text === null) return null
+  const trimmed = text.trim()
+  if (!trimmed.startsWith("{") && !trimmed.startsWith("[")) return trimmed
+  try {
+    return JSON.stringify(JSON.parse(trimmed), null, 2)
+  } catch {
+    return trimmed
+  }
+}
+
 const transcriptRoleFromMessageRole = (role: string | null): CodingTranscriptRole => {
   if (
     role === "assistant" ||
@@ -401,6 +427,54 @@ const transcriptRoleFromMessageRole = (role: string | null): CodingTranscriptRol
   return "event"
 }
 
+const transcriptStatusFromUnknown = (
+  value: unknown,
+): CodingTranscriptMessage["status"] | null => {
+  const normalized =
+    typeof value === "string" ? value.trim().toLowerCase() : null
+  if (normalized === null || normalized === "") return null
+  if (
+    normalized.includes("fail") ||
+    normalized.includes("error") ||
+    normalized.includes("denied")
+  ) {
+    return "error"
+  }
+  if (
+    normalized.includes("complete") ||
+    normalized.includes("success") ||
+    normalized.includes("done")
+  ) {
+    return "completed"
+  }
+  if (
+    normalized.includes("running") ||
+    normalized.includes("started") ||
+    normalized.includes("pending")
+  ) {
+    return "active"
+  }
+  return "info"
+}
+
+const transcriptMessage = (
+  message: Omit<CodingTranscriptMessage, "detail" | "label" | "status" | "title"> & {
+    readonly detail?: string | null
+    readonly label?: string
+    readonly status?: CodingTranscriptMessage["status"]
+    readonly title?: string | null
+  },
+): CodingTranscriptMessage => ({
+  detail: message.detail ?? null,
+  kind: message.kind,
+  label: message.label ?? message.role,
+  role: message.role,
+  status: message.status ?? "info",
+  text: message.text,
+  timestamp: message.timestamp,
+  title: message.title ?? null,
+})
+
 const transcriptMessageFromResponseItem = (
   payload: JsonObject,
   timestamp: string | null,
@@ -412,66 +486,97 @@ const transcriptMessageFromResponseItem = (
     const text = textFromUnknown(payload.content)
     if (text === null || text.trim() === "") return null
     const role = transcriptRoleFromMessageRole(stringValueFromUnknown(payload.role))
-    return {
+    return transcriptMessage({
       kind: "message",
+      label: role === "assistant" ? "Assistant" : role,
       role,
+      status: role === "assistant" ? "completed" : "info",
       text: truncateTranscriptText(text),
       timestamp,
-    }
+    })
   }
 
   if (type === "agent_message") {
     const text = textFromUnknown(payload.content)
     if (text === null || text.trim() === "") return null
-    return {
+    return transcriptMessage({
       kind: "agent message",
+      label: "Assistant",
       role: "assistant",
+      status: "completed",
       text: truncateTranscriptText(text),
       timestamp,
-    }
+    })
   }
 
   if (type === "reasoning") {
     const text = textFromUnknown(payload.summary) ?? "Reasoning"
-    return {
+    return transcriptMessage({
       kind: "reasoning",
+      label: "Reasoning",
       role: "reasoning",
+      status: "active",
       text: truncateTranscriptText(text),
       timestamp,
-    }
+    })
   }
 
   if (type === "function_call" || type === "custom_tool_call") {
     const name = stringValueFromUnknown(payload.name) ?? "tool"
-    const args = stringValueFromUnknown(payload.arguments) ??
-      stringValueFromUnknown(payload.input)
-    return {
+    const args = normalizeToolArguments(payload.arguments) ??
+      normalizeToolArguments(payload.input)
+    const callId =
+      stringValueFromUnknown(payload.call_id) ??
+      stringValueFromUnknown(payload.id)
+    return transcriptMessage({
+      detail: callId,
       kind: "tool call",
+      label: "Tool call",
       role: "tool",
-      text: args === null ? name : `${name} ${truncateTranscriptText(args)}`,
+      status: transcriptStatusFromUnknown(payload.status) ?? "active",
+      text: args === null ? name : truncateTranscriptText(args),
       timestamp,
-    }
+      title: name,
+    })
   }
 
   if (type === "function_call_output" || type === "custom_tool_call_output") {
-    const text = textFromUnknown(payload.output)
+    const text =
+      textFromUnknown(payload.output) ??
+      stringValueFromUnknown(payload.error) ??
+      stringValueFromUnknown(payload.message)
     if (text === null || text.trim() === "") return null
-    return {
+    const callId =
+      stringValueFromUnknown(payload.call_id) ??
+      stringValueFromUnknown(payload.id)
+    const status =
+      transcriptStatusFromUnknown(payload.status) ??
+      (stringValueFromUnknown(payload.error) === null ? "completed" : "error")
+    return transcriptMessage({
+      detail: callId,
       kind: "tool output",
+      label: status === "error" ? "Tool error" : "Tool result",
       role: "tool",
+      status,
       text: truncateTranscriptText(text),
       timestamp,
-    }
+    })
   }
 
   if (type === "local_shell_call") {
-    const text = textFromUnknown(payload.action) ?? "shell command"
-    return {
+    const text =
+      normalizeToolArguments(payload.action) ??
+      textFromUnknown(payload.action) ??
+      "shell command"
+    return transcriptMessage({
       kind: "shell",
+      label: "Shell",
       role: "tool",
+      status: transcriptStatusFromUnknown(payload.status) ?? "active",
       text: truncateTranscriptText(text),
       timestamp,
-    }
+      title: "local shell",
+    })
   }
 
   return null
@@ -487,12 +592,14 @@ const transcriptMessageFromEvent = (
   if (type === "user_message") {
     const text = stringValueFromUnknown(payload.message) ?? textFromUnknown(payload.text_elements)
     if (text === null || text.trim() === "") return null
-    return {
+    return transcriptMessage({
       kind: "user event",
+      label: "User",
       role: "user",
+      status: "info",
       text: truncateTranscriptText(text),
       timestamp,
-    }
+    })
   }
 
   if (type === "agent_message") {
@@ -500,12 +607,14 @@ const transcriptMessageFromEvent = (
       stringValueFromUnknown(payload.text) ??
       textFromUnknown(payload.content)
     if (text === null || text.trim() === "") return null
-    return {
+    return transcriptMessage({
       kind: "agent event",
+      label: "Assistant",
       role: "assistant",
+      status: "completed",
       text: truncateTranscriptText(text),
       timestamp,
-    }
+    })
   }
 
   const text =
@@ -514,12 +623,16 @@ const transcriptMessageFromEvent = (
     stringValueFromUnknown(payload.text)
   if (text === null) return null
 
-  return {
+  return transcriptMessage({
     kind: type.replaceAll("_", " "),
+    label: type.replaceAll("_", " "),
     role: "event",
+    status:
+      transcriptStatusFromUnknown(payload.status) ??
+      (stringValueFromUnknown(payload.error) === null ? "info" : "error"),
     text: truncateTranscriptText(text),
     timestamp,
-  }
+  })
 }
 
 const firstTranscriptLine = (value: string): string | null => {

--- a/clients/openagents-desktop/src/ui/main.ts
+++ b/clients/openagents-desktop/src/ui/main.ts
@@ -117,6 +117,18 @@ const formatRelativeTimestamp = (value: string | null): string => {
   return `${formatCount(Math.round(hours / 24))}d ago`
 }
 
+const formatMessageTimestamp = (value: string | null): string => {
+  if (value === null) return "No timestamp"
+  const date = new Date(value)
+  if (!Number.isFinite(date.getTime())) return value
+  return new Intl.DateTimeFormat("en-US", {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  }).format(date)
+}
+
 const pylonIsOnline = (pylon: DesktopPylon): boolean =>
   pylon.heartbeatFresh || pylon.status.trim().toLowerCase() === "online"
 
@@ -258,24 +270,62 @@ const messageRow = (message: CodingTranscriptMessage): HTMLElement => {
   const row = document.createElement("article")
   row.className = "coding-message"
   row.dataset.role = message.role
+  row.dataset.kind = message.kind.replaceAll(" ", "-")
+  row.dataset.status = message.status
+
+  const rail = document.createElement("span")
+  rail.className = "coding-message-rail"
+  rail.setAttribute("aria-hidden", "true")
+
+  const content = document.createElement("div")
+  content.className = "coding-message-content"
 
   const heading = document.createElement("div")
   heading.className = "coding-message-heading"
 
-  const role = document.createElement("strong")
-  role.textContent = message.role
+  const identity = document.createElement("div")
+  identity.className = "coding-message-identity"
 
-  const meta = document.createElement("span")
-  meta.textContent = [
-    message.kind,
+  const label = document.createElement("strong")
+  label.textContent = message.label
+
+  const title = document.createElement("span")
+  title.textContent = message.title ?? message.kind
+
+  identity.append(label, title)
+
+  const meta = document.createElement("div")
+  meta.className = "coding-message-meta"
+
+  if (message.detail !== null) {
+    const detail = document.createElement("span")
+    detail.className = "coding-message-detail"
+    detail.textContent = message.detail
+    meta.append(detail)
+  }
+
+  const status = document.createElement("span")
+  status.className = "coding-message-status"
+  status.textContent = message.status
+
+  const time = document.createElement("time")
+  if (message.timestamp !== null) time.dateTime = message.timestamp
+  time.textContent = [
+    formatMessageTimestamp(message.timestamp),
     formatRelativeTimestamp(message.timestamp),
   ].join(" · ")
 
-  const body = document.createElement("p")
+  meta.append(status, time)
+
+  const body = document.createElement(
+    message.role === "tool" ? "pre" : "p",
+  )
+  body.className = "coding-message-body"
   body.textContent = message.text
 
-  heading.append(role, meta)
-  row.append(heading, body)
+  heading.append(identity, meta)
+  content.append(heading, body)
+  row.append(rail, content)
   return row
 }
 

--- a/clients/openagents-desktop/src/ui/styles.css
+++ b/clients/openagents-desktop/src/ui/styles.css
@@ -638,54 +638,214 @@ button {
 }
 
 .coding-transcript-messages {
+  position: relative;
   display: grid;
   align-content: start;
-  gap: 8px;
+  gap: 0;
   min-height: 0;
   overflow: auto;
-  padding: 12px;
+  padding: 12px 12px 12px 10px;
 }
 
 .coding-message {
+  position: relative;
   display: grid;
-  gap: 8px;
-  background: rgba(10, 17, 31, 0.78);
+  grid-template-columns: 18px minmax(0, 1fr);
+  gap: 10px;
+  padding: 0 0 12px;
+  background: transparent;
+  border: 0;
+  border-radius: 0;
 }
 
-.coding-message[data-role="user"] {
+.coding-message:last-child {
+  padding-bottom: 0;
+}
+
+.coding-message-rail {
+  position: relative;
+  min-height: 100%;
+}
+
+.coding-message-rail::before {
+  content: "";
+  position: absolute;
+  top: 20px;
+  bottom: -12px;
+  left: 8px;
+  width: 1px;
+  background: rgba(125, 153, 194, 0.22);
+}
+
+.coding-message:last-child .coding-message-rail::before {
+  display: none;
+}
+
+.coding-message-rail::after {
+  content: "";
+  position: absolute;
+  top: 11px;
+  left: 4px;
+  width: 9px;
+  height: 9px;
+  background: #7d99c2;
+  border: 1px solid rgba(219, 232, 255, 0.56);
+  border-radius: 999px;
+  box-shadow: 0 0 16px -5px rgba(143, 182, 255, 0.74);
+}
+
+.coding-message-content {
+  display: grid;
+  gap: 9px;
+  min-width: 0;
+  padding: 11px 12px 12px;
+  background: rgba(10, 17, 31, 0.78);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 8px;
+}
+
+.coding-message[data-role="user"] .coding-message-content {
   border-color: rgba(143, 182, 255, 0.28);
 }
 
-.coding-message[data-role="assistant"] {
+.coding-message[data-role="assistant"] .coding-message-content {
   border-color: rgba(79, 208, 255, 0.28);
 }
 
 .coding-message[data-role="tool"],
 .coding-message[data-role="reasoning"] {
+  color: #dbe8ff;
+}
+
+.coding-message[data-role="tool"] .coding-message-content,
+.coding-message[data-role="reasoning"] .coding-message-content {
   border-color: rgba(125, 153, 194, 0.22);
+}
+
+.coding-message[data-role="assistant"] .coding-message-rail::after {
+  background: #4fd0ff;
+  box-shadow: 0 0 18px -4px rgba(79, 208, 255, 0.88);
+}
+
+.coding-message[data-role="user"] .coding-message-rail::after {
+  background: #8fb6ff;
+}
+
+.coding-message[data-role="reasoning"] .coding-message-rail::after {
+  background: #c6d8ff;
+}
+
+.coding-message[data-status="error"] .coding-message-content {
+  border-color: rgba(255, 111, 111, 0.46);
+}
+
+.coding-message[data-status="error"] .coding-message-rail::after {
+  background: #ff6f6f;
+  box-shadow: 0 0 18px -4px rgba(255, 111, 111, 0.78);
 }
 
 .coding-message-heading {
   display: flex;
-  align-items: baseline;
+  align-items: flex-start;
   justify-content: space-between;
   gap: 10px;
 }
 
-.coding-message-heading strong {
+.coding-message-identity {
+  display: grid;
+  min-width: 0;
+  gap: 3px;
+}
+
+.coding-message-identity strong {
   color: #dbe8ff;
   font-size: 0.68rem;
   line-height: 1.4;
   text-transform: uppercase;
 }
 
-.coding-message p {
+.coding-message-identity span {
+  overflow: hidden;
+  color: #f4f8ff;
+  font-size: 0.76rem;
+  line-height: 1.35;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.coding-message-meta {
+  display: flex;
+  flex: 0 0 auto;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 6px;
+  min-width: 0;
+}
+
+.coding-message-status,
+.coding-message-detail {
+  max-width: 136px;
+  overflow: hidden;
+  padding: 5px 7px;
+  color: #b6c8e8;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.09);
+  border-radius: 999px;
+  font-size: 0.62rem;
+  font-weight: 700;
+  line-height: 1;
+  text-overflow: ellipsis;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.coding-message-detail {
+  color: #8fa9d6;
+  text-transform: none;
+}
+
+.coding-message[data-status="active"] .coding-message-status {
+  color: #dff8ff;
+  background: rgba(79, 208, 255, 0.1);
+  border-color: rgba(79, 208, 255, 0.35);
+}
+
+.coding-message[data-status="completed"] .coding-message-status {
+  color: #e7f5ff;
+  background: rgba(143, 182, 255, 0.1);
+  border-color: rgba(143, 182, 255, 0.25);
+}
+
+.coding-message[data-status="error"] .coding-message-status {
+  color: #fff0f0;
+  background: rgba(255, 111, 111, 0.12);
+  border-color: rgba(255, 111, 111, 0.42);
+}
+
+.coding-message-meta time {
+  color: #8fa9d6;
+  font-size: 0.66rem;
+  line-height: 1.3;
+  white-space: nowrap;
+}
+
+.coding-message-body {
   margin: 0;
   overflow-wrap: anywhere;
   color: #e6efff;
   font-size: 0.74rem;
   line-height: 1.5;
   white-space: pre-wrap;
+}
+
+.coding-message pre.coding-message-body {
+  overflow: auto;
+  max-height: 220px;
+  padding: 9px 10px;
+  color: #dbe8ff;
+  background: rgba(0, 0, 0, 0.28);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 6px;
 }
 
 .coding-events-block {
@@ -822,9 +982,14 @@ button {
   }
 
   .coding-transcript-heading,
-  .coding-message-heading {
+  .coding-message-heading,
+  .coding-message-meta {
     align-items: stretch;
     flex-direction: column;
+  }
+
+  .coding-message-meta {
+    justify-content: flex-start;
   }
 }
 

--- a/clients/openagents-desktop/tests/coding-status.test.ts
+++ b/clients/openagents-desktop/tests/coding-status.test.ts
@@ -96,7 +96,46 @@ Pylon presence failed: OpenAgents presence request failed (401): {"error":"unaut
       "tool",
       "assistant",
     ])
+    expect(parsed.messages[1]).toMatchObject({
+      detail: "call-1",
+      label: "Tool call",
+      status: "active",
+      title: "shell",
+    })
+    expect(parsed.messages[2]).toMatchObject({
+      detail: "call-1",
+      label: "Tool result",
+      status: "completed",
+    })
     expect(parsed.messages.at(-1)?.text).toBe("Done.")
+  })
+
+  test("classifies reasoning and failed Codex tool output", () => {
+    const parsed = parseCodexSessionRollout(`
+{"timestamp":"2026-06-29T02:44:00.929Z","type":"response_item","payload":{"type":"reasoning","summary":[{"type":"summary_text","text":"Checking the failure."}]}}
+{"timestamp":"2026-06-29T02:45:00.000Z","type":"response_item","payload":{"type":"function_call","name":"shell","arguments":"{\\"cmd\\":\\"bun test\\"}","call_id":"call-2","status":"completed"}}
+{"timestamp":"2026-06-29T02:45:01.000Z","type":"response_item","payload":{"type":"function_call_output","call_id":"call-2","output":"exit code 1","status":"failed"}}
+`)
+
+    expect(parsed.messages).toHaveLength(3)
+    expect(parsed.messages[0]).toMatchObject({
+      label: "Reasoning",
+      role: "reasoning",
+      status: "active",
+      text: "Checking the failure.",
+    })
+    expect(parsed.messages[1]).toMatchObject({
+      detail: "call-2",
+      status: "completed",
+      text: '{\n  "cmd": "bun test"\n}',
+      title: "shell",
+    })
+    expect(parsed.messages[2]).toMatchObject({
+      detail: "call-2",
+      label: "Tool error",
+      status: "error",
+      text: "exit code 1",
+    })
   })
 
   test("uses task-like rollout text instead of injected AGENTS context as title", () => {


### PR DESCRIPTION
## Summary
- Enrich Codex rollout parsing with labels, status, detail refs, tool names, and structured tool argument text.
- Render the desktop Codex transcript as an Orca-like timeline with role/status rails, tool call/result/error treatment, reasoning rows, and absolute plus relative timestamps.
- Preserve the existing desktop 3D background, route layout, and status badge surfaces.

## Verification
- `bun run verify` from `clients/openagents-desktop`
- `bun run test:openagents-desktop`
- `bun run typecheck:openagents-desktop`

Note: I searched the checkout and local task cache for `command.public.pylon_khala.verify.b5bea41b6c623f7c09f1bf24`, but the hashed argv was not present in retrievable metadata. The desktop package verifier above is the focused verification path for this change.
