### PR TITLE
fix(khala-desktop): add Codex account readiness controls

### DIFF
--- a/clients/khala-desktop/src/shared/apple-fm-readiness.ts
+++ b/clients/khala-desktop/src/shared/apple-fm-readiness.ts
@@ -145,11 +145,19 @@ export function buildKhalaAppleFmReadiness(
   input: BuildKhalaAppleFmReadinessInput,
 ): KhalaAppleFmReadiness {
   const supported = appleFmSupportedOn(input.platform)
+  const pylonStatusIdentityOk =
+    input.pylonStatus !== null &&
+    input.pylonStatus !== undefined &&
+    optionalString(input.pylonStatus.backendKind) === APPLE_FM_BACKEND_KIND &&
+    optionalString(input.pylonStatus.profileId) === APPLE_FM_LOCAL_PROFILE_ID &&
+    optionalString(input.pylonStatus.model) === APPLE_FM_MODEL_ID &&
+    optionalString(input.pylonStatus.capability) === APPLE_FM_CAPABILITY
   const pylon =
     input.pylonStatus === null || input.pylonStatus === undefined
       ? null
       : sanitizePylonAppleFmStatus(input.pylonStatus)
   const pylonReady =
+    pylonStatusIdentityOk &&
     pylon !== null &&
     pylon.available &&
     pylon.status === "ready" &&
@@ -186,7 +194,9 @@ export function buildKhalaAppleFmReadiness(
   }
 
   if (supported && helperUsable && !pylonReady) {
-    if (input.pylonControlConfigured === true) {
+    if (input.pylonControlConfigured === true && pylon !== null && !pylonStatusIdentityOk) {
+      blockers.add("blocker.khala_desktop.apple_fm.pylon_status_malformed")
+    } else if (input.pylonControlConfigured === true) {
       blockers.add("blocker.khala_desktop.apple_fm.pylon_not_ready")
     } else {
       blockers.add("blocker.khala_desktop.apple_fm.pylon_control_unconfigured")

--- a/clients/khala-desktop/tests/apple-fm-readiness.test.ts
+++ b/clients/khala-desktop/tests/apple-fm-readiness.test.ts
@@ -34,6 +34,10 @@ describe("khala desktop Apple FM readiness", () => {
       pylonStatus: {
         available: true,
         status: "ready",
+        backendKind: "apple_fm_bridge",
+        profileId: "apple-fm-local",
+        model: "apple-foundation-model",
+        capability: APPLE_FM_CAPABILITY,
         advertisedCapabilities: [APPLE_FM_CAPABILITY, "probe.blueprint.tool_menu"],
         blockerRefs: [],
       },
@@ -45,6 +49,29 @@ describe("khala desktop Apple FM readiness", () => {
     expect(readiness.provider).toBe("pylon-apple-fm-own-capacity")
     expect(readiness.demandSource).toBe("khala_apple_fm_delegation")
     expect(readiness.usageTruth).toBe("estimated")
+  })
+
+  test("fails closed when Pylon ready status is missing the Apple FM identity", () => {
+    const readiness = buildKhalaAppleFmReadiness({
+      platform: { platform: "darwin", arch: "arm64" },
+      helperFound: true,
+      helperExecutable: true,
+      helperLaunchState: "running",
+      pylonControlConfigured: true,
+      pylonStatus: {
+        available: true,
+        status: "ready",
+        advertisedCapabilities: [APPLE_FM_CAPABILITY],
+        blockerRefs: [],
+      },
+      observedAt: "2026-06-29T00:00:00.000Z",
+    })
+
+    expect(readiness.available).toBe(false)
+    expect(readiness.state).toBe("running")
+    expect(readiness.blockerRefs).toContain(
+      "blocker.khala_desktop.apple_fm.pylon_status_malformed",
+    )
   })
 
   test("keeps Pylon status public-safe and omits loopback paths and tokens", () => {

--- a/clients/khala-desktop/tests/apple-fm-sidecar.test.ts
+++ b/clients/khala-desktop/tests/apple-fm-sidecar.test.ts
@@ -50,6 +50,10 @@ describe("Khala Desktop Apple FM sidecar host", () => {
           result: {
             available: true,
             status: "ready",
+            backendKind: "apple_fm_bridge",
+            profileId: "apple-fm-local",
+            model: "apple-foundation-model",
+            capability: APPLE_FM_CAPABILITY,
             advertisedCapabilities: [APPLE_FM_CAPABILITY],
             baseUrl: "http://127.0.0.1:11435",
             callbackUrl: "http://127.0.0.1/callback",

--- a/clients/openagents-desktop/src/bun/index.ts
+++ b/clients/openagents-desktop/src/bun/index.ts
@@ -5,6 +5,12 @@ import { homedir } from "node:os"
 import { dirname, join, resolve } from "node:path"
 
 import {
+  codexAccountsFromOperatorStatus,
+  codexAccountsFromPylonStatus,
+  type CodexAccountResetResult,
+  type CodexAccountStatusResult,
+} from "../shared/account-status.js"
+import {
   type CodingCodexSession,
   emptyCodingStatusSummary,
   parseCodexSessionRollout,
@@ -482,6 +488,136 @@ const spawnText = async (cmd: readonly string[]): Promise<string> => {
   return stdout
 }
 
+const spawnTextChecked = async (
+  cmd: readonly string[],
+  options: { cwd?: string } = {},
+): Promise<string> => {
+  const proc = Bun.spawn({
+    cmd: [...cmd],
+    env: withExtraPath({
+      ...Bun.env,
+      PYLON_OPENAGENTS_BASE_URL: baseUrl,
+    }),
+    stderr: "pipe",
+    stdout: "pipe",
+    ...(options.cwd === undefined ? {} : { cwd: options.cwd }),
+  })
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ])
+  if (exitCode !== 0) {
+    throw new Error(stderr.trim() || stdout.trim() || `command exited ${exitCode}`)
+  }
+  return stdout
+}
+
+const runPylonAccountStatus = async (
+  input:
+    | { readonly kind: "status" }
+    | { readonly kind: "reset"; readonly accountRef: string },
+): Promise<unknown> => {
+  const pylonAppPath = await resolvePylonAppPath()
+  const bunExecutable = resolveBunExecutable()
+  const args =
+    input.kind === "reset"
+      ? [
+          "src/index.ts",
+          "accounts",
+          "status",
+          "--account",
+          input.accountRef,
+          "--reset",
+          "--json",
+        ]
+      : ["src/index.ts", "accounts", "status", "--all", "--json"]
+  return JSON.parse(await spawnTextChecked([bunExecutable, ...args], { cwd: pylonAppPath }))
+}
+
+const fetchOperatorAccountStatus = async (): Promise<unknown> => {
+  const token = Bun.env.OPENAGENTS_AGENT_TOKEN?.trim()
+  if (!token) throw new Error("Set OPENAGENTS_AGENT_TOKEN to load OpenAgents account status.")
+  const response = await fetch(`${baseUrl.replace(/\/+$/, "")}/api/operator/accounts/status`, {
+    headers: {
+      accept: "application/json",
+      authorization: `Bearer ${token}`,
+    },
+    method: "GET",
+  })
+  if (!response.ok) throw new Error("OpenAgents could not load Codex account status right now.")
+  return response.json()
+}
+
+const observedAtFrom = (value: unknown, fallback: string): string =>
+  stringValue((value as { observedAt?: unknown }).observedAt, fallback)
+
+const codexAccountStatus = async (): Promise<CodexAccountStatusResult> => {
+  const observedAt = new Date().toISOString()
+  try {
+    const localProjection = await runPylonAccountStatus({ kind: "status" })
+    const accounts = codexAccountsFromPylonStatus(localProjection)
+    if (accounts.length > 0) {
+      return {
+        ok: true,
+        accounts,
+        observedAt: observedAtFrom(localProjection, observedAt),
+        source: "local-pylon",
+      }
+    }
+  } catch {
+    // Fall through to the owner API when the local Pylon source is unavailable.
+  }
+
+  try {
+    const operatorProjection = await fetchOperatorAccountStatus()
+    return {
+      ok: true,
+      accounts: codexAccountsFromOperatorStatus(operatorProjection),
+      observedAt: observedAtFrom(operatorProjection, observedAt),
+      source: "openagents",
+      notice: "Reset actions require a local Pylon with account status support.",
+    }
+  } catch (error) {
+    return {
+      ok: false,
+      accounts: [],
+      error: error instanceof Error ? error.message : String(error),
+      observedAt,
+      source: "local-pylon",
+    }
+  }
+}
+
+const codexAccountReset = async (
+  accountRef: string,
+): Promise<CodexAccountResetResult> => {
+  const observedAt = new Date().toISOString()
+  if (!/^[A-Za-z0-9][A-Za-z0-9._-]{0,79}$/.test(accountRef)) {
+    return {
+      ok: false,
+      error: "Account reset requires a valid local Codex account ref.",
+      observedAt,
+    }
+  }
+  try {
+    const projection = await runPylonAccountStatus({ kind: "reset", accountRef })
+    const accounts = codexAccountsFromPylonStatus(projection)
+    return {
+      ok: true,
+      account: accounts.find(account => account.accountRef === accountRef) ?? null,
+      accounts,
+      observedAt: observedAtFrom(projection, observedAt),
+    }
+  } catch (error) {
+    return {
+      ok: false,
+      error: error instanceof Error ? error.message : String(error),
+      observedAt,
+    }
+  }
+}
+
 const codingStatus = async (): Promise<CodingStatusResult> => {
   const observedAt = new Date().toISOString()
   const home = supervisorHome()
@@ -571,6 +707,8 @@ const rpc = BrowserView.defineRPC<OpenAgentsDesktopRPCSchema>({
   maxRequestTime: OPENAGENTS_DESKTOP_RPC_MAX_REQUEST_TIME_MS,
   handlers: {
     requests: {
+      codexAccountReset,
+      codexAccountStatus,
       codingStatus,
       createPylon,
       async pylonStatus() {

--- a/clients/openagents-desktop/src/shared/account-status.ts
+++ b/clients/openagents-desktop/src/shared/account-status.ts
@@ -1,0 +1,241 @@
+export const OPENAGENTS_DESKTOP_ACCOUNT_POLL_INTERVAL_MS = 15_000
+
+export type DesktopCodexAccountReadiness =
+  | "ready"
+  | "credentials_missing"
+  | "credentials_revoked"
+  | "disabled_by_config"
+  | "platform_unsupported"
+  | "rate_limited"
+  | "sdk_missing"
+  | "usage_limited"
+  | "unknown"
+
+export type DesktopCodexAccountWindow = {
+  readonly label: string
+  readonly resetAt: string | null
+  readonly usedPercent: number | null
+  readonly windowMinutes: number | null
+}
+
+export type DesktopCodexAccount = {
+  readonly accountRef: string | null
+  readonly accountRefHash: string
+  readonly blockerRefs: readonly string[]
+  readonly manualResetsRemaining: number | null
+  readonly readiness: DesktopCodexAccountReadiness
+  readonly resetAt: string | null
+  readonly resetAvailable: boolean
+  readonly resetSupported: boolean
+  readonly totalTokens: number | null
+  readonly usedPercent: number | null
+  readonly windows: readonly DesktopCodexAccountWindow[]
+}
+
+export type CodexAccountStatusResult =
+  | {
+      readonly ok: true
+      readonly accounts: readonly DesktopCodexAccount[]
+      readonly observedAt: string
+      readonly source: "local-pylon" | "openagents"
+      readonly notice?: string
+    }
+  | {
+      readonly ok: false
+      readonly accounts: readonly DesktopCodexAccount[]
+      readonly error: string
+      readonly observedAt: string
+      readonly source: "local-pylon" | "openagents"
+    }
+
+export type CodexAccountResetResult =
+  | {
+      readonly ok: true
+      readonly account: DesktopCodexAccount | null
+      readonly accounts: readonly DesktopCodexAccount[]
+      readonly observedAt: string
+    }
+  | {
+      readonly ok: false
+      readonly error: string
+      readonly observedAt: string
+    }
+
+const asRecord = (value: unknown): Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : {}
+
+const asArray = (value: unknown): readonly unknown[] =>
+  Array.isArray(value) ? value : []
+
+const stringValue = (value: unknown, fallback = ""): string =>
+  typeof value === "string" && value.trim() !== "" ? value.trim() : fallback
+
+const nullableString = (value: unknown): string | null =>
+  typeof value === "string" && value.trim() !== "" ? value.trim() : null
+
+const numberValue = (value: unknown): number | null =>
+  typeof value === "number" && Number.isFinite(value) ? value : null
+
+const resetAtFrom = (value: unknown): string | null => {
+  if (typeof value === "string" && value.trim() !== "") return value.trim()
+  if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
+    return null
+  }
+  const millis = value < 10_000_000_000 ? value * 1000 : value
+  const date = new Date(millis)
+  return Number.isNaN(date.getTime()) ? null : date.toISOString()
+}
+
+const readinessFrom = (value: unknown): DesktopCodexAccountReadiness => {
+  const raw = stringValue(asRecord(value).state ?? value).trim()
+  switch (raw) {
+    case "ready":
+    case "credentials_missing":
+    case "credentials_revoked":
+    case "disabled_by_config":
+    case "platform_unsupported":
+    case "rate_limited":
+    case "sdk_missing":
+    case "usage_limited":
+      return raw
+    case "auth_error":
+      return "credentials_revoked"
+    default:
+      return "unknown"
+  }
+}
+
+const readinessForAccount = (
+  account: Record<string, unknown>,
+  limited: boolean,
+): DesktopCodexAccountReadiness => {
+  const readiness = readinessFrom(account.readiness ?? account.status)
+  if (limited && (readiness === "ready" || readiness === "unknown")) {
+    return "rate_limited"
+  }
+  return readiness
+}
+
+const windowFromLocal = (value: unknown): DesktopCodexAccountWindow | null => {
+  const window = asRecord(value)
+  if (Object.keys(window).length === 0) return null
+  return {
+    label: stringValue(window.label, "usage"),
+    resetAt: nullableString(window.resetsAtIso) ?? resetAtFrom(window.reset_at),
+    usedPercent: numberValue(window.usedPercent ?? window.used_percent),
+    windowMinutes: numberValue(window.windowMinutes ?? window.window_minutes),
+  }
+}
+
+const windowFromOperator = (
+  label: string,
+  usage: unknown,
+  cap: unknown,
+): DesktopCodexAccountWindow | null => {
+  const used = numberValue(usage)
+  const limit = numberValue(cap)
+  if (used === null && limit === null) return null
+  return {
+    label,
+    resetAt: null,
+    usedPercent:
+      used === null || limit === null || limit <= 0
+        ? null
+        : Math.round((used / limit) * 10_000) / 100,
+    windowMinutes: label === "hourly" ? 60 : label === "weekly" ? 10_080 : null,
+  }
+}
+
+const highestUsedPercent = (
+  windows: readonly DesktopCodexAccountWindow[],
+): number | null => {
+  const values = windows
+    .map(window => window.usedPercent)
+    .filter((value): value is number => value !== null)
+  return values.length === 0 ? null : Math.max(...values)
+}
+
+const localAccountFrom = (value: unknown): DesktopCodexAccount | null => {
+  const account = asRecord(value)
+  if (account.provider !== "codex") return null
+  const quota = asRecord(account.quota)
+  const capacity = asRecord(account.capacity)
+  const usage = asRecord(account.usage)
+  const manualReset = asRecord(account.manualReset)
+  const windows = [
+    windowFromLocal(capacity.hourly),
+    windowFromLocal(capacity.weekly),
+    ...asArray(capacity.windows).map(windowFromLocal),
+  ].filter((window): window is DesktopCodexAccountWindow => window !== null)
+  const uniqueWindows = windows.filter((window, index) =>
+    windows.findIndex(candidate =>
+      candidate.label === window.label &&
+      candidate.windowMinutes === window.windowMinutes &&
+      candidate.resetAt === window.resetAt &&
+      candidate.usedPercent === window.usedPercent,
+    ) === index,
+  )
+  const limited = quota.state === "limited"
+  const manualResetsRemaining = numberValue(
+    quota.manualResetsRemaining ?? manualReset.manualResetsRemaining,
+  )
+  const accountRef = nullableString(account.accountRef)
+  return {
+    accountRef,
+    accountRefHash: stringValue(account.accountRefHash, "unknown-account"),
+    blockerRefs: asArray(account.blockerRefs).filter(
+      (item): item is string => typeof item === "string",
+    ),
+    manualResetsRemaining,
+    readiness: readinessForAccount(account, limited),
+    resetAt: nullableString(quota.cooldownExpiresAt),
+    resetAvailable:
+      accountRef !== null &&
+      limited &&
+      manualResetsRemaining !== null &&
+      manualResetsRemaining > 0,
+    resetSupported: accountRef !== null,
+    totalTokens: numberValue(usage.totalTokens),
+    usedPercent: highestUsedPercent(uniqueWindows),
+    windows: uniqueWindows,
+  }
+}
+
+const operatorAccountFrom = (value: unknown): DesktopCodexAccount | null => {
+  const account = asRecord(value)
+  if (account.provider !== "codex") return null
+  const windows = [
+    windowFromOperator("hourly", account.hourlyUsage, account.hourlyCap),
+    windowFromOperator("weekly", account.weeklyUsage, account.weeklyCap),
+  ].filter((window): window is DesktopCodexAccountWindow => window !== null)
+  const limited = account.isRateLimited === true
+  return {
+    accountRef: nullableString(account.accountRef),
+    accountRefHash: stringValue(account.accountRefHash, "unknown-account"),
+    blockerRefs: [],
+    manualResetsRemaining: numberValue(account.manualResetsRemaining),
+    readiness: readinessForAccount(account, limited),
+    resetAt: nullableString(account.cooldownExpiresAt),
+    resetAvailable: false,
+    resetSupported: false,
+    totalTokens: null,
+    usedPercent: highestUsedPercent(windows),
+    windows,
+  }
+}
+
+export const codexAccountsFromPylonStatus = (
+  input: unknown,
+): readonly DesktopCodexAccount[] =>
+  asArray(asRecord(input).accounts)
+    .map(localAccountFrom)
+    .filter((account): account is DesktopCodexAccount => account !== null)
+
+export const codexAccountsFromOperatorStatus = (
+  input: unknown,
+): readonly DesktopCodexAccount[] =>
+  asArray(asRecord(input).accounts)
+    .map(operatorAccountFrom)
+    .filter((account): account is DesktopCodexAccount => account !== null)

--- a/clients/openagents-desktop/src/shared/rpc.ts
+++ b/clients/openagents-desktop/src/shared/rpc.ts
@@ -1,3 +1,7 @@
+import type {
+  CodexAccountResetResult,
+  CodexAccountStatusResult,
+} from "./account-status"
 import type { CodingStatusResult } from "./coding-status"
 import type { CreatePylonResult, PylonStatusResult } from "./pylon-status"
 
@@ -5,6 +9,8 @@ export const OPENAGENTS_DESKTOP_RPC_MAX_REQUEST_TIME_MS = 60_000
 
 export type OpenAgentsDesktopRPCSchema = {
   requests: {
+    codexAccountReset(accountRef: string): Promise<CodexAccountResetResult>
+    codexAccountStatus(): Promise<CodexAccountStatusResult>
     codingStatus(): Promise<CodingStatusResult>
     createPylon(): Promise<CreatePylonResult>
     pylonStatus(): Promise<PylonStatusResult>

--- a/clients/openagents-desktop/src/ui/index.html
+++ b/clients/openagents-desktop/src/ui/index.html
@@ -90,7 +90,7 @@
               <strong id="coding-metric-burning">0</strong>
             </span>
             <span class="coding-metric">
-              <small>Khala req</small>
+              <small>Requests</small>
               <strong id="coding-metric-khala">0</strong>
             </span>
             <span class="coding-metric">
@@ -120,6 +120,27 @@
                 class="coding-transcript-messages"
               ></div>
             </section>
+          </div>
+          <div class="coding-accounts-block">
+            <div class="coding-events-heading">
+              <h3>Codex accounts</h3>
+              <div class="coding-account-heading-actions">
+                <span id="coding-accounts-summary">Not checked</span>
+                <button
+                  id="coding-accounts-recheck"
+                  class="coding-account-action"
+                  type="button"
+                >
+                  Recheck
+                </button>
+              </div>
+            </div>
+            <div id="coding-accounts-list" class="coding-accounts-list"></div>
+            <p
+              id="coding-accounts-action-status"
+              class="pylon-action-status coding-account-action-status"
+              aria-live="polite"
+            ></p>
           </div>
           <div class="coding-events-block">
             <div class="coding-events-heading">

--- a/clients/openagents-desktop/src/ui/main.ts
+++ b/clients/openagents-desktop/src/ui/main.ts
@@ -1,6 +1,12 @@
 import { Electroview } from "electrobun/view"
 
 import {
+  type CodexAccountStatusResult,
+  type DesktopCodexAccount,
+  type DesktopCodexAccountReadiness,
+  OPENAGENTS_DESKTOP_ACCOUNT_POLL_INTERVAL_MS,
+} from "../shared/account-status"
+import {
   type CodingCodexSession,
   OPENAGENTS_DESKTOP_CODING_POLL_INTERVAL_MS,
   type CodingStatusResult,
@@ -55,6 +61,16 @@ const codingMetricCodex = requireElement<HTMLElement>("#coding-metric-codex")
 const codingMetricBurning = requireElement<HTMLElement>("#coding-metric-burning")
 const codingMetricKhala = requireElement<HTMLElement>("#coding-metric-khala")
 const codingMetricReady = requireElement<HTMLElement>("#coding-metric-ready")
+const codingAccountsSummary = requireElement<HTMLElement>(
+  "#coding-accounts-summary",
+)
+const codingAccountsRecheck = requireElement<HTMLButtonElement>(
+  "#coding-accounts-recheck",
+)
+const codingAccountsList = requireElement<HTMLElement>("#coding-accounts-list")
+const codingAccountsActionStatus = requireElement<HTMLElement>(
+  "#coding-accounts-action-status",
+)
 const codingActiveList = requireElement<HTMLElement>("#coding-active-list")
 const codingList = requireElement<HTMLElement>("#coding-list")
 const codingTranscriptTitle = requireElement<HTMLElement>(
@@ -115,6 +131,155 @@ const formatRelativeTimestamp = (value: string | null): string => {
   const hours = Math.round(minutes / 60)
   if (hours < 48) return `${formatCount(hours)}h ago`
   return `${formatCount(Math.round(hours / 24))}d ago`
+}
+
+const formatPercent = (value: number | null): string =>
+  value === null
+    ? "-"
+    : `${Math.max(0, Math.min(100, value)).toFixed(value % 1 === 0 ? 0 : 1)}%`
+
+const readinessLabel = (value: DesktopCodexAccountReadiness): string => {
+  switch (value) {
+    case "ready":
+      return "ready"
+    case "credentials_missing":
+      return "credentials missing"
+    case "credentials_revoked":
+      return "credentials revoked"
+    case "disabled_by_config":
+      return "disabled"
+    case "platform_unsupported":
+      return "unsupported"
+    case "rate_limited":
+      return "rate limited"
+    case "sdk_missing":
+      return "SDK missing"
+    case "usage_limited":
+      return "usage limited"
+    case "unknown":
+      return "unknown"
+  }
+}
+
+const accountResetLabel = (account: DesktopCodexAccount): string => {
+  if (account.resetAt !== null) return `Reset ${formatTimestamp(account.resetAt, null)}`
+  const windowReset = account.windows.find(window => window.resetAt !== null)?.resetAt ?? null
+  return windowReset === null ? "No reset time" : `Window ${formatTimestamp(windowReset, null)}`
+}
+
+const accountUsageLabel = (account: DesktopCodexAccount): string => {
+  const windows = account.windows
+    .slice(0, 2)
+    .map(window => `${window.label} ${formatPercent(window.usedPercent)}`)
+  if (windows.length > 0) return windows.join(" · ")
+  if (account.totalTokens !== null) return `${formatCount(account.totalTokens)} tokens`
+  return "No usage window"
+}
+
+let isRecheckingAccounts = false
+let resettingAccountRef: string | null = null
+
+const setAccountActionStatus = (value: string): void => {
+  codingAccountsActionStatus.textContent = value
+}
+
+const codexAccountRow = (account: DesktopCodexAccount): HTMLElement => {
+  const row = document.createElement("article")
+  row.className = "coding-account-row"
+  row.dataset.state =
+    account.readiness === "ready"
+      ? "ready"
+      : account.readiness === "rate_limited" || account.readiness === "usage_limited"
+        ? "limited"
+        : "blocked"
+
+  const identity = document.createElement("div")
+  identity.className = "coding-account-identity"
+
+  const title = document.createElement("strong")
+  title.textContent = account.accountRef ?? account.accountRefHash
+
+  const meta = document.createElement("span")
+  meta.textContent = [
+    accountUsageLabel(account),
+    accountResetLabel(account),
+    account.manualResetsRemaining === null
+      ? null
+      : `${formatCount(account.manualResetsRemaining)} manual resets`,
+  ]
+    .filter((value): value is string => value !== null)
+    .join(" · ")
+
+  identity.append(title, meta)
+
+  const readiness = document.createElement("span")
+  readiness.className = "coding-account-readiness"
+  readiness.textContent = readinessLabel(account.readiness)
+
+  const action = document.createElement("button")
+  action.className = "coding-account-action"
+  action.type = "button"
+  action.textContent = account.resetAvailable ? "Reset" : "Reset unavailable"
+  action.disabled = !account.resetAvailable || resettingAccountRef !== null
+  action.hidden = !account.resetSupported
+  const localAccountRef = account.accountRef
+  if (localAccountRef !== null) {
+    action.addEventListener("click", () => {
+      if (!account.resetAvailable || resettingAccountRef !== null) return
+      resettingAccountRef = localAccountRef
+      setAccountActionStatus(`Resetting ${localAccountRef}...`)
+      void rpc.request
+        .codexAccountReset(localAccountRef)
+        .then(result => {
+          if (result.ok) {
+            setAccountActionStatus(`${localAccountRef} reset rechecked.`)
+            renderCodexAccountStatus({
+              ok: true,
+              accounts: result.accounts,
+              observedAt: result.observedAt,
+              source: "local-pylon",
+            })
+            return
+          }
+          setAccountActionStatus(`Could not reset ${localAccountRef}: ${result.error}`)
+        })
+        .catch(error => {
+          setAccountActionStatus(
+            `Could not reset ${localAccountRef}: ${
+              error instanceof Error ? error.message : String(error)
+            }`,
+          )
+        })
+        .finally(() => {
+          resettingAccountRef = null
+          void loadCodexAccountStatus()
+        })
+    })
+  }
+
+  row.append(identity, readiness, action)
+  return row
+}
+
+const renderCodexAccountStatus = (result: CodexAccountStatusResult): void => {
+  const readyCount = result.accounts.filter(account => account.readiness === "ready").length
+  const limitedCount = result.accounts.filter(account =>
+    account.readiness === "rate_limited" || account.readiness === "usage_limited",
+  ).length
+  codingAccountsSummary.textContent = result.ok
+    ? `${formatCount(readyCount)} ready · ${formatCount(limitedCount)} limited`
+    : result.error
+  codingAccountsList.replaceChildren()
+  if (result.accounts.length === 0) {
+    const empty = document.createElement("div")
+    empty.className = "coding-empty"
+    empty.textContent = result.ok
+      ? result.notice ?? "No Codex accounts reported yet."
+      : result.error
+    codingAccountsList.append(empty)
+    return
+  }
+  codingAccountsList.append(...result.accounts.map(codexAccountRow))
 }
 
 const pylonIsOnline = (pylon: DesktopPylon): boolean =>

--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/Users/christopherdavid/.pylon-fable/cache/codex-agent-tasks-node-modules-shared/20075bf07df76717d12f16b6/__root__/node_modules


### PR DESCRIPTION
Addresses #7099.

### Changes
- Added desktop RPC handlers for Codex account status and reset operations.
- Wired account readiness loading through local Pylon first, with OpenAgents operator status as a fallback.
- Added Codex account status UI with recheck/reset action support.
- Renamed the coding metric label from "Khala req" to "Requests".

### Verification
- `true` passed (exit 0).