### PR TITLE
Fix desktop Coding session empty state

### DIFF
--- a/clients/openagents-desktop/src/bun/index.ts
+++ b/clients/openagents-desktop/src/bun/index.ts
@@ -6,6 +6,8 @@ import { dirname, join, resolve } from "node:path"
 
 import {
   type CodingCodexSession,
+  codexProcessSessionFromProcess,
+  codingSessionMatchesProcess,
   emptyCodingStatusSummary,
   parseCodexSessionRollout,
   parseCodingProcesses,
@@ -398,21 +400,7 @@ const matchingCodexProcess = (
   },
   processes: readonly CodingProcess[],
 ): CodingProcess | null =>
-  processes.find(process => {
-    if (process.kind !== "codex_exec") return false
-    if (
-      session.accountRef !== null &&
-      process.accountRef !== null &&
-      session.accountRef !== process.accountRef
-    ) {
-      return false
-    }
-    return (
-      session.cwd !== null &&
-      process.workspacePath !== null &&
-      session.cwd === process.workspacePath
-    )
-  }) ?? null
+  processes.find(process => codingSessionMatchesProcess(session, process)) ?? null
 
 const fallbackSessionTitle = (sessionId: string): string =>
   sessionId.startsWith("rollout-") ? sessionId : `Codex ${sessionId.slice(0, 8)}`
@@ -456,7 +444,17 @@ const readCodexSessions = async (
     }),
   )
 
-  return sessions
+  const matchedPids = new Set(
+    sessions
+      .map(session => session.pid)
+      .filter((pid): pid is number => pid !== null),
+  )
+  const observedAt = new Date().toISOString()
+  const processSessions = processes
+    .filter(process => process.kind === "codex_exec" && !matchedPids.has(process.pid))
+    .map(process => codexProcessSessionFromProcess(process, observedAt))
+
+  return [...sessions, ...processSessions]
     .sort((left, right) => {
       if (left.active !== right.active) return left.active ? -1 : 1
       if (left.status !== right.status) {

--- a/clients/openagents-desktop/src/shared/coding-status.ts
+++ b/clients/openagents-desktop/src/shared/coding-status.ts
@@ -110,6 +110,47 @@ export type CodingStatusResult =
       readonly summary: CodingStatusSummary
     }
 
+export const codingSessionMatchesProcess = (
+  session: {
+    readonly accountRef: string | null
+    readonly cwd: string | null
+  },
+  process: CodingProcess,
+): boolean => {
+  if (process.kind !== "codex_exec") return false
+  if (
+    session.accountRef !== null &&
+    process.accountRef !== null &&
+    session.accountRef !== process.accountRef
+  ) {
+    return false
+  }
+  return (
+    session.cwd !== null &&
+    process.workspacePath !== null &&
+    session.cwd === process.workspacePath
+  )
+}
+
+export const codexProcessSessionFromProcess = (
+  process: CodingProcess,
+  observedAt: string,
+): CodingCodexSession => ({
+  accountRef: process.accountRef,
+  active: true,
+  cwd: process.workspacePath,
+  issueRef: process.issueRef,
+  messageCount: 0,
+  messages: [],
+  modifiedAt: observedAt,
+  path: `process:${process.pid}`,
+  pid: process.pid,
+  sessionId: `process-${process.pid}`,
+  source: "process",
+  status: "active",
+  title: process.label,
+})
+
 const processKindLabel: Record<CodingProcessKind, string> = {
   assignment_runner: "Assignment runner",
   codex_exec: "Codex exec",

--- a/clients/openagents-desktop/tests/coding-status.test.ts
+++ b/clients/openagents-desktop/tests/coding-status.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test } from "bun:test"
 
 import {
+  codexProcessSessionFromProcess,
+  codingSessionMatchesProcess,
   parseCodexSessionRollout,
   parseCodingProcesses,
   parseSupervisorLog,
@@ -97,6 +99,46 @@ Pylon presence failed: OpenAgents presence request failed (401): {"error":"unaut
       "assistant",
     ])
     expect(parsed.messages.at(-1)?.text).toBe("Done.")
+  })
+
+  test("derives active Codex session rows from unmatched live processes", () => {
+    const [process] = parseCodingProcesses(`
+  102     1  0.1      00:30 /Users/me/node_modules/@openai/codex/vendor/aarch64-apple-darwin/bin/codex exec --cd /tmp/workspace-one --account-ref codex-6
+`)
+    if (process === undefined) throw new Error("expected process fixture")
+
+    expect(
+      codingSessionMatchesProcess(
+        { accountRef: "codex-6", cwd: "/tmp/workspace-one" },
+        process,
+      ),
+    ).toBe(true)
+    expect(
+      codingSessionMatchesProcess(
+        { accountRef: "codex-7", cwd: "/tmp/workspace-one" },
+        process,
+      ),
+    ).toBe(false)
+    expect(
+      codingSessionMatchesProcess({ accountRef: "codex-6", cwd: null }, process),
+    ).toBe(false)
+
+    expect(
+      codexProcessSessionFromProcess(process, "2026-06-29T03:00:00.000Z"),
+    ).toMatchObject({
+      accountRef: "codex-6",
+      active: true,
+      cwd: "/tmp/workspace-one",
+      messageCount: 0,
+      messages: [],
+      modifiedAt: "2026-06-29T03:00:00.000Z",
+      path: "process:102",
+      pid: 102,
+      sessionId: "process-102",
+      source: "process",
+      status: "active",
+      title: "Codex exec codex-6",
+    })
   })
 
   test("uses task-like rollout text instead of injected AGENTS context as title", () => {


### PR DESCRIPTION
## Summary
- add active process-backed Codex session rows when a live `codex exec` process has no matched rollout file
- share and test the session/process matching logic so active and recent labels stay derived from live process plus rollout state
- preserve the existing desktop UI and empty-state rendering; the payload now only has no active rows when there are truly no live Codex sessions

## Verification
- `bun run --cwd clients/openagents-desktop verify`
- `bun run test:openagents-desktop`

## Note
- Requested command ref `command.public.pylon_khala.verify.4e3e82daa9d3450372aa61a2` could not be resolved to local argv from the checkout metadata; the repo Pylon CLI in this checkout fails to start because `@openagentsinc/tassadar-executor/self-test` is missing from local `node_modules`. The stronger desktop package verify above completed successfully.