### PR TITLE
Update stats Khala counter layout

### DIFF
--- a/apps/openagents.com/apps/web/src/page/loggedOut/page/home.ts
+++ b/apps/openagents.com/apps/web/src/page/loggedOut/page/home.ts
@@ -970,6 +970,65 @@ export const khalaTokensServedCounter = (
   )
 }
 
+export const khalaTokensServedHeaderCounter = (
+  model: PublicKhalaTokensServedModel,
+): Html => {
+  const h = html<Message>()
+  const display = formatKhalaTokensServed(model)
+  const live = model._tag === 'PublicKhalaTokensServedLoaded'
+
+  return h.section(
+    [
+      h.DataAttribute('counter', 'khala-tokens-served'),
+      Ui.className<Message>(
+        'flex min-w-[15rem] flex-col gap-2 border border-[#242424] bg-[#050505] px-3 py-2 text-left sm:items-end sm:text-right',
+      ),
+    ],
+    [
+      h.div(
+        [
+          Ui.className<Message>(
+            'flex items-center gap-2 text-[0.62rem] uppercase leading-none tracking-[0.08em] text-white/45 sm:justify-end',
+          ),
+        ],
+        [
+          h.span(
+            [
+              h.DataAttribute('status', live ? 'live' : 'pending'),
+              Ui.className<Message>(
+                `inline-block h-1.5 w-1.5 rounded-full ${
+                  live ? 'bg-[#00c853]' : 'bg-white/30'
+                }`,
+              ),
+            ],
+            [],
+          ),
+          h.span([], ['Khala Tokens Served']),
+        ],
+      ),
+      h.p(
+        [
+          Ui.className<Message>(
+            'm-0 w-full min-w-0 max-w-full text-[1.28rem] font-semibold leading-none tabular-nums text-[#f1efe8] sm:text-[1.42rem]',
+          ),
+        ],
+        [
+          h.span(
+            [
+              h.DataAttribute('value', display),
+              h.DataAttribute('counter-display', 'khala-tokens-served'),
+              Ui.className<Message>(
+                `${motionOdometerClass} block w-full max-w-full whitespace-nowrap`,
+              ),
+            ],
+            [display],
+          ),
+        ],
+      ),
+    ],
+  )
+}
+
 // "Khala Tokens Served" history graph (#6227): a small hand-rolled SVG bar
 // chart of tokens-per-day for the last 30 days, sitting next to the live
 // counter on /stats. Public-safe: the series is bare day + sum. No chart
@@ -982,6 +1041,7 @@ export const khalaTokensServedCounter = (
 
 const HISTORY_DAY_SECONDS = 24 * 60 * 60
 const HISTORY_CHART_MAX_DAYS = 4
+const HISTORY_CHART_START_DAY = '2026-06-24'
 
 const compactNumberFormatter = new Intl.NumberFormat('en-US', {
   notation: 'compact',
@@ -1152,6 +1212,13 @@ const historyDayNumber = (day: string): number | undefined => {
   return era * 146_097 + dayOfEra
 }
 
+const historyDayFromDayNumber = (dayNumber: number): string => {
+  const epochDayNumber = historyDayNumber('1970-01-01') ?? 0
+  return new Date((dayNumber - epochDayNumber) * HISTORY_DAY_SECONDS * 1_000)
+    .toISOString()
+    .slice(0, 10)
+}
+
 const recentContiguousHistorySeries = (
   series: ReadonlyArray<PublicKhalaTokensServedHistoryPoint>,
 ): ReadonlyArray<PublicKhalaTokensServedHistoryPoint> => {
@@ -1197,6 +1264,67 @@ const recentContiguousHistorySeries = (
 
   return selected
 }
+
+const khalaLaunchHistorySeries = (
+  series: ReadonlyArray<PublicKhalaTokensServedHistoryPoint>,
+  generatedAt: string | undefined,
+  timezone: string,
+): ReadonlyArray<PublicKhalaTokensServedHistoryPoint> => {
+  const points = series
+    .map(point => ({ point, dayNumber: historyDayNumber(point.day) }))
+    .filter(
+      (
+        entry,
+      ): entry is {
+        point: PublicKhalaTokensServedHistoryPoint
+        dayNumber: number
+      } => entry.dayNumber !== undefined,
+    )
+    .sort((left, right) => left.dayNumber - right.dayNumber)
+
+  if (points.length === 0) {
+    return series
+  }
+
+  const startDayNumber = historyDayNumber(HISTORY_CHART_START_DAY)
+  const generatedAtParts = historyTimezoneParts(generatedAt, timezone)
+  const generatedAtDayNumber =
+    generatedAtParts === undefined
+      ? undefined
+      : historyDayNumber(historyDayFromTimezoneParts(generatedAtParts))
+  const latestPointDayNumber = points[points.length - 1]?.dayNumber
+  const endDayNumber =
+    generatedAtDayNumber ?? latestPointDayNumber ?? startDayNumber
+
+  if (startDayNumber === undefined || endDayNumber === undefined) {
+    return points.map(entry => entry.point)
+  }
+
+  if (endDayNumber < startDayNumber) {
+    return points.map(entry => entry.point)
+  }
+
+  const tokensByDay = new Map(
+    points.map(entry => [
+      entry.point.day,
+      Math.max(0, entry.point.tokensServed),
+    ]),
+  )
+  const selected: Array<PublicKhalaTokensServedHistoryPoint> = []
+
+  for (
+    let dayNumber = startDayNumber;
+    dayNumber <= endDayNumber;
+    dayNumber += 1
+  ) {
+    const day = historyDayFromDayNumber(dayNumber)
+    selected.push({ day, tokensServed: tokensByDay.get(day) ?? 0 })
+  }
+
+  return selected
+}
+
+type KhalaTokensServedHistoryChartMode = 'recent' | 'launch-window'
 
 type HistoryTimezoneParts = Readonly<{
   day: number
@@ -1539,6 +1667,7 @@ const historyChartBars = (
 
 export const khalaTokensServedHistoryChart = (
   model: PublicKhalaTokensServedHistoryModel,
+  mode: KhalaTokensServedHistoryChartMode = 'recent',
 ): Html =>
   M.value(model).pipe(
     M.tagsExhaustive({
@@ -1569,7 +1698,14 @@ export const khalaTokensServedHistoryChart = (
               `Daily all-demand input + output tokens served across the network in ${history.timezone}.`,
             ),
           onNonEmpty: series => {
-            const chartSeries = recentContiguousHistorySeries(series)
+            const chartSeries =
+              mode === 'launch-window'
+                ? khalaLaunchHistorySeries(
+                    series,
+                    history.generatedAt,
+                    history.timezone,
+                  )
+                : recentContiguousHistorySeries(series)
             const peakTokens = chartSeries.reduce(
               (max, point) =>
                 point.tokensServed > max ? point.tokensServed : max,

--- a/apps/openagents.com/apps/web/src/page/loggedOut/page/khalaTokensServed.story.test.ts
+++ b/apps/openagents.com/apps/web/src/page/loggedOut/page/khalaTokensServed.story.test.ts
@@ -52,12 +52,27 @@ const sparseRecentHistory = PublicKhalaTokensServedHistory.make({
   window: '30d',
   bucket: 'day',
   timezone: 'America/Chicago',
-  generatedAt: '2026-06-26T19:20:00.000Z',
+  generatedAt: '2026-06-29T19:20:00.000Z',
   series: [
     { day: '2026-06-11', tokensServed: 7 },
-    { day: '2026-06-24', tokensServed: 14_700_000 },
-    { day: '2026-06-25', tokensServed: 73_300_000 },
     { day: '2026-06-26', tokensServed: 206_200_000 },
+    { day: '2026-06-28', tokensServed: 73_300_000 },
+    { day: '2026-06-29', tokensServed: 14_700_000 },
+  ],
+})
+
+const statsLaunchHistory = PublicKhalaTokensServedHistory.make({
+  window: '30d',
+  bucket: 'day',
+  timezone: 'America/Chicago',
+  generatedAt: '2026-06-29T19:20:00.000Z',
+  series: [
+    { day: '2026-06-24', tokensServed: 31_000 },
+    { day: '2026-06-25', tokensServed: 0 },
+    { day: '2026-06-26', tokensServed: 206_200_000 },
+    { day: '2026-06-27', tokensServed: 96_250 },
+    { day: '2026-06-28', tokensServed: 73_300_000 },
+    { day: '2026-06-29', tokensServed: 14_700_000 },
   ],
 })
 
@@ -79,6 +94,9 @@ const homeInputWithTokens = (tokensServed: number) => ({
 
 const statsInputWithModelMix = () => ({
   ...homeInputWithTokens(1_250_000),
+  publicKhalaTokensServedHistory: LoadedPublicKhalaTokensServedHistory({
+    history: statsLaunchHistory,
+  }),
   publicKhalaTokensServedModelMix: LoadedPublicKhalaTokensServedModelMix({
     mix: {
       schemaVersion: 'openagents.public_khala_model_mix.v1',
@@ -267,7 +285,7 @@ describe('Khala Tokens Served history chart (#6227)', () => {
     expect(markup).toContain('"data-day":"2026-06-23"')
   })
 
-  test('starts the compact chart at the latest contiguous daily run', () => {
+  test('renders the /stats chart from June 24 through the current Central day', () => {
     const markup = JSON.stringify(
       StatsPage.view(statsInputWithHistory(sparseRecentHistory)),
     )
@@ -277,10 +295,14 @@ describe('Khala Tokens Served history chart (#6227)', () => {
     expect(markup).toContain('"data-day":"2026-06-24"')
     expect(markup).toContain('"data-day":"2026-06-25"')
     expect(markup).toContain('"data-day":"2026-06-26"')
+    expect(markup).toContain('"data-day":"2026-06-27"')
+    expect(markup).toContain('"data-day":"2026-06-28"')
+    expect(markup).toContain('"data-day":"2026-06-29"')
+    expect(markup).toContain('2026-06-24: 0 tokens')
     expect(markup).toContain('06/24')
     expect(markup).toContain('14.7M')
     expect(markup).toContain('"data-highlight":"peak"')
-    expect(markup).toContain('Last 3 days, peak 206.2M in a day.')
+    expect(markup).toContain('Last 6 days, peak 206.2M in a day.')
   })
 
   test('aligns every day label directly under its bar and projects today to midnight', () => {
@@ -289,18 +311,18 @@ describe('Khala Tokens Served history chart (#6227)', () => {
     )
 
     expect(markup).toContain(
-      'grid-template-columns: repeat(3, minmax(0, 1fr));',
+      'grid-template-columns: repeat(6, minmax(0, 1fr));',
     )
     expect(markup).toContain('grid-rows-[9.25rem_auto]')
     expect(markup).toContain('h-[9.25rem]')
     expect(markup).toContain('"data-projection":"end-of-day"')
-    expect(markup).toContain('"data-projected-tokens":"345265116"')
+    expect(markup).toContain('"data-projected-tokens":"24613953"')
     expect(markup).toContain('repeating-linear-gradient(135deg')
-    expect(markup).toContain('EOD est. 345.3M')
+    expect(markup).toContain('EOD est. 24.6M')
     expect(markup).toContain(
-      '2026-06-26 projected by midnight: 345,265,116 tokens',
+      '2026-06-29 projected by midnight: 24,613,953 tokens',
     )
-    expect(markup).toContain('Current pace projects 345.3M by midnight.')
+    expect(markup).toContain('Current pace projects 24.6M by midnight.')
   })
 
   test('renders the same per-day curve on public /stats', () => {
@@ -311,8 +333,10 @@ describe('Khala Tokens Served history chart (#6227)', () => {
       },
       Scene.with(LoggedOut.init(HomeRoute())),
       Scene.expect(Scene.text('Network Stats')).toExist(),
+      Scene.expect(Scene.text('Khala Tokens Served')).toExist(),
       Scene.expect(Scene.text('Tokens Served / Day')).toExist(),
-      Scene.expect(Scene.text('2026-06-23: 96,250 tokens')).toExist(),
+      Scene.expect(Scene.text('2026-06-24: 31,000 tokens')).toExist(),
+      Scene.expect(Scene.text('2026-06-29: 14,700,000 tokens')).toExist(),
       Scene.expect(Scene.text('Model Family Mix')).toExist(),
       Scene.expect(Scene.text('GLM family')).toExist(),
       Scene.expect(Scene.text('Pylon-Codex')).toExist(),

--- a/apps/openagents.com/apps/web/src/page/loggedOut/page/stats.ts
+++ b/apps/openagents.com/apps/web/src/page/loggedOut/page/stats.ts
@@ -9,7 +9,9 @@ import {
   copyBoundaryPanel,
   endpointManifestPanel,
   forumStatsPanel,
-  khalaTokensServedPanel,
+  khalaTokensServedHeaderCounter,
+  khalaTokensServedHistoryChart,
+  khalaTokensServedModelMixPanel,
   nostrRelayPanel,
   pylonStatsPanel,
 } from './home'
@@ -36,7 +38,7 @@ export const view = (input: HomeViewInput): Html => {
             h.div(
               [
                 Ui.className<Message>(
-                  'flex flex-wrap items-end justify-between gap-2 border border-[#242424] bg-[#030303] p-3',
+                  'grid gap-3 border border-[#242424] bg-[#030303] p-3 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-end',
                 ),
               ],
               [
@@ -71,21 +73,42 @@ export const view = (input: HomeViewInput): Html => {
                     ),
                   ],
                 ),
-                h.a(
+                h.div(
                   [
-                    h.Href('/'),
                     Ui.className<Message>(
-                      'border border-[#282828] bg-[#0b0b0b] px-2.5 py-2 text-[0.65rem] uppercase leading-none text-white/55 hover:border-[#444] hover:text-[#f1efe8]',
+                      'grid gap-2 sm:justify-items-end',
                     ),
                   ],
-                  ['Home'],
+                  [
+                    khalaTokensServedHeaderCounter(input.publicKhalaTokensServed),
+                    h.a(
+                      [
+                        h.Href('/'),
+                        Ui.className<Message>(
+                          'border border-[#282828] bg-[#0b0b0b] px-2.5 py-2 text-[0.65rem] uppercase leading-none text-white/55 hover:border-[#444] hover:text-[#f1efe8]',
+                        ),
+                      ],
+                      ['Home'],
+                    ),
+                  ],
                 ),
               ],
             ),
-            khalaTokensServedPanel(
-              input.publicKhalaTokensServed,
-              input.publicKhalaTokensServedHistory,
-              input.publicKhalaTokensServedModelMix,
+            h.div(
+              [
+                Ui.className<Message>(
+                  'grid gap-3 lg:grid-cols-[minmax(0,1.75fr)_minmax(18rem,0.85fr)]',
+                ),
+              ],
+              [
+                khalaTokensServedHistoryChart(
+                  input.publicKhalaTokensServedHistory,
+                  'launch-window',
+                ),
+                khalaTokensServedModelMixPanel(
+                  input.publicKhalaTokensServedModelMix,
+                ),
+              ],
             ),
             h.div(
               [


### PR DESCRIPTION
## Summary
- Move the /stats Khala tokens-served counter into a compact header box beside the Network Stats title area.
- Split the /stats Khala evidence row so the tokens-served-per-day chart gets the wider track and model mix stays secondary.
- Anchor the /stats chart at 2026-06-24 and fill each day through the current Central day, including missing days as zero.

## Verification
- `bun run --cwd apps/openagents.com/apps/web test -- src/page/loggedOut/page/khalaTokensServed.story.test.ts`
- `bun run --cwd apps/openagents.com/apps/web typecheck`

## Deploy
- Not deployed from this checkout: `docs/DEPLOYMENT.md` and `apps/openagents.com/AGENTS.md` require `bun run --cwd apps/openagents.com/workers/api deploy:safe` only from clean `origin/main`. This work is in a PR branch, not clean main.

## Note
- The requested verification ref `command.public.pylon_khala.verify.4e3e82daa9d3450372aa61a2` was not resolvable from local assignment metadata in this bounded checkout. The focused web test and typecheck above were run after rebasing onto current `origin/main`.
