### PR TITLE
fix(desktop): hide coding empty state when sessions exist

### DIFF
--- a/clients/openagents-desktop/src/bun/index.ts
+++ b/clients/openagents-desktop/src/bun/index.ts
@@ -7,6 +7,7 @@ import { dirname, join, resolve } from "node:path"
 import {
   type CodingCodexSession,
   emptyCodingStatusSummary,
+  latestCodingTranscriptActivityMs,
   parseCodexSessionRollout,
   parseCodingProcesses,
   parseSupervisorLog,
@@ -434,9 +435,13 @@ const readCodexSessions = async (
         },
         processes,
       )
-      const isRecent = Date.now() - file.modifiedAtMs <= 10 * 60 * 1_000
+      const activityAtMs = Math.max(
+        file.modifiedAtMs,
+        latestCodingTranscriptActivityMs(parsed.messages) ?? file.modifiedAtMs,
+      )
+      const isRecent = Date.now() - activityAtMs <= 10 * 60 * 1_000
       const active = process !== null
-      const modifiedAt = new Date(file.modifiedAtMs).toISOString()
+      const modifiedAt = new Date(activityAtMs).toISOString()
 
       return {
         accountRef,

--- a/clients/openagents-desktop/src/shared/coding-status.ts
+++ b/clients/openagents-desktop/src/shared/coding-status.ts
@@ -618,3 +618,16 @@ export const parseCodexSessionRollout = (
     title,
   }
 }
+
+export const latestCodingTranscriptActivityMs = (
+  messages: readonly CodingTranscriptMessage[],
+): number | null => {
+  let latest: number | null = null
+  for (const message of messages) {
+    if (message.timestamp === null) continue
+    const millis = Date.parse(message.timestamp)
+    if (!Number.isFinite(millis)) continue
+    latest = latest === null ? millis : Math.max(latest, millis)
+  }
+  return latest
+}

--- a/clients/openagents-desktop/src/ui/main.ts
+++ b/clients/openagents-desktop/src/ui/main.ts
@@ -329,15 +329,21 @@ const renderCodingSessions = (
     sessions.find(session => session.path === selectedSessionPath) ?? null
 
   codingActiveList.replaceChildren()
-  const activeSessions = sessions.filter(session => session.active).slice(0, 8)
-  if (activeSessions.length === 0) {
+  const activeSessions = sessions.filter(session => session.active)
+  const recentSessions = sessions.filter(session => session.status === "recent")
+  const visibleSessions = (
+    activeSessions.length + recentSessions.length > 0
+      ? [...activeSessions, ...recentSessions]
+      : sessions
+  ).slice(0, 8)
+  if (visibleSessions.length === 0) {
     const empty = document.createElement("div")
     empty.className = "coding-empty coding-active-empty"
     empty.textContent = "No active Codex sessions."
     codingActiveList.append(empty)
   } else {
     codingActiveList.append(
-      ...activeSessions.map(session => sessionButton(session, "chip")),
+      ...visibleSessions.map(session => sessionButton(session, "chip")),
     )
   }
 

--- a/clients/openagents-desktop/tests/coding-status.test.ts
+++ b/clients/openagents-desktop/tests/coding-status.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test"
 
 import {
+  latestCodingTranscriptActivityMs,
   parseCodexSessionRollout,
   parseCodingProcesses,
   parseSupervisorLog,
@@ -97,6 +98,9 @@ Pylon presence failed: OpenAgents presence request failed (401): {"error":"unaut
       "assistant",
     ])
     expect(parsed.messages.at(-1)?.text).toBe("Done.")
+    expect(latestCodingTranscriptActivityMs(parsed.messages)).toBe(
+      Date.parse("2026-06-29T02:46:00.000Z"),
+    )
   })
 
   test("uses task-like rollout text instead of injected AGENTS context as title", () => {


### PR DESCRIPTION
## Summary
- derive desktop Coding session recency from the latest parsed transcript/tool activity when available
- render active/recent session chips in the top Coding strip, falling back to visible rows before showing the empty notice
- add focused coverage for latest transcript activity parsing

## Verification
- bun run --cwd clients/openagents-desktop verify
- bun run test:openagents-desktop
- command.public.pylon_khala.verify.b5bea41b6c623f7c09f1bf24 (`true`)
- git diff --check