### PR TITLE
desktop: render Codex transcripts as an operator timeline

### DIFF
--- a/clients/openagents-desktop/src/shared/coding-status.ts
+++ b/clients/openagents-desktop/src/shared/coding-status.ts
@@ -40,11 +40,16 @@ export type CodingTranscriptRole =
   | "tool"
   | "user"
 
+export type CodingTranscriptStatus = "error" | "info" | "ok" | "running"
+
 export type CodingTranscriptMessage = {
+  readonly detail: string | null
   readonly kind: string
   readonly role: CodingTranscriptRole
+  readonly status: CodingTranscriptStatus
   readonly text: string
   readonly timestamp: string | null
+  readonly title: string
 }
 
 export type CodingCodexSession = {
@@ -363,6 +368,19 @@ const truncateTranscriptText = (value: string): string => {
   return trimmed.length > 2_400 ? `${trimmed.slice(0, 2_397)}...` : trimmed
 }
 
+const transcriptMessage = (
+  message: Omit<CodingTranscriptMessage, "detail" | "status" | "title"> &
+    Partial<Pick<CodingTranscriptMessage, "detail" | "status" | "title">>,
+): CodingTranscriptMessage => ({
+  detail: message.detail ?? null,
+  kind: message.kind,
+  role: message.role,
+  status: message.status ?? "info",
+  text: message.text,
+  timestamp: message.timestamp,
+  title: message.title ?? message.kind,
+})
+
 const textFromUnknown = (value: unknown): string | null => {
   if (typeof value === "string") return value
   if (Array.isArray(value)) {
@@ -389,6 +407,16 @@ const textFromUnknown = (value: unknown): string | null => {
   )
 }
 
+const compactJsonFromUnknown = (value: unknown): string | null => {
+  if (typeof value === "string") return value
+  if (value === null || value === undefined) return null
+  try {
+    return JSON.stringify(value, null, 2)
+  } catch {
+    return null
+  }
+}
+
 const transcriptRoleFromMessageRole = (role: string | null): CodingTranscriptRole => {
   if (
     role === "assistant" ||
@@ -412,66 +440,84 @@ const transcriptMessageFromResponseItem = (
     const text = textFromUnknown(payload.content)
     if (text === null || text.trim() === "") return null
     const role = transcriptRoleFromMessageRole(stringValueFromUnknown(payload.role))
-    return {
+    return transcriptMessage({
       kind: "message",
       role,
       text: truncateTranscriptText(text),
       timestamp,
-    }
+      title: role,
+    })
   }
 
   if (type === "agent_message") {
     const text = textFromUnknown(payload.content)
     if (text === null || text.trim() === "") return null
-    return {
+    return transcriptMessage({
       kind: "agent message",
       role: "assistant",
       text: truncateTranscriptText(text),
       timestamp,
-    }
+      title: "assistant",
+    })
   }
 
   if (type === "reasoning") {
     const text = textFromUnknown(payload.summary) ?? "Reasoning"
-    return {
+    return transcriptMessage({
       kind: "reasoning",
       role: "reasoning",
       text: truncateTranscriptText(text),
       timestamp,
-    }
+      title: "reasoning",
+    })
   }
 
   if (type === "function_call" || type === "custom_tool_call") {
     const name = stringValueFromUnknown(payload.name) ?? "tool"
     const args = stringValueFromUnknown(payload.arguments) ??
-      stringValueFromUnknown(payload.input)
-    return {
+      stringValueFromUnknown(payload.input) ??
+      compactJsonFromUnknown(payload.arguments) ??
+      compactJsonFromUnknown(payload.input)
+    return transcriptMessage({
+      detail: stringValueFromUnknown(payload.call_id),
       kind: "tool call",
       role: "tool",
-      text: args === null ? name : `${name} ${truncateTranscriptText(args)}`,
+      status: "running",
+      text: args === null ? "No input captured." : truncateTranscriptText(args),
       timestamp,
-    }
+      title: name,
+    })
   }
 
   if (type === "function_call_output" || type === "custom_tool_call_output") {
-    const text = textFromUnknown(payload.output)
+    const text = textFromUnknown(payload.output) ?? compactJsonFromUnknown(payload.output)
     if (text === null || text.trim() === "") return null
-    return {
+    const isError = payload.is_error === true
+    return transcriptMessage({
+      detail: stringValueFromUnknown(payload.call_id),
       kind: "tool output",
       role: "tool",
+      status: isError ? "error" : "ok",
       text: truncateTranscriptText(text),
       timestamp,
-    }
+      title: isError ? "tool error" : "tool result",
+    })
   }
 
   if (type === "local_shell_call") {
-    const text = textFromUnknown(payload.action) ?? "shell command"
-    return {
+    const text =
+      textFromUnknown(payload.action) ??
+      compactJsonFromUnknown(payload.action) ??
+      "shell command"
+    return transcriptMessage({
+      detail: stringValueFromUnknown(payload.call_id),
       kind: "shell",
       role: "tool",
+      status: "running",
       text: truncateTranscriptText(text),
       timestamp,
-    }
+      title: "shell",
+    })
   }
 
   return null
@@ -487,12 +533,13 @@ const transcriptMessageFromEvent = (
   if (type === "user_message") {
     const text = stringValueFromUnknown(payload.message) ?? textFromUnknown(payload.text_elements)
     if (text === null || text.trim() === "") return null
-    return {
+    return transcriptMessage({
       kind: "user event",
       role: "user",
       text: truncateTranscriptText(text),
       timestamp,
-    }
+      title: "user",
+    })
   }
 
   if (type === "agent_message") {
@@ -500,12 +547,13 @@ const transcriptMessageFromEvent = (
       stringValueFromUnknown(payload.text) ??
       textFromUnknown(payload.content)
     if (text === null || text.trim() === "") return null
-    return {
+    return transcriptMessage({
       kind: "agent event",
       role: "assistant",
       text: truncateTranscriptText(text),
       timestamp,
-    }
+      title: "assistant",
+    })
   }
 
   const text =
@@ -514,12 +562,16 @@ const transcriptMessageFromEvent = (
     stringValueFromUnknown(payload.text)
   if (text === null) return null
 
-  return {
-    kind: type.replaceAll("_", " "),
+  const kind = type.replaceAll("_", " ")
+  const isError = /\berror\b|failed|failure/i.test(kind)
+  return transcriptMessage({
+    kind,
     role: "event",
+    status: isError ? "error" : "info",
     text: truncateTranscriptText(text),
     timestamp,
-  }
+    title: isError ? "error" : kind,
+  })
 }
 
 const firstTranscriptLine = (value: string): string | null => {

--- a/clients/openagents-desktop/src/ui/main.ts
+++ b/clients/openagents-desktop/src/ui/main.ts
@@ -117,6 +117,19 @@ const formatRelativeTimestamp = (value: string | null): string => {
   return `${formatCount(Math.round(hours / 24))}d ago`
 }
 
+const formatAbsoluteTimestamp = (value: string | null): string => {
+  if (value === null) return "No timestamp"
+  const date = new Date(value)
+  if (!Number.isFinite(date.getTime())) return value
+  return new Intl.DateTimeFormat("en-US", {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+    second: "2-digit",
+  }).format(date)
+}
+
 const pylonIsOnline = (pylon: DesktopPylon): boolean =>
   pylon.heartbeatFresh || pylon.status.trim().toLowerCase() === "online"
 
@@ -258,23 +271,65 @@ const messageRow = (message: CodingTranscriptMessage): HTMLElement => {
   const row = document.createElement("article")
   row.className = "coding-message"
   row.dataset.role = message.role
+  row.dataset.status = message.status
 
   const heading = document.createElement("div")
   heading.className = "coding-message-heading"
 
+  const marker = document.createElement("span")
+  marker.className = "coding-message-marker"
+  marker.setAttribute("aria-hidden", "true")
+
+  const label = document.createElement("div")
+  label.className = "coding-message-label"
+
   const role = document.createElement("strong")
-  role.textContent = message.role
+  role.textContent = message.title
+
+  const kind = document.createElement("span")
+  kind.textContent = message.kind
+
+  label.append(role, kind)
+
+  const chips = document.createElement("div")
+  chips.className = "coding-message-chips"
+
+  if (message.detail !== null) {
+    const detail = document.createElement("span")
+    detail.className = "coding-message-chip"
+    detail.textContent = message.detail
+    chips.append(detail)
+  }
+
+  if (message.status !== "info") {
+    const status = document.createElement("span")
+    status.className = "coding-message-chip"
+    status.dataset.status = message.status
+    status.textContent = message.status
+    chips.append(status)
+  }
+
+  const time = document.createElement("time")
+  time.className = "coding-message-time"
+  if (message.timestamp !== null) time.dateTime = message.timestamp
+  time.textContent = formatAbsoluteTimestamp(message.timestamp)
 
   const meta = document.createElement("span")
-  meta.textContent = [
-    message.kind,
-    formatRelativeTimestamp(message.timestamp),
-  ].join(" · ")
+  meta.className = "coding-message-relative-time"
+  meta.textContent = formatRelativeTimestamp(message.timestamp)
 
-  const body = document.createElement("p")
+  const body =
+    message.role === "tool" || message.status === "error"
+      ? document.createElement("pre")
+      : document.createElement("p")
+  body.className = "coding-message-body"
   body.textContent = message.text
 
-  heading.append(role, meta)
+  const metaGroup = document.createElement("div")
+  metaGroup.className = "coding-message-meta"
+  metaGroup.append(chips, time, meta)
+
+  heading.append(marker, label, metaGroup)
   row.append(heading, body)
   return row
 }

--- a/clients/openagents-desktop/src/ui/styles.css
+++ b/clients/openagents-desktop/src/ui/styles.css
@@ -638,18 +638,39 @@ button {
 }
 
 .coding-transcript-messages {
+  position: relative;
   display: grid;
   align-content: start;
-  gap: 8px;
+  gap: 10px;
   min-height: 0;
   overflow: auto;
-  padding: 12px;
+  padding: 14px 12px 14px 20px;
+}
+
+.coding-transcript-messages::before {
+  content: "";
+  position: absolute;
+  top: 18px;
+  bottom: 18px;
+  left: 21px;
+  width: 1px;
+  pointer-events: none;
+  background: linear-gradient(
+    180deg,
+    rgba(79, 208, 255, 0),
+    rgba(79, 208, 255, 0.32) 12%,
+    rgba(143, 182, 255, 0.18) 72%,
+    rgba(79, 208, 255, 0)
+  );
 }
 
 .coding-message {
+  position: relative;
   display: grid;
-  gap: 8px;
-  background: rgba(10, 17, 31, 0.78);
+  gap: 10px;
+  margin-left: 10px;
+  background: rgba(7, 13, 24, 0.76);
+  box-shadow: 0 0 0 1px rgba(79, 208, 255, 0.03) inset;
 }
 
 .coding-message[data-role="user"] {
@@ -665,11 +686,58 @@ button {
   border-color: rgba(125, 153, 194, 0.22);
 }
 
+.coding-message[data-status="running"] {
+  background: rgba(7, 18, 31, 0.82);
+  border-color: rgba(143, 182, 255, 0.24);
+}
+
+.coding-message[data-status="ok"] {
+  border-color: rgba(79, 208, 255, 0.3);
+}
+
+.coding-message[data-status="error"] {
+  background: rgba(31, 10, 16, 0.82);
+  border-color: rgba(255, 107, 122, 0.42);
+}
+
 .coding-message-heading {
-  display: flex;
-  align-items: baseline;
-  justify-content: space-between;
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: start;
   gap: 10px;
+  min-width: 0;
+}
+
+.coding-message-marker {
+  position: relative;
+  z-index: 1;
+  width: 9px;
+  height: 9px;
+  margin-top: 5px;
+  margin-left: -22px;
+  background: #7f99c8;
+  border: 1px solid rgba(219, 232, 255, 0.4);
+  border-radius: 999px;
+  box-shadow: 0 0 12px -4px rgba(143, 182, 255, 0.8);
+}
+
+.coding-message[data-role="assistant"] .coding-message-marker,
+.coding-message[data-status="ok"] .coding-message-marker {
+  background: #4fd0ff;
+  border-color: rgba(79, 208, 255, 0.72);
+  box-shadow: 0 0 16px -3px rgba(79, 208, 255, 0.9);
+}
+
+.coding-message[data-status="error"] .coding-message-marker {
+  background: #ff6b7a;
+  border-color: rgba(255, 107, 122, 0.78);
+  box-shadow: 0 0 16px -3px rgba(255, 107, 122, 0.76);
+}
+
+.coding-message-label {
+  display: grid;
+  min-width: 0;
+  gap: 3px;
 }
 
 .coding-message-heading strong {
@@ -679,13 +747,83 @@ button {
   text-transform: uppercase;
 }
 
-.coding-message p {
+.coding-message-label span,
+.coding-message-time,
+.coding-message-relative-time,
+.coding-message-chip {
+  color: #9bb8e8;
+  font-size: 0.68rem;
+  line-height: 1.4;
+}
+
+.coding-message-label span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.coding-message-meta {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 6px;
+  min-width: 0;
+}
+
+.coding-message-chips {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 5px;
+  min-width: 0;
+}
+
+.coding-message-chip {
+  max-width: 180px;
+  overflow: hidden;
+  padding: 3px 6px;
+  color: #cfe3ff;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.09);
+  border-radius: 999px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.coding-message-chip[data-status="running"] {
+  color: #dbe8ff;
+  border-color: rgba(143, 182, 255, 0.26);
+}
+
+.coding-message-chip[data-status="ok"] {
+  color: #dff8ff;
+  background: rgba(79, 208, 255, 0.1);
+  border-color: rgba(79, 208, 255, 0.32);
+}
+
+.coding-message-chip[data-status="error"] {
+  color: #ffd8dd;
+  background: rgba(255, 107, 122, 0.1);
+  border-color: rgba(255, 107, 122, 0.34);
+}
+
+.coding-message-body {
   margin: 0;
   overflow-wrap: anywhere;
   color: #e6efff;
   font-size: 0.74rem;
   line-height: 1.5;
   white-space: pre-wrap;
+}
+
+pre.coding-message-body {
+  max-height: 220px;
+  overflow: auto;
+  padding: 9px 10px;
+  color: #d7e2f0;
+  background: rgba(0, 0, 0, 0.22);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 6px;
 }
 
 .coding-events-block {

--- a/clients/openagents-desktop/tests/coding-status.test.ts
+++ b/clients/openagents-desktop/tests/coding-status.test.ts
@@ -80,12 +80,14 @@ Pylon presence failed: OpenAgents presence request failed (401): {"error":"unaut
 {"timestamp":"2026-06-29T02:44:00.929Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"Implement issue #6958"}]}}
 {"timestamp":"2026-06-29T02:45:00.000Z","type":"response_item","payload":{"type":"function_call","name":"shell","arguments":"{\\"cmd\\":\\"git status\\"}","call_id":"call-1"}}
 {"timestamp":"2026-06-29T02:45:01.000Z","type":"response_item","payload":{"type":"function_call_output","call_id":"call-1","output":"clean"}}
+{"timestamp":"2026-06-29T02:45:02.000Z","type":"response_item","payload":{"type":"reasoning","summary":[{"type":"summary_text","text":"Check the working tree before editing."}]}}
+{"timestamp":"2026-06-29T02:45:03.000Z","type":"response_item","payload":{"type":"function_call_output","call_id":"call-2","output":"permission denied","is_error":true}}
 {"timestamp":"2026-06-29T02:46:00.000Z","type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"Done."}]}}
 `)
 
     expect(parsed).toMatchObject({
       cwd: "/tmp/workspace-one",
-      messageCount: 4,
+      messageCount: 6,
       sessionId: "019f1143-24ae-76b1-851b-494930817124",
       source: "exec",
       title: "Implement issue #6958",
@@ -94,8 +96,36 @@ Pylon presence failed: OpenAgents presence request failed (401): {"error":"unaut
       "user",
       "tool",
       "tool",
+      "reasoning",
+      "tool",
       "assistant",
     ])
+    expect(parsed.messages[1]).toMatchObject({
+      detail: "call-1",
+      kind: "tool call",
+      status: "running",
+      text: "{\"cmd\":\"git status\"}",
+      title: "shell",
+    })
+    expect(parsed.messages[2]).toMatchObject({
+      detail: "call-1",
+      kind: "tool output",
+      status: "ok",
+      title: "tool result",
+    })
+    expect(parsed.messages[3]).toMatchObject({
+      kind: "reasoning",
+      status: "info",
+      text: "Check the working tree before editing.",
+      title: "reasoning",
+    })
+    expect(parsed.messages[4]).toMatchObject({
+      detail: "call-2",
+      kind: "tool output",
+      status: "error",
+      text: "permission denied",
+      title: "tool error",
+    })
     expect(parsed.messages.at(-1)?.text).toBe("Done.")
   })
 


### PR DESCRIPTION
## Summary

- Enrich desktop Codex transcript parsing with presentation-safe title/detail/status metadata for messages, reasoning, tool calls, tool results, and tool errors.
- Render the desktop coding transcript as an Orca-like operator timeline with rail markers, state chips, absolute and relative timestamps, and preformatted tool/error output.
- Preserve the existing 3D background, status strip, metrics, session list, and dispatch view.

## Verification

- `bun run verify` from `clients/openagents-desktop`
- Required ref `command.public.pylon_khala.verify.b5bea41b6c623f7c09f1bf24` maps locally to `true`; ran and passed.
