### PR TITLE
Harden Pylon agent runner resolution

### DIFF
--- a/apps/pylon/src/agent-runner-registry.ts
+++ b/apps/pylon/src/agent-runner-registry.ts
@@ -72,6 +72,15 @@ export type AgentRunnerDescriptor = {
   ) => Promise<AgentRunnerCloseoutRecord | null>
 }
 
+export type AgentRunnerResolution =
+  | { status: "matched"; runner: AgentRunnerDescriptor }
+  | { status: "none" }
+  | {
+      status: "ambiguous"
+      runnerKinds: AgentRunnerKind[]
+      blockerRef: "blocker.assignment.agent_runner_ambiguous"
+    }
+
 function hasObjectField(value: unknown, key: string): boolean {
   const field = (value as Record<string, unknown> | undefined)?.[key]
   return field !== null && typeof field === "object"
@@ -127,13 +136,26 @@ export function agentRunnerForAdapterKind(
   return AGENT_RUNNER_REGISTRY.find((runner) => runner.adapterKind === adapterKind) ?? null
 }
 
+export function agentRunnerResolutionForLease(lease: PylonAssignmentLease): AgentRunnerResolution {
+  const matches = AGENT_RUNNER_REGISTRY.filter((runner) => runner.canRunAssignment(lease.codingAssignment))
+  if (matches.length === 0) return { status: "none" }
+  if (matches.length === 1) return { status: "matched", runner: matches[0] }
+  return {
+    status: "ambiguous",
+    runnerKinds: matches.map((runner) => runner.kind),
+    blockerRef: "blocker.assignment.agent_runner_ambiguous",
+  }
+}
+
 export function agentRunnerForLease(lease: PylonAssignmentLease): AgentRunnerDescriptor | null {
-  return AGENT_RUNNER_REGISTRY.find((runner) => runner.canRunAssignment(lease.codingAssignment)) ?? null
+  const resolution = agentRunnerResolutionForLease(lease)
+  return resolution.status === "matched" ? resolution.runner : null
 }
 
 export function agentRunnerServiceForLease(lease: PylonAssignmentLease): AgentRunnerServiceRef | null {
-  const runner = agentRunnerForLease(lease)
-  if (runner !== null) return runner.serviceRef
+  const resolution = agentRunnerResolutionForLease(lease)
+  if (resolution.status === "matched") return resolution.runner.serviceRef
+  if (resolution.status === "ambiguous") return null
 
   const codingAssignment = lease.codingAssignment
   const legacyRunner = AGENT_RUNNER_REGISTRY.find((candidate) => {
@@ -151,7 +173,7 @@ export async function executeRegisteredAgentRunner(
   now: Date,
   options: AgentRunnerExecutionOptions,
 ): Promise<AgentRunnerCloseoutRecord | null> {
-  const runner = agentRunnerForLease(lease)
-  if (runner === null) return null
-  return runner.execute(state, lease, now, options)
+  const resolution = agentRunnerResolutionForLease(lease)
+  if (resolution.status !== "matched") return null
+  return resolution.runner.execute(state, lease, now, options)
 }

--- a/apps/pylon/src/assignment.ts
+++ b/apps/pylon/src/assignment.ts
@@ -27,6 +27,7 @@ import {
 import type { CodexAgentRuntimePhase, CodexAgentRunner } from "./codex-agent-executor.js"
 import {
   agentRunnerForLease,
+  agentRunnerResolutionForLease,
   agentRunnerServiceForLease,
   executeRegisteredAgentRunner,
   type AgentRunnerCloseoutRecord,
@@ -1103,6 +1104,8 @@ export async function computeAssignmentAdmission(
     if (age > (options.staleAfterMs ?? 120_000)) blockerRefs.add("blocker.assignment.presence_stale")
   }
   if (!hasRequiredCapabilities(state, lease)) blockerRefs.add("blocker.assignment.wrong_capability")
+  const runnerResolution = agentRunnerResolutionForLease(lease)
+  if (runnerResolution.status === "ambiguous") blockerRefs.add(runnerResolution.blockerRef)
   if (lease.backendRef && !state.runtime.capabilityRefs.includes(lease.backendRef)) {
     blockerRefs.add("blocker.assignment.unsupported_backend")
   }

--- a/apps/pylon/tests/agent-runtime-adapter.test.ts
+++ b/apps/pylon/tests/agent-runtime-adapter.test.ts
@@ -22,6 +22,7 @@ import {
 import {
   AGENT_RUNNER_REGISTRY,
   agentRunnerForLease,
+  agentRunnerResolutionForLease,
   agentRunnerServiceForLease,
 } from "../src/agent-runner-registry"
 import { createBootstrapSummary, parseBootstrapArgs } from "../src/bootstrap"
@@ -166,6 +167,38 @@ describe("AgentRuntimeAdapter", () => {
     expect(agentRunnerServiceForLease(claudeLease)).toBe("claude")
     expect(agentRunnerForLease(codexLease)?.adapterKind).toBe("codex")
     expect(agentRunnerServiceForLease(codexLease)).toBe("codex")
+  })
+
+  test("registry resolution rejects ambiguous mixed-runner assignment payloads", () => {
+    const lease = {
+      schema: "openagents.pylon.assignment_lease.v0.3",
+      assignmentRef: "assignment.public.registry.ambiguous",
+      leaseRef: "lease.public.registry.ambiguous",
+      goal: "goal.public.registry.ambiguous",
+      paymentMode: "no-spend",
+      capabilityRefs: [],
+      codingAssignment: {
+        claudeAgent: {
+          schema: CLAUDE_AGENT_TASK_SCHEMA,
+          agentKind: "claude_agent_sdk",
+          fixtureRef: CLAUDE_AGENT_SUM_REPAIR_FIXTURE_REF,
+        },
+        codex: {
+          schema: CODEX_AGENT_TASK_SCHEMA,
+          agentKind: "codex_sdk",
+          fixtureRef: CODEX_AGENT_SUM_REPAIR_FIXTURE_REF,
+        },
+      },
+      expiresAt: now.toISOString(),
+    } as const
+
+    expect(agentRunnerResolutionForLease(lease)).toEqual({
+      status: "ambiguous",
+      runnerKinds: ["claude_agent", "codex"],
+      blockerRef: "blocker.assignment.agent_runner_ambiguous",
+    })
+    expect(agentRunnerForLease(lease)).toBeNull()
+    expect(agentRunnerServiceForLease(lease)).toBeNull()
   })
 
   test("fixture, Codex, and Claude wrappers emit the same kernel event contract", async () => {

--- a/apps/pylon/tests/assignment.test.ts
+++ b/apps/pylon/tests/assignment.test.ts
@@ -19,6 +19,7 @@ import { assertPublicProjectionSafe, ensurePylonLocalState, writePresenceState }
 import { PSIONIC_QWEN_MODEL_REFS, type PsionicQwenModelAdmission } from "../packages/runtime/src/index"
 import { CLAUDE_AGENT_SDK_PACKAGE } from "../src/claude-agent"
 import {
+  CLAUDE_AGENT_SUM_REPAIR_FIXTURE_REF,
   CLAUDE_AGENT_TASK_SCHEMA,
   type ClaudeAgentCheckoutRunner,
   type ClaudeAgentRunner,
@@ -194,6 +195,41 @@ async function readySummary(home: string, capabilityRefs: string[] = ["cap.gepa.
 }
 
 describe("Pylon assignment lease flow", () => {
+  test("admission blocks ambiguous mixed-runner coding assignments", async () => {
+    await withTempHome(async (home) => {
+      const fake = fakeAssignmentServer()
+      const summary = await readySummary(home, [])
+      await sendHeartbeat(summary, {
+        baseUrl: fake.baseUrl,
+        now: () => new Date("2026-06-09T00:00:00.000Z"),
+      })
+      const state = await ensurePylonLocalState(summary)
+      const admission = await computeAssignmentAdmission(
+        state,
+        lease({
+          capabilityRefs: [],
+          codingAssignment: {
+            claudeAgent: {
+              schema: CLAUDE_AGENT_TASK_SCHEMA,
+              agentKind: "claude_agent_sdk",
+              fixtureRef: CLAUDE_AGENT_SUM_REPAIR_FIXTURE_REF,
+            },
+            codex: {
+              schema: CODEX_AGENT_TASK_SCHEMA,
+              agentKind: "codex_sdk",
+              fixtureRef: CODEX_AGENT_SUM_REPAIR_FIXTURE_REF,
+            },
+          },
+          expiresAt: "2026-06-09T01:00:00.000Z",
+        }),
+        { now: () => new Date("2026-06-09T00:00:30.000Z") },
+      )
+
+      expect(admission.admissible).toBe(false)
+      expect(admission.blockerRefs).toContain("blocker.assignment.agent_runner_ambiguous")
+    })
+  })
+
   test("polls, accepts, submits progress/proof refs, and closes a no-spend assignment", async () => {
     await withTempHome(async (home) => {
       const fake = fakeAssignmentServer()


### PR DESCRIPTION
## Summary
- add a typed AgentRunnerResolution for matched/none/ambiguous registry outcomes
- prevent ambiguous mixed-runner assignment payloads from getting a service/account route
- block ambiguous runner payloads during assignment admission before generic runtime fallback

## Verification
- bun test tests/agent-runtime-adapter.test.ts tests/assignment.test.ts (from apps/pylon)
- bun run --cwd apps/pylon typecheck
- required command ref command.public.pylon_khala.verify.b5bea41b6c623f7c09f1bf24 resolved from local logs to argv ["true"] and passed
