### PR TITLE
Expose Codex quota reset policy status

### DIFF
--- a/apps/pylon/src/account-status.test.ts
+++ b/apps/pylon/src/account-status.test.ts
@@ -123,10 +123,229 @@ describe("#6637 account status observability", () => {
         cooldownSecondsRemaining: 900,
         manualResetsRemaining: 3,
       })
+      expect(status.accounts[0]?.quotaPolicy).toMatchObject({
+        state: "limited_unknown",
+        limitScope: "unknown",
+        resetAtIso: "2026-06-28T22:00:00.000Z",
+        shouldWaitForReset: true,
+        operatorRecovery: {
+          required: false,
+          manualResetAvailable: false,
+          status: "not_applicable",
+        },
+      })
       expect(status.accounts[0]?.capacity.hourly?.remainingPercent).toBe(75)
       expect(status.accounts[0]?.capacity.weekly?.remainingPercent).toBe(50)
       expect(status.accounts[0]?.usage.totalTokens).toBe(140)
       expect(status.accounts[0]?.manualReset.manualResetsRemaining).toBe(3)
+    })
+  })
+
+  test("treats Codex 5-hour exhaustion with weekly headroom as wait-only cooldown", async () => {
+    await withTempHome(async ({ home, summary }) => {
+      const accountHome = join(home, "accounts", "codex", "codex")
+      await mkdir(accountHome, { recursive: true })
+      await writeFile(summary.paths.config, JSON.stringify({
+        dev: {
+          accounts: [
+            {
+              provider: "codex",
+              ref: "codex",
+              home: accountHome,
+            },
+          ],
+        },
+      }))
+      const accountRefHash = hashPylonAccountRef("codex", "codex")
+      await recordQuotaBlock(summary, {
+        accountRefHash,
+        provider: "codex",
+        retryAtIso: "2026-06-29T02:00:00.000Z",
+        sourceDigestRef: "digest.pylon.account_quota.short_window",
+        now: new Date("2026-06-28T21:30:00.000Z"),
+      })
+      await recordPylonAccountUsageObservation(summary, {
+        provider: "codex",
+        account: {
+          provider: "codex",
+          selector: "registry_ref",
+          accountRef: "codex",
+          accountRefHash,
+          home: accountHome,
+        },
+        providerSnapshots: [
+          {
+            provider: "codex",
+            limitId: "codex",
+            limitName: "Codex",
+            primary: {
+              usedPercent: 100,
+              remainingPercent: 0,
+              windowMinutes: 5 * 60,
+              resetsAt: 1_782_698_400,
+              label: "5h",
+            },
+            secondary: {
+              usedPercent: 64,
+              remainingPercent: 36,
+              windowMinutes: 7 * 24 * 60,
+              resetsAt: 1_783_286_400,
+              label: "weekly",
+            },
+            credits: null,
+            planType: "pro",
+            rateLimitReachedType: "primary",
+          },
+        ],
+        observedAt: new Date("2026-06-28T21:31:00.000Z"),
+      })
+
+      const status = await collectPylonAccountsStatus(
+        summary,
+        parsePylonAccountsStatusArgs(["--account", "codex", "--json"]),
+        {
+          env: { PYLON_HOME: home, CODEX_HOME: accountHome, PYLON_ACCOUNT_HOME_ROOT: join(home, "empty-siblings") },
+          now: new Date("2026-06-28T21:45:00.000Z"),
+        },
+      )
+
+      expect(status.accounts[0]?.quotaPolicy).toMatchObject({
+        state: "short_window_cooldown",
+        limitScope: "short_window",
+        resetAtIso: "2026-06-29T02:00:00.000Z",
+        shouldWaitForReset: true,
+        operatorRecovery: {
+          required: false,
+          manualResetAvailable: false,
+          status: "not_applicable",
+        },
+      })
+      expect(status.accounts[0]?.quotaPolicy.exhaustedWindow?.label).toBe("5h")
+      expect(status.accounts[0]?.quotaPolicy.weeklyWindow?.remainingPercent).toBe(36)
+
+      const resetAttempt = await collectPylonAccountsStatus(
+        summary,
+        parsePylonAccountsStatusArgs(["--account", "codex", "--reset", "--json"]),
+        {
+          env: { PYLON_HOME: home, CODEX_HOME: accountHome, PYLON_ACCOUNT_HOME_ROOT: join(home, "empty-siblings") },
+          now: new Date("2026-06-28T21:46:00.000Z"),
+        },
+      )
+
+      expect(resetAttempt.accounts[0]?.manualReset.performed).toBe(false)
+      expect(resetAttempt.accounts[0]?.manualReset.blockerRefs).toContain(
+        "blocker.pylon.accounts_status.manual_reset_not_applicable",
+      )
+      expect(await loadQuotaRecord(summary, accountRefHash)).not.toBeNull()
+    })
+  })
+
+  test("exposes Codex weekly exhaustion as operator recovery without faking provider reset", async () => {
+    await withTempHome(async ({ home, summary }) => {
+      const accountHome = join(home, "accounts", "codex", "codex")
+      await mkdir(accountHome, { recursive: true })
+      await writeFile(summary.paths.config, JSON.stringify({
+        dev: {
+          accounts: [
+            {
+              provider: "codex",
+              ref: "codex",
+              home: accountHome,
+            },
+          ],
+        },
+      }))
+      const accountRefHash = hashPylonAccountRef("codex", "codex")
+      await recordQuotaBlock(summary, {
+        accountRefHash,
+        provider: "codex",
+        retryAtIso: "2026-07-05T00:00:00.000Z",
+        sourceDigestRef: "digest.pylon.account_quota.weekly",
+        manualResetsRemaining: 2,
+        now: new Date("2026-06-28T21:30:00.000Z"),
+      })
+      await recordPylonAccountUsageObservation(summary, {
+        provider: "codex",
+        account: {
+          provider: "codex",
+          selector: "registry_ref",
+          accountRef: "codex",
+          accountRefHash,
+          home: accountHome,
+        },
+        providerSnapshots: [
+          {
+            provider: "codex",
+            limitId: "codex",
+            limitName: "Codex",
+            primary: {
+              usedPercent: 41,
+              remainingPercent: 59,
+              windowMinutes: 5 * 60,
+              resetsAt: 1_782_698_400,
+              label: "5h",
+            },
+            secondary: {
+              usedPercent: 100,
+              remainingPercent: 0,
+              windowMinutes: 7 * 24 * 60,
+              resetsAt: 1_783_209_600,
+              label: "weekly",
+            },
+            credits: null,
+            planType: "pro",
+            rateLimitReachedType: "secondary",
+          },
+        ],
+        observedAt: new Date("2026-06-28T21:31:00.000Z"),
+      })
+
+      const status = await collectPylonAccountsStatus(
+        summary,
+        parsePylonAccountsStatusArgs(["--account", "codex", "--json"]),
+        {
+          env: { PYLON_HOME: home, CODEX_HOME: accountHome, PYLON_ACCOUNT_HOME_ROOT: join(home, "empty-siblings") },
+          now: new Date("2026-06-28T21:45:00.000Z"),
+        },
+      )
+
+      expect(status.accounts[0]?.quotaPolicy).toMatchObject({
+        state: "weekly_exhausted",
+        limitScope: "weekly",
+        resetAtIso: "2026-07-05T00:00:00.000Z",
+        shouldWaitForReset: false,
+        operatorRecovery: {
+          required: true,
+          manualResetAvailable: false,
+          manualResetsRemaining: 3,
+          command: "pylon accounts usage --account codex --refresh --json",
+          status: "provider_reset_required",
+        },
+      })
+
+      const reset = await collectPylonAccountsStatus(
+        summary,
+        parsePylonAccountsStatusArgs(["--account", "codex", "--reset", "--json"]),
+        {
+          env: { PYLON_HOME: home, CODEX_HOME: accountHome, PYLON_ACCOUNT_HOME_ROOT: join(home, "empty-siblings") },
+          now: new Date("2026-06-28T21:46:00.000Z"),
+        },
+      )
+
+      expect(reset.accounts[0]?.manualReset.performed).toBe(false)
+      expect(reset.accounts[0]?.manualReset.blockerRefs).toContain(
+        "blocker.pylon.accounts_status.manual_reset_not_applicable",
+      )
+      expect(reset.accounts[0]?.quota.state).toBe("limited")
+      expect(reset.accounts[0]?.quotaPolicy.state).toBe("weekly_exhausted")
+      expect(reset.accounts[0]?.quotaPolicy.operatorRecovery).toMatchObject({
+        required: true,
+        manualResetAvailable: false,
+        manualResetsRemaining: 3,
+        command: "pylon accounts usage --account codex --refresh --json",
+        status: "provider_reset_required",
+      })
+      expect(await loadQuotaRecord(summary, accountRefHash)).not.toBeNull()
     })
   })
 

--- a/apps/pylon/src/account-status.test.ts
+++ b/apps/pylon/src/account-status.test.ts
@@ -375,6 +375,47 @@ describe("#6637 account status observability", () => {
     })
   })
 
+  test("accounts status manual reset clears an unknown local quota block", async () => {
+    await withTempHome(async ({ home, summary }) => {
+      const accountHome = join(home, "accounts", "codex", "codex")
+      await mkdir(accountHome, { recursive: true })
+      await writeFile(summary.paths.config, JSON.stringify({
+        dev: {
+          accounts: [
+            {
+              provider: "codex",
+              ref: "codex",
+              home: accountHome,
+            },
+          ],
+        },
+      }))
+      const accountRefHash = hashPylonAccountRef("codex", "codex")
+      await recordQuotaBlock(summary, {
+        accountRefHash,
+        provider: "codex",
+        retryAtIso: "2026-06-28T22:00:00.000Z",
+        sourceDigestRef: "digest.pylon.account_quota.unknown",
+        now: new Date("2026-06-28T21:30:00.000Z"),
+      })
+
+      const reset = await collectPylonAccountsStatus(
+        summary,
+        parsePylonAccountsStatusArgs(["--account", "codex", "--reset", "--json"]),
+        {
+          env: { PYLON_HOME: home, CODEX_HOME: accountHome, PYLON_ACCOUNT_HOME_ROOT: join(home, "empty-siblings") },
+          now: new Date("2026-06-28T21:35:00.000Z"),
+        },
+      )
+
+      expect(reset.accounts[0]?.manualReset.performed).toBe(true)
+      expect(reset.accounts[0]?.manualReset.blockerRefs).toEqual([])
+      expect(reset.accounts[0]?.quota.state).toBe("available")
+      expect(reset.accounts[0]?.quotaPolicy.state).toBe("available")
+      expect(await loadQuotaRecord(summary, accountRefHash)).toBeNull()
+    })
+  })
+
   test("projects specific Codex account auth health reasons", async () => {
     await withTempHome(async ({ home, summary }) => {
       const accountHome = join(home, "accounts", "codex", "codex-revoked")

--- a/apps/pylon/src/account-status.ts
+++ b/apps/pylon/src/account-status.ts
@@ -12,7 +12,10 @@ import {
 import {
   countAccountRollingWindowLocalSessionTokens,
   loadAccountUsageStore,
+  quotaPolicyFromAccountStatus,
+  type PylonAccountQuotaPolicyStatus,
   type PylonAccountUsageStoreEntry,
+  type PylonAccountWindowStatus,
   type PylonProviderRateLimitSnapshot,
 } from "./account-usage.js"
 import type { BootstrapSummary } from "./bootstrap.js"
@@ -31,6 +34,7 @@ export type PylonOperatorAccountStatusEntry = {
   weeklyCap: number | null
   weeklyUsage: number | null
   manualResetsRemaining: number | null
+  quotaPolicy: PylonAccountQuotaPolicyStatus
 }
 
 export type PylonOperatorAccountStatusProjection = {
@@ -90,6 +94,37 @@ function usageFor(
   return null
 }
 
+function isoFromResetEpoch(value: number | null): string | null {
+  if (value === null || !Number.isFinite(value) || value <= 0) return null
+  const millis = value < 10_000_000_000 ? value * 1000 : value
+  const date = new Date(millis)
+  return Number.isNaN(date.getTime()) ? null : date.toISOString()
+}
+
+function capacityWindowsFrom(entry: PylonAccountUsageStoreEntry | undefined): PylonAccountWindowStatus[] {
+  if (!entry?.providerTruth) return []
+  const windows: PylonAccountWindowStatus[] = []
+  for (const snapshot of entry.providerTruth.snapshots) {
+    for (const window of [snapshot.primary, snapshot.secondary]) {
+      if (window === null) continue
+      windows.push({
+        usedPercent: window.usedPercent,
+        remainingPercent: window.remainingPercent,
+        windowMinutes: window.windowMinutes,
+        resetsAtIso: isoFromResetEpoch(window.resetsAt),
+        label: window.label,
+      })
+    }
+  }
+  const seen = new Set<string>()
+  return windows.filter((window) => {
+    const key = `${window.label}:${window.windowMinutes ?? "unknown"}:${window.usedPercent}:${window.resetsAtIso ?? "none"}`
+    if (seen.has(key)) return false
+    seen.add(key)
+    return true
+  })
+}
+
 export async function collectPylonOperatorAccountStatus(
   summary: Pick<BootstrapSummary, "paths">,
   options: { now?: Date } = {},
@@ -108,16 +143,27 @@ export async function collectPylonOperatorAccountStatus(
       defaultManualResetsRemaining: account.manualResetsRemaining,
     })
     const usageEntry = usageStore.accounts[accountRefHash]
+    const accountCooldownExpiresAt = cooldownExpiresAt(quotaRecord, now)
+    const accountQuotaLimited = !isAccountAvailable(quotaRecord, now)
+    const accountManualResetsRemaining = resetRecord.manualResetsRemaining
     accounts.push({
       accountRefHash,
       provider: account.provider,
-      isRateLimited: !isAccountAvailable(quotaRecord, now),
-      cooldownExpiresAt: cooldownExpiresAt(quotaRecord, now),
+      isRateLimited: accountQuotaLimited,
+      cooldownExpiresAt: accountCooldownExpiresAt,
       hourlyCap: account.hourlyCap,
       hourlyUsage: usageFor(usageEntry, "hourly", account.hourlyCap, now),
       weeklyCap: account.weeklyCap,
       weeklyUsage: usageFor(usageEntry, "weekly", account.weeklyCap, now),
-      manualResetsRemaining: resetRecord.manualResetsRemaining,
+      manualResetsRemaining: accountManualResetsRemaining,
+      quotaPolicy: quotaPolicyFromAccountStatus({
+        quotaLimited: accountQuotaLimited,
+        quotaCooldownExpiresAt: accountCooldownExpiresAt,
+        windows: capacityWindowsFrom(usageEntry),
+        manualResetsRemaining: accountManualResetsRemaining,
+        accountRef: null,
+        hasLocalQuotaBlock: quotaRecord !== null,
+      }),
     })
   }
 

--- a/apps/pylon/src/account-usage.ts
+++ b/apps/pylon/src/account-usage.ts
@@ -1332,7 +1332,7 @@ export async function collectPylonAccountsStatus(
     let resetPerformed = false
     let resetBlockerRefs: string[] = []
     if (args.reset && args.accountRef === target.accountRef) {
-      if (preResetPolicy.state !== "weekly_exhausted" || !preResetPolicy.operatorRecovery.manualResetAvailable) {
+      if (preResetPolicy.state === "short_window_cooldown" || preResetPolicy.state === "weekly_exhausted") {
         resetBlockerRefs = ["blocker.pylon.accounts_status.manual_reset_not_applicable"]
       } else {
         try {

--- a/apps/pylon/src/account-usage.ts
+++ b/apps/pylon/src/account-usage.ts
@@ -145,6 +145,23 @@ export type PylonAccountWindowStatus = {
   label: string
 }
 
+export type PylonAccountQuotaPolicyStatus = {
+  state: "available" | "short_window_cooldown" | "weekly_exhausted" | "limited_unknown"
+  limitScope: "none" | "short_window" | "weekly" | "unknown"
+  exhaustedWindow: PylonAccountWindowStatus | null
+  weeklyWindow: PylonAccountWindowStatus | null
+  resetAtIso: string | null
+  shouldWaitForReset: boolean
+  operatorRecovery: {
+    required: boolean
+    manualResetAvailable: boolean
+    manualResetsRemaining: number
+    command: string | null
+    status: "not_applicable" | "available" | "unavailable" | "exhausted" | "provider_reset_required"
+  }
+  blockerRefs: string[]
+}
+
 export type PylonAccountsStatusProjection = {
   schema: typeof PYLON_ACCOUNTS_STATUS_SCHEMA
   observedAt: string
@@ -162,6 +179,7 @@ export type PylonAccountsStatusProjection = {
       sourceDigestRef: string | null
       manualResetsRemaining: number
     }
+    quotaPolicy: PylonAccountQuotaPolicyStatus
     capacity: {
       hourly: PylonAccountWindowStatus | null
       weekly: PylonAccountWindowStatus | null
@@ -1174,6 +1192,114 @@ function firstWindowByLabel(windows: PylonAccountWindowStatus[], label: string):
   return windows.find((window) => window.label === label) ?? null
 }
 
+function exhaustedWindow(windows: PylonAccountWindowStatus[], labels: readonly string[]): PylonAccountWindowStatus | null {
+  return windows.find((window) =>
+    labels.includes(window.label) &&
+    (window.remainingPercent <= 0 || window.usedPercent >= 100)
+  ) ?? null
+}
+
+function resetAtForPolicy(window: PylonAccountWindowStatus | null, quotaCooldownExpiresAt: string | null): string | null {
+  return window?.resetsAtIso ?? quotaCooldownExpiresAt
+}
+
+export function quotaPolicyFromAccountStatus(input: {
+  quotaLimited: boolean
+  quotaCooldownExpiresAt: string | null
+  windows: PylonAccountWindowStatus[]
+  manualResetsRemaining: number
+  accountRef: string | null
+  hasLocalQuotaBlock: boolean
+}): PylonAccountQuotaPolicyStatus {
+  const weeklyWindow = firstWindowByLabel(input.windows, "weekly")
+  const weeklyExhausted = exhaustedWindow(input.windows, ["weekly"])
+  const shortWindowExhausted = exhaustedWindow(input.windows, ["5h", "hourly"])
+  const weeklyStillAvailable =
+    weeklyWindow === null ||
+    (weeklyWindow.remainingPercent > 0 && weeklyWindow.usedPercent < 100)
+
+  const resetCommand = input.accountRef === null
+    ? null
+    : `pylon accounts status --account ${input.accountRef} --reset --json`
+  const refreshCommand = input.accountRef === null
+    ? null
+    : `pylon accounts usage --account ${input.accountRef} --refresh --json`
+  const recovery = (
+    required: boolean,
+    status: PylonAccountQuotaPolicyStatus["operatorRecovery"]["status"],
+    options: { command?: string | null; manualResetAllowed?: boolean } = {},
+  ): PylonAccountQuotaPolicyStatus["operatorRecovery"] => {
+    const manualResetAvailable =
+      required &&
+      options.manualResetAllowed !== false &&
+      input.hasLocalQuotaBlock &&
+      input.manualResetsRemaining > 0 &&
+      resetCommand !== null
+    return {
+      required,
+      manualResetAvailable,
+      manualResetsRemaining: input.manualResetsRemaining,
+      command: options.command === undefined
+        ? manualResetAvailable ? resetCommand : null
+        : options.command,
+      status,
+    }
+  }
+
+  if (weeklyExhausted) {
+    return {
+      state: "weekly_exhausted",
+      limitScope: "weekly",
+      exhaustedWindow: weeklyExhausted,
+      weeklyWindow,
+      resetAtIso: resetAtForPolicy(weeklyExhausted, input.quotaCooldownExpiresAt),
+      shouldWaitForReset: false,
+      operatorRecovery: recovery(true, "provider_reset_required", {
+        command: refreshCommand,
+        manualResetAllowed: false,
+      }),
+      blockerRefs: ["blocker.pylon.accounts_status.weekly_quota_exhausted"],
+    }
+  }
+
+  if (input.quotaLimited && shortWindowExhausted && weeklyStillAvailable) {
+    return {
+      state: "short_window_cooldown",
+      limitScope: "short_window",
+      exhaustedWindow: shortWindowExhausted,
+      weeklyWindow,
+      resetAtIso: resetAtForPolicy(shortWindowExhausted, input.quotaCooldownExpiresAt),
+      shouldWaitForReset: true,
+      operatorRecovery: recovery(false, "not_applicable"),
+      blockerRefs: ["blocker.pylon.accounts_status.short_window_cooldown"],
+    }
+  }
+
+  if (input.quotaLimited) {
+    return {
+      state: "limited_unknown",
+      limitScope: "unknown",
+      exhaustedWindow: null,
+      weeklyWindow,
+      resetAtIso: input.quotaCooldownExpiresAt,
+      shouldWaitForReset: input.quotaCooldownExpiresAt !== null,
+      operatorRecovery: recovery(false, "not_applicable"),
+      blockerRefs: ["blocker.pylon.accounts_status.quota_limited"],
+    }
+  }
+
+  return {
+    state: "available",
+    limitScope: "none",
+    exhaustedWindow: null,
+    weeklyWindow,
+    resetAtIso: null,
+    shouldWaitForReset: false,
+    operatorRecovery: recovery(false, "not_applicable"),
+    blockerRefs: [],
+  }
+}
+
 export async function collectPylonAccountsStatus(
   summary: Pick<BootstrapSummary, "paths">,
   args: PylonAccountsStatusArgs,
@@ -1188,28 +1314,44 @@ export async function collectPylonAccountsStatus(
 
   for (const target of targets) {
     const readiness = (await readinessForTarget(summary, target, env)).readiness
-    let resetPerformed = false
-    let resetBlockerRefs: string[] = []
-    if (args.reset && args.accountRef === target.accountRef) {
-      try {
-        await consumeManualQuotaReset(summary, {
-          accountRefHash: target.accountRefHash,
-          provider: target.provider,
-          now,
-        })
-        resetPerformed = true
-      } catch {
-        resetBlockerRefs = ["blocker.pylon.accounts_status.manual_resets_exhausted"]
-      }
-    }
-
-    const quotaRecord = await loadQuotaRecord(summary, target.accountRefHash)
-    const resetRecord = await loadManualQuotaResetRecord(summary, {
+    const entry = store.accounts[target.accountRefHash]
+    const windows = capacityWindowsFrom(entry)
+    let quotaRecord = await loadQuotaRecord(summary, target.accountRefHash)
+    let resetRecord = await loadManualQuotaResetRecord(summary, {
       accountRefHash: target.accountRefHash,
       provider: target.provider,
     })
-    const entry = store.accounts[target.accountRefHash]
-    const windows = capacityWindowsFrom(entry)
+    const preResetPolicy = quotaPolicyFromAccountStatus({
+      quotaLimited: !isAccountAvailable(quotaRecord, now),
+      quotaCooldownExpiresAt: quotaCooldownExpiresAt(quotaRecord),
+      windows,
+      manualResetsRemaining: resetRecord.manualResetsRemaining,
+      accountRef: target.accountRef,
+      hasLocalQuotaBlock: quotaRecord !== null,
+    })
+    let resetPerformed = false
+    let resetBlockerRefs: string[] = []
+    if (args.reset && args.accountRef === target.accountRef) {
+      if (preResetPolicy.state !== "weekly_exhausted" || !preResetPolicy.operatorRecovery.manualResetAvailable) {
+        resetBlockerRefs = ["blocker.pylon.accounts_status.manual_reset_not_applicable"]
+      } else {
+        try {
+          await consumeManualQuotaReset(summary, {
+            accountRefHash: target.accountRefHash,
+            provider: target.provider,
+            now,
+          })
+          resetPerformed = true
+          quotaRecord = await loadQuotaRecord(summary, target.accountRefHash)
+          resetRecord = await loadManualQuotaResetRecord(summary, {
+            accountRefHash: target.accountRefHash,
+            provider: target.provider,
+          })
+        } catch {
+          resetBlockerRefs = ["blocker.pylon.accounts_status.manual_resets_exhausted"]
+        }
+      }
+    }
     const localUsage = entry?.localSessionTruth?.usage ?? null
     const quotaLimited = !isAccountAvailable(quotaRecord, now)
     const quota = {
@@ -1220,6 +1362,14 @@ export async function collectPylonAccountsStatus(
       sourceDigestRef: quotaRecord?.sourceDigestRef ?? null,
       manualResetsRemaining: resetRecord.manualResetsRemaining,
     }
+    const quotaPolicy = quotaPolicyFromAccountStatus({
+      quotaLimited,
+      quotaCooldownExpiresAt: quota.cooldownExpiresAt,
+      windows,
+      manualResetsRemaining: resetRecord.manualResetsRemaining,
+      accountRef: target.accountRef,
+      hasLocalQuotaBlock: quotaRecord !== null,
+    })
     const manualReset = {
       performed: resetPerformed,
       manualResetsRemaining: resetRecord.manualResetsRemaining,
@@ -1233,6 +1383,7 @@ export async function collectPylonAccountsStatus(
       accountRefHash: target.accountRefHash,
       readiness,
       quota,
+      quotaPolicy,
       capacity: {
         hourly: firstWindowByLabel(windows, "hourly"),
         weekly: firstWindowByLabel(windows, "weekly"),
@@ -1248,7 +1399,7 @@ export async function collectPylonAccountsStatus(
       manualReset,
       blockerRefs: [
         ...readiness.blockerRefs,
-        ...(quotaLimited ? ["blocker.pylon.accounts_status.quota_limited"] : []),
+        ...quotaPolicy.blockerRefs,
         ...manualReset.blockerRefs,
       ],
     })

--- a/apps/pylon/tests/account-status.test.ts
+++ b/apps/pylon/tests/account-status.test.ts
@@ -96,7 +96,7 @@ describe("pylon operator account status", () => {
       })
 
       expect(projection.accounts).toEqual([
-        {
+        expect.objectContaining({
           accountRefHash,
           provider: "codex",
           isRateLimited: true,
@@ -106,7 +106,12 @@ describe("pylon operator account status", () => {
           weeklyCap: 10_000,
           weeklyUsage: 4_000,
           manualResetsRemaining: 2,
-        },
+          quotaPolicy: expect.objectContaining({
+            state: "limited_unknown",
+            resetAtIso: "2026-06-28T02:00:00.000Z",
+            shouldWaitForReset: true,
+          }),
+        }),
       ])
       expect(JSON.stringify(projection)).not.toContain(codexHome)
       assertPublicProjectionSafe(projection)


### PR DESCRIPTION
## Summary
- add typed `quotaPolicy` status for Codex account cooldown versus weekly exhaustion
- report 5-hour exhaustion with weekly headroom as wait-only cooldown/reset-at status
- report weekly exhaustion as provider-reset-required recovery status and block fake local reset while provider truth still says exhausted

## Verification
- `bun run --cwd apps/pylon typecheck`
- `bun test apps/pylon/src/account-status.test.ts apps/pylon/tests/account-status.test.ts apps/pylon/tests/account-usage.test.ts`

Note: `command.public.pylon_khala.verify.b5bea41b6c623f7c09f1bf24` is an opaque hash ref; I could not resolve its argv from local checkout metadata, so I ran the focused Pylon verification above.