### PR TITLE
Fix desktop Codex session empty state

### DIFF
--- a/clients/openagents-desktop/src/ui/main.ts
+++ b/clients/openagents-desktop/src/ui/main.ts
@@ -211,6 +211,26 @@ const sessionSubtitle = (session: CodingCodexSession): string => {
   return parts.join(" · ")
 }
 
+const sessionStatusRank = (session: CodingCodexSession): number => {
+  if (session.active || session.status === "active") return 0
+  if (session.status === "recent") return 1
+  return 2
+}
+
+const sessionModifiedAtMs = (session: CodingCodexSession): number => {
+  const millis = Date.parse(session.modifiedAt)
+  return Number.isFinite(millis) ? millis : 0
+}
+
+const visibleCodingSessions = (
+  sessions: readonly CodingCodexSession[],
+): readonly CodingCodexSession[] =>
+  [...sessions].sort((left, right) => {
+    const statusDelta = sessionStatusRank(left) - sessionStatusRank(right)
+    if (statusDelta !== 0) return statusDelta
+    return sessionModifiedAtMs(right) - sessionModifiedAtMs(left)
+  })
+
 const selectSession = (session: CodingCodexSession): void => {
   selectedSessionPath = session.path
   if (latestCodingResult !== null) renderCodingStatus(latestCodingResult)
@@ -237,10 +257,10 @@ const sessionButton = (
 
   const status = document.createElement("span")
   status.className = "coding-session-status"
-  status.textContent = session.status
+  status.textContent = session.status.toUpperCase()
 
   if (variant === "chip") {
-    button.append(title, meta)
+    button.append(title, meta, status)
   } else {
     const preview = document.createElement("span")
     preview.className = "coding-session-preview"
@@ -317,38 +337,42 @@ const renderCodingTranscript = (
 const renderCodingSessions = (
   sessions: readonly CodingCodexSession[],
 ): void => {
+  const visibleSessions = visibleCodingSessions(sessions)
+
   if (
-    sessions.length > 0 &&
+    visibleSessions.length > 0 &&
     (selectedSessionPath === null ||
-      !sessions.some(session => session.path === selectedSessionPath))
+      !visibleSessions.some(session => session.path === selectedSessionPath))
   ) {
-    selectedSessionPath = sessions[0].path
+    selectedSessionPath = visibleSessions[0].path
   }
 
   const selectedSession =
-    sessions.find(session => session.path === selectedSessionPath) ?? null
+    visibleSessions.find(session => session.path === selectedSessionPath) ?? null
 
   codingActiveList.replaceChildren()
-  const activeSessions = sessions.filter(session => session.active).slice(0, 8)
-  if (activeSessions.length === 0) {
+  const topSessions = visibleSessions.slice(0, 8)
+  if (topSessions.length === 0) {
     const empty = document.createElement("div")
     empty.className = "coding-empty coding-active-empty"
     empty.textContent = "No active Codex sessions."
     codingActiveList.append(empty)
   } else {
     codingActiveList.append(
-      ...activeSessions.map(session => sessionButton(session, "chip")),
+      ...topSessions.map(session => sessionButton(session, "chip")),
     )
   }
 
   codingList.replaceChildren()
-  if (sessions.length === 0) {
+  if (visibleSessions.length === 0) {
     const empty = document.createElement("div")
     empty.className = "coding-empty"
     empty.textContent = "No Codex session rollouts found."
     codingList.append(empty)
   } else {
-    codingList.append(...sessions.map(session => sessionButton(session, "row")))
+    codingList.append(
+      ...visibleSessions.map(session => sessionButton(session, "row")),
+    )
   }
 
   renderCodingTranscript(selectedSession)

--- a/clients/openagents-desktop/src/ui/styles.css
+++ b/clients/openagents-desktop/src/ui/styles.css
@@ -494,6 +494,7 @@ button {
   display: grid;
   flex: 0 0 220px;
   gap: 7px;
+  padding-right: 96px;
   padding-left: 28px;
 }
 
@@ -589,10 +590,18 @@ button {
   text-transform: uppercase;
 }
 
+.coding-active-session[data-state="active"] .coding-session-status,
 .coding-session-row[data-state="active"] .coding-session-status {
   color: #dff8ff;
   background: rgba(79, 208, 255, 0.1);
   border-color: rgba(79, 208, 255, 0.35);
+}
+
+.coding-active-session[data-state="recent"] .coding-session-status,
+.coding-session-row[data-state="recent"] .coding-session-status {
+  color: #e8f0ff;
+  background: rgba(143, 182, 255, 0.09);
+  border-color: rgba(143, 182, 255, 0.28);
 }
 
 .coding-transcript {


### PR DESCRIPTION
## Summary
- Reuse one visible Codex session collection for the top session strip and the full session list.
- Sort sessions by ACTIVE, RECENT, then IDLE, with newest `modifiedAt` first within each group so fresh transcript/tool updates rise to the top.
- Show uppercase ACTIVE/RECENT/IDLE labels on both top cards and list rows while preserving existing transcript/tool rendering and styling.

This consolidates the empty-state approach from the related desktop PRs without pulling in broader backend session synthesis or transcript timeline restyling.

## Verification
```sh
bun run --cwd clients/openagents-desktop typecheck
# tsc -p tsconfig.typecheck.json --noEmit
```

```sh
bun run --cwd clients/openagents-desktop test
# 11 pass
# 0 fail
# 35 expect() calls
# Ran 11 tests across 3 files.
```

```sh
git diff --check
# passed
```

Required ref: `command.public.pylon_khala.verify.fcbcf165908dd18a9e49f7ff`. I searched the bounded checkout and local Pylon active-run metadata for the ref-to-argv mapping; this checkout does not expose the mapping. Local Pylon `khala status`/`khala proof` for the likely running assignment is readable and confirms exact token/proof rows, but those projections do not expose the verification argv. The narrow desktop typecheck and test commands above completed successfully.