### PR TITLE
Align Pylon coordinator with runner registry

### DIFF
--- a/apps/pylon/src/orchestration/coordinator.ts
+++ b/apps/pylon/src/orchestration/coordinator.ts
@@ -4,7 +4,17 @@ export type DispatchLiveness = "fresh" | "stale" | "missing" | "hung"
 
 export type DispatchEligibility =
   | { ok: true }
-  | { ok: false; reason: "not_idle" | "circuit_broken" | "heartbeat_missing" | "heartbeat_stale" | "dispatch_hung" | "base_drift" }
+  | {
+      ok: false
+      reason:
+        | "not_idle"
+        | "circuit_broken"
+        | "heartbeat_missing"
+        | "heartbeat_stale"
+        | "dispatch_hung"
+        | "base_drift"
+        | "runner_mismatch"
+    }
 
 export type SupervisorCoordinatorOptions = {
   now?: Date
@@ -44,10 +54,20 @@ export function dispatchLiveness(
 
 export function dispatchEligibility(
   context: DispatchContext,
-  options: SupervisorCoordinatorOptions = {},
+  taskOrOptions?: OrchestrationTask | SupervisorCoordinatorOptions,
+  maybeOptions: SupervisorCoordinatorOptions = {},
 ): DispatchEligibility {
+  const task = taskOrOptions !== undefined && "status" in taskOrOptions && "spec" in taskOrOptions
+    ? taskOrOptions
+    : undefined
+  const options = task === undefined
+    ? (taskOrOptions as SupervisorCoordinatorOptions | undefined) ?? maybeOptions
+    : maybeOptions
   if (context.status === "circuit_broken") return { ok: false, reason: "circuit_broken" }
   if (context.status !== "idle") return { ok: false, reason: "not_idle" }
+  if (task?.spec.runnerKind !== undefined && context.runnerKind !== "generic" && context.runnerKind !== task.spec.runnerKind) {
+    return { ok: false, reason: "runner_mismatch" }
+  }
   const liveness = dispatchLiveness(context, options)
   if (liveness === "missing") return { ok: false, reason: "heartbeat_missing" }
   if (liveness === "stale") return { ok: false, reason: "heartbeat_stale" }
@@ -69,16 +89,22 @@ export function planSupervisorDispatch(
   const readyTasks = tasks.filter((task) => task.status === "ready")
   const planned: PlannedDispatch[] = []
   const refused: DispatchCoordinatorResult["refused"] = []
+  const plannedTaskIds = new Set<string>()
 
   for (const context of contexts) {
     if (planned.length >= capacity || planned.length >= readyTasks.length) break
-    const eligibility = dispatchEligibility(context, options)
+    const firstUnplannedTask = readyTasks.find((candidate) => !plannedTaskIds.has(candidate.id))
+    const task = readyTasks.find((candidate) => {
+      if (plannedTaskIds.has(candidate.id)) return false
+      return dispatchEligibility(context, candidate, options).ok
+    })
+    const eligibility = dispatchEligibility(context, task ?? firstUnplannedTask, options)
     if (!eligibility.ok) {
       refused.push({ context, eligibility })
       continue
     }
-    const task = readyTasks[planned.length]
     if (task === undefined) break
+    plannedTaskIds.add(task.id)
     planned.push({ task, context })
   }
 

--- a/apps/pylon/src/orchestration/groups.ts
+++ b/apps/pylon/src/orchestration/groups.ts
@@ -1,14 +1,24 @@
-import type { DispatchContext } from "./store.js"
+import type { DispatchContext, OrchestrationRunnerKind } from "./store.js"
+import { normalizeOrchestrationRunnerKind } from "./store.js"
 
 export type OrchestrationGroupAddress =
   | { kind: "all" }
   | { kind: "idle" }
+  | { kind: "runner"; runnerKind: OrchestrationRunnerKind }
   | { kind: "worktree"; worktreeId: string }
   | { kind: "assignee"; assigneeHandle: string }
 
 export function parseOrchestrationGroupAddress(address: string): OrchestrationGroupAddress {
   if (address === "@all") return { kind: "all" }
   if (address === "@idle") return { kind: "idle" }
+  if (address.startsWith("@runner:")) {
+    const rawRunnerKind = address.slice("@runner:".length).trim()
+    if (rawRunnerKind.length === 0) throw new Error("empty @runner group address")
+    if (rawRunnerKind !== "codex" && rawRunnerKind !== "claude_agent" && rawRunnerKind !== "claude" && rawRunnerKind !== "generic") {
+      throw new Error(`unsupported @runner group address: ${address}`)
+    }
+    return { kind: "runner", runnerKind: normalizeOrchestrationRunnerKind(rawRunnerKind) }
+  }
   if (address.startsWith("@worktree:")) {
     const worktreeId = address.slice("@worktree:".length).trim()
     if (worktreeId.length === 0) throw new Error("empty @worktree group address")
@@ -32,6 +42,8 @@ export function resolveOrchestrationGroup(
       return contexts.filter((context) => context.status !== "circuit_broken")
     case "idle":
       return contexts.filter((context) => context.status === "idle")
+    case "runner":
+      return contexts.filter((context) => context.runnerKind === parsed.runnerKind)
     case "worktree":
       return contexts.filter((context) => context.worktreeId === parsed.worktreeId)
     case "assignee":

--- a/apps/pylon/src/orchestration/store.ts
+++ b/apps/pylon/src/orchestration/store.ts
@@ -1,5 +1,6 @@
 import type { Database } from "bun:sqlite"
 import { createHash } from "node:crypto"
+import type { AgentRunnerKind } from "../agent-runner-registry.js"
 
 export const ORCHESTRATION_SCHEMA_VERSION = 1
 
@@ -14,6 +15,7 @@ export type OrchestrationTaskStatus =
 export type OrchestrationTaskSpec = {
   title: string
   prompt: string
+  runnerKind?: OrchestrationRunnerKind
   verifyCommand?: string
   repo?: string
   branch?: string
@@ -60,10 +62,13 @@ export type DispatchContextStatus =
   | "blocked"
   | "circuit_broken"
 
+export type OrchestrationRunnerKind = AgentRunnerKind | "generic"
+type StoredRunnerKind = OrchestrationRunnerKind | "claude"
+
 export type DispatchContext = {
   id: string
   assigneeHandle: string
-  runnerKind: "codex" | "claude" | "generic"
+  runnerKind: OrchestrationRunnerKind
   worktreeId: string | null
   worktreePath: string | null
   status: DispatchContextStatus
@@ -96,7 +101,7 @@ export type CreateTaskInput = {
 export type CreateDispatchContextInput = {
   id: string
   assigneeHandle: string
-  runnerKind?: DispatchContext["runnerKind"]
+  runnerKind?: OrchestrationRunnerKind | "claude"
   worktreeId?: string | null
   worktreePath?: string | null
   maxConcurrentSlots?: number
@@ -119,7 +124,16 @@ const parsePendingTaskIds = (value: string): string[] => [...new Set(parseJsonAr
 const parseSpec = (value: string): OrchestrationTaskSpec => {
   const parsed: unknown = JSON.parse(value)
   if (typeof parsed !== "object" || parsed === null) throw new Error("invalid orchestration task spec")
-  return parsed as OrchestrationTaskSpec
+  const spec = parsed as Omit<OrchestrationTaskSpec, "runnerKind"> & { runnerKind?: StoredRunnerKind }
+  const { runnerKind, ...rest } = spec
+  return {
+    ...rest,
+    ...(runnerKind === undefined ? {} : { runnerKind: normalizeOrchestrationRunnerKind(runnerKind) }),
+  }
+}
+
+export function normalizeOrchestrationRunnerKind(kind: OrchestrationRunnerKind | "claude"): OrchestrationRunnerKind {
+  return kind === "claude" ? "claude_agent" : kind
 }
 
 type TaskRow = {
@@ -137,7 +151,7 @@ type TaskRow = {
 type DispatchContextRow = {
   id: string
   assignee_handle: string
-  runner_kind: DispatchContext["runnerKind"]
+  runner_kind: StoredRunnerKind
   worktree_id: string | null
   worktree_path: string | null
   status: DispatchContextStatus
@@ -175,7 +189,7 @@ const taskFromRow = (row: TaskRow): OrchestrationTask => ({
 const contextFromRow = (row: DispatchContextRow): DispatchContext => ({
   id: row.id,
   assigneeHandle: row.assignee_handle,
-  runnerKind: row.runner_kind,
+  runnerKind: normalizeOrchestrationRunnerKind(row.runner_kind),
   worktreeId: row.worktree_id,
   worktreePath: row.worktree_path,
   status: row.status,
@@ -233,7 +247,7 @@ export class PylonOrchestrationStore {
       CREATE TABLE IF NOT EXISTS pylon_orchestration_dispatch_contexts (
         id TEXT PRIMARY KEY,
         assignee_handle TEXT NOT NULL,
-        runner_kind TEXT NOT NULL CHECK (runner_kind IN ('codex', 'claude', 'generic')),
+        runner_kind TEXT NOT NULL CHECK (runner_kind IN ('codex', 'claude_agent', 'claude', 'generic')),
         worktree_id TEXT,
         worktree_path TEXT,
         status TEXT NOT NULL CHECK (status IN ('idle', 'dispatched', 'completed', 'failed', 'blocked', 'circuit_broken')),
@@ -361,7 +375,7 @@ export class PylonOrchestrationStore {
       .run({
         $id: input.id,
         $assigneeHandle: input.assigneeHandle,
-        $runnerKind: input.runnerKind ?? "generic",
+        $runnerKind: normalizeOrchestrationRunnerKind(input.runnerKind ?? "generic"),
         $worktreeId: input.worktreeId ?? null,
         $worktreePath: input.worktreePath ?? null,
         $lastHeartbeatAt: input.lastHeartbeatAt === undefined ? null : input.lastHeartbeatAt === null ? null : iso(input.lastHeartbeatAt),

--- a/apps/pylon/src/orchestration/supervisor-orchestration.test.ts
+++ b/apps/pylon/src/orchestration/supervisor-orchestration.test.ts
@@ -95,6 +95,70 @@ describe("Pylon supervisor orchestration store", () => {
     expect(store.getDispatchContext("ctx.fresh")?.currentTaskId).toBe("task.a")
   })
 
+  test("uses registry runner kinds to match typed tasks to compatible contexts", () => {
+    const now = new Date("2026-06-27T12:00:00.000Z")
+    const store = createPylonOrchestrationStore(new Database(":memory:"))
+    store.createTask({
+      id: "task.claude",
+      spec: { ...baseTaskSpec, title: "Claude task", runnerKind: "claude_agent" },
+      now,
+    })
+    store.createTask({
+      id: "task.codex",
+      spec: { ...baseTaskSpec, title: "Codex task", runnerKind: "codex" },
+      now,
+    })
+    store.createDispatchContext({
+      id: "ctx.codex",
+      assigneeHandle: "codex-1",
+      runnerKind: "codex",
+      lastHeartbeatAt: now,
+      now,
+    })
+    store.createDispatchContext({
+      id: "ctx.claude",
+      assigneeHandle: "claude-1",
+      runnerKind: "claude_agent",
+      lastHeartbeatAt: now,
+      now,
+    })
+
+    const result = dispatchReadySupervisorTasks(store, { now, maxConcurrentSlots: 2 })
+
+    expect(result.planned.map((entry) => [entry.task.id, entry.context.id])).toEqual([
+      ["task.codex", "ctx.codex"],
+      ["task.claude", "ctx.claude"],
+    ])
+    expect(store.getTask("task.codex")?.status).toBe("dispatched")
+    expect(store.getTask("task.claude")?.status).toBe("dispatched")
+  })
+
+  test("refuses an otherwise healthy idle context when the ready task requires another runner", () => {
+    const now = new Date("2026-06-27T12:00:00.000Z")
+    const store = createPylonOrchestrationStore(new Database(":memory:"))
+    store.createTask({
+      id: "task.claude",
+      spec: { ...baseTaskSpec, title: "Claude task", runnerKind: "claude_agent" },
+      now,
+    })
+    store.createDispatchContext({
+      id: "ctx.codex",
+      assigneeHandle: "codex-1",
+      runnerKind: "codex",
+      lastHeartbeatAt: now,
+      now,
+    })
+
+    const result = dispatchReadySupervisorTasks(store, { now })
+
+    expect(result.planned).toEqual([])
+    expect(result.refused.map((entry) => [entry.context.id, entry.eligibility.ok ? "ok" : entry.eligibility.reason])).toEqual([
+      ["ctx.codex", "runner_mismatch"],
+    ])
+    expect(store.getTask("task.claude")?.status).toBe("ready")
+    expect(store.getDispatchContext("ctx.codex")?.status).toBe("idle")
+  })
+
   test("tracks a virtual HEAD chain for concurrently dispatched git tasks", () => {
     const now = new Date("2026-06-27T12:00:00.000Z")
     const store = createPylonOrchestrationStore(new Database(":memory:"))
@@ -169,6 +233,7 @@ describe("Pylon supervisor group addressing", () => {
     store.createDispatchContext({
       id: "ctx.a",
       assigneeHandle: "codex-1",
+      runnerKind: "codex",
       worktreeId: "wt-a",
       lastHeartbeatAt: now,
       now,
@@ -187,6 +252,9 @@ describe("Pylon supervisor group addressing", () => {
 
     expect(resolveOrchestrationGroup("@all", contexts).map((context) => context.id)).toEqual(["ctx.a", "ctx.b"])
     expect(resolveOrchestrationGroup("@idle", contexts).map((context) => context.id)).toEqual(["ctx.a"])
+    expect(resolveOrchestrationGroup("@runner:codex", contexts).map((context) => context.id)).toEqual(["ctx.a"])
+    expect(resolveOrchestrationGroup("@runner:claude", contexts).map((context) => context.id)).toEqual(["ctx.b"])
+    expect(resolveOrchestrationGroup("@runner:claude_agent", contexts).map((context) => context.id)).toEqual(["ctx.b"])
     expect(resolveOrchestrationGroup("@worktree:wt-b", contexts).map((context) => context.id)).toEqual(["ctx.b"])
     expect(resolveOrchestrationGroup("@codex-1", contexts).map((context) => context.id)).toEqual(["ctx.a"])
   })


### PR DESCRIPTION
## Summary
- add registry-aligned `runnerKind` targeting to Pylon orchestration task specs
- normalize legacy `claude` dispatch-context rows to `claude_agent` while preserving DB compatibility
- make supervisor dispatch skip/refuse incompatible runner contexts and add `@runner:<kind>` group addressing

## Verification
- `bun test apps/pylon/src/orchestration/supervisor-orchestration.test.ts` passed
- `bun run --cwd apps/openagents.com check:deploy` ran for required verifier ref `command.public.pylon_khala.verify.b5bea41b6c623f7c09f1bf24`, failed in existing unrelated architecture gates:
  - raw `JSON.parse` outside json-boundary: `workers/api/src/forge-control-plane-routes.ts`
  - raw Env parameter annotations budget exceeded: 169/166
  - `/api/public/business/coding-quick-win-receipts` missing from public projection surface ledger
- `bun run --cwd apps/pylon typecheck` could not complete because this checkout cannot resolve workspace dependencies such as `effect` and `@openagentsinc/*`; it also surfaced the local `parseSpec` type issue, which this PR fixed before commit
- `bun test apps/pylon/tests/agent-runtime-adapter.test.ts` could not start for the same missing `effect` package resolution issue