### PR TITLE
Khala Code: reconcile desktop Pylon fleet state

### DIFF
--- a/apps/autopilot-desktop/src/bun/pylon-control.ts
+++ b/apps/autopilot-desktop/src/bun/pylon-control.ts
@@ -1,4 +1,6 @@
 import { existsSync, readFileSync } from "node:fs"
+import { readdir, readFile, stat } from "node:fs/promises"
+import { homedir } from "node:os"
 import { join } from "node:path"
 import {
   CONTROL_HEALTH_CAPABILITIES,
@@ -8,6 +10,12 @@ import {
   type BridgeCredential,
   type SessionSummary,
 } from "@openagentsinc/autopilot-control-protocol"
+import {
+  reconcilePylonFleet,
+  summarizeAssignmentLogTexts,
+  type ActiveAssignmentMarker,
+  type PresenceSnapshot,
+} from "../shared/pylon-fleet-reconciliation.js"
 import type {
   AccountRow,
   AppleFmReadinessResponse,
@@ -19,6 +27,7 @@ import type {
   SessionArtifactStats,
   SessionEventRow,
   WalletStatusRow,
+  PylonFleetReconciliation,
 } from "../shared/rpc.js"
 
 // ── CL-14 bridge transport (desktop) ──────────────────────────────────────
@@ -113,6 +122,193 @@ const optionalString = (value: unknown): string | null =>
 
 const requiredString = (value: unknown, fallback: string): string =>
   typeof value === "string" && value.trim() !== "" ? value : fallback
+
+const optionalObject = (value: unknown): Record<string, unknown> | null =>
+  value !== null && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null
+
+const pylonHomeCandidates = (): readonly string[] => {
+  const homes = [
+    process.env.PYLON_HOME?.trim(),
+    join(homedir(), ".pylon-fable"),
+    join(homedir(), ".openagents", "pylon"),
+    join(homedir(), ".pylon"),
+  ].filter((value): value is string => typeof value === "string" && value.length > 0)
+  return [...new Set(homes)]
+}
+
+const readJsonRecord = async (path: string): Promise<Record<string, unknown> | null> => {
+  try {
+    return optionalObject(JSON.parse(await readFile(path, "utf8")))
+  } catch {
+    return null
+  }
+}
+
+const readPresenceSnapshots = async (
+  homes: readonly string[],
+): Promise<PresenceSnapshot[]> => {
+  const snapshots: PresenceSnapshot[] = []
+  for (const home of homes) {
+    const record = await readJsonRecord(join(home, "presence-state.json"))
+    if (record === null) continue
+    snapshots.push({
+      blockerRefs: stringArray(record.blockerRefs),
+      lastHeartbeatAt: optionalString(record.lastHeartbeatAt),
+      pylonRef: optionalString(record.pylonRef),
+    })
+  }
+  return snapshots
+}
+
+const readActiveAssignmentMarkers = async (
+  homes: readonly string[],
+): Promise<ActiveAssignmentMarker[]> => {
+  const markers: ActiveAssignmentMarker[] = []
+  for (const home of homes) {
+    const dir = join(home, "active-assignment-runs")
+    let filenames: string[] = []
+    try {
+      filenames = await readdir(dir)
+    } catch {
+      continue
+    }
+    for (const filename of filenames) {
+      if (!filename.endsWith(".json")) continue
+      const record = await readJsonRecord(join(dir, filename))
+      if (record === null) continue
+      const assignmentRef = optionalString(record.assignmentRef)
+      const leaseRef = optionalString(record.leaseRef)
+      const refreshedAt = optionalString(record.refreshedAt)
+      const service = optionalString(record.service)
+      if (
+        assignmentRef === null ||
+        leaseRef === null ||
+        refreshedAt === null ||
+        service === null
+      ) {
+        continue
+      }
+      const accountRefHash = optionalString(record.accountRefHash)
+      markers.push({
+        ...(accountRefHash === null ? {} : { accountRefHash }),
+        assignmentRef,
+        leaseRef,
+        refreshedAt,
+        service,
+      })
+    }
+  }
+  return markers
+}
+
+const processInventory = async (): Promise<{
+  codexExec: number
+  khalaRequestWrappers: number
+}> => {
+  try {
+    const proc = Bun.spawn(["ps", "-axo", "pid,ppid,etime,command"], {
+      stderr: "pipe",
+      stdout: "pipe",
+    })
+    const [stdout, exitCode] = await Promise.all([
+      new Response(proc.stdout).text(),
+      proc.exited,
+    ])
+    if (exitCode !== 0) return { codexExec: 0, khalaRequestWrappers: 0 }
+    const lines = stdout.split(/\r?\n/)
+    return {
+      codexExec: lines.filter(line => /\bcodex\s+exec\b/.test(line)).length,
+      khalaRequestWrappers: lines.filter(line =>
+        line.includes("apps/pylon/src/index.ts khala request"),
+      ).length,
+    }
+  } catch {
+    return { codexExec: 0, khalaRequestWrappers: 0 }
+  }
+}
+
+const recentAssignmentLogTexts = async (
+  homes: readonly string[],
+): Promise<readonly string[]> => {
+  const dirs = [
+    ...homes.map(home => join(home, "pr-resolver-logs")),
+    join(homedir(), ".pylon-fable", "pr-resolver-logs"),
+  ]
+  const entries: Array<{ path: string; mtimeMs: number }> = []
+  for (const dir of [...new Set(dirs)]) {
+    let filenames: string[] = []
+    try {
+      filenames = await readdir(dir)
+    } catch {
+      continue
+    }
+    for (const filename of filenames) {
+      if (!filename.startsWith("pr-review-") || !filename.endsWith(".log")) continue
+      const path = join(dir, filename)
+      try {
+        const info = await stat(path)
+        if (info.isFile()) entries.push({ path, mtimeMs: info.mtimeMs })
+      } catch {
+        // Ignore files that rotate while the poll is running.
+      }
+    }
+  }
+  entries.sort((a, b) => b.mtimeMs - a.mtimeMs)
+  const texts: string[] = []
+  for (const entry of entries.slice(0, 160)) {
+    try {
+      texts.push(await readFile(entry.path, "utf8"))
+    } catch {
+      texts.push("")
+    }
+  }
+  return texts
+}
+
+const tokenFailureCount = async (): Promise<number> => {
+  const path = join(homedir(), ".pylon-fable", "codex-turn-report-failures.jsonl")
+  try {
+    const text = await readFile(path, "utf8")
+    return text.split(/\r?\n/).filter(line => line.trim() !== "").length
+  } catch {
+    return 0
+  }
+}
+
+const availableCodexSlotsFromEnv = (): number | null => {
+  const concurrency = Number.parseInt(process.env.OPENAGENTS_PYLON_CODEX_CONCURRENCY ?? "", 10)
+  if (!Number.isSafeInteger(concurrency) || concurrency < 0) return null
+  const busy = Number.parseInt(process.env.OPENAGENTS_PYLON_CODEX_BUSY ?? "0", 10)
+  const queued = Number.parseInt(process.env.OPENAGENTS_PYLON_CODEX_QUEUED ?? "0", 10)
+  const load =
+    (Number.isSafeInteger(busy) && busy > 0 ? busy : 0) +
+    (Number.isSafeInteger(queued) && queued > 0 ? queued : 0)
+  return Math.max(0, concurrency - load)
+}
+
+export async function fetchPylonFleetReconciliation(): Promise<PylonFleetReconciliation> {
+  const fetchedAt = new Date().toISOString()
+  const homes = pylonHomeCandidates()
+  const [presences, markers, processCounts, logs, failures] = await Promise.all([
+    readPresenceSnapshots(homes),
+    readActiveAssignmentMarkers(homes),
+    processInventory(),
+    recentAssignmentLogTexts(homes).then(summarizeAssignmentLogTexts),
+    tokenFailureCount(),
+  ])
+  return reconcilePylonFleet({
+    availableCodexSlots: availableCodexSlotsFromEnv(),
+    fetchedAt,
+    khalaRequestWrappers: processCounts.khalaRequestWrappers,
+    liveCodexExecCount: processCounts.codexExec,
+    logs,
+    markers,
+    presences,
+    tokenFailureCount: failures,
+  })
+}
 
 export function controlHealthSupportsDesktop(health: NodeHealth): boolean {
   if (health.ok !== true || typeof health.schema !== "string") return false
@@ -802,6 +998,7 @@ export async function fetchNodeState(input: {
   approvals: ApprovalRow[]
   wallet: WalletStatusRow | null
   assignments: AssignmentRow[]
+  pylonFleet: PylonFleetReconciliation
   coordinatorPaused: boolean | null
 }> {
   const fetchFn = input.fetchFn ?? fetch
@@ -902,12 +1099,13 @@ export async function fetchNodeState(input: {
   // CL-47..CL-51: parity surfaces — owner asks, approvals, wallet, assignments,
   // and the coordinator paused flag. All read-only; each degrades to empty/null
   // independently so one missing command can't blank the whole projection.
-  const [intents, approvals, wallet, assignments, coordinatorPaused] = await Promise.all([
+  const [intents, approvals, wallet, assignments, coordinatorPaused, pylonFleet] = await Promise.all([
     fetchIntentRows({ baseUrl, token: input.token, fetchFn }),
     fetchApprovalRows({ baseUrl, token: input.token, fetchFn }),
     fetchWalletRow({ baseUrl, token: input.token, fetchFn }),
     fetchAssignmentRows({ baseUrl, token: input.token, fetchFn }),
     fetchCoordinatorPausedFlag({ baseUrl, token: input.token, fetchFn }),
+    fetchPylonFleetReconciliation(),
   ])
 
   return {
@@ -922,6 +1120,7 @@ export async function fetchNodeState(input: {
     approvals,
     wallet,
     assignments,
+    pylonFleet,
     coordinatorPaused,
   }
 }

--- a/apps/autopilot-desktop/src/shared/pylon-fleet-reconciliation.ts
+++ b/apps/autopilot-desktop/src/shared/pylon-fleet-reconciliation.ts
@@ -1,0 +1,211 @@
+import type {
+  PylonFleetAssignmentRow,
+  PylonFleetCapacityState,
+  PylonFleetReconciliation,
+} from "./rpc.js"
+
+export type ActiveAssignmentMarker = {
+  readonly accountRefHash?: string
+  readonly assignmentRef: string
+  readonly leaseRef: string
+  readonly refreshedAt: string
+  readonly service: "codex" | "claude" | string
+}
+
+export type PresenceSnapshot = {
+  readonly blockerRefs: readonly string[]
+  readonly lastHeartbeatAt: string | null
+  readonly pylonRef: string | null
+}
+
+export type RecentAssignmentLogState =
+  | "accepted"
+  | "rejected"
+  | "running_or_unknown"
+  | "failed_before_accept"
+  | "pending_output"
+  | "empty"
+
+export type RecentAssignmentLogSummary = Record<RecentAssignmentLogState, number>
+
+const LOG_STATES: readonly RecentAssignmentLogState[] = [
+  "accepted",
+  "rejected",
+  "running_or_unknown",
+  "failed_before_accept",
+  "pending_output",
+  "empty",
+]
+
+export const emptyAssignmentLogSummary = (): RecentAssignmentLogSummary =>
+  Object.fromEntries(LOG_STATES.map((state) => [state, 0])) as RecentAssignmentLogSummary
+
+export const classifyAssignmentLogText = (
+  text: string,
+): RecentAssignmentLogState => {
+  if (text.trim() === "") return "empty"
+  if (
+    text.includes('"event":"assignment_run.completed"') &&
+    text.includes('"status":"accepted"')
+  ) {
+    return "accepted"
+  }
+  if (
+    text.includes('"event":"assignment_run.completed"') &&
+    text.includes('"status":"rejected"')
+  ) {
+    return "rejected"
+  }
+  if (text.includes('"event":"assignment_run.accepted"')) {
+    return "running_or_unknown"
+  }
+  if (text.includes('"ok": false') || text.includes('"error":')) {
+    return "failed_before_accept"
+  }
+  return "pending_output"
+}
+
+export const summarizeAssignmentLogTexts = (
+  texts: readonly string[],
+): RecentAssignmentLogSummary => {
+  const summary = emptyAssignmentLogSummary()
+  for (const text of texts) {
+    const state = classifyAssignmentLogText(text)
+    summary[state] = summary[state] + 1
+  }
+  return summary
+}
+
+const parseDateMs = (value: string | null): number | null => {
+  if (value === null) return null
+  const ms = Date.parse(value)
+  return Number.isFinite(ms) ? ms : null
+}
+
+const capacityState = (input: {
+  lastHeartbeatAt: string | null
+  blockerRefs: readonly string[]
+  nowMs: number
+  freshAfterMs: number
+}): { state: PylonFleetCapacityState; ageSeconds: number | null } => {
+  const lastHeartbeatMs = parseDateMs(input.lastHeartbeatAt)
+  const ageSeconds =
+    lastHeartbeatMs === null
+      ? null
+      : Math.max(0, Math.floor((input.nowMs - lastHeartbeatMs) / 1000))
+  if (input.blockerRefs.length > 0) return { state: "blocked", ageSeconds }
+  if (lastHeartbeatMs === null) return { state: "unknown", ageSeconds }
+  return {
+    state: input.nowMs - lastHeartbeatMs <= input.freshAfterMs ? "verified" : "stale",
+    ageSeconds,
+  }
+}
+
+const safeService = (
+  service: ActiveAssignmentMarker["service"],
+): PylonFleetAssignmentRow["service"] =>
+  service === "codex" || service === "claude" ? service : "unknown"
+
+export const reconcilePylonFleet = (input: {
+  readonly availableCodexSlots?: number | null
+  readonly fetchedAt: string
+  readonly freshAfterMs?: number
+  readonly khalaRequestWrappers: number
+  readonly liveCodexExecCount: number
+  readonly logs: RecentAssignmentLogSummary
+  readonly markers: readonly ActiveAssignmentMarker[]
+  readonly presences: readonly PresenceSnapshot[]
+  readonly tokenFailureCount: number
+}): PylonFleetReconciliation => {
+  const freshAfterMs = input.freshAfterMs ?? 5 * 60 * 1000
+  const nowMs = parseDateMs(input.fetchedAt) ?? Date.now()
+  const codexMarkers = input.markers.filter((marker) => marker.service === "codex")
+  const executingCodexAssignments = Math.min(
+    input.liveCodexExecCount,
+    codexMarkers.length,
+  )
+  const sortedMarkers = [...input.markers].sort((a, b) => {
+    const aMs = parseDateMs(a.refreshedAt) ?? 0
+    const bMs = parseDateMs(b.refreshedAt) ?? 0
+    return bMs - aMs
+  })
+  let codexExecutingSlots = executingCodexAssignments
+  const assignments = sortedMarkers.slice(0, 12).map((marker): PylonFleetAssignmentRow => {
+    const refreshedMs = parseDateMs(marker.refreshedAt)
+    const isCodex = marker.service === "codex"
+    const state =
+      isCodex && codexExecutingSlots > 0
+        ? "executing"
+        : isCodex
+          ? "stale_unknown"
+          : "marker_only"
+    if (isCodex && codexExecutingSlots > 0) codexExecutingSlots -= 1
+    return {
+      accountRefHash:
+        typeof marker.accountRefHash === "string" && marker.accountRefHash.trim() !== ""
+          ? marker.accountRefHash
+          : null,
+      ageSeconds:
+        refreshedMs === null
+          ? null
+          : Math.max(0, Math.floor((nowMs - refreshedMs) / 1000)),
+      assignmentRef: marker.assignmentRef,
+      leaseRef: marker.leaseRef,
+      service: safeService(marker.service),
+      state,
+    }
+  })
+
+  const newestPresence = [...input.presences]
+    .filter((presence) => presence.pylonRef !== null)
+    .sort((a, b) => {
+      const aMs = parseDateMs(a.lastHeartbeatAt) ?? 0
+      const bMs = parseDateMs(b.lastHeartbeatAt) ?? 0
+      return bMs - aMs
+    })[0]
+  const pylonRefs = [
+    ...new Set(
+      input.presences
+        .map((presence) => presence.pylonRef)
+        .filter((ref): ref is string => ref !== null && ref.trim() !== ""),
+    ),
+  ]
+  const blockers = [
+    ...new Set(input.presences.flatMap((presence) => presence.blockerRefs)),
+  ]
+  const capacity = capacityState({
+    blockerRefs: blockers,
+    freshAfterMs,
+    lastHeartbeatAt: newestPresence?.lastHeartbeatAt ?? null,
+    nowMs,
+  })
+  const stale = Math.max(0, codexMarkers.length - executingCodexAssignments)
+
+  return {
+    assignments,
+    capacity: {
+      ageSeconds: capacity.ageSeconds,
+      availableCodexSlots: input.availableCodexSlots ?? null,
+      blockerRefs: blockers,
+      lastHeartbeatAt: newestPresence?.lastHeartbeatAt ?? null,
+      sourceRefs: [
+        "source.local.pylon.presence_state",
+        "source.local.pylon.active_assignment_markers",
+        "source.local.process_table",
+      ],
+      state: capacity.state,
+    },
+    counts: {
+      accepted: input.logs.accepted,
+      assigned: input.markers.length,
+      executing: input.liveCodexExecCount,
+      khalaRequestWrappers: input.khalaRequestWrappers,
+      pylons: pylonRefs.length,
+      rejected: input.logs.rejected,
+      stale,
+      tokenFailures: input.tokenFailureCount,
+    },
+    fetchedAt: input.fetchedAt,
+    pylonRefs,
+  }
+}

--- a/apps/autopilot-desktop/src/shared/rpc.ts
+++ b/apps/autopilot-desktop/src/shared/rpc.ts
@@ -899,6 +899,50 @@ export type AssignmentRow = {
   readonly expiresAt: string
 }
 
+export type PylonFleetAssignmentState =
+  | "executing"
+  | "stale_unknown"
+  | "marker_only"
+
+export type PylonFleetCapacityState =
+  | "verified"
+  | "stale"
+  | "unknown"
+  | "blocked"
+
+export type PylonFleetAssignmentRow = {
+  readonly assignmentRef: string
+  readonly leaseRef: string
+  readonly service: "codex" | "claude" | "unknown"
+  readonly state: PylonFleetAssignmentState
+  readonly accountRefHash: string | null
+  readonly ageSeconds: number | null
+}
+
+export type PylonFleetReconciliation = {
+  readonly fetchedAt: string
+  readonly pylonRefs: readonly string[]
+  readonly counts: {
+    readonly pylons: number
+    readonly assigned: number
+    readonly executing: number
+    readonly stale: number
+    readonly accepted: number
+    readonly rejected: number
+    readonly tokenFailures: number
+    readonly khalaRequestWrappers: number
+  }
+  readonly capacity: {
+    readonly state: PylonFleetCapacityState
+    readonly lastHeartbeatAt: string | null
+    readonly ageSeconds: number | null
+    readonly availableCodexSlots: number | null
+    readonly sourceRefs: readonly string[]
+    readonly blockerRefs: readonly string[]
+  }
+  readonly assignments: readonly PylonFleetAssignmentRow[]
+}
+
 export type NodeStateMessage = {
   readonly ok: boolean
   readonly schema: string
@@ -919,6 +963,11 @@ export type NodeStateMessage = {
   readonly wallet?: WalletStatusRow | null
   // CL-50: open work-lease assignments (read-only).
   readonly assignments?: AssignmentRow[]
+  // #7593: public-safe local Pylon/Codex assignment reconciliation. Read-only:
+  // active marker counts, live child-process counts, recent closeout log
+  // classification, and heartbeat freshness. Never includes raw paths,
+  // prompts, command output, tokens, or secrets.
+  readonly pylonFleet?: PylonFleetReconciliation
   // CL-51: node coordinator paused flag (null when the node doesn't expose it).
   readonly coordinatorPaused?: boolean | null
   // #5468 (EPIC #5461): the BOUNDED auto-approve audit trail, refs-only. Present

--- a/apps/autopilot-desktop/src/ui/helpers.ts
+++ b/apps/autopilot-desktop/src/ui/helpers.ts
@@ -8,6 +8,8 @@ import type { SessionSummary } from "@openagentsinc/autopilot-control-protocol"
 import type {
   AssignmentRow,
   IntentRow,
+  PylonFleetCapacityState,
+  PylonFleetReconciliation,
   SessionArtifactStats,
   SessionEventRow,
   TrainingRunsResponse,
@@ -204,6 +206,60 @@ export function assignmentMeta(row: AssignmentRow): { goal: string; meta: string
   const refSuffix = row.assignmentRef.slice(-6)
   const meta = `${row.paymentMode}${datePart} · ${refSuffix}`
   return { goal, meta }
+}
+
+export function pylonFleetCapacityLabel(
+  state: PylonFleetCapacityState,
+): string {
+  switch (state) {
+    case "verified":
+      return "capacity verified"
+    case "stale":
+      return "heartbeat stale"
+    case "blocked":
+      return "capacity blocked"
+    case "unknown":
+      return "capacity unknown"
+  }
+}
+
+export function pylonFleetSummary(
+  fleet: PylonFleetReconciliation,
+): {
+  line: string
+  capacityLine: string
+  tone: "ready" | "watch" | "blocked"
+} {
+  const parts = [
+    `${fleet.counts.pylons} pylons`,
+    `${fleet.counts.assigned} assigned`,
+    `${fleet.counts.executing} executing`,
+    `${fleet.counts.stale} stale`,
+    `${fleet.counts.accepted} accepted`,
+    `${fleet.counts.rejected} rejected`,
+    `${fleet.counts.tokenFailures} token failures`,
+  ]
+  const age =
+    fleet.capacity.ageSeconds === null
+      ? "no heartbeat"
+      : `${fleet.capacity.ageSeconds}s old`
+  const slots =
+    fleet.capacity.availableCodexSlots === null
+      ? "slots unknown"
+      : `${fleet.capacity.availableCodexSlots} slots available`
+  const tone =
+    fleet.capacity.state === "blocked"
+      ? "blocked"
+      : fleet.capacity.state === "verified" &&
+          fleet.counts.stale === 0 &&
+          fleet.counts.tokenFailures === 0
+        ? "ready"
+        : "watch"
+  return {
+    capacityLine: `${pylonFleetCapacityLabel(fleet.capacity.state)} · ${age} · ${slots}`,
+    line: parts.join(" · "),
+    tone,
+  }
 }
 
 // ── Settings: connection summary ──────────────────────────────────────────────

--- a/apps/autopilot-desktop/src/ui/styles.css
+++ b/apps/autopilot-desktop/src/ui/styles.css
@@ -2406,6 +2406,80 @@ body {
   text-overflow: ellipsis;
   white-space: nowrap;
 }
+
+.fleet-capacity {
+  margin: 0;
+  color: var(--text-secondary, #8a8c93);
+  font-size: 0.78rem;
+}
+
+.fleet-capacity-ready {
+  color: var(--success, #00c853);
+}
+
+.fleet-capacity-watch {
+  color: var(--warning, #ffb400);
+}
+
+.fleet-capacity-blocked {
+  color: var(--danger, #d32f2f);
+}
+
+.fleet-assignment-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+}
+
+.fleet-assignment-row {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  min-width: 0;
+  border: 1px solid var(--outline, #525458);
+  border-radius: 6px;
+  background: rgb(255 255 255 / 0.035);
+  padding: 0.45rem 0.55rem;
+}
+
+.fleet-assignment-executing {
+  border-color: color-mix(in srgb, var(--success, #00c853) 54%, var(--outline, #525458));
+}
+
+.fleet-assignment-stale_unknown {
+  border-color: color-mix(in srgb, var(--warning, #ffb400) 58%, var(--outline, #525458));
+}
+
+.fleet-assignment-main,
+.fleet-assignment-meta {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  min-width: 0;
+}
+
+.fleet-assignment-main code {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.fleet-assignment-state {
+  flex: 0 0 auto;
+  color: var(--text-secondary, #8a8c93);
+  font-size: 0.68rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.fleet-assignment-meta {
+  overflow: hidden;
+  color: var(--text-secondary, #8a8c93);
+  font-size: 0.72rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .session-detail-context-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(9rem, 1fr));

--- a/apps/autopilot-desktop/src/ui/view.ts
+++ b/apps/autopilot-desktop/src/ui/view.ts
@@ -348,6 +348,7 @@ import {
   nodeStatusLine,
   orderSwarmSessions,
   parseVerifyLines,
+  pylonFleetSummary,
   sessionCancellable,
   shipStatusLine,
   stateBreakdown,
@@ -1001,6 +1002,49 @@ const assignmentsCard = (model: Model): Html => {
   ])
 }
 
+const pylonFleetCard = (model: Model): Html => {
+  const fleet = modelNode(model)?.pylonFleet ?? null
+  if (fleet === null) return h.empty
+  const summary = pylonFleetSummary(fleet)
+  const rows = fleet.assignments.slice(0, 6)
+  return card("Pylon / Codex fleet", [
+    h.p([cls(`fleet-capacity fleet-capacity-${summary.tone}`)], [
+      summary.capacityLine,
+    ]),
+    h.p([cls("card-subtitle")], [summary.line]),
+    rows.length === 0
+      ? h.p([cls("empty-state")], ["No active assignment markers observed."])
+      : h.div(
+          [cls("fleet-assignment-list")],
+          rows.map((row) =>
+            h.div(
+              [
+                cls(`fleet-assignment-row fleet-assignment-${row.state}`),
+                h.DataAttribute("pylon-fleet-assignment-state", row.state),
+              ],
+              [
+                h.div([cls("fleet-assignment-main")], [
+                  h.code([cls("mono"), h.Title(row.assignmentRef)], [
+                    row.assignmentRef.slice(-16),
+                  ]),
+                  h.span([cls("fleet-assignment-state")], [row.state]),
+                ]),
+                h.div([cls("fleet-assignment-meta mono")], [
+                  [
+                    row.service,
+                    row.ageSeconds === null ? "age unknown" : `${row.ageSeconds}s`,
+                    row.accountRefHash === null
+                      ? "account unkeyed"
+                      : `acct ${row.accountRefHash.slice(0, 10)}`,
+                  ].join(" · "),
+                ]),
+              ],
+            ),
+          ),
+        ),
+  ])
+}
+
 const cloudCard = (model: Model): Html => {
   const view = cloudCardView(modelNode(model) ?? null)
   if (!view.visible) return h.empty
@@ -1402,6 +1446,7 @@ const nodesPane = (model: Model): Html => {
       approvalsCard(model),
       balanceCard(model),
       assignmentsCard(model),
+      pylonFleetCard(model),
       cloudCard(model),
       node ? accountsSection(node) : h.empty,
       notifications ? notificationsSection(notifications) : h.empty,

--- a/apps/autopilot-desktop/tests/cl-53-foldkit.test.ts
+++ b/apps/autopilot-desktop/tests/cl-53-foldkit.test.ts
@@ -23,6 +23,7 @@ import {
   coordinatorToggleLabel,
   nodeStatusLine,
   parseVerifyLines,
+  pylonFleetSummary,
   shipStatusLine,
   stateBreakdown,
   trainingProjectionMeta,
@@ -287,6 +288,36 @@ describe("helpers (CL-47..CL-58 parity, pure)", () => {
     expect(goal).toBe("Fix the bug")
     expect(meta).toContain("fixed")
     expect(meta).toContain("expires 2026-07-01")
+  })
+
+  test("pylonFleetSummary distinguishes verified capacity from stale work", () => {
+    const summary = pylonFleetSummary({
+      assignments: [],
+      capacity: {
+        ageSeconds: 30,
+        availableCodexSlots: 2,
+        blockerRefs: [],
+        lastHeartbeatAt: "2026-06-29T15:00:00.000Z",
+        sourceRefs: ["source.local.pylon.presence_state"],
+        state: "verified",
+      },
+      counts: {
+        accepted: 3,
+        assigned: 2,
+        executing: 2,
+        khalaRequestWrappers: 1,
+        pylons: 1,
+        rejected: 1,
+        stale: 0,
+        tokenFailures: 0,
+      },
+      fetchedAt: "2026-06-29T15:00:30.000Z",
+      pylonRefs: ["pylon.local"],
+    })
+    expect(summary.tone).toBe("ready")
+    expect(summary.capacityLine).toContain("capacity verified")
+    expect(summary.capacityLine).toContain("2 slots available")
+    expect(summary.line).toContain("2 executing")
   })
 
   test("connectionSummary + coordinatorToggleLabel", () => {

--- a/apps/autopilot-desktop/tests/pylon-fleet-reconciliation.test.ts
+++ b/apps/autopilot-desktop/tests/pylon-fleet-reconciliation.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, test } from "bun:test"
+import {
+  classifyAssignmentLogText,
+  emptyAssignmentLogSummary,
+  reconcilePylonFleet,
+  summarizeAssignmentLogTexts,
+} from "../src/shared/pylon-fleet-reconciliation"
+
+describe("pylon fleet reconciliation (#7593)", () => {
+  test("classifies recent assignment logs into accepted and rejected closeouts", () => {
+    expect(
+      classifyAssignmentLogText(
+        '{"event":"assignment_run.completed","status":"accepted"}',
+      ),
+    ).toBe("accepted")
+    expect(
+      classifyAssignmentLogText(
+        '{"event":"assignment_run.completed","status":"rejected"}',
+      ),
+    ).toBe("rejected")
+    expect(
+      summarizeAssignmentLogTexts([
+        '{"event":"assignment_run.accepted"}',
+        '{"ok": false, "error":"dispatch_gate_blocked"}',
+        "",
+      ]),
+    ).toMatchObject({
+      empty: 1,
+      failed_before_accept: 1,
+      running_or_unknown: 1,
+    })
+  })
+
+  test("detects marker without live Codex child as stale unknown", () => {
+    const logs = emptyAssignmentLogSummary()
+    logs.accepted = 4
+    logs.rejected = 2
+    const projection = reconcilePylonFleet({
+      availableCodexSlots: 1,
+      fetchedAt: "2026-06-29T15:05:00.000Z",
+      khalaRequestWrappers: 1,
+      liveCodexExecCount: 1,
+      logs,
+      markers: [
+        {
+          accountRefHash: "acctaaa111",
+          assignmentRef: "assignment.alpha",
+          leaseRef: "lease.alpha",
+          refreshedAt: "2026-06-29T15:04:40.000Z",
+          service: "codex",
+        },
+        {
+          accountRefHash: "acctbbb222",
+          assignmentRef: "assignment.bravo",
+          leaseRef: "lease.bravo",
+          refreshedAt: "2026-06-29T15:04:20.000Z",
+          service: "codex",
+        },
+      ],
+      presences: [
+        {
+          blockerRefs: [],
+          lastHeartbeatAt: "2026-06-29T15:04:50.000Z",
+          pylonRef: "pylon.local",
+        },
+      ],
+      tokenFailureCount: 3,
+    })
+
+    expect(projection.counts).toMatchObject({
+      accepted: 4,
+      assigned: 2,
+      executing: 1,
+      khalaRequestWrappers: 1,
+      pylons: 1,
+      rejected: 2,
+      stale: 1,
+      tokenFailures: 3,
+    })
+    expect(projection.capacity.state).toBe("verified")
+    expect(projection.assignments.map(row => row.state)).toEqual([
+      "executing",
+      "stale_unknown",
+    ])
+  })
+
+  test("marks capacity stale when the last heartbeat is too old", () => {
+    const projection = reconcilePylonFleet({
+      fetchedAt: "2026-06-29T15:10:00.000Z",
+      khalaRequestWrappers: 0,
+      liveCodexExecCount: 0,
+      logs: emptyAssignmentLogSummary(),
+      markers: [],
+      presences: [
+        {
+          blockerRefs: [],
+          lastHeartbeatAt: "2026-06-29T15:00:00.000Z",
+          pylonRef: "pylon.local",
+        },
+      ],
+      tokenFailureCount: 0,
+    })
+    expect(projection.capacity.state).toBe("stale")
+    expect(projection.capacity.ageSeconds).toBe(600)
+  })
+})


### PR DESCRIPTION
## Summary
- add a public-safe desktop Pylon/Codex fleet reconciliation projection over active assignment markers, live `codex exec` children, recent assignment logs, token failure spool counts, and heartbeat freshness
- render the reconciliation in the Desktop Nodes pane with assigned/executing/stale/accepted/rejected/token-failure counts and typed `stale_unknown` marker states
- cover log classification, stale marker detection, heartbeat freshness, and summary copy with focused tests

Closes #7593

## Verification
- `bun test --preload ./apps/autopilot-desktop/tests/preload.ts ./apps/autopilot-desktop/tests/cl-53-foldkit.test.ts ./apps/autopilot-desktop/tests/pylon-fleet-reconciliation.test.ts` ✅
- `bun test ./apps/autopilot-desktop/tests/pylon-fleet-reconciliation.test.ts` ✅
- required verification ref `command.public.pylon_khala.verify.b5bea41b6c623f7c09f1bf24` resolved to `true`; ran `true` ✅

## Note
- `bun run --cwd apps/autopilot-desktop typecheck` currently fails on pre-existing fixture drift in `src/shared/chat-world-scene.test.ts` (`lastHeartbeatAgeSeconds` / `cumulativeSettledSats` not in `RecentPylon`).