### PR TITLE
Expose Codex account readiness and cooldowns in desktop

### DIFF
--- a/apps/autopilot-desktop/src/bun/index.ts
+++ b/apps/autopilot-desktop/src/bun/index.ts
@@ -72,11 +72,13 @@ import {
   cancelSession,
   deployToCloud,
   fetchAppleFmReadiness,
+  fetchAccountStatus,
   fetchNodeSparkAddress,
   fetchNodeState,
   fetchOnboardingSignals,
   probeControlToken,
   readControlToken,
+  requestAccountManualReset,
   resolveApproval,
   resolveManagedWorktreeRepoRef,
   setCoordinatorPaused,
@@ -1252,6 +1254,24 @@ const rpc = BrowserView.defineRPC<DesktopRPCSchema>({
       // node's local dev.accounts config. Bun owns the home + config path.
       async listManagedAccounts() {
         return listManagedAccounts(resolveHome())
+      },
+      async getAccountStatus() {
+        const token = await acceptedControlTokenForCommand()
+        if (token === null) {
+          return { ok: false, accounts: [], error: CONTROL_TOKEN_NOT_ACCEPTED }
+        }
+        return fetchAccountStatus({ baseUrl: controlBaseUrl, token })
+      },
+      async resetAccountStatus(params: { accountRef: string }) {
+        const token = await acceptedControlTokenForCommand()
+        if (token === null) {
+          return { ok: false, accounts: [], error: CONTROL_TOKEN_NOT_ACCEPTED }
+        }
+        return requestAccountManualReset({
+          baseUrl: controlBaseUrl,
+          token,
+          accountRef: params.accountRef,
+        })
       },
       async addManagedAccount(params) {
         return addManagedAccount(resolveHome(), {

--- a/apps/autopilot-desktop/src/bun/pylon-control.ts
+++ b/apps/autopilot-desktop/src/bun/pylon-control.ts
@@ -9,6 +9,7 @@ import {
   type SessionSummary,
 } from "@openagentsinc/autopilot-control-protocol"
 import type {
+  AccountStatusResponse,
   AccountRow,
   AppleFmReadinessResponse,
   AppleFmSessionStartResponse,
@@ -280,6 +281,53 @@ async function fetchAccountRows(input: {
     }))
   } catch {
     return []
+  }
+}
+
+export async function fetchAccountStatus(input: {
+  baseUrl: string
+  token: string
+  fetchFn?: typeof fetch
+}): Promise<AccountStatusResponse> {
+  const fetchFn = input.fetchFn ?? fetch
+  try {
+    const res = await fetchFn(`${input.baseUrl.replace(/\/+$/, "")}/command`, {
+      method: "POST",
+      headers: { Authorization: `Bearer ${input.token}`, "content-type": "application/json" },
+      body: JSON.stringify({ type: "accounts.status.detailed" }),
+    })
+    if (!res.ok) return { ok: false, accounts: [], error: `control ${res.status}` }
+    const json = await res.json()
+    if (json !== null && typeof json === "object" && Array.isArray((json as { accounts?: unknown }).accounts)) {
+      return json as AccountStatusResponse
+    }
+    return { ok: false, accounts: [], error: "malformed account status response" }
+  } catch (error) {
+    return { ok: false, accounts: [], error: error instanceof Error ? error.message : String(error) }
+  }
+}
+
+export async function requestAccountManualReset(input: {
+  baseUrl: string
+  token: string
+  accountRef: string
+  fetchFn?: typeof fetch
+}): Promise<AccountStatusResponse> {
+  const fetchFn = input.fetchFn ?? fetch
+  try {
+    const res = await fetchFn(`${input.baseUrl.replace(/\/+$/, "")}/command`, {
+      method: "POST",
+      headers: { Authorization: `Bearer ${input.token}`, "content-type": "application/json" },
+      body: JSON.stringify({ type: "accounts.status.manual_reset", accountRef: input.accountRef }),
+    })
+    if (!res.ok) return { ok: false, accounts: [], error: `control ${res.status}` }
+    const json = await res.json()
+    if (json !== null && typeof json === "object" && Array.isArray((json as { accounts?: unknown }).accounts)) {
+      return json as AccountStatusResponse
+    }
+    return { ok: false, accounts: [], error: "malformed account reset response" }
+  } catch (error) {
+    return { ok: false, accounts: [], error: error instanceof Error ? error.message : String(error) }
   }
 }
 

--- a/apps/autopilot-desktop/src/shared/pylon-network-scene.ts
+++ b/apps/autopilot-desktop/src/shared/pylon-network-scene.ts
@@ -45,6 +45,9 @@ export type RecentPylon = {
   readonly onlineNow?: boolean | null
   readonly walletReadyNow?: boolean | null
   readonly assignmentReadyNow?: boolean | null
+  readonly cumulativeSettledSats?: number | null
+  readonly lastHeartbeatAgeSeconds?: number | null
+  readonly products?: ReadonlyArray<string> | null
 }
 
 const cleanLabel = (value: string | null | undefined): string => {

--- a/apps/autopilot-desktop/src/shared/rpc.ts
+++ b/apps/autopilot-desktop/src/shared/rpc.ts
@@ -70,6 +70,64 @@ export type ManagedAccountMutationResponse = {
   readonly error?: string
 }
 
+export type AccountWindowStatus = {
+  readonly usedPercent: number
+  readonly remainingPercent: number
+  readonly windowMinutes: number | null
+  readonly resetsAtIso: string | null
+  readonly label: string
+}
+
+export type AccountStatusRow = {
+  readonly provider: "codex" | "claude_agent" | string
+  readonly selector: "registry_ref" | "default_home" | string
+  readonly accountRef: string | null
+  readonly accountRefHash: string
+  readonly readiness: {
+    readonly state: string
+    readonly blockerRefs: readonly string[]
+  }
+  readonly quota: {
+    readonly state: "available" | "cooldown" | "weekly_exhausted" | "limited" | string
+    readonly kind: string | null
+    readonly observedAt: string | null
+    readonly cooldownExpiresAt: string | null
+    readonly cooldownSecondsRemaining: number | null
+    readonly sourceDigestRef: string | null
+    readonly manualResetsRemaining: number
+    readonly resetAllowed: boolean
+    readonly operatorAction: "wait_for_cooldown" | "manual_recovery_available" | "none" | string
+  }
+  readonly capacity: {
+    readonly hourly: AccountWindowStatus | null
+    readonly weekly: AccountWindowStatus | null
+    readonly windows: readonly AccountWindowStatus[]
+  }
+  readonly usage: {
+    readonly observedAt: string | null
+    readonly inputTokens: number | null
+    readonly outputTokens: number | null
+    readonly totalTokens: number | null
+    readonly totalCostUsd?: number
+  }
+  readonly manualReset: {
+    readonly performed: boolean
+    readonly manualResetsRemaining: number
+    readonly updatedAt: string
+    readonly blockerRefs: readonly string[]
+  }
+  readonly blockerRefs: readonly string[]
+}
+
+export type AccountStatusResponse = {
+  readonly schema?: string
+  readonly observedAt?: string
+  readonly accounts: readonly AccountStatusRow[]
+  readonly blockerRefs?: readonly string[]
+  readonly ok?: boolean
+  readonly error?: string
+}
+
 export type SessionArtifactStats = {
   readonly kind: string
   readonly outcome: string | null
@@ -1223,6 +1281,14 @@ export type DesktopRPCSchema = {
       readonly listManagedAccounts: {
         readonly params: Record<string, never>
         readonly response: ManagedAccountsResponse
+      }
+      readonly getAccountStatus: {
+        readonly params: Record<string, never>
+        readonly response: AccountStatusResponse
+      }
+      readonly resetAccountStatus: {
+        readonly params: { accountRef: string }
+        readonly response: AccountStatusResponse
       }
       readonly addManagedAccount: {
         readonly params: {

--- a/apps/autopilot-desktop/src/ui/bridge.ts
+++ b/apps/autopilot-desktop/src/ui/bridge.ts
@@ -28,6 +28,7 @@ import type {
   KhalaTurnResponse,
   ManagedAccountMutationResponse,
   ManagedAccountsResponse,
+  AccountStatusResponse,
   OnboardingStatusResponse,
   PublicActivityTimelineResponse,
   PromiseSurfacingInput,
@@ -197,6 +198,8 @@ export type DesktopRequests = {
   }): Promise<AppleFmSessionStartResponse>
   // CS-A1 account management against the node's local dev.accounts config.
   listManagedAccounts(p: Record<string, never>): Promise<ManagedAccountsResponse>
+  getAccountStatus(p: Record<string, never>): Promise<AccountStatusResponse>
+  resetAccountStatus(p: { accountRef: string }): Promise<AccountStatusResponse>
   addManagedAccount(p: {
     ref: string
     provider: "codex" | "claude_agent"

--- a/apps/autopilot-desktop/src/ui/code-mode-sync.ts
+++ b/apps/autopilot-desktop/src/ui/code-mode-sync.ts
@@ -9,6 +9,8 @@
 import type { SessionSummary } from "@openagentsinc/autopilot-control-protocol"
 import type {
   AccountRow,
+  AccountStatusResponse,
+  AccountStatusRow,
   AppleFmReadinessResponse,
   ApprovalRow,
   BuiltInAgentReadinessResponse,
@@ -51,6 +53,7 @@ export type CodeModeSyncAccountRow = Readonly<{
   homePresent: boolean | null
   priority: number | null
   blockerRefs: readonly string[]
+  status: AccountStatusRow | null
   source: "managed_live" | "managed_only" | "live_only" | "default_home"
 }>
 
@@ -80,6 +83,7 @@ export type CodeModeSyncSnapshot = Readonly<{
   accounts: readonly CodeModeSyncAccountRow[]
   liveAccounts: readonly AccountRow[]
   managedAccounts: readonly ManagedAccountRow[]
+  accountStatus?: AccountStatusResponse | null
   approvals: readonly ApprovalRow[]
   artifacts: Readonly<Record<string, SessionArtifactStats>>
   readiness: CodeModeSyncReadiness
@@ -100,6 +104,7 @@ export type CodeModeSyncInput = Readonly<{
   source: CodeModeSyncSource
   node: NodeStateMessage | null
   managedAccounts: ManagedAccountsResponse | null
+  accountStatus?: AccountStatusResponse | null
   inferenceGatewayReadiness: InferenceGatewayReadinessResponse | null
   builtInAgentReadiness: BuiltInAgentReadinessResponse | null
   appleFmReadiness: AppleFmReadinessResponse | null
@@ -150,16 +155,50 @@ const uniqueStrings = (values: readonly string[]): readonly string[] =>
 const mergeAccountRows = (
   liveAccounts: readonly AccountRow[],
   managedAccounts: readonly ManagedAccountRow[],
+  accountStatus: AccountStatusResponse | null,
 ): readonly CodeModeSyncAccountRow[] => {
   const liveByKey = new Map<string, AccountRow>()
   for (const row of liveAccounts) {
     liveByKey.set(accountKey(row.provider, row.accountRef, row.accountRefHash), row)
   }
+  const statusByHash = new Map<string, AccountStatusRow>()
+  const statusByRef = new Map<string, AccountStatusRow>()
+  for (const status of accountStatus?.accounts ?? []) {
+    statusByHash.set(status.accountRefHash, status)
+    if (status.accountRef !== null) statusByRef.set(`${status.provider}:${status.accountRef}`, status)
+  }
+  const statusFor = (
+    provider: string,
+    accountRef: string | null,
+    hash: string | null | undefined,
+  ): AccountStatusRow | null => {
+    if (hash !== null && hash !== undefined) {
+      const byHash = statusByHash.get(hash)
+      if (byHash !== undefined) return byHash
+    }
+    return accountRef === null ? null : statusByRef.get(`${provider}:${accountRef}`) ?? null
+  }
+  const readyFromStatus = (fallback: boolean, status: AccountStatusRow | null): boolean =>
+    status === null
+      ? fallback
+      : status.readiness.state === "ready" && status.quota.state === "available"
+  const blockersFromStatus = (
+    existing: readonly string[],
+    status: AccountStatusRow | null,
+  ): readonly string[] =>
+    uniqueStrings([
+      ...existing,
+      ...(status?.blockerRefs ?? []),
+      ...(status !== null && status.quota.state !== "available"
+        ? [`blocker.pylon.accounts_status.${status.quota.state}`]
+        : []),
+    ])
 
   const rows = new Map<string, CodeModeSyncAccountRow>()
   for (const managed of managedAccounts) {
     const key = accountKey(managed.provider, managed.ref, null)
     const live = liveByKey.get(key) ?? null
+    const status = statusFor(managed.provider, managed.ref, live?.accountRefHash ?? null)
     rows.set(key, {
       key,
       provider: managed.provider,
@@ -167,12 +206,13 @@ const mergeAccountRows = (
       accountRefHash: live?.accountRefHash ?? null,
       label: accountLabel(managed.provider, managed.ref, live?.accountRefHash ?? null),
       selector: live?.selector ?? "managed",
-      ready: live?.ready ?? managed.homePresent,
+      ready: readyFromStatus(live?.ready ?? managed.homePresent, status),
       managed: true,
       live: live !== null,
       homePresent: managed.homePresent,
       priority: managed.priority,
-      blockerRefs: uniqueStrings(live?.blockerRefs ?? []),
+      blockerRefs: blockersFromStatus(live?.blockerRefs ?? [], status),
+      status,
       source: live === null ? "managed_only" : "managed_live",
     })
   }
@@ -180,6 +220,7 @@ const mergeAccountRows = (
   for (const live of liveAccounts) {
     const key = accountKey(live.provider, live.accountRef, live.accountRefHash)
     if (rows.has(key)) continue
+    const status = statusFor(live.provider, live.accountRef, live.accountRefHash)
     rows.set(key, {
       key,
       provider: live.provider,
@@ -187,12 +228,13 @@ const mergeAccountRows = (
       accountRefHash: live.accountRefHash,
       label: accountLabel(live.provider, live.accountRef, live.accountRefHash),
       selector: live.selector,
-      ready: live.ready,
+      ready: readyFromStatus(live.ready, status),
       managed: false,
       live: true,
       homePresent: null,
       priority: live.priority,
-      blockerRefs: uniqueStrings(live.blockerRefs),
+      blockerRefs: blockersFromStatus(live.blockerRefs, status),
+      status,
       source: live.selector === "default_home" ? "default_home" : "live_only",
     })
   }
@@ -427,7 +469,8 @@ export const projectCodeModeSyncSnapshot = (
     if (priorityA !== priorityB) return priorityA - priorityB
     return `${a.provider}:${a.ref}`.localeCompare(`${b.provider}:${b.ref}`)
   })
-  const accounts = mergeAccountRows(liveAccounts, managedAccounts)
+  const accountStatus = input.accountStatus ?? null
+  const accounts = mergeAccountRows(liveAccounts, managedAccounts, accountStatus)
   const artifacts = input.node?.artifacts ?? {}
   const approvals = input.node?.approvals ?? []
   const readiness = readinessProjection(input)
@@ -463,6 +506,7 @@ export const projectCodeModeSyncSnapshot = (
     accounts,
     liveAccounts,
     managedAccounts,
+    accountStatus,
     approvals,
     artifacts,
     readiness,

--- a/apps/autopilot-desktop/src/ui/commands.ts
+++ b/apps/autopilot-desktop/src/ui/commands.ts
@@ -63,6 +63,8 @@ import {
   SettledReconcileTrainingWindow,
   SettledRequestTrainingBootstrap,
   SettledManagedAccountMutation,
+  GotAccountStatus,
+  SettledAccountStatusReset,
   SettledResolveApproval,
   SettledSubmitIntent,
   GotManagedAccounts,
@@ -1541,6 +1543,39 @@ export const LoadManagedAccounts = Command.define(
     Effect.catch((error) =>
       Effect.succeed(
         GotManagedAccounts({
+          projection: { ok: false, accounts: [], error: errorText(error) },
+        }),
+      ),
+    ),
+  ),
+)
+
+export const LoadAccountStatus = Command.define(
+  "LoadAccountStatus",
+  GotAccountStatus,
+)(
+  Effect.tryPromise(() => getRequest().getAccountStatus({})).pipe(
+    Effect.map((projection) => GotAccountStatus({ projection })),
+    Effect.catch((error) =>
+      Effect.succeed(
+        GotAccountStatus({
+          projection: { ok: false, accounts: [], error: errorText(error) },
+        }),
+      ),
+    ),
+  ),
+)
+
+export const ResetAccountStatus = Command.define(
+  "ResetAccountStatus",
+  { accountRef: S.String },
+  SettledAccountStatusReset,
+)(({ accountRef }) =>
+  Effect.tryPromise(() => getRequest().resetAccountStatus({ accountRef })).pipe(
+    Effect.map((projection) => SettledAccountStatusReset({ projection })),
+    Effect.catch((error) =>
+      Effect.succeed(
+        SettledAccountStatusReset({
           projection: { ok: false, accounts: [], error: errorText(error) },
         }),
       ),

--- a/apps/autopilot-desktop/src/ui/index.html
+++ b/apps/autopilot-desktop/src/ui/index.html
@@ -325,6 +325,7 @@
 
       /* Accounts (autopilot-ui AccountList renders inside) */
       .accounts h2 { font-size:.95rem; }
+      .managed-account-reset-controls { display:flex; flex-wrap:wrap; gap:.45rem; margin-top:.55rem; }
 
       /* Notifications */
       .notifications { text-align:left; margin-top:1rem; }

--- a/apps/autopilot-desktop/src/ui/message.ts
+++ b/apps/autopilot-desktop/src/ui/message.ts
@@ -614,6 +614,7 @@ export const SelectedComposerAccount = m("SelectedComposerAccount", {
 // dev.accounts config the runtime reads). Bun owns the home + config path.
 export const ClickedRefreshManagedAccounts = m("ClickedRefreshManagedAccounts")
 export const GotManagedAccounts = m("GotManagedAccounts", { projection: S.Unknown })
+export const GotAccountStatus = m("GotAccountStatus", { projection: S.Unknown })
 export const ChangedAddAccountRef = m("ChangedAddAccountRef", { value: S.String })
 export const ChangedAddAccountProvider = m("ChangedAddAccountProvider", {
   provider: S.Literals(["codex", "claude_agent"]),
@@ -635,8 +636,14 @@ export const ClickedBumpManagedAccountPriority = m(
     priority: S.Number,
   },
 )
+export const ClickedResetAccountStatus = m("ClickedResetAccountStatus", {
+  accountRef: S.String,
+})
 // Settled (shared by add/remove/set-priority). Carries the refreshed list.
 export const SettledManagedAccountMutation = m("SettledManagedAccountMutation", {
+  projection: S.Unknown,
+})
+export const SettledAccountStatusReset = m("SettledAccountStatusReset", {
   projection: S.Unknown,
 })
 
@@ -935,6 +942,7 @@ export const Message = S.Union([
   SelectedComposerAccount,
   ClickedRefreshManagedAccounts,
   GotManagedAccounts,
+  GotAccountStatus,
   ChangedAddAccountRef,
   ChangedAddAccountProvider,
   ChangedAddAccountHome,
@@ -942,7 +950,9 @@ export const Message = S.Union([
   ClickedAddManagedAccount,
   ClickedRemoveManagedAccount,
   ClickedBumpManagedAccountPriority,
+  ClickedResetAccountStatus,
   SettledManagedAccountMutation,
+  SettledAccountStatusReset,
   ChangedThemePreference,
   ChangedDefaultAdapter,
   ChangedDefaultLane,

--- a/apps/autopilot-desktop/src/ui/model.ts
+++ b/apps/autopilot-desktop/src/ui/model.ts
@@ -49,6 +49,7 @@ import {
 } from "../shared/proof-replays.js"
 import type {
   AppleFmReadinessResponse,
+  AccountStatusResponse,
   BuiltInAgentReadinessResponse,
   IdentityChoiceStateResponse,
   InferenceGatewayReadinessResponse,
@@ -703,6 +704,7 @@ export const Model = ts("AutopilotDesktop", {
   // ManagedAccountsResponse projection (opaque, read via the typed accessor);
   // the rest are the add-account form fields + transient status.
   managedAccounts: S.NullOr(S.Unknown),
+  accountStatus: S.NullOr(S.Unknown),
   // VCODE-12 (#5929): one de-duped code-mode sync snapshot over managed
   // accounts, live account readiness, node sessions, event tails, artifacts,
   // approvals, and quota/readiness projections. Opaque like `node`, read via
@@ -869,6 +871,11 @@ export const modelManagedAccounts = (
   model: Model,
 ): ManagedAccountsResponse | null =>
   model.managedAccounts as ManagedAccountsResponse | null
+
+export const modelAccountStatus = (
+  model: Model,
+): AccountStatusResponse | null =>
+  model.accountStatus as AccountStatusResponse | null
 
 export const modelCodeModeSync = (
   model: Model,
@@ -1312,6 +1319,7 @@ export const initialModel: Model = Model.make({
   verseSpawnedScenes: [],
   verseGameScreenActive: false,
   managedAccounts: null,
+  accountStatus: null,
   codeModeSync: null,
   managedAccountsPending: false,
   managedAccountsStatus: { text: "", tone: "idle" },

--- a/apps/autopilot-desktop/src/ui/update.ts
+++ b/apps/autopilot-desktop/src/ui/update.ts
@@ -18,6 +18,7 @@ import {
   ClaimTrainingWindowLease,
   ChooseIdentity,
   DeployCloud,
+  LoadAccountStatus,
   LoadAppleFmReadiness,
   LoadBuiltInAgentReadiness,
   LoadIdentityChoiceState,
@@ -41,6 +42,7 @@ import {
   PersistPreferences,
   ReconcileTrainingWindow,
   RemoveManagedAccount,
+  ResetAccountStatus,
   RequestTrainingBootstrapGrant,
   RespondToVerseInput,
   RespondToShellInput,
@@ -125,6 +127,7 @@ import {
   BLUEPRINT_CHAT_REPLAY_TOOL_REF,
   Model,
   modelAppleFmReadiness,
+  modelAccountStatus,
   modelBuiltInAgentReadiness,
   modelInferenceGatewayReadiness,
   modelManagedAccounts,
@@ -207,6 +210,7 @@ const withCodeModeSync = (
       source,
       node: modelNode(model),
       managedAccounts: modelManagedAccounts(model),
+      accountStatus: modelAccountStatus(model),
       inferenceGatewayReadiness: modelInferenceGatewayReadiness(model),
       builtInAgentReadiness: modelBuiltInAgentReadiness(model),
       appleFmReadiness: modelAppleFmReadiness(model),
@@ -291,7 +295,7 @@ const openNewCoderSession = (model: Model): Result => {
       }),
       "model_tick",
     ),
-    [LoadManagedAccounts()],
+    [LoadManagedAccounts(), LoadAccountStatus()],
   ]
 }
 
@@ -754,6 +758,7 @@ const isAccountManagingPane = (pane: PaneId): boolean =>
 
 const diagnosticsRefreshCommands = (): ReadonlyArray<Command.Command<Message>> => [
   LoadManagedAccounts(),
+  LoadAccountStatus(),
   LoadInferenceGatewayReadiness(),
   LoadBuiltInAgentReadiness(),
   LoadAppleFmReadiness(),
@@ -798,6 +803,7 @@ const fallbackCodeModeAccountRows = (model: Model): readonly CodeModeSyncAccount
     homePresent: null,
     priority: row.priority,
     blockerRefs: row.blockerRefs,
+    status: null,
     source: row.selector === "default_home" ? "default_home" : "live_only",
   }))
 
@@ -1423,7 +1429,7 @@ export const update = (model: Model, message: Message): Result => {
             ? // #5485: the account-managing panes (composer/spawn/settings) are
               // exactly where the own-auth-vs-gateway routing matters, so refresh
               // the gateway readiness (credits/hint) on enter alongside accounts.
-              [LoadManagedAccounts(), LoadInferenceGatewayReadiness()]
+              [LoadManagedAccounts(), LoadAccountStatus(), LoadInferenceGatewayReadiness()]
             : noCommands),
           ...(isDiagnosticsPane(message.pane) ? diagnosticsRefreshCommands() : noCommands),
         ],
@@ -1708,7 +1714,7 @@ export const update = (model: Model, message: Message): Result => {
           }),
           "model_tick",
         ),
-        enteringCode ? [LoadManagedAccounts()] : noCommands,
+        enteringCode ? [LoadManagedAccounts(), LoadAccountStatus()] : noCommands,
       ]
     }
 
@@ -3124,7 +3130,7 @@ export const update = (model: Model, message: Message): Result => {
         }),
         // #5485: + warm the gateway readiness so the composer's route hint is
         // accurate the moment an adopted session opens (matches NavigatedTo).
-        [LoadManagedAccounts(), LoadInferenceGatewayReadiness()],
+        [LoadManagedAccounts(), LoadAccountStatus(), LoadInferenceGatewayReadiness()],
       ]
 
     // ── #5469 (EPIC #5461): swarm batch launch ──────────────────────────────────
@@ -3550,7 +3556,7 @@ export const update = (model: Model, message: Message): Result => {
         }),
         // CS-A1: a fresh thread reloads the account list so a newly added
         // account is pickable without re-navigating.
-        [LoadManagedAccounts()],
+        [LoadManagedAccounts(), LoadAccountStatus()],
       ]
     case "SucceededComposerTurn":
       return [
@@ -4041,7 +4047,7 @@ export const update = (model: Model, message: Message): Result => {
           pane: message.pane,
         })
         const accountCommands = isAccountManagingPane(message.pane)
-          ? [LoadManagedAccounts(), LoadInferenceGatewayReadiness()]
+          ? [LoadManagedAccounts(), LoadAccountStatus(), LoadInferenceGatewayReadiness()]
           : noCommands
         const diagnosticCommands = isDiagnosticsPane(message.pane)
           ? diagnosticsRefreshCommands()
@@ -4082,7 +4088,7 @@ export const update = (model: Model, message: Message): Result => {
           managedAccountsPending: true,
           managedAccountsStatus: { text: "loading accounts...", tone: "info" },
         }),
-        [LoadManagedAccounts()],
+        [LoadManagedAccounts(), LoadAccountStatus()],
       ]
     case "GotManagedAccounts": {
       const projection = message.projection as {
@@ -4099,6 +4105,27 @@ export const update = (model: Model, message: Message): Result => {
             managedAccountsStatus: projection.ok
               ? { text: "", tone: "idle" }
               : { text: projection.error ?? "could not load accounts", tone: "error" },
+          }),
+          "managed_accounts",
+        ),
+        noCommands,
+      ]
+    }
+    case "GotAccountStatus": {
+      const projection = message.projection as {
+        accounts?: ReadonlyArray<unknown>
+        ok?: boolean
+        error?: string
+      }
+      return [
+        withCodeModeSync(
+          Model.make({
+            ...model,
+            accountStatus: message.projection,
+            managedAccountsStatus:
+              projection.ok === false
+                ? { text: projection.error ?? "could not load account status", tone: "error" }
+                : model.managedAccountsStatus,
           }),
           "managed_accounts",
         ),
@@ -4204,6 +4231,37 @@ export const update = (model: Model, message: Message): Result => {
           }),
         ],
       ]
+    case "ClickedResetAccountStatus":
+      return [
+        Model.make({
+          ...model,
+          managedAccountsPending: true,
+          managedAccountsStatus: { text: "requesting account reset...", tone: "info" },
+        }),
+        [ResetAccountStatus({ accountRef: message.accountRef })],
+      ]
+    case "SettledAccountStatusReset": {
+      const projection = message.projection as {
+        ok?: boolean
+        accounts?: ReadonlyArray<unknown>
+        error?: string
+      }
+      return [
+        withCodeModeSync(
+          Model.make({
+            ...model,
+            accountStatus: message.projection,
+            managedAccountsPending: false,
+            managedAccountsStatus:
+              projection.ok === false
+                ? { text: projection.error ?? "account reset failed", tone: "error" }
+                : { text: "account reset recorded", tone: "success" },
+          }),
+          "managed_accounts",
+        ),
+        noCommands,
+      ]
+    }
     case "SettledManagedAccountMutation": {
       const projection = message.projection as {
         ok: boolean

--- a/apps/autopilot-desktop/src/ui/view.ts
+++ b/apps/autopilot-desktop/src/ui/view.ts
@@ -151,6 +151,7 @@ import {
 
 import type {
   AccountRow,
+  AccountStatusRow,
   AppleFmReadinessResponse,
   ApprovalRow,
   AssignmentRow,
@@ -225,6 +226,7 @@ import {
   ClickedLoadGeneratedProofReplay,
   ClickedRefreshManagedAccounts,
   ClickedRemoveManagedAccount,
+  ClickedResetAccountStatus,
   ChangedVerseLocalPose,
   ChangedVersePresenceZone,
   ChangedVerseWorldItemProximity,
@@ -413,6 +415,7 @@ import {
   modelVerseSpawnedScenes,
   modelCodeModeSync,
   modelManagedAccounts,
+  modelAccountStatus,
   modelPaneLayer,
   modelPromiseSurfacingReadiness,
   modelPromiseSurfacingResult,
@@ -1010,10 +1013,101 @@ const cloudCard = (model: Model): Html => {
   ])
 }
 
-// AccountRow (rpc.ts) → AccountSummary (autopilot-ui). Read-only display via the
-// shared AccountList component. CS-A1: use the node's stable accountRefHash and
-// keep readiness state honest (ready vs blocked).
-const toAccountSummary = (row: AccountRow): AccountSummary => ({
+const activeSessionStates = new Set(["queued", "started", "running"])
+
+const accountStatusState = (
+  row: AccountRow,
+  status: AccountStatusRow | null,
+): AccountSummary["state"] => {
+  if (status !== null) {
+    if (status.quota.state === "cooldown") return "cooldown"
+    if (status.quota.state === "weekly_exhausted") return "weekly_exhausted"
+    if (status.quota.state !== "available") return "quota_blocked"
+    if (status.readiness.state === "credentials_missing" || status.readiness.state === "credentials_revoked") {
+      return "credentials_missing"
+    }
+    if (status.readiness.state === "auth_refresh_failed") return "auth_refresh_failed"
+    if (status.readiness.state === "model_unavailable") return "model_unavailable"
+    if (status.readiness.state === "execution_refused") return "execution_refused"
+    if (status.readiness.state !== "ready") return "unavailable"
+  }
+  return row.ready ? "ready" : "quota_blocked"
+}
+
+const statusForAccount = (
+  statuses: readonly AccountStatusRow[],
+  row: AccountRow,
+): AccountStatusRow | null =>
+  statuses.find((status) => status.accountRefHash === row.accountRefHash) ??
+  statuses.find((status) =>
+    status.provider === row.provider &&
+    status.accountRef !== null &&
+    status.accountRef === row.accountRef
+  ) ??
+  null
+
+const lastSuccessfulTurnForAccount = (model: Model, accountHash: string): string | null => {
+  const session = (modelNode(model)?.sessions ?? [])
+    .filter((row) => row.accountRefHash === accountHash && row.state === "completed")
+    .sort((a, b) => Date.parse(b.updatedAt) - Date.parse(a.updatedAt))[0]
+  return session?.updatedAt ?? null
+}
+
+const recentRefusalForAccount = (model: Model, accountHash: string): string | null => {
+  const node = modelNode(model)
+  const session = (node?.sessions ?? [])
+    .filter((row) => row.accountRefHash === accountHash && row.state === "failed")
+    .sort((a, b) => Date.parse(b.updatedAt) - Date.parse(a.updatedAt))[0]
+  if (session === undefined) return null
+  const detail = node?.events?.[session.sessionRef]
+    ?.slice()
+    .reverse()
+    .find((event) => /refus|blocker|limit|unavailable/i.test(event.detail))?.detail
+  return detail ?? session.lastProgressRef ?? "failed"
+}
+
+// AccountRow (rpc.ts) + AccountStatusRow → AccountSummary (autopilot-ui).
+// Read-only display via the shared AccountList component; reset actions stay in
+// the desktop pane below so the shared component remains message-agnostic.
+const toAccountSummary = (
+  model: Model,
+  row: AccountRow,
+  status: AccountStatusRow | null = null,
+): AccountSummary => {
+  const hourly = status?.capacity.hourly ?? null
+  const weekly = status?.capacity.weekly ?? null
+  const usage =
+    weekly !== null
+      ? { used: Math.round(100 - weekly.remainingPercent), limit: 100 }
+      : hourly !== null
+        ? { used: Math.round(100 - hourly.remainingPercent), limit: 100 }
+        : undefined
+  return {
+    accountRefHash: row.accountRefHash,
+    provider: row.provider,
+    state: accountStatusState(row, status),
+    ...(usage === undefined ? {} : { usage }),
+    resetAt: status?.quota.cooldownExpiresAt ?? weekly?.resetsAtIso ?? hourly?.resetsAtIso ?? null,
+    cooldownSecondsRemaining: status?.quota.cooldownSecondsRemaining ?? null,
+    activeSlots: (modelNode(model)?.sessions ?? []).filter(
+      (session) =>
+        session.accountRefHash === row.accountRefHash &&
+        activeSessionStates.has(session.state),
+    ).length,
+    recentRefusalReason: recentRefusalForAccount(model, row.accountRefHash),
+    lastSuccessfulTurn: lastSuccessfulTurnForAccount(model, row.accountRefHash),
+    ...(status === null
+      ? {}
+      : {
+          manualReset: {
+            allowed: status.quota.resetAllowed,
+            remaining: status.quota.manualResetsRemaining,
+          },
+        }),
+  }
+}
+
+const toBasicAccountSummary = (row: AccountRow): AccountSummary => ({
   accountRefHash: row.accountRefHash,
   provider: row.provider,
   state: row.ready ? "ready" : "quota_blocked",
@@ -1074,6 +1168,7 @@ const fallbackCodeModeAccountRows = (model: Model): readonly CodeModeSyncAccount
     homePresent: null,
     priority: row.priority,
     blockerRefs: row.blockerRefs,
+    status: null,
     source: row.selector === "default_home" ? "default_home" : "live_only",
   }))
 
@@ -1314,7 +1409,7 @@ const verseCodeAccountInventory = (model: Model): Html => {
 const accountsSection = (node: NodeStateMessage): Html => {
   const accounts = node.accounts ?? []
   if (accounts.length === 0) return h.empty
-  return card("Accounts", [AccountList({ accounts: accounts.map(toAccountSummary) })])
+  return card("Accounts", [AccountList({ accounts: accounts.map(toBasicAccountSummary) })])
 }
 
 const notificationsSection = (view: NotificationCenterView): Html => {
@@ -6732,6 +6827,31 @@ const sortManagedAccountRows = (
     return a.ref.localeCompare(b.ref)
   })
 
+const accountResetControls = (statuses: readonly AccountStatusRow[]): Html => {
+  const resettable = statuses.filter(
+    (status) =>
+      status.provider === "codex" &&
+      status.accountRef !== null &&
+      status.quota.operatorAction === "manual_recovery_available" &&
+      status.quota.resetAllowed,
+  )
+  if (resettable.length === 0) return h.empty
+  return h.div(
+    [cls("managed-account-reset-controls")],
+    resettable.map((status) =>
+      h.button(
+        [
+          cls("link-button"),
+          h.Type("button"),
+          h.Title("Request a provider-supported manual reset for this exhausted account"),
+          h.OnClick(ClickedResetAccountStatus({ accountRef: status.accountRef ?? "" })),
+        ],
+        [`Reset ${status.accountRef}`],
+      ),
+    ),
+  )
+}
+
 // CS-A1: account-management surface — add / select / priority / quota over the
 // node's local dev.accounts config. Turns the read-only AccountList into a
 // managed registry (audit gap #2). Readiness/quota stays the live accounts.list
@@ -6742,6 +6862,7 @@ const accountManagementCard = (model: Model): Html => {
   const rows = sortManagedAccountRows(managed?.accounts ?? [])
   const node = modelNode(model)
   const liveAccounts = modelCodeModeSync(model)?.liveAccounts ?? node?.accounts ?? []
+  const accountStatuses = modelAccountStatus(model)?.accounts ?? []
   return card("Accounts", [
     h.p([cls("card-body")], [
       "Manage which provider accounts this node can run coding sessions under. Priority orders dispatch (lower runs first).",
@@ -6757,7 +6878,14 @@ const accountManagementCard = (model: Model): Html => {
     liveAccounts.length > 0
       ? h.div(
           [cls("managed-account-readiness")],
-          [AccountList({ accounts: liveAccounts.map(toAccountSummary) })],
+          [
+            AccountList({
+              accounts: liveAccounts.map((row) =>
+                toAccountSummary(model, row, statusForAccount(accountStatuses, row)),
+              ),
+            }),
+            accountResetControls(accountStatuses),
+          ],
         )
       : h.empty,
     // Managed registry rows (editable).

--- a/apps/autopilot-desktop/tests/account-management.test.ts
+++ b/apps/autopilot-desktop/tests/account-management.test.ts
@@ -230,7 +230,7 @@ describe("CS-A1 account-management reducer", () => {
     expect(model.verseMode).toBe("code")
     expect(model.managedAccountsPending).toBe(true)
     expect(model.managedAccountsStatus.text).toContain("Codex accounts")
-    expect(commands.map((command) => command.name)).toEqual(["LoadManagedAccounts"])
+    expect(commands.map((command) => command.name)).toEqual(["LoadManagedAccounts", "LoadAccountStatus"])
   })
 
   test("GotManagedAccounts stores the projection and clears pending", () => {
@@ -333,16 +333,118 @@ describe("CS-A1 account-management reducer", () => {
     expect(modelPaneLayer(model).panes.map((pane) => pane.kind)).toEqual(["accounts"])
     expect(commands.map((command) => command.name)).toEqual([
       "LoadManagedAccounts",
+      "LoadAccountStatus",
       "LoadInferenceGatewayReadiness",
     ])
 
-    const tree = serializeView(view(model).body)
+    const [opened] = update(model, OpenedManagedPane({ pane: "accounts" }))
+    const tree = serializeView(view(opened).body)
     expect(tree).toContain("pane-window")
     expect(tree).toContain("Accounts")
     expect(tree).toContain("Add account")
     expect(tree).toContain("work")
     expect(tree).toContain("home missing")
     expect(tree).toContain("claude_agent")
+  })
+
+  test("Accounts pane shows Codex cooldowns and manual reset controls", () => {
+    const node = nodeWithAccounts([
+      {
+        provider: "codex",
+        homeState: "present",
+        ready: true,
+        accountRef: "work",
+        accountRefHash: "account.pylon.codex.workabcdef",
+        selector: "registry_ref",
+        blockerRefs: [],
+        priority: 1,
+      },
+      {
+        provider: "codex",
+        homeState: "present",
+        ready: true,
+        accountRef: "weekly",
+        accountRefHash: "account.pylon.codex.weeklyabcdef",
+        selector: "registry_ref",
+        blockerRefs: [],
+        priority: 2,
+      },
+    ])
+    const model = Model.make({
+      ...initialModel,
+      pane: "chat",
+      verseMode: "code",
+      node,
+      accountStatus: {
+        schema: "openagents.pylon.accounts_status.v0.1",
+        observedAt: "2026-06-29T15:00:00.000Z",
+        accounts: [
+          {
+            provider: "codex",
+            selector: "registry_ref",
+            accountRef: "work",
+            accountRefHash: "account.pylon.codex.workabcdef",
+            readiness: { state: "ready", blockerRefs: [] },
+            quota: {
+              state: "cooldown",
+              kind: "cooldown",
+              observedAt: "2026-06-29T14:55:00.000Z",
+              cooldownExpiresAt: "2026-06-29T20:00:00.000Z",
+              cooldownSecondsRemaining: 18_000,
+              sourceDigestRef: "digest.public.cooldown",
+              manualResetsRemaining: 3,
+              resetAllowed: false,
+              operatorAction: "wait_for_cooldown",
+            },
+            capacity: { hourly: null, weekly: null, windows: [] },
+            usage: { observedAt: null, inputTokens: null, outputTokens: null, totalTokens: null },
+            manualReset: {
+              performed: false,
+              manualResetsRemaining: 3,
+              updatedAt: "2026-06-29T14:55:00.000Z",
+              blockerRefs: [],
+            },
+            blockerRefs: ["blocker.pylon.accounts_status.cooldown"],
+          },
+          {
+            provider: "codex",
+            selector: "registry_ref",
+            accountRef: "weekly",
+            accountRefHash: "account.pylon.codex.weeklyabcdef",
+            readiness: { state: "ready", blockerRefs: [] },
+            quota: {
+              state: "weekly_exhausted",
+              kind: "weekly_exhausted",
+              observedAt: "2026-06-29T14:55:00.000Z",
+              cooldownExpiresAt: null,
+              cooldownSecondsRemaining: null,
+              sourceDigestRef: "digest.public.weekly",
+              manualResetsRemaining: 2,
+              resetAllowed: true,
+              operatorAction: "manual_recovery_available",
+            },
+            capacity: { hourly: null, weekly: null, windows: [] },
+            usage: { observedAt: null, inputTokens: null, outputTokens: null, totalTokens: null },
+            manualReset: {
+              performed: false,
+              manualResetsRemaining: 2,
+              updatedAt: "2026-06-29T14:55:00.000Z",
+              blockerRefs: [],
+            },
+            blockerRefs: ["blocker.pylon.accounts_status.weekly_exhausted"],
+          },
+        ],
+      },
+    })
+    const [opened] = update(model, OpenedManagedPane({ pane: "accounts" }))
+    const tree = serializeView(view(opened).body)
+    expect(tree).toContain("cooldown")
+    expect(tree).toContain("reset_at: 2026-06-29T20:00:00.000Z")
+    expect(tree).toContain("cooldown: 18000s")
+    expect(tree).toContain("weekly_exhausted")
+    expect(tree).toContain("manual reset: available (2 left)")
+    expect(tree).toContain("Reset weekly")
+    expect(tree).not.toContain("Reset work")
   })
 
   test("managed account mutations update Verse code inventory without restarting Verse", () => {

--- a/apps/autopilot-desktop/tests/code-mode-sync.test.ts
+++ b/apps/autopilot-desktop/tests/code-mode-sync.test.ts
@@ -8,6 +8,7 @@ import { describe, expect, test } from "bun:test"
 import type { SessionSummary } from "@openagentsinc/autopilot-control-protocol"
 import type {
   AccountRow,
+  AccountStatusResponse,
   BuiltInAgentReadinessResponse,
   InferenceGatewayReadinessResponse,
   ManagedAccountsResponse,
@@ -86,6 +87,47 @@ const managed = (
     homePresent: true,
     priority: index,
   })),
+})
+
+const accountStatus = (
+  accountRefHash: string,
+  state: "available" | "cooldown" | "weekly_exhausted" = "available",
+): AccountStatusResponse => ({
+  schema: "openagents.pylon.accounts_status.v0.1",
+  observedAt: "2026-06-21T22:00:00.000Z",
+  accounts: [
+    {
+      provider: "codex",
+      selector: "registry_ref",
+      accountRef: "work",
+      accountRefHash,
+      readiness: { state: "ready", blockerRefs: [] },
+      quota: {
+        state,
+        kind: state === "available" ? null : state,
+        observedAt: state === "available" ? null : "2026-06-21T22:00:00.000Z",
+        cooldownExpiresAt: state === "cooldown" ? "2026-06-22T03:00:00.000Z" : null,
+        cooldownSecondsRemaining: state === "cooldown" ? 18_000 : null,
+        sourceDigestRef: state === "available" ? null : "digest.public.status",
+        manualResetsRemaining: 3,
+        resetAllowed: state === "weekly_exhausted",
+        operatorAction: state === "cooldown"
+          ? "wait_for_cooldown"
+          : state === "weekly_exhausted"
+            ? "manual_recovery_available"
+            : "none",
+      },
+      capacity: { hourly: null, weekly: null, windows: [] },
+      usage: { observedAt: null, inputTokens: null, outputTokens: null, totalTokens: null },
+      manualReset: {
+        performed: false,
+        manualResetsRemaining: 3,
+        updatedAt: "2026-06-21T22:00:00.000Z",
+        blockerRefs: [],
+      },
+      blockerRefs: state === "available" ? [] : [`blocker.pylon.accounts_status.${state}`],
+    },
+  ],
 })
 
 const session = (input: Partial<SessionSummary> = {}): SessionSummary => ({
@@ -269,6 +311,25 @@ describe("code-mode sync projection (#5929)", () => {
     expect(nodeDiagnostic?.title).toBe("Node sync reconnecting")
     expect(nodeDiagnostic?.body).not.toContain("not OK")
     expect(nodeDiagnostic?.body).not.toContain("blocked")
+  })
+
+  test("cooling Codex accounts are excluded from ready routing", () => {
+    const snapshot = projectCodeModeSyncSnapshot({
+      source: "node_state",
+      node: nodeState(),
+      managedAccounts: managed(["work"]),
+      accountStatus: accountStatus(workHash, "cooldown"),
+      inferenceGatewayReadiness: gatewayReadiness(),
+      builtInAgentReadiness: builtInReadiness(),
+      appleFmReadiness: null,
+      selectedSessionRef: sessionRef,
+      composerAdapter: "codex",
+      composerAccountRef: "work",
+    })
+
+    expect(snapshot.accounts[0]?.ready).toBe(false)
+    expect(snapshot.accounts[0]?.blockerRefs).toContain("blocker.pylon.accounts_status.cooldown")
+    expect(snapshot.counts.readyAccounts).toBe(0)
   })
 
   test("one node-state tick updates Sessions, Agent Stream, Decisions, and Diff/Artifacts", () => {

--- a/apps/pylon/src/index.ts
+++ b/apps/pylon/src/index.ts
@@ -1182,7 +1182,19 @@ const runHeadlessNode = Effect.gen(function* () {
             },
             { env: Bun.env },
           )
-        : collectPylonOperatorAccountStatus(bootstrapSummary),
+        : input?.detailed
+          ? collectPylonAccountsStatus(
+              bootstrapSummary,
+              {
+                accountRef: null,
+                provider: null,
+                all: true,
+                json: true,
+                reset: false,
+              },
+              { env: Bun.env },
+            )
+          : collectPylonOperatorAccountStatus(bootstrapSummary),
       // The supervisor-status provider comes from the launch lifecycle owner
       // above (undefined unless PYLON_APPLE_FM_SUPERVISE=1 and a helper exists),
       // so by default this is the unsupervised projection unchanged.

--- a/apps/pylon/src/node/control-server.ts
+++ b/apps/pylon/src/node/control-server.ts
@@ -145,7 +145,7 @@ export interface ControlCommandActions {
   }
   // CL-18: read-only accounts + readiness panel (public-projection-safe).
   accountsList?: () => Promise<unknown>
-  accountsStatus?: (input?: { accountRef?: string; reset?: boolean }) => Promise<unknown>
+  accountsStatus?: (input?: { accountRef?: string; reset?: boolean; detailed?: boolean }) => Promise<unknown>
   // CL-16: read-only pending approvals + exactly-once resolve (approve/deny/answer).
   approvals?: {
     list: () => Promise<unknown>
@@ -361,6 +361,15 @@ export const startControlServer = (
         case "accounts.status":
           if (!options.actions.accountsStatus) throw new Error("account status unavailable on this node")
           return options.actions.accountsStatus()
+        case "accounts.status.detailed":
+          if (!options.actions.accountsStatus) throw new Error("account status unavailable on this node")
+          return options.actions.accountsStatus({ detailed: true })
+        case "accounts.status.manual_reset": {
+          if (!options.actions.accountsStatus) throw new Error("account status unavailable on this node")
+          const accountRef = typeof command.accountRef === "string" ? command.accountRef : ""
+          if (accountRef.length === 0) throw new Error("account ref required")
+          return options.actions.accountsStatus({ accountRef, reset: true })
+        }
         case "bridge.issueBootstrap":
           // Returns { bootstrapId, secret } for the operator to hand to a client
           // (QR/connect payload). Single-use; the secret is exchanged at

--- a/packages/autopilot-ui/src/accounts.ts
+++ b/packages/autopilot-ui/src/accounts.ts
@@ -6,10 +6,28 @@ import { statusChip } from "./view.js"
 export type AccountSummary = Readonly<{
   accountRefHash: string
   provider: "codex" | "claude" | string
-  state: "ready" | "quota_blocked" | "unavailable"
+  state:
+    | "ready"
+    | "credentials_missing"
+    | "auth_refresh_failed"
+    | "cooldown"
+    | "weekly_exhausted"
+    | "model_unavailable"
+    | "execution_refused"
+    | "quota_blocked"
+    | "unavailable"
   usage?: {
     used: number
     limit: number
+  }
+  resetAt?: string | null
+  cooldownSecondsRemaining?: number | null
+  activeSlots?: number | null
+  recentRefusalReason?: string | null
+  lastSuccessfulTurn?: string | null
+  manualReset?: {
+    allowed: boolean
+    remaining: number
   }
 }>
 
@@ -21,8 +39,14 @@ const accountStateTone = (state: AccountSummary["state"]): ChipTone => {
   switch (state) {
     case "ready":
       return "success"
+    case "cooldown":
+    case "weekly_exhausted":
     case "quota_blocked":
       return "warning"
+    case "credentials_missing":
+    case "auth_refresh_failed":
+    case "model_unavailable":
+    case "execution_refused":
     case "unavailable":
       return "danger"
   }
@@ -38,6 +62,28 @@ const quotaTone = (account: AccountSummary): ChipTone => {
 
 const quotaLabel = (usage: AccountSummary["usage"]): string =>
   usage === undefined ? "quota: unknown" : `quota: ${usage.used}/${usage.limit}`
+
+const accountDetails = (account: AccountSummary): string[] =>
+  [
+    account.resetAt === undefined || account.resetAt === null ? null : `reset_at: ${account.resetAt}`,
+    account.cooldownSecondsRemaining === undefined || account.cooldownSecondsRemaining === null
+      ? null
+      : `cooldown: ${account.cooldownSecondsRemaining}s`,
+    account.activeSlots === undefined || account.activeSlots === null
+      ? null
+      : `active slots: ${account.activeSlots}`,
+    account.recentRefusalReason === undefined || account.recentRefusalReason === null
+      ? null
+      : `recent refusal: ${account.recentRefusalReason}`,
+    account.lastSuccessfulTurn === undefined || account.lastSuccessfulTurn === null
+      ? null
+      : `last successful turn: ${account.lastSuccessfulTurn}`,
+    account.manualReset === undefined
+      ? null
+      : account.manualReset.allowed
+        ? `manual reset: available (${account.manualReset.remaining} left)`
+        : `manual reset: not available (${account.manualReset.remaining} left)`,
+  ].filter((value): value is string => value !== null)
 
 export const AccountRow = (account: AccountSummary): Html =>
   h.article(
@@ -64,6 +110,12 @@ export const AccountRow = (account: AccountSummary): Html =>
         tone: quotaTone(account),
         attrs: [h.DataAttribute("autopilot-account-quota", account.accountRefHash)],
       }),
+      ...accountDetails(account).map((detail) =>
+        h.span(
+          [className("font-mono text-xs text-[var(--text-secondary,#8a8c93)] sm:col-span-4")],
+          [detail],
+        ),
+      ),
     ],
   )
 


### PR DESCRIPTION
Closes #7592.

## Summary
- add a detailed Pylon `accounts.status.detailed` control command plus manual reset command for desktop
- thread account readiness/quota status into Autopilot Desktop sync so cooldown/exhausted Codex accounts are excluded from ready routing
- show per-account readiness, reset/cooldown, active slots, recent refusal, last successful turn, and supported manual reset controls in the Accounts pane

## Verification
- `bun run typecheck` in `apps/autopilot-desktop`
- `bun test tests/account-management.test.ts tests/code-mode-sync.test.ts` in `apps/autopilot-desktop`
- `bun test src/account-status.test.ts tests/control-protocol.test.ts` in `apps/pylon`
- required verification `command.public.pylon_khala.verify.b5bea41b6c623f7c09f1bf24` resolved to `true` and passed
