### PR TITLE
feat(desktop): add Khala Code queue planner

### DIFF
--- a/clients/openagents-desktop/src/shared/khala-code-queue-planner.ts
+++ b/clients/openagents-desktop/src/shared/khala-code-queue-planner.ts
@@ -1,0 +1,350 @@
+export type KhalaCodeQueueCandidateKind = "issue" | "pull_request"
+
+export type KhalaCodeQueueCandidateState = "closed" | "open"
+
+export type KhalaCodeQueueLane = {
+  readonly description?: string
+  readonly laneRef: string
+  readonly priority: number
+  readonly title: string
+}
+
+export type KhalaCodeQueueCandidateDispatch =
+  | {
+      readonly state: "ready"
+    }
+  | {
+      readonly reason: KhalaCodeRetryReason
+      readonly retryAt: string
+      readonly state: "retry"
+    }
+  | {
+      readonly reason: KhalaCodeBlockReason
+      readonly state: "blocked"
+    }
+
+export type KhalaCodeQueueCandidate = {
+  readonly closedAt?: string | null
+  readonly dispatch?: KhalaCodeQueueCandidateDispatch
+  readonly kind: KhalaCodeQueueCandidateKind
+  readonly labels?: readonly string[]
+  readonly laneRefs: readonly string[]
+  readonly mergedAt?: string | null
+  readonly number: number
+  readonly priority: number
+  readonly repository: string
+  readonly state: KhalaCodeQueueCandidateState
+  readonly supersededBy?: string | null
+  readonly title: string
+  readonly updatedAt?: string | null
+  readonly url?: string | null
+}
+
+export type KhalaCodeActiveClaim = {
+  readonly accountRef?: string | null
+  readonly assignmentRef?: string | null
+  readonly candidateRef: string
+  readonly claimedAt: string
+  readonly claimRef: string
+  readonly laneRef: string
+}
+
+export type KhalaCodeSkipReason =
+  | "duplicate_candidate"
+  | "duplicate_claim"
+  | "lane_mismatch"
+  | "superseded"
+
+export type KhalaCodeClaimReason =
+  | "priority_lane_capacity"
+  | "priority_lane_dry_run"
+
+export type KhalaCodeRetryReason =
+  | "capacity_unavailable"
+  | "failed_before_accept"
+  | "provider_cooldown"
+  | "verification_failed"
+
+export type KhalaCodeBlockReason =
+  | "account_not_ready"
+  | "missing_verification"
+  | "owner_action_required"
+  | "unsafe_candidate"
+
+export type KhalaCodeMergeReason = "merged_upstream"
+
+export type KhalaCodeCloseReason =
+  | "closed_unmerged"
+  | "issue_closed"
+  | "pull_request_closed"
+
+export type KhalaCodeQueueReason =
+  | {
+      readonly kind: "skip"
+      readonly reason: KhalaCodeSkipReason
+    }
+  | {
+      readonly kind: "claim"
+      readonly reason: KhalaCodeClaimReason
+    }
+  | {
+      readonly kind: "retry"
+      readonly reason: KhalaCodeRetryReason
+      readonly retryAt: string
+    }
+  | {
+      readonly kind: "block"
+      readonly reason: KhalaCodeBlockReason
+    }
+  | {
+      readonly kind: "merge"
+      readonly reason: KhalaCodeMergeReason
+    }
+  | {
+      readonly kind: "close"
+      readonly reason: KhalaCodeCloseReason
+    }
+
+export type KhalaCodeQueueDecision =
+  | "block"
+  | "claim"
+  | "close"
+  | "merge"
+  | "retry"
+  | "skip"
+
+export type KhalaCodeQueueRow = {
+  readonly candidate: KhalaCodeQueueCandidate
+  readonly candidateRef: string
+  readonly claim?: KhalaCodePlannedClaim
+  readonly decision: KhalaCodeQueueDecision
+  readonly laneRef: string | null
+  readonly reason: KhalaCodeQueueReason
+}
+
+export type KhalaCodePlannedClaim = {
+  readonly candidateRef: string
+  readonly claimRef: string
+  readonly laneRef: string
+  readonly plannedAt: string
+}
+
+export type PlanKhalaCodeQueueInput = {
+  readonly activeClaims?: readonly KhalaCodeActiveClaim[]
+  readonly candidates: readonly KhalaCodeQueueCandidate[]
+  readonly lanes: readonly KhalaCodeQueueLane[]
+  readonly maxClaims?: number
+  readonly now: string
+  readonly targetLaneRef: string
+}
+
+export type KhalaCodeQueuePlan = {
+  readonly claims: readonly KhalaCodePlannedClaim[]
+  readonly lane: KhalaCodeQueueLane | null
+  readonly rows: readonly KhalaCodeQueueRow[]
+  readonly targetLaneRef: string
+}
+
+export const khalaCodeCandidateRef = (
+  candidate: Pick<KhalaCodeQueueCandidate, "kind" | "number" | "repository">,
+): string => {
+  const prefix = candidate.kind === "pull_request" ? "pr" : "issue"
+  return `${candidate.repository}#${prefix}.${candidate.number}`
+}
+
+const claimRefFor = (
+  candidateRef: string,
+  laneRef: string,
+  plannedAt: string,
+): string =>
+  `khala_code_claim.${laneRef}.${candidateRef.replace(/[^a-z0-9._-]+/gi, "_")}.${plannedAt.replace(/[^0-9TZ]+/g, "")}`
+
+const closedReasonFor = (
+  candidate: KhalaCodeQueueCandidate,
+): KhalaCodeQueueReason => {
+  if (candidate.kind === "pull_request" && candidate.mergedAt !== null && candidate.mergedAt !== undefined) {
+    return { kind: "merge", reason: "merged_upstream" }
+  }
+  if (candidate.kind === "issue") return { kind: "close", reason: "issue_closed" }
+  return { kind: "close", reason: "closed_unmerged" }
+}
+
+const lanePriority = (lanes: readonly KhalaCodeQueueLane[], laneRef: string): number =>
+  lanes.find(lane => lane.laneRef === laneRef)?.priority ?? 0
+
+const sortedCandidates = (
+  candidates: readonly KhalaCodeQueueCandidate[],
+  lanes: readonly KhalaCodeQueueLane[],
+  targetLaneRef: string,
+): readonly KhalaCodeQueueCandidate[] =>
+  [...candidates].sort((left, right) => {
+    const targetDelta =
+      Number(right.laneRefs.includes(targetLaneRef)) -
+      Number(left.laneRefs.includes(targetLaneRef))
+    if (targetDelta !== 0) return targetDelta
+
+    const laneDelta =
+      Math.max(0, ...right.laneRefs.map(ref => lanePriority(lanes, ref))) -
+      Math.max(0, ...left.laneRefs.map(ref => lanePriority(lanes, ref)))
+    if (laneDelta !== 0) return laneDelta
+
+    const priorityDelta = right.priority - left.priority
+    if (priorityDelta !== 0) return priorityDelta
+
+    const updatedDelta =
+      Date.parse(right.updatedAt ?? "1970-01-01T00:00:00.000Z") -
+      Date.parse(left.updatedAt ?? "1970-01-01T00:00:00.000Z")
+    if (updatedDelta !== 0) return updatedDelta
+
+    return left.number - right.number
+  })
+
+export const planKhalaCodeQueue = (
+  input: PlanKhalaCodeQueueInput,
+): KhalaCodeQueuePlan => {
+  const maxClaims = Math.max(0, input.maxClaims ?? 1)
+  const targetLane =
+    input.lanes.find(lane => lane.laneRef === input.targetLaneRef) ?? null
+  const activeClaimRefs = new Set(
+    (input.activeClaims ?? []).map(claim => claim.candidateRef),
+  )
+  const seenCandidateRefs = new Set<string>()
+  const rows: KhalaCodeQueueRow[] = []
+  const claims: KhalaCodePlannedClaim[] = []
+
+  for (const candidate of sortedCandidates(
+    input.candidates,
+    input.lanes,
+    input.targetLaneRef,
+  )) {
+    const candidateRef = khalaCodeCandidateRef(candidate)
+    const laneRef = candidate.laneRefs.includes(input.targetLaneRef)
+      ? input.targetLaneRef
+      : candidate.laneRefs[0] ?? null
+
+    if (seenCandidateRefs.has(candidateRef)) {
+      rows.push({
+        candidate,
+        candidateRef,
+        decision: "skip",
+        laneRef,
+        reason: { kind: "skip", reason: "duplicate_candidate" },
+      })
+      continue
+    }
+    seenCandidateRefs.add(candidateRef)
+
+    if (!candidate.laneRefs.includes(input.targetLaneRef)) {
+      rows.push({
+        candidate,
+        candidateRef,
+        decision: "skip",
+        laneRef,
+        reason: { kind: "skip", reason: "lane_mismatch" },
+      })
+      continue
+    }
+
+    if (candidate.state === "closed") {
+      const reason = closedReasonFor(candidate)
+      rows.push({
+        candidate,
+        candidateRef,
+        decision: reason.kind,
+        laneRef,
+        reason,
+      })
+      continue
+    }
+
+    if (candidate.supersededBy !== null && candidate.supersededBy !== undefined) {
+      rows.push({
+        candidate,
+        candidateRef,
+        decision: "skip",
+        laneRef,
+        reason: { kind: "skip", reason: "superseded" },
+      })
+      continue
+    }
+
+    if (activeClaimRefs.has(candidateRef)) {
+      rows.push({
+        candidate,
+        candidateRef,
+        decision: "skip",
+        laneRef,
+        reason: { kind: "skip", reason: "duplicate_claim" },
+      })
+      continue
+    }
+
+    if (candidate.dispatch?.state === "blocked") {
+      rows.push({
+        candidate,
+        candidateRef,
+        decision: "block",
+        laneRef,
+        reason: { kind: "block", reason: candidate.dispatch.reason },
+      })
+      continue
+    }
+
+    if (candidate.dispatch?.state === "retry") {
+      rows.push({
+        candidate,
+        candidateRef,
+        decision: "retry",
+        laneRef,
+        reason: {
+          kind: "retry",
+          reason: candidate.dispatch.reason,
+          retryAt: candidate.dispatch.retryAt,
+        },
+      })
+      continue
+    }
+
+    if (claims.length >= maxClaims) {
+      rows.push({
+        candidate,
+        candidateRef,
+        decision: "retry",
+        laneRef,
+        reason: {
+          kind: "retry",
+          reason: "capacity_unavailable",
+          retryAt: input.now,
+        },
+      })
+      continue
+    }
+
+    const claim = {
+      candidateRef,
+      claimRef: claimRefFor(candidateRef, input.targetLaneRef, input.now),
+      laneRef: input.targetLaneRef,
+      plannedAt: input.now,
+    } satisfies KhalaCodePlannedClaim
+    claims.push(claim)
+    activeClaimRefs.add(candidateRef)
+    rows.push({
+      candidate,
+      candidateRef,
+      claim,
+      decision: "claim",
+      laneRef,
+      reason: {
+        kind: "claim",
+        reason: maxClaims === 0 ? "priority_lane_dry_run" : "priority_lane_capacity",
+      },
+    })
+  }
+
+  return {
+    claims,
+    lane: targetLane,
+    rows,
+    targetLaneRef: input.targetLaneRef,
+  }
+}

--- a/clients/openagents-desktop/tests/khala-code-queue-planner.test.ts
+++ b/clients/openagents-desktop/tests/khala-code-queue-planner.test.ts
@@ -1,0 +1,215 @@
+import { describe, expect, test } from "bun:test"
+
+import {
+  khalaCodeCandidateRef,
+  planKhalaCodeQueue,
+  type KhalaCodeQueueCandidate,
+} from "../src/shared/khala-code-queue-planner.js"
+
+const now = "2026-06-29T18:00:00.000Z"
+
+const candidate = (
+  overrides: Partial<KhalaCodeQueueCandidate> &
+    Pick<KhalaCodeQueueCandidate, "kind" | "number" | "title">,
+): KhalaCodeQueueCandidate => ({
+  laneRefs: ["lane.pylon_codex_rate_limits"],
+  priority: 50,
+  repository: "OpenAgentsInc/openagents",
+  state: "open",
+  ...overrides,
+})
+
+describe("Khala Code queue planner", () => {
+  test("targets the requested priority lane before lower-priority candidates", () => {
+    const highValuePr = candidate({
+      kind: "pull_request",
+      number: 7557,
+      priority: 100,
+      title: "Expose Codex fleet quota cooldown state",
+    })
+    const genericIssue = candidate({
+      kind: "issue",
+      laneRefs: ["lane.generic_burndown"],
+      number: 7595,
+      priority: 999,
+      title: "Build unrelated queue work",
+    })
+
+    const plan = planKhalaCodeQueue({
+      candidates: [genericIssue, highValuePr],
+      lanes: [
+        {
+          laneRef: "lane.pylon_codex_rate_limits",
+          priority: 100,
+          title: "Pylon/Codex rate limits",
+        },
+        {
+          laneRef: "lane.generic_burndown",
+          priority: 1,
+          title: "Generic burndown",
+        },
+      ],
+      maxClaims: 1,
+      now,
+      targetLaneRef: "lane.pylon_codex_rate_limits",
+    })
+
+    expect(plan.lane?.title).toBe("Pylon/Codex rate limits")
+    expect(plan.claims).toEqual([
+      expect.objectContaining({
+        candidateRef: khalaCodeCandidateRef(highValuePr),
+        laneRef: "lane.pylon_codex_rate_limits",
+      }),
+    ])
+    expect(plan.rows.map(row => [row.candidate.number, row.decision])).toEqual([
+      [7557, "claim"],
+      [7595, "skip"],
+    ])
+    expect(plan.rows[1]?.reason).toEqual({
+      kind: "skip",
+      reason: "lane_mismatch",
+    })
+  })
+
+  test("skips closed, merged, and superseded candidates before dispatch", () => {
+    const plan = planKhalaCodeQueue({
+      candidates: [
+        candidate({
+          kind: "pull_request",
+          mergedAt: "2026-06-29T17:00:00.000Z",
+          number: 7486,
+          state: "closed",
+          title: "Harden Pylon agent runner registry contract",
+        }),
+        candidate({
+          closedAt: "2026-06-29T17:05:00.000Z",
+          kind: "pull_request",
+          number: 6831,
+          state: "closed",
+          title: "Close stale queue work",
+        }),
+        candidate({
+          kind: "issue",
+          number: 7590,
+          state: "closed",
+          title: "Parent planning issue",
+        }),
+        candidate({
+          kind: "pull_request",
+          number: 7558,
+          supersededBy: "OpenAgentsInc/openagents#pr.7560",
+          title: "Classify Codex account execution refusals",
+        }),
+      ],
+      lanes: [
+        {
+          laneRef: "lane.pylon_codex_rate_limits",
+          priority: 100,
+          title: "Pylon/Codex rate limits",
+        },
+      ],
+      maxClaims: 4,
+      now,
+      targetLaneRef: "lane.pylon_codex_rate_limits",
+    })
+
+    expect(plan.claims).toEqual([])
+    expect(
+      Object.fromEntries(plan.rows.map(row => [row.candidate.number, row.reason])),
+    ).toEqual({
+      7486: { kind: "merge", reason: "merged_upstream" },
+      6831: { kind: "close", reason: "closed_unmerged" },
+      7590: { kind: "close", reason: "issue_closed" },
+      7558: { kind: "skip", reason: "superseded" },
+    })
+  })
+
+  test("prevents duplicate claims for the same PR or issue", () => {
+    const pr = candidate({
+      kind: "pull_request",
+      number: 7579,
+      title: "Expose Codex quota reset policy status",
+    })
+    const issue = candidate({
+      kind: "issue",
+      number: 7595,
+      title: "Build GitHub PR/issue queue planner",
+    })
+
+    const plan = planKhalaCodeQueue({
+      activeClaims: [
+        {
+          candidateRef: khalaCodeCandidateRef(pr),
+          claimedAt: "2026-06-29T17:55:00.000Z",
+          claimRef: "claim.existing",
+          laneRef: "lane.pylon_codex_rate_limits",
+        },
+      ],
+      candidates: [pr, issue, issue],
+      lanes: [
+        {
+          laneRef: "lane.pylon_codex_rate_limits",
+          priority: 100,
+          title: "Pylon/Codex rate limits",
+        },
+      ],
+      maxClaims: 2,
+      now,
+      targetLaneRef: "lane.pylon_codex_rate_limits",
+    })
+
+    expect(plan.claims).toHaveLength(1)
+    expect(plan.claims[0]?.candidateRef).toBe(khalaCodeCandidateRef(issue))
+    expect(plan.rows.map(row => row.reason)).toEqual([
+      { kind: "skip", reason: "duplicate_claim" },
+      { kind: "claim", reason: "priority_lane_capacity" },
+      { kind: "skip", reason: "duplicate_candidate" },
+    ])
+  })
+
+  test("records typed retry and block reasons without claiming", () => {
+    const plan = planKhalaCodeQueue({
+      candidates: [
+        candidate({
+          dispatch: {
+            reason: "provider_cooldown",
+            retryAt: "2026-06-29T20:00:00.000Z",
+            state: "retry",
+          },
+          kind: "pull_request",
+          number: 7523,
+          title: "Parse provider quota reset hints",
+        }),
+        candidate({
+          dispatch: {
+            reason: "missing_verification",
+            state: "blocked",
+          },
+          kind: "issue",
+          number: 7600,
+          title: "Needs a verifier before fanout",
+        }),
+      ],
+      lanes: [
+        {
+          laneRef: "lane.pylon_codex_rate_limits",
+          priority: 100,
+          title: "Pylon/Codex rate limits",
+        },
+      ],
+      maxClaims: 2,
+      now,
+      targetLaneRef: "lane.pylon_codex_rate_limits",
+    })
+
+    expect(plan.claims).toEqual([])
+    expect(plan.rows.map(row => row.reason)).toEqual([
+      {
+        kind: "retry",
+        reason: "provider_cooldown",
+        retryAt: "2026-06-29T20:00:00.000Z",
+      },
+      { kind: "block", reason: "missing_verification" },
+    ])
+  })
+})

--- a/scripts/check-conflict-markers.mjs
+++ b/scripts/check-conflict-markers.mjs
@@ -1,0 +1,21 @@
+#!/usr/bin/env bun
+
+import { spawnSync } from "node:child_process"
+import { dirname, resolve } from "node:path"
+import { fileURLToPath } from "node:url"
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..")
+const appRoot = resolve(repoRoot, "apps/openagents.com")
+const scriptPath = resolve(appRoot, "scripts/check-conflict-markers.mjs")
+
+const result = spawnSync("bun", [scriptPath], {
+  cwd: appRoot,
+  stdio: "inherit",
+})
+
+if (result.error) {
+  console.error(result.error.message)
+  process.exit(1)
+}
+
+process.exit(result.status ?? 1)


### PR DESCRIPTION
Closes #7595.

## Summary
- add a structured Khala Code queue planner for desktop PR/issue fanout lanes
- classify claim, skip, retry, block, merge, and close outcomes with typed reasons
- prevent duplicate candidate and active-claim dispatches, and restore the public conflict-marker verifier entrypoint

## Verification
- bun run --cwd clients/openagents-desktop typecheck
- bun run --cwd clients/openagents-desktop test
- bun scripts/check-conflict-markers.mjs