### PR TITLE
Add Khala dispatch planning APIs

### DIFF
--- a/apps/pylon/src/index.ts
+++ b/apps/pylon/src/index.ts
@@ -314,6 +314,11 @@ import {
   runPylonKhalaBurndownPlan,
 } from "./khala-burndown.js"
 import {
+  buildPylonKhalaDispatchPlan,
+  normalizeKhalaDispatchCandidateRefs,
+  type KhalaDispatchAccountTarget,
+} from "./khala-dispatch.js"
+import {
   buildPylonKhalaSpawnPlan,
   repeatedKhalaSpawnObjectives,
   runPylonKhalaSpawnPlan,
@@ -4136,6 +4141,76 @@ async function main() {
           summary,
         })
         emit(result)
+        return
+      }
+
+      if (command === "dispatch") {
+        const commit = optionString(options, "commit")
+        const repository = optionString(options, "repo") ?? "OpenAgentsInc/openagents"
+        const verificationCommand = optionString(options, "verify")
+        const candidatesOption =
+          optionString(options, "candidates") ??
+          optionString(options, "candidate-refs")
+        const accountsOption =
+          optionString(options, "accounts") ??
+          optionString(options, "account-targets")
+        const missingPins = [
+          commit === undefined ? "--commit" : null,
+          verificationCommand === undefined ? "--verify" : null,
+          candidatesOption === undefined ? "--candidates" : null,
+          accountsOption === undefined ? "--accounts" : null,
+        ].filter((pin): pin is string => pin !== null)
+        if (missingPins.length > 0) {
+          throw new Error(
+            `usage: pylon khala dispatch --candidates <pr:1,issue:2> --accounts <refs> --commit <sha> --verify <argv> [--repo owner/repo] [--concurrency n] [--priority-lane name] [--json]; missing ${missingPins.join(", ")}`,
+          )
+        }
+        const candidateRefsArg = candidatesOption as string
+        const accountTargetsArg = accountsOption as string
+        const pinnedCommit = commit as string
+        const pinnedVerificationCommand = verificationCommand as string
+        const state = await ensurePylonLocalState(summary)
+        const targetPylonRef =
+          optionString(options, "pylon-ref") ??
+          optionString(options, "target-pylon-ref") ??
+          localPylonTargetRef(state)
+        const accounts = await collectPylonAccountsList(summary, { env: Bun.env })
+        const wantedAccounts = new Set(
+          accountTargetsArg
+            .split(",")
+            .map((value) => value.trim())
+            .filter((value) => value !== ""),
+        )
+        const accountTargets: KhalaDispatchAccountTarget[] = accounts.accounts
+          .filter((account) =>
+            account.provider === "codex" &&
+            ((account.accountRef !== null && wantedAccounts.has(account.accountRef)) ||
+              wantedAccounts.has(account.accountRefHash))
+          )
+          .map((account) => ({
+            accountRef: account.accountRef,
+            accountRefHash: account.accountRefHash,
+            provider: "codex",
+          }))
+        const branch = optionString(options, "branch")
+        const plan = buildPylonKhalaDispatchPlan({
+          accountTargets,
+          candidateRefs: normalizeKhalaDispatchCandidateRefs(
+            candidateRefsArg.split(","),
+          ),
+          concurrency:
+            positiveIntegerOption(options, "concurrency", "khala dispatch --concurrency") ??
+            1,
+          priorityLane: optionString(options, "priority-lane") ?? "default",
+          targetPylonRef,
+          verifier: {
+            ...(branch === undefined ? {} : { branch }),
+            commit: pinnedCommit,
+            command: pinnedVerificationCommand,
+            repository,
+          },
+        })
+        emit(plan)
         return
       }
 

--- a/apps/pylon/src/khala-dispatch.ts
+++ b/apps/pylon/src/khala-dispatch.ts
@@ -1,0 +1,247 @@
+import {
+  buildPylonKhalaGitCheckoutWorkspace,
+  type PylonKhalaRequestInput,
+} from "./khala-requester.js"
+
+export const PYLON_KHALA_DISPATCH_PLAN_SCHEMA = "openagents.pylon.khala_dispatch_plan.v0.1"
+
+export type KhalaDispatchCandidateKind = "issue" | "pr"
+
+export type KhalaDispatchCandidateRef = {
+  kind: KhalaDispatchCandidateKind
+  number: number
+  ref: string
+  objective: string
+}
+
+export type KhalaDispatchAccountTarget = {
+  accountRef: string | null
+  accountRefHash: string
+  provider: "codex"
+}
+
+export type KhalaDispatchVerifier = {
+  branch?: string
+  commit: string
+  command: string
+  repository: string
+}
+
+export type KhalaDispatchSlot = {
+  account: KhalaDispatchAccountTarget
+  candidate: KhalaDispatchCandidateRef
+  priorityLane: string
+  requestInput: PylonKhalaRequestInput
+  slotIndex: number
+}
+
+export type KhalaDispatchPlan = {
+  schema: typeof PYLON_KHALA_DISPATCH_PLAN_SCHEMA
+  blockerRefs: string[]
+  concurrency: number
+  priorityLane: string
+  slots: KhalaDispatchSlot[]
+  verifier: KhalaDispatchVerifier
+}
+
+export type KhalaDispatchLifecycleEvent =
+  | {
+      kind: "assignment_run.accepted"
+      observedAt?: string
+    }
+  | {
+      kind: "assignment_run.completed"
+      observedAt?: string
+      status: "accepted" | "rejected"
+    }
+  | {
+      error: string
+      kind: "request.failed"
+      observedAt?: string
+    }
+
+export type KhalaDispatchLifecycleClassification = {
+  action: "hold" | "release" | "complete"
+  state:
+    | "accepted_running"
+    | "completed_accepted"
+    | "completed_rejected"
+    | "failed_before_accept"
+    | "planned"
+  finalStatus: "accepted" | "rejected" | null
+}
+
+export type KhalaDispatchStructuredRecord = {
+  account: KhalaDispatchAccountTarget
+  candidate: KhalaDispatchCandidateRef
+  events: readonly KhalaDispatchLifecycleEvent[]
+  legacyFilename?: string
+}
+
+export type KhalaDispatchRecordProjection = {
+  accountRef: string | null
+  action: KhalaDispatchLifecycleClassification["action"]
+  candidateRef: string
+  lifecycle: KhalaDispatchLifecycleClassification["state"]
+  number: number
+  priorityLane: string
+}
+
+const publicRefPattern = /^[A-Za-z0-9_.:/#=-]{1,200}$/
+const accountHashPattern = /^account\.pylon\.codex\.[a-f0-9]{6,64}$/
+
+const uniqueByRef = <T extends { ref: string }>(values: readonly T[]): T[] => {
+  const seen = new Set<string>()
+  const out: T[] = []
+  for (const value of values) {
+    if (seen.has(value.ref)) continue
+    seen.add(value.ref)
+    out.push(value)
+  }
+  return out
+}
+
+export function normalizeKhalaDispatchCandidateRefs(
+  values: readonly (number | string | KhalaDispatchCandidateRef)[],
+): KhalaDispatchCandidateRef[] {
+  return uniqueByRef(
+    values.flatMap((value) => {
+      if (typeof value === "number") {
+        return Number.isSafeInteger(value) && value > 0
+          ? [{ kind: "issue" as const, number: value, objective: `Implement OpenAgents issue #${value}.`, ref: `issue:${value}` }]
+          : []
+      }
+      if (typeof value === "string") {
+        const trimmed = value.trim()
+        const match = trimmed.match(/^(?:(pr|issue):)?#?([1-9][0-9]{0,9})$/i)
+        if (match === null) return []
+        const kind = match[1]?.toLowerCase() === "pr" ? "pr" : "issue"
+        const number = Number.parseInt(match[2], 10)
+        return [{
+          kind,
+          number,
+          objective: kind === "pr"
+            ? `Resolve OpenAgents pull request #${number}.`
+            : `Implement OpenAgents issue #${number}.`,
+          ref: `${kind}:${number}`,
+        }]
+      }
+      if (
+        Number.isSafeInteger(value.number) &&
+        value.number > 0 &&
+        (value.kind === "issue" || value.kind === "pr") &&
+        publicRefPattern.test(value.ref) &&
+        value.objective.trim().length >= 3
+      ) {
+        return [{ ...value, objective: value.objective.trim() }]
+      }
+      return []
+    }),
+  )
+}
+
+export function buildPylonKhalaDispatchPlan(input: {
+  accountTargets: readonly KhalaDispatchAccountTarget[]
+  candidateRefs: readonly KhalaDispatchCandidateRef[]
+  concurrency: number
+  priorityLane: string
+  targetPylonRef: string
+  verifier: KhalaDispatchVerifier
+}): KhalaDispatchPlan {
+  const candidateRefs = normalizeKhalaDispatchCandidateRefs(input.candidateRefs)
+  const accountTargets = input.accountTargets.filter((account) =>
+    account.provider === "codex" && accountHashPattern.test(account.accountRefHash)
+  )
+  const concurrency = Math.max(1, Math.floor(input.concurrency))
+  const selectedCount = Math.min(concurrency, candidateRefs.length, accountTargets.length)
+  const priorityLane = input.priorityLane.trim() || "default"
+  const blockerRefs = [
+    ...(candidateRefs.length === 0 ? ["blocker.khala_dispatch.no_candidate_refs"] : []),
+    ...(accountTargets.length === 0 ? ["blocker.khala_dispatch.no_account_targets"] : []),
+    ...(selectedCount === 0 ? ["blocker.khala_dispatch.no_dispatch_slots"] : []),
+  ]
+  const workspace = buildPylonKhalaGitCheckoutWorkspace({
+    branch: input.verifier.branch,
+    commit: input.verifier.commit,
+    repository: input.verifier.repository,
+    verificationCommand: input.verifier.command,
+  })
+  const slots = candidateRefs.slice(0, selectedCount).map((candidate, index) => {
+    const account = accountTargets[index % accountTargets.length]
+    const objective = `${candidate.objective} Priority lane: ${priorityLane}. Run verifier: ${input.verifier.command}.`
+    return {
+      account,
+      candidate,
+      priorityLane,
+      requestInput: {
+        objectiveSummary: objective,
+        prompt: objective,
+        targetAccountRefHash: account.accountRefHash,
+        targetPylonRef: input.targetPylonRef,
+        workflow: "codex_agent_task",
+        workspace,
+      },
+      slotIndex: index,
+    } satisfies KhalaDispatchSlot
+  })
+  return {
+    schema: PYLON_KHALA_DISPATCH_PLAN_SCHEMA,
+    blockerRefs,
+    concurrency,
+    priorityLane,
+    slots,
+    verifier: input.verifier,
+  }
+}
+
+export function classifyKhalaDispatchLifecycle(
+  events: readonly KhalaDispatchLifecycleEvent[],
+): KhalaDispatchLifecycleClassification {
+  const completed = [...events]
+    .reverse()
+    .find((event): event is Extract<KhalaDispatchLifecycleEvent, { kind: "assignment_run.completed" }> =>
+      event.kind === "assignment_run.completed"
+    )
+  if (completed !== undefined) {
+    return completed.status === "accepted"
+      ? { action: "complete", finalStatus: "accepted", state: "completed_accepted" }
+      : { action: "release", finalStatus: "rejected", state: "completed_rejected" }
+  }
+  if (events.some((event) => event.kind === "assignment_run.accepted")) {
+    return { action: "hold", finalStatus: null, state: "accepted_running" }
+  }
+  if (events.some((event) => event.kind === "request.failed")) {
+    return { action: "release", finalStatus: null, state: "failed_before_accept" }
+  }
+  return { action: "hold", finalStatus: null, state: "planned" }
+}
+
+export function projectKhalaDispatchRecord(
+  record: KhalaDispatchStructuredRecord,
+  priorityLane = "default",
+): KhalaDispatchRecordProjection {
+  const lifecycle = classifyKhalaDispatchLifecycle(record.events)
+  return {
+    accountRef: record.account.accountRef,
+    action: lifecycle.action,
+    candidateRef: record.candidate.ref,
+    lifecycle: lifecycle.state,
+    number: record.candidate.number,
+    priorityLane,
+  }
+}
+
+export function enforceSingleKhalaDispatchController(input: {
+  activeControllerIds: readonly string[]
+  namespace: string
+  requestedControllerId: string
+}): { ok: true; controllerId: string } | { ok: false; blockerRefs: string[] } {
+  const active = [...new Set(input.activeControllerIds.filter((id) => id.trim() !== ""))]
+  if (active.length === 0 || (active.length === 1 && active[0] === input.requestedControllerId)) {
+    return { ok: true, controllerId: input.requestedControllerId }
+  }
+  return {
+    ok: false,
+    blockerRefs: [`blocker.khala_dispatch.controller_conflict.${input.namespace}`],
+  }
+}

--- a/apps/pylon/tests/khala-dispatch.test.ts
+++ b/apps/pylon/tests/khala-dispatch.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, test } from "bun:test"
+
+import {
+  buildPylonKhalaDispatchPlan,
+  classifyKhalaDispatchLifecycle,
+  enforceSingleKhalaDispatchController,
+  normalizeKhalaDispatchCandidateRefs,
+  projectKhalaDispatchRecord,
+  type KhalaDispatchAccountTarget,
+} from "../src/khala-dispatch"
+
+const commit = "7ab7cb401803f6e04a6c93b7aa9102405de66419"
+const verifier = {
+  commit,
+  command: "bun scripts/check-conflict-markers.mjs",
+  repository: "OpenAgentsInc/openagents",
+}
+
+const account = (ref: string, hash: string): KhalaDispatchAccountTarget => ({
+  accountRef: ref,
+  accountRefHash: `account.pylon.codex.${hash}`,
+  provider: "codex",
+})
+
+describe("pylon khala dispatch planning", () => {
+  test("accepts structured candidate refs, account targets, concurrency, verifier, and priority lane", () => {
+    const plan = buildPylonKhalaDispatchPlan({
+      accountTargets: [
+        account("codex-3", "abcdef123456"),
+        account("codex-4", "fedcba654321"),
+      ],
+      candidateRefs: normalizeKhalaDispatchCandidateRefs(["pr:7557", "issue:7598"]),
+      concurrency: 2,
+      priorityLane: "rate-limit",
+      targetPylonRef: "pylon.public.local",
+      verifier,
+    })
+
+    expect(plan.schema).toBe("openagents.pylon.khala_dispatch_plan.v0.1")
+    expect(plan.blockerRefs).toEqual([])
+    expect(plan.concurrency).toBe(2)
+    expect(plan.priorityLane).toBe("rate-limit")
+    expect(plan.slots.map((slot) => slot.candidate.ref)).toEqual([
+      "pr:7557",
+      "issue:7598",
+    ])
+    expect(plan.slots.map((slot) => slot.account.accountRef)).toEqual([
+      "codex-3",
+      "codex-4",
+    ])
+    expect(plan.slots[0]?.requestInput).toMatchObject({
+      targetAccountRefHash: "account.pylon.codex.abcdef123456",
+      targetPylonRef: "pylon.public.local",
+      workflow: "codex_agent_task",
+    })
+    expect(plan.slots[0]?.requestInput.workspace).toMatchObject({
+      repository: {
+        commitSha: commit,
+        fullName: "OpenAgentsInc/openagents",
+      },
+      verificationCommand: {
+        args: ["bun", "scripts/check-conflict-markers.mjs"],
+      },
+    })
+  })
+})
+
+describe("pylon khala dispatch lifecycle", () => {
+  test("keeps codex-3 filenames out of PR number and account lifecycle state", () => {
+    const candidate = normalizeKhalaDispatchCandidateRefs(["pr:7557"])[0]
+    const projection = projectKhalaDispatchRecord({
+      account: account("codex-3", "abcdef123456"),
+      candidate,
+      events: [{ kind: "assignment_run.accepted" }],
+      legacyFilename: "pr-review-20260629-codex-3-7557-rate-limit.log",
+    }, "rate-limit")
+
+    expect(projection).toMatchObject({
+      accountRef: "codex-3",
+      action: "hold",
+      candidateRef: "pr:7557",
+      lifecycle: "accepted_running",
+      number: 7557,
+      priorityLane: "rate-limit",
+    })
+  })
+
+  test("releases a lock when an accepted run later completes rejected", () => {
+    expect(
+      classifyKhalaDispatchLifecycle([
+        { kind: "assignment_run.accepted" },
+        { kind: "assignment_run.completed", status: "rejected" },
+      ]),
+    ).toEqual({
+      action: "release",
+      finalStatus: "rejected",
+      state: "completed_rejected",
+    })
+  })
+
+  test("enforces a single active controller per namespace", () => {
+    expect(
+      enforceSingleKhalaDispatchController({
+        activeControllerIds: ["controller.a"],
+        namespace: "pr-review",
+        requestedControllerId: "controller.b",
+      }),
+    ).toEqual({
+      ok: false,
+      blockerRefs: ["blocker.khala_dispatch.controller_conflict.pr-review"],
+    })
+    expect(
+      enforceSingleKhalaDispatchController({
+        activeControllerIds: ["controller.a"],
+        namespace: "pr-review",
+        requestedControllerId: "controller.a",
+      }),
+    ).toEqual({ ok: true, controllerId: "controller.a" })
+  })
+})

--- a/clients/openagents-desktop/src/bun/index.ts
+++ b/clients/openagents-desktop/src/bun/index.ts
@@ -15,6 +15,10 @@ import {
   type CodingStatusResult,
   type CodingStatusSummary,
 } from "../shared/coding-status.js"
+import type {
+  DesktopKhalaDispatchPlanInput,
+  DesktopKhalaDispatchPlanResult,
+} from "../shared/khala-dispatch.js"
 import {
   connectedPylonCount,
   type CreatePylonResult,
@@ -482,6 +486,75 @@ const spawnText = async (cmd: readonly string[]): Promise<string> => {
   return stdout
 }
 
+const khalaDispatchPlan = async (
+  input: DesktopKhalaDispatchPlanInput,
+): Promise<DesktopKhalaDispatchPlanResult> => {
+  const observedAt = new Date().toISOString()
+  const args = [
+    "src/index.ts",
+    "khala",
+    "dispatch",
+    "--candidates",
+    input.candidateRefs.join(","),
+    "--accounts",
+    input.accounts.join(","),
+    "--concurrency",
+    String(input.concurrency),
+    "--priority-lane",
+    input.priorityLane,
+    "--repo",
+    input.repository,
+    "--commit",
+    input.commit,
+    "--verify",
+    input.verifier,
+    "--json",
+  ]
+  if (input.branch !== undefined) {
+    args.push("--branch", input.branch)
+  }
+  if (input.targetPylonRef !== undefined) {
+    args.push("--pylon-ref", input.targetPylonRef)
+  }
+
+  try {
+    const pylonAppPath = await resolvePylonAppPath()
+    const proc = Bun.spawn({
+      cmd: [resolveBunExecutable(), ...args],
+      cwd: pylonAppPath,
+      env: withExtraPath({
+        ...Bun.env,
+        PYLON_OPENAGENTS_BASE_URL: baseUrl,
+      }),
+      stderr: "pipe",
+      stdout: "pipe",
+    })
+    const [stdout, stderr, exitCode] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ])
+    if (exitCode !== 0) {
+      return {
+        ok: false,
+        error: stderr.trim() || stdout.trim() || `pylon exited ${exitCode}`,
+        observedAt,
+      }
+    }
+    return {
+      ok: true,
+      observedAt,
+      plan: JSON.parse(stdout),
+    }
+  } catch (error) {
+    return {
+      ok: false,
+      error: error instanceof Error ? error.message : String(error),
+      observedAt,
+    }
+  }
+}
+
 const codingStatus = async (): Promise<CodingStatusResult> => {
   const observedAt = new Date().toISOString()
   const home = supervisorHome()
@@ -573,6 +646,7 @@ const rpc = BrowserView.defineRPC<OpenAgentsDesktopRPCSchema>({
     requests: {
       codingStatus,
       createPylon,
+      khalaDispatchPlan,
       async pylonStatus() {
         return desktopPylonStatus()
       },

--- a/clients/openagents-desktop/src/shared/khala-dispatch.ts
+++ b/clients/openagents-desktop/src/shared/khala-dispatch.ts
@@ -1,0 +1,23 @@
+export type DesktopKhalaDispatchPlanInput = {
+  readonly accounts: readonly string[]
+  readonly candidateRefs: readonly string[]
+  readonly concurrency: number
+  readonly priorityLane: string
+  readonly repository: string
+  readonly branch?: string
+  readonly commit: string
+  readonly verifier: string
+  readonly targetPylonRef?: string
+}
+
+export type DesktopKhalaDispatchPlanResult =
+  | {
+      readonly ok: true
+      readonly observedAt: string
+      readonly plan: unknown
+    }
+  | {
+      readonly ok: false
+      readonly observedAt: string
+      readonly error: string
+    }

--- a/clients/openagents-desktop/src/shared/rpc.ts
+++ b/clients/openagents-desktop/src/shared/rpc.ts
@@ -1,4 +1,8 @@
 import type { CodingStatusResult } from "./coding-status"
+import type {
+  DesktopKhalaDispatchPlanInput,
+  DesktopKhalaDispatchPlanResult,
+} from "./khala-dispatch"
 import type { CreatePylonResult, PylonStatusResult } from "./pylon-status"
 
 export const OPENAGENTS_DESKTOP_RPC_MAX_REQUEST_TIME_MS = 60_000
@@ -7,6 +11,9 @@ export type OpenAgentsDesktopRPCSchema = {
   requests: {
     codingStatus(): Promise<CodingStatusResult>
     createPylon(): Promise<CreatePylonResult>
+    khalaDispatchPlan(
+      input: DesktopKhalaDispatchPlanInput,
+    ): Promise<DesktopKhalaDispatchPlanResult>
     pylonStatus(): Promise<PylonStatusResult>
   }
 }

--- a/scripts/check-conflict-markers.mjs
+++ b/scripts/check-conflict-markers.mjs
@@ -1,0 +1,35 @@
+#!/usr/bin/env bun
+
+import { spawnSync } from "node:child_process"
+import { readFileSync } from "node:fs"
+
+const tracked = spawnSync("git", ["ls-files"], {
+  encoding: "utf8",
+  stdio: ["ignore", "pipe", "pipe"],
+})
+
+if (tracked.status !== 0) {
+  process.stderr.write(tracked.stderr || "failed to list tracked files\n")
+  process.exit(tracked.status ?? 1)
+}
+
+const conflictBlockPattern = /^<<<<<<<(?: .*)?$\n[\s\S]*?^=======$\n[\s\S]*?^>>>>>>>(?: .*)?$/m
+const offenders = []
+
+for (const path of tracked.stdout.split("\n")) {
+  if (path === "") continue
+  let text
+  try {
+    text = readFileSync(path, "utf8")
+  } catch {
+    continue
+  }
+  if (conflictBlockPattern.test(text)) offenders.push(path)
+}
+
+if (offenders.length > 0) {
+  process.stderr.write(`conflict markers found:\n${offenders.join("\n")}\n`)
+  process.exit(1)
+}
+
+process.stdout.write("no conflict markers found\n")


### PR DESCRIPTION
## Summary
- add a structured Pylon `khala dispatch` planner for candidate refs, account targets, concurrency, verifier pins, and priority lanes
- expose a desktop RPC that delegates dispatch planning to the checked-in Pylon API instead of temp refill scripts
- add lifecycle classification tests for codex-3 filename avoidance, accepted-then-rejected release, and single-controller enforcement
- add the checked-in lightweight conflict-marker verifier used by the required command ref

Closes #7598

## Verification
- `bun test apps/pylon/tests/khala-dispatch.test.ts`
- `bun test clients/openagents-desktop/tests/coding-status.test.ts clients/openagents-desktop/tests/app-shell.test.ts`
- `bun test apps/pylon/tests/khala-dispatch.test.ts clients/openagents-desktop/tests/coding-status.test.ts clients/openagents-desktop/tests/app-shell.test.ts`
- `bun scripts/check-conflict-markers.mjs` (`command.public.pylon_khala.verify.4e3e82daa9d3450372aa61a2`)

## Notes
- `bun run --cwd apps/pylon typecheck` is still blocked by missing workspace dependencies and pre-existing unrelated `src/index.ts` errors in this checkout; the new `khala-dispatch.ts` file did not appear in the filtered error output.
- `bun run --cwd clients/openagents-desktop typecheck` is still blocked by missing `three` / `@openagentsinc/three-effect` dependencies in this checkout; the touched desktop files did not appear in the filtered error output.