### PR TITLE
[codex] Add desktop Khala fleet manager event store

### DIFF
--- a/clients/openagents-desktop/src/bun/index.ts
+++ b/clients/openagents-desktop/src/bun/index.ts
@@ -16,6 +16,10 @@ import {
   type CodingStatusSummary,
 } from "../shared/coding-status.js"
 import {
+  type KhalaFleetSnapshotResult,
+  OpenAgentsDesktopFleetManager,
+} from "../shared/khala-fleet-manager.js"
+import {
   connectedPylonCount,
   type CreatePylonResult,
   type DesktopPylon,
@@ -32,6 +36,10 @@ const baseUrl =
   Bun.env.PYLON_OPENAGENTS_BASE_URL ??
   Bun.env.OPENAGENTS_COM_BASE_URL ??
   OPENAGENTS_DESKTOP_DEFAULT_BASE_URL
+
+const khalaFleetStorePath = (): string =>
+  Bun.env.OPENAGENTS_DESKTOP_KHALA_FLEET_DB ??
+  join(homedir(), ".openagents", "desktop", "khala-fleet.sqlite")
 
 const pathCandidates = (): readonly string[] => [
   Bun.env.PATH ?? "",
@@ -567,12 +575,32 @@ const createPylon = async (): Promise<CreatePylonResult> => {
   }
 }
 
+const khalaFleetSnapshot = async (): Promise<KhalaFleetSnapshotResult> => {
+  const observedAt = new Date()
+  try {
+    const manager = OpenAgentsDesktopFleetManager.acquire({
+      path: khalaFleetStorePath(),
+    })
+    return {
+      ok: true,
+      snapshot: manager.reconstructActiveState(observedAt),
+    }
+  } catch (error) {
+    return {
+      ok: false,
+      error: error instanceof Error ? error.message : String(error),
+      observedAt: observedAt.toISOString(),
+    }
+  }
+}
+
 const rpc = BrowserView.defineRPC<OpenAgentsDesktopRPCSchema>({
   maxRequestTime: OPENAGENTS_DESKTOP_RPC_MAX_REQUEST_TIME_MS,
   handlers: {
     requests: {
       codingStatus,
       createPylon,
+      khalaFleetSnapshot,
       async pylonStatus() {
         return desktopPylonStatus()
       },

--- a/clients/openagents-desktop/src/shared/khala-fleet-manager.ts
+++ b/clients/openagents-desktop/src/shared/khala-fleet-manager.ts
@@ -1,0 +1,676 @@
+import { Database } from "bun:sqlite"
+import { Schema } from "effect"
+import { mkdirSync } from "node:fs"
+import { dirname } from "node:path"
+
+export const KhalaFleetRowState = Schema.Literals([
+  "planned",
+  "dispatched",
+  "accepted",
+  "executing",
+  "completed",
+  "rejected",
+  "retryable",
+  "blocked",
+])
+export type KhalaFleetRowState = typeof KhalaFleetRowState.Type
+
+export const KhalaFleetReasonKind = Schema.Literals([
+  "none",
+  "capacity_unavailable",
+  "credentials_missing",
+  "execution_refused",
+  "github_closed",
+  "pylon_unavailable",
+  "token_reconciliation_failed",
+  "verifier_failed",
+  "worker_stale",
+  "unknown",
+])
+export type KhalaFleetReasonKind = typeof KhalaFleetReasonKind.Type
+
+export type KhalaFleetTaskRef = {
+  readonly issueRef: string | null
+  readonly prRef: string | null
+}
+
+export type KhalaFleetPlanInput = KhalaFleetTaskRef & {
+  readonly accountRef: string
+  readonly claimRef?: string | null
+  readonly originMainCommit: string
+  readonly queueDecision?: string | null
+  readonly queueLane?: string | null
+  readonly verifier: string
+  readonly reasonKind?: KhalaFleetReasonKind
+  readonly reasonDetail?: string | null
+}
+
+export type KhalaFleetLifecycleInput = {
+  readonly assignmentRef?: string | null
+  readonly pid?: number | null
+  readonly reasonKind?: KhalaFleetReasonKind
+  readonly reasonDetail?: string | null
+}
+
+export type KhalaFleetLogInput = {
+  readonly assignmentRef?: string | null
+  readonly eventType: string
+  readonly message?: string | null
+  readonly payload?: unknown
+}
+
+export type KhalaFleetRow = KhalaFleetTaskRef & {
+  readonly id: number
+  readonly accountRef: string
+  readonly assignmentRef: string | null
+  readonly claimRef: string | null
+  readonly verifier: string
+  readonly originMainCommit: string
+  readonly queueDecision: string | null
+  readonly queueLane: string | null
+  readonly pid: number | null
+  readonly state: KhalaFleetRowState
+  readonly reasonKind: KhalaFleetReasonKind
+  readonly reasonDetail: string | null
+  readonly createdAt: string
+  readonly updatedAt: string
+  readonly plannedAt: string | null
+  readonly dispatchedAt: string | null
+  readonly acceptedAt: string | null
+  readonly executingAt: string | null
+  readonly completedAt: string | null
+  readonly rejectedAt: string | null
+  readonly retryableAt: string | null
+  readonly blockedAt: string | null
+  readonly tokenFailureCount: number
+  readonly tokenInputTokens: number | null
+  readonly tokenOutputTokens: number | null
+  readonly tokenReasoningTokens: number | null
+  readonly tokenReconciledAt: string | null
+  readonly tokenTotalTokens: number | null
+}
+
+export type KhalaFleetLogRow = {
+  readonly id: number
+  readonly rowId: number
+  readonly assignmentRef: string | null
+  readonly eventType: string
+  readonly message: string | null
+  readonly payloadJson: string | null
+  readonly createdAt: string
+}
+
+export type KhalaFleetRestartSnapshot = {
+  readonly activeRows: readonly KhalaFleetRow[]
+  readonly blockedRows: readonly KhalaFleetRow[]
+  readonly completedRows: readonly KhalaFleetRow[]
+  readonly controller: {
+    readonly singletonActive: boolean
+    readonly storePath: string
+  }
+  readonly observedAt: string
+  readonly retryableRows: readonly KhalaFleetRow[]
+}
+
+export type KhalaFleetSnapshotResult =
+  | {
+      readonly ok: true
+      readonly snapshot: KhalaFleetRestartSnapshot
+    }
+  | {
+      readonly ok: false
+      readonly error: string
+      readonly observedAt: string
+    }
+
+type FleetStoreOptions = {
+  readonly path: string
+}
+
+const activeStates = new Set<KhalaFleetRowState>([
+  "planned",
+  "dispatched",
+  "accepted",
+  "executing",
+])
+
+const timestampColumns: Partial<Record<KhalaFleetRowState, keyof KhalaFleetRow>> = {
+  accepted: "acceptedAt",
+  blocked: "blockedAt",
+  completed: "completedAt",
+  dispatched: "dispatchedAt",
+  executing: "executingAt",
+  planned: "plannedAt",
+  rejected: "rejectedAt",
+  retryable: "retryableAt",
+}
+
+const stringValue = (value: unknown, fallback = ""): string =>
+  typeof value === "string" && value.trim() !== "" ? value.trim() : fallback
+
+const nullableString = (value: unknown): string | null =>
+  typeof value === "string" && value.trim() !== "" ? value.trim() : null
+
+const nullableNumber = (value: unknown): number | null =>
+  typeof value === "number" && Number.isFinite(value) ? value : null
+
+const stateValue = (value: unknown): KhalaFleetRowState =>
+  Schema.decodeUnknownSync(KhalaFleetRowState)(value)
+
+const reasonValue = (value: unknown): KhalaFleetReasonKind =>
+  Schema.decodeUnknownSync(KhalaFleetReasonKind)(value)
+
+export const redactKhalaFleetLogText = (value: string): string => {
+  return value
+    .replace(/Bearer\s+[A-Za-z0-9._~+/=-]+/gi, "Bearer [REDACTED]")
+    .replace(
+      /\b(OPENAGENTS_AGENT_TOKEN|GITHUB_TOKEN|NPM_TOKEN|ANTHROPIC_API_KEY|OPENAI_API_KEY)=([^\s"'`]+)/gi,
+      "$1=[REDACTED]",
+    )
+    .replace(
+      /("(?:access_token|refresh_token|id_token|api_key|authorization|token)"\s*:\s*)"[^"]*"/gi,
+      "$1\"[REDACTED]\"",
+    )
+    .replace(/\/Users\/[^/\s]+\/\.codex\/auth\.json/g, "[REDACTED_CODEX_AUTH]")
+    .replace(
+      /\/Users\/[^/\s]+\/\.pylon-fable\/accounts\/codex\/[^/\s]+\/auth\.json/g,
+      "[REDACTED_CODEX_AUTH]",
+    )
+}
+
+const redactedPayloadJson = (payload: unknown): string | null => {
+  if (payload === undefined || payload === null) return null
+  try {
+    return redactKhalaFleetLogText(JSON.stringify(payload))
+  } catch {
+    return redactKhalaFleetLogText(String(payload))
+  }
+}
+
+const rowFromSql = (row: Record<string, unknown>): KhalaFleetRow => ({
+  id: Number(row.id),
+  accountRef: stringValue(row.account_ref),
+  assignmentRef: nullableString(row.assignment_ref),
+  claimRef: nullableString(row.claim_ref),
+  prRef: nullableString(row.pr_ref),
+  issueRef: nullableString(row.issue_ref),
+  verifier: stringValue(row.verifier),
+  originMainCommit: stringValue(row.origin_main_commit),
+  queueDecision: nullableString(row.queue_decision),
+  queueLane: nullableString(row.queue_lane),
+  pid: nullableNumber(row.pid),
+  state: stateValue(row.state),
+  reasonKind: reasonValue(row.reason_kind),
+  reasonDetail: nullableString(row.reason_detail),
+  createdAt: stringValue(row.created_at),
+  updatedAt: stringValue(row.updated_at),
+  plannedAt: nullableString(row.planned_at),
+  dispatchedAt: nullableString(row.dispatched_at),
+  acceptedAt: nullableString(row.accepted_at),
+  executingAt: nullableString(row.executing_at),
+  completedAt: nullableString(row.completed_at),
+  rejectedAt: nullableString(row.rejected_at),
+  retryableAt: nullableString(row.retryable_at),
+  blockedAt: nullableString(row.blocked_at),
+  tokenFailureCount: Number(row.token_failure_count ?? 0),
+  tokenInputTokens: nullableNumber(row.token_input_tokens),
+  tokenOutputTokens: nullableNumber(row.token_output_tokens),
+  tokenReasoningTokens: nullableNumber(row.token_reasoning_tokens),
+  tokenReconciledAt: nullableString(row.token_reconciled_at),
+  tokenTotalTokens: nullableNumber(row.token_total_tokens),
+})
+
+const logFromSql = (row: Record<string, unknown>): KhalaFleetLogRow => ({
+  id: Number(row.id),
+  rowId: Number(row.row_id),
+  assignmentRef: nullableString(row.assignment_ref),
+  eventType: stringValue(row.event_type),
+  message: nullableString(row.message),
+  payloadJson: nullableString(row.payload_json),
+  createdAt: stringValue(row.created_at),
+})
+
+export class KhalaFleetEventStore {
+  readonly path: string
+  private readonly db: Database
+
+  constructor(options: FleetStoreOptions) {
+    this.path = options.path
+    if (this.path !== ":memory:") {
+      mkdirSync(dirname(this.path), { recursive: true })
+    }
+    this.db = new Database(this.path, { create: true, strict: true })
+    this.db.exec("PRAGMA journal_mode = WAL")
+    this.db.exec("PRAGMA foreign_keys = ON")
+    this.migrate()
+  }
+
+  close(): void {
+    this.db.close()
+  }
+
+  plan(input: KhalaFleetPlanInput, now = new Date()): KhalaFleetRow {
+    const observedAt = now.toISOString()
+    const insert = this.db.prepare(`
+      INSERT INTO khala_fleet_rows (
+        account_ref, assignment_ref, claim_ref, pr_ref, issue_ref, verifier,
+        origin_main_commit, queue_lane, queue_decision, pid, state,
+        reason_kind, reason_detail,
+        created_at, updated_at, planned_at
+      )
+      VALUES ($accountRef, NULL, $claimRef, $prRef, $issueRef, $verifier,
+        $originMainCommit, $queueLane, $queueDecision, NULL, 'planned',
+        $reasonKind, $reasonDetail, $observedAt, $observedAt, $observedAt)
+      RETURNING *
+    `)
+
+    return rowFromSql(insert.get({
+      accountRef: input.accountRef,
+      claimRef: input.claimRef ?? null,
+      issueRef: input.issueRef,
+      originMainCommit: input.originMainCommit,
+      prRef: input.prRef,
+      queueDecision: input.queueDecision ?? null,
+      queueLane: input.queueLane ?? null,
+      reasonDetail: input.reasonDetail ?? null,
+      reasonKind: input.reasonKind ?? "none",
+      observedAt: observedAt,
+      verifier: input.verifier,
+    }) as Record<string, unknown>)
+  }
+
+  transition(
+    rowId: number,
+    state: KhalaFleetRowState,
+    input: KhalaFleetLifecycleInput = {},
+    now = new Date(),
+  ): KhalaFleetRow {
+    const observedAt = now.toISOString()
+    const timestampColumn = timestampColumns[state]
+    if (timestampColumn === undefined) {
+      throw new Error(`No timestamp column for fleet state ${state}`)
+    }
+    const sqlColumn = this.sqlTimestampColumn(timestampColumn)
+    const existing = this.requireRow(rowId)
+    const assignmentRef = input.assignmentRef ?? existing.assignmentRef
+    const pid = input.pid ?? existing.pid
+    const reasonKind = input.reasonKind ?? existing.reasonKind
+    const reasonDetail =
+      input.reasonDetail === undefined ? existing.reasonDetail : input.reasonDetail
+
+    const update = this.db.prepare(`
+      UPDATE khala_fleet_rows
+         SET assignment_ref = $assignmentRef,
+             pid = $pid,
+             state = $state,
+             reason_kind = $reasonKind,
+             reason_detail = $reasonDetail,
+             updated_at = $observedAt,
+             ${sqlColumn} = $observedAt
+       WHERE id = $rowId
+      RETURNING *
+    `)
+    return rowFromSql(update.get({
+      assignmentRef: assignmentRef,
+      observedAt: observedAt,
+      pid: pid,
+      reasonDetail: reasonDetail,
+      reasonKind: reasonKind,
+      rowId: rowId,
+      state: state,
+    }) as Record<string, unknown>)
+  }
+
+  appendLog(
+    rowId: number,
+    input: KhalaFleetLogInput,
+    now = new Date(),
+  ): KhalaFleetLogRow {
+    this.requireRow(rowId)
+    const observedAt = now.toISOString()
+    const insert = this.db.prepare(`
+      INSERT INTO khala_fleet_events (
+        row_id, assignment_ref, event_type, message, payload_json, created_at
+      )
+      VALUES ($rowId, $assignmentRef, $eventType, $message, $payloadJson, $observedAt)
+      RETURNING *
+    `)
+
+    return logFromSql(insert.get({
+      assignmentRef: input.assignmentRef ?? null,
+      eventType: input.eventType,
+      message:
+        input.message === undefined || input.message === null
+          ? null
+          : redactKhalaFleetLogText(input.message),
+      observedAt: observedAt,
+      payloadJson: redactedPayloadJson(input.payload),
+      rowId: rowId,
+    }) as Record<string, unknown>)
+  }
+
+  reconcileTokens(
+    rowId: number,
+    input: {
+      readonly inputTokens: number
+      readonly outputTokens: number
+      readonly reasoningTokens?: number | null
+      readonly totalTokens: number
+    },
+    now = new Date(),
+  ): KhalaFleetRow {
+    this.requireRow(rowId)
+    const observedAt = now.toISOString()
+    const update = this.db.prepare(`
+      UPDATE khala_fleet_rows
+         SET token_input_tokens = $inputTokens,
+             token_output_tokens = $outputTokens,
+             token_reasoning_tokens = $reasoningTokens,
+             token_total_tokens = $totalTokens,
+             token_reconciled_at = $observedAt,
+             updated_at = $observedAt
+       WHERE id = $rowId
+      RETURNING *
+    `)
+
+    return rowFromSql(update.get({
+      inputTokens: input.inputTokens,
+      observedAt,
+      outputTokens: input.outputTokens,
+      reasoningTokens: input.reasoningTokens ?? null,
+      rowId,
+      totalTokens: input.totalTokens,
+    }) as Record<string, unknown>)
+  }
+
+  recordTokenFailure(rowId: number, now = new Date()): KhalaFleetRow {
+    this.requireRow(rowId)
+    const observedAt = now.toISOString()
+    const update = this.db.prepare(`
+      UPDATE khala_fleet_rows
+         SET token_failure_count = token_failure_count + 1,
+             updated_at = $observedAt
+       WHERE id = $rowId
+      RETURNING *
+    `)
+
+    return rowFromSql(update.get({ observedAt, rowId }) as Record<string, unknown>)
+  }
+
+  getRow(rowId: number): KhalaFleetRow | null {
+    const row = this.db
+      .prepare("SELECT * FROM khala_fleet_rows WHERE id = $rowId")
+      .get({ rowId: rowId }) as Record<string, unknown> | null
+    return row === null ? null : rowFromSql(row)
+  }
+
+  requireRow(rowId: number): KhalaFleetRow {
+    const row = this.getRow(rowId)
+    if (row === null) throw new Error(`Unknown Khala fleet row ${rowId}`)
+    return row
+  }
+
+  logsForRow(rowId: number): readonly KhalaFleetLogRow[] {
+    return (this.db
+      .prepare(`
+        SELECT * FROM khala_fleet_events
+         WHERE row_id = $rowId
+         ORDER BY id ASC
+      `)
+      .all({ rowId: rowId }) as Record<string, unknown>[]).map(logFromSql)
+  }
+
+  reconstructActiveState(now = new Date()): KhalaFleetRestartSnapshot {
+    const rows = this.listRows()
+    return {
+      activeRows: rows.filter(row => activeStates.has(row.state)),
+      blockedRows: rows.filter(row => row.state === "blocked"),
+      completedRows: rows.filter(
+        row => row.state === "completed" || row.state === "rejected",
+      ),
+      controller: {
+        singletonActive: OpenAgentsDesktopFleetManager.hasSingleton(this.path),
+        storePath: this.path,
+      },
+      observedAt: now.toISOString(),
+      retryableRows: rows.filter(row => row.state === "retryable"),
+    }
+  }
+
+  private listRows(): readonly KhalaFleetRow[] {
+    return (this.db
+      .prepare("SELECT * FROM khala_fleet_rows ORDER BY id ASC")
+      .all() as Record<string, unknown>[]).map(rowFromSql)
+  }
+
+  private migrate(): void {
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS khala_fleet_rows (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        account_ref TEXT NOT NULL,
+        assignment_ref TEXT,
+        claim_ref TEXT,
+        pr_ref TEXT,
+        issue_ref TEXT,
+        verifier TEXT NOT NULL,
+        origin_main_commit TEXT NOT NULL,
+        queue_lane TEXT,
+        queue_decision TEXT,
+        pid INTEGER,
+        state TEXT NOT NULL CHECK (state IN (
+          'planned', 'dispatched', 'accepted', 'executing',
+          'completed', 'rejected', 'retryable', 'blocked'
+        )),
+        reason_kind TEXT NOT NULL DEFAULT 'none' CHECK (reason_kind IN (
+          'none', 'capacity_unavailable', 'credentials_missing',
+          'execution_refused', 'github_closed', 'pylon_unavailable',
+          'token_reconciliation_failed', 'verifier_failed', 'worker_stale',
+          'unknown'
+        )),
+        reason_detail TEXT,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL,
+        planned_at TEXT,
+        dispatched_at TEXT,
+        accepted_at TEXT,
+        executing_at TEXT,
+        completed_at TEXT,
+        rejected_at TEXT,
+        retryable_at TEXT,
+        blocked_at TEXT,
+        token_input_tokens INTEGER,
+        token_output_tokens INTEGER,
+        token_reasoning_tokens INTEGER,
+        token_total_tokens INTEGER,
+        token_reconciled_at TEXT,
+        token_failure_count INTEGER NOT NULL DEFAULT 0,
+        CHECK (pr_ref IS NOT NULL OR issue_ref IS NOT NULL)
+      );
+
+      CREATE INDEX IF NOT EXISTS khala_fleet_rows_state_idx
+        ON khala_fleet_rows(state, updated_at);
+      CREATE INDEX IF NOT EXISTS khala_fleet_rows_assignment_idx
+        ON khala_fleet_rows(assignment_ref);
+      CREATE INDEX IF NOT EXISTS khala_fleet_rows_task_idx
+        ON khala_fleet_rows(pr_ref, issue_ref);
+
+      CREATE TABLE IF NOT EXISTS khala_fleet_events (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        row_id INTEGER NOT NULL REFERENCES khala_fleet_rows(id) ON DELETE CASCADE,
+        assignment_ref TEXT,
+        event_type TEXT NOT NULL,
+        message TEXT,
+        payload_json TEXT,
+        created_at TEXT NOT NULL
+      );
+
+      CREATE INDEX IF NOT EXISTS khala_fleet_events_row_idx
+        ON khala_fleet_events(row_id, id);
+    `)
+    this.addMissingFleetColumns()
+  }
+
+  private addMissingFleetColumns(): void {
+    const existingColumns = new Set(
+      (this.db
+        .prepare("PRAGMA table_info(khala_fleet_rows)")
+        .all() as Array<{ name: string }>).map(column => column.name),
+    )
+    const additions: ReadonlyArray<readonly [string, string]> = [
+      ["claim_ref", "TEXT"],
+      ["queue_lane", "TEXT"],
+      ["queue_decision", "TEXT"],
+      ["token_input_tokens", "INTEGER"],
+      ["token_output_tokens", "INTEGER"],
+      ["token_reasoning_tokens", "INTEGER"],
+      ["token_total_tokens", "INTEGER"],
+      ["token_reconciled_at", "TEXT"],
+      ["token_failure_count", "INTEGER NOT NULL DEFAULT 0"],
+    ]
+
+    for (const [column, definition] of additions) {
+      if (existingColumns.has(column)) continue
+      this.db.exec(`ALTER TABLE khala_fleet_rows ADD COLUMN ${column} ${definition}`)
+    }
+  }
+
+  private sqlTimestampColumn(column: keyof KhalaFleetRow): string {
+    switch (column) {
+      case "acceptedAt":
+        return "accepted_at"
+      case "blockedAt":
+        return "blocked_at"
+      case "completedAt":
+        return "completed_at"
+      case "dispatchedAt":
+        return "dispatched_at"
+      case "executingAt":
+        return "executing_at"
+      case "plannedAt":
+        return "planned_at"
+      case "rejectedAt":
+        return "rejected_at"
+      case "retryableAt":
+        return "retryable_at"
+      default:
+        throw new Error(`Unsupported timestamp column ${String(column)}`)
+    }
+  }
+}
+
+export class OpenAgentsDesktopFleetManager {
+  private static readonly singletons = new Map<string, OpenAgentsDesktopFleetManager>()
+
+  readonly store: KhalaFleetEventStore
+
+  private constructor(store: KhalaFleetEventStore) {
+    this.store = store
+  }
+
+  static acquire(options: FleetStoreOptions): OpenAgentsDesktopFleetManager {
+    const existing = this.singletons.get(options.path)
+    if (existing !== undefined) return existing
+
+    const manager = new OpenAgentsDesktopFleetManager(
+      new KhalaFleetEventStore(options),
+    )
+    this.singletons.set(options.path, manager)
+    return manager
+  }
+
+  static hasSingleton(path: string): boolean {
+    return this.singletons.has(path)
+  }
+
+  static release(path: string): void {
+    const manager = this.singletons.get(path)
+    if (manager === undefined) return
+    manager.store.close()
+    this.singletons.delete(path)
+  }
+
+  plan(input: KhalaFleetPlanInput, now?: Date): KhalaFleetRow {
+    return this.store.plan(input, now)
+  }
+
+  dispatch(
+    rowId: number,
+    input: KhalaFleetLifecycleInput,
+    now?: Date,
+  ): KhalaFleetRow {
+    return this.store.transition(rowId, "dispatched", input, now)
+  }
+
+  accept(
+    rowId: number,
+    input: KhalaFleetLifecycleInput = {},
+    now?: Date,
+  ): KhalaFleetRow {
+    return this.store.transition(rowId, "accepted", input, now)
+  }
+
+  execute(
+    rowId: number,
+    input: KhalaFleetLifecycleInput,
+    now?: Date,
+  ): KhalaFleetRow {
+    return this.store.transition(rowId, "executing", input, now)
+  }
+
+  complete(
+    rowId: number,
+    input: KhalaFleetLifecycleInput = {},
+    now?: Date,
+  ): KhalaFleetRow {
+    return this.store.transition(rowId, "completed", input, now)
+  }
+
+  reject(
+    rowId: number,
+    input: KhalaFleetLifecycleInput,
+    now?: Date,
+  ): KhalaFleetRow {
+    return this.store.transition(rowId, "rejected", input, now)
+  }
+
+  retry(
+    rowId: number,
+    input: KhalaFleetLifecycleInput,
+    now?: Date,
+  ): KhalaFleetRow {
+    return this.store.transition(rowId, "retryable", input, now)
+  }
+
+  block(
+    rowId: number,
+    input: KhalaFleetLifecycleInput,
+    now?: Date,
+  ): KhalaFleetRow {
+    return this.store.transition(rowId, "blocked", input, now)
+  }
+
+  appendLog(rowId: number, input: KhalaFleetLogInput, now?: Date): KhalaFleetLogRow {
+    return this.store.appendLog(rowId, input, now)
+  }
+
+  reconcileTokens(
+    rowId: number,
+    input: {
+      readonly inputTokens: number
+      readonly outputTokens: number
+      readonly reasoningTokens?: number | null
+      readonly totalTokens: number
+    },
+    now?: Date,
+  ): KhalaFleetRow {
+    return this.store.reconcileTokens(rowId, input, now)
+  }
+
+  recordTokenFailure(rowId: number, now?: Date): KhalaFleetRow {
+    return this.store.recordTokenFailure(rowId, now)
+  }
+
+  reconstructActiveState(now?: Date): KhalaFleetRestartSnapshot {
+    return this.store.reconstructActiveState(now)
+  }
+}

--- a/clients/openagents-desktop/src/shared/rpc.ts
+++ b/clients/openagents-desktop/src/shared/rpc.ts
@@ -1,4 +1,5 @@
 import type { CodingStatusResult } from "./coding-status"
+import type { KhalaFleetSnapshotResult } from "./khala-fleet-manager"
 import type { CreatePylonResult, PylonStatusResult } from "./pylon-status"
 
 export const OPENAGENTS_DESKTOP_RPC_MAX_REQUEST_TIME_MS = 60_000
@@ -7,6 +8,7 @@ export type OpenAgentsDesktopRPCSchema = {
   requests: {
     codingStatus(): Promise<CodingStatusResult>
     createPylon(): Promise<CreatePylonResult>
+    khalaFleetSnapshot(): Promise<KhalaFleetSnapshotResult>
     pylonStatus(): Promise<PylonStatusResult>
   }
 }

--- a/clients/openagents-desktop/tests/khala-fleet-manager.test.ts
+++ b/clients/openagents-desktop/tests/khala-fleet-manager.test.ts
@@ -1,0 +1,262 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { mkdtempSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+import {
+  KhalaFleetEventStore,
+  OpenAgentsDesktopFleetManager,
+  redactKhalaFleetLogText,
+} from "../src/shared/khala-fleet-manager.js"
+
+const tempPaths: string[] = []
+const tempStorePaths: string[] = []
+
+const tempDbPath = (): string => {
+  const directory = mkdtempSync(join(tmpdir(), "openagents-desktop-fleet-"))
+  tempPaths.push(directory)
+  const path = join(directory, "fleet.sqlite")
+  tempStorePaths.push(path)
+  return path
+}
+
+afterEach(() => {
+  for (const path of tempStorePaths.splice(0)) {
+    OpenAgentsDesktopFleetManager.release(path)
+  }
+  for (const directory of tempPaths.splice(0)) {
+    rmSync(directory, { force: true, recursive: true })
+  }
+})
+
+describe("openagents desktop Khala fleet manager", () => {
+  test("records every local lifecycle state as structured rows", () => {
+    const manager = OpenAgentsDesktopFleetManager.acquire({ path: tempDbPath() })
+    const planned = manager.plan(
+      {
+        accountRef: "codex-3",
+        claimRef: "claim.issue.7591",
+        issueRef: "7591",
+        originMainCommit: "0549290f5974d2a86be4ca8764c29728070038f3",
+        prRef: null,
+        queueDecision: "selected urgent desktop issue",
+        queueLane: "khala-code",
+        verifier: "bun run --cwd clients/openagents-desktop test",
+      },
+      new Date("2026-06-29T15:00:00.000Z"),
+    )
+
+    expect(planned).toMatchObject({
+      accountRef: "codex-3",
+      claimRef: "claim.issue.7591",
+      issueRef: "7591",
+      queueDecision: "selected urgent desktop issue",
+      queueLane: "khala-code",
+      state: "planned",
+    })
+    expect(planned.plannedAt).toBe("2026-06-29T15:00:00.000Z")
+
+    const dispatched = manager.dispatch(
+      planned.id,
+      { assignmentRef: "assignment.one" },
+      new Date("2026-06-29T15:01:00.000Z"),
+    )
+    const accepted = manager.accept(
+      planned.id,
+      {},
+      new Date("2026-06-29T15:02:00.000Z"),
+    )
+    const executing = manager.execute(
+      planned.id,
+      { pid: 4242 },
+      new Date("2026-06-29T15:03:00.000Z"),
+    )
+    const completed = manager.complete(
+      planned.id,
+      {},
+      new Date("2026-06-29T15:04:00.000Z"),
+    )
+    const rejected = manager.reject(
+      planned.id,
+      {
+        reasonDetail: "provider refused the execution",
+        reasonKind: "execution_refused",
+      },
+      new Date("2026-06-29T15:05:00.000Z"),
+    )
+    const retryable = manager.retry(
+      planned.id,
+      {
+        reasonDetail: "capacity is cooling down",
+        reasonKind: "capacity_unavailable",
+      },
+      new Date("2026-06-29T15:06:00.000Z"),
+    )
+    const blocked = manager.block(
+      planned.id,
+      {
+        reasonDetail: "token usage did not reconcile",
+        reasonKind: "token_reconciliation_failed",
+      },
+      new Date("2026-06-29T15:07:00.000Z"),
+    )
+
+    expect([
+      planned.state,
+      dispatched.state,
+      accepted.state,
+      executing.state,
+      completed.state,
+      rejected.state,
+      retryable.state,
+      blocked.state,
+    ]).toEqual([
+      "planned",
+      "dispatched",
+      "accepted",
+      "executing",
+      "completed",
+      "rejected",
+      "retryable",
+      "blocked",
+    ])
+    expect(executing.pid).toBe(4242)
+    expect(dispatched.assignmentRef).toBe("assignment.one")
+    expect(blocked).toMatchObject({
+      reasonKind: "token_reconciliation_failed",
+      state: "blocked",
+    })
+
+    const tokenFailed = manager.recordTokenFailure(planned.id)
+    expect(tokenFailed.tokenFailureCount).toBe(1)
+    const counted = manager.reconcileTokens(planned.id, {
+      inputTokens: 100,
+      outputTokens: 40,
+      reasoningTokens: 10,
+      totalTokens: 150,
+    })
+    expect(counted).toMatchObject({
+      tokenInputTokens: 100,
+      tokenOutputTokens: 40,
+      tokenReasoningTokens: 10,
+      tokenTotalTokens: 150,
+    })
+    expect(counted.tokenReconciledAt).not.toBeNull()
+  })
+
+  test("keeps one controller instance per desktop fleet store", () => {
+    const path = tempDbPath()
+    const first = OpenAgentsDesktopFleetManager.acquire({ path })
+    const second = OpenAgentsDesktopFleetManager.acquire({ path })
+
+    expect(second).toBe(first)
+    expect(first.reconstructActiveState().controller).toMatchObject({
+      singletonActive: true,
+      storePath: path,
+    })
+
+    OpenAgentsDesktopFleetManager.release(path)
+    const third = OpenAgentsDesktopFleetManager.acquire({ path })
+    expect(third).not.toBe(first)
+  })
+
+  test("reconstructs active, retryable, blocked, and completed rows after restart", () => {
+    const path = tempDbPath()
+    const firstStore = new KhalaFleetEventStore({ path })
+    const active = firstStore.plan({
+      accountRef: "codex-4",
+      issueRef: "7591",
+      originMainCommit: "0549290f5974d2a86be4ca8764c29728070038f3",
+      prRef: null,
+      verifier: "bun run --cwd clients/openagents-desktop typecheck",
+    })
+    firstStore.transition(active.id, "executing", {
+      assignmentRef: "assignment.active",
+      pid: 5001,
+    })
+
+    const retryable = firstStore.plan({
+      accountRef: "codex-5",
+      issueRef: null,
+      originMainCommit: "0549290f5974d2a86be4ca8764c29728070038f3",
+      prRef: "7557",
+      verifier: "bun scripts/check-conflict-markers.mjs",
+    })
+    firstStore.transition(retryable.id, "retryable", {
+      reasonKind: "capacity_unavailable",
+    })
+
+    const blocked = firstStore.plan({
+      accountRef: "codex-6",
+      issueRef: "7590",
+      originMainCommit: "0549290f5974d2a86be4ca8764c29728070038f3",
+      prRef: null,
+      verifier: "bun test",
+    })
+    firstStore.transition(blocked.id, "blocked", {
+      reasonKind: "credentials_missing",
+    })
+
+    const completed = firstStore.plan({
+      accountRef: "codex-7",
+      issueRef: "7589",
+      originMainCommit: "0549290f5974d2a86be4ca8764c29728070038f3",
+      prRef: null,
+      verifier: "bun test",
+    })
+    firstStore.transition(completed.id, "completed")
+    firstStore.close()
+
+    const restartedStore = new KhalaFleetEventStore({ path })
+    const snapshot = restartedStore.reconstructActiveState(
+      new Date("2026-06-29T16:00:00.000Z"),
+    )
+
+    expect(snapshot.observedAt).toBe("2026-06-29T16:00:00.000Z")
+    expect(snapshot.activeRows.map(row => row.assignmentRef)).toEqual([
+      "assignment.active",
+    ])
+    expect(snapshot.retryableRows.map(row => row.reasonKind)).toEqual([
+      "capacity_unavailable",
+    ])
+    expect(snapshot.blockedRows.map(row => row.reasonKind)).toEqual([
+      "credentials_missing",
+    ])
+    expect(snapshot.completedRows.map(row => row.state)).toEqual(["completed"])
+    restartedStore.close()
+  })
+
+  test("redacts secrets and local auth paths from event logs", () => {
+    const store = new KhalaFleetEventStore({ path: tempDbPath() })
+    const row = store.plan({
+      accountRef: "codex-3",
+      issueRef: "7591",
+      originMainCommit: "0549290f5974d2a86be4ca8764c29728070038f3",
+      prRef: null,
+      verifier: "bun test",
+    })
+
+    const log = store.appendLog(row.id, {
+      assignmentRef: "assignment.secret",
+      eventType: "worker.output",
+      message:
+        "Bearer abc.def OPENAGENTS_AGENT_TOKEN=secret /Users/alice/.codex/auth.json",
+      payload: {
+        access_token: "secret-access-token",
+        nested: "OPENAI_API_KEY=sk-secret",
+      },
+    })
+
+    expect(log.message).toBe(
+      "Bearer [REDACTED] OPENAGENTS_AGENT_TOKEN=[REDACTED] [REDACTED_CODEX_AUTH]",
+    )
+    expect(log.payloadJson).toContain("\"access_token\":\"[REDACTED]\"")
+    expect(log.payloadJson).toContain("OPENAI_API_KEY=[REDACTED]")
+    expect(log.payloadJson).not.toContain("secret")
+    expect(redactKhalaFleetLogText("GITHUB_TOKEN=ghp_example")).toBe(
+      "GITHUB_TOKEN=[REDACTED]",
+    )
+
+    store.close()
+  })
+})


### PR DESCRIPTION
## Summary

- Add a typed OpenAgents Desktop Khala fleet manager service backed by local SQLite.
- Store structured rows for planned, dispatched, accepted, executing, completed, rejected, retryable, and blocked states, including account, claim, assignment, PR/issue, verifier, origin/main commit, PID, queue decision, token reconciliation, timestamps, and typed reasons.
- Add singleton controller acquisition, restart reconstruction snapshots, and redacted local lifecycle event logs.
- Expose the restart snapshot through the desktop RPC surface.

Closes #7591

## Verification

- PASS: `bun run --cwd clients/openagents-desktop typecheck`
- PASS: `bun test clients/openagents-desktop/tests/*.test.ts`
- BLOCKED: requested verifier ref `command.public.pylon_khala.verify.4e3e82daa9d3450372aa61a2` resolves to `bun scripts/check-conflict-markers.mjs`, but that script is absent in this checkout and the command fails with `Module not found "scripts/check-conflict-markers.mjs"`.