### PR TITLE
[codex] Add desktop manager resume checks

### DIFF
--- a/clients/openagents-desktop/src/bun/index.ts
+++ b/clients/openagents-desktop/src/bun/index.ts
@@ -5,13 +5,22 @@ import { homedir } from "node:os"
 import { dirname, join, resolve } from "node:path"
 
 import {
+  buildManagerResumeSnapshot,
+  type CodingManagerAssignmentMarker,
+  type CodingManagerGithubCounts,
+  type CodingManagerPrState,
+  type CodingManagerQueueMarker,
+  type CodingManagerTokenFailure,
+  type CodingManagerTokenFailures,
   type CodingCodexSession,
   emptyCodingStatusSummary,
+  OPENAGENTS_DESKTOP_MANAGER_GITHUB_SINCE,
   parseCodexSessionRollout,
   parseCodingProcesses,
   parseSupervisorLog,
   type CodingProcess,
   summarizeCodingProcesses,
+  summarizeManagerAssignmentLogs,
   type CodingStatusResult,
   type CodingStatusSummary,
 } from "../shared/coding-status.js"
@@ -242,12 +251,302 @@ const supervisorHome = (): string =>
   Bun.env.CODEX_SUPERVISOR_HOME ??
   join(homedir(), ".codex-supervisor")
 
+const pylonFableHome = (): string =>
+  Bun.env.PYLON_FABLE_HOME ?? join(homedir(), ".pylon-fable")
+
 const countDirectoryEntries = async (path: string): Promise<number> => {
   try {
     return (await readdir(path)).length
   } catch {
     return 0
   }
+}
+
+const listFiles = async (path: string): Promise<readonly string[]> => {
+  try {
+    const entries = await readdir(path, { withFileTypes: true })
+    return entries
+      .filter(entry => entry.isFile())
+      .map(entry => resolve(path, entry.name))
+      .sort()
+  } catch {
+    return []
+  }
+}
+
+const numberValue = (value: unknown): number | null =>
+  typeof value === "number" && Number.isFinite(value) ? value : null
+
+const markerIssueRef = (marker: Record<string, unknown>): string | null => {
+  const direct =
+    nullableString(marker.issueRef) ??
+    nullableString(marker.prRef) ??
+    nullableString(marker.pullRequestRef)
+  if (direct !== null) return direct.match(/\d+/)?.[0] ?? direct
+  const text = JSON.stringify(marker)
+  return text.match(/(?:issue|PR|pull request)\s+#?(\d{3,})/i)?.[1] ??
+    text.match(/#(\d{3,})/)?.[1] ??
+    null
+}
+
+const readActiveAssignmentMarkers = async (): Promise<
+  readonly CodingManagerAssignmentMarker[]
+> => {
+  const files = await listFiles(resolve(pylonFableHome(), "active-assignment-runs"))
+  const markers = await Promise.all(
+    files
+      .filter(path => path.endsWith(".json"))
+      .map(async markerPath => {
+        const [marker, fileStat] = await Promise.all([
+          readJsonFile(markerPath),
+          stat(markerPath).catch(() => null),
+        ])
+        if (marker === null) return null
+        return {
+          accountRef: nullableString(marker.accountRef),
+          accountRefHash: nullableString(marker.accountRefHash),
+          assignmentRef: nullableString(marker.assignmentRef),
+          issueRef: markerIssueRef(marker),
+          markerPath,
+          updatedAt:
+            nullableString(marker.updatedAt) ??
+            nullableString(marker.observedAt) ??
+            (fileStat === null ? null : new Date(fileStat.mtimeMs).toISOString()),
+        } satisfies CodingManagerAssignmentMarker
+      }),
+  )
+  return markers
+    .filter((marker): marker is CodingManagerAssignmentMarker => marker !== null)
+    .sort((left, right) =>
+      compactNullableTime(right.updatedAt) - compactNullableTime(left.updatedAt),
+    )
+}
+
+const compactNullableTime = (value: string | null): number => {
+  if (value === null) return 0
+  const millis = Date.parse(value)
+  return Number.isFinite(millis) ? millis : 0
+}
+
+const issueRefFromQueueMarkerPath = (path: string): string | null =>
+  path.match(/(?:^|\/)pr\.(\d+)(?:\.|$)/)?.[1] ??
+  path.match(/(\d{3,})/)?.[1] ??
+  null
+
+const readQueueMarkers = async (): Promise<
+  readonly Omit<CodingManagerQueueMarker, "prState">[]
+> => {
+  const root = resolve(supervisorHome(), "pr-review")
+  const markerFiles = [
+    ...(await listFiles(resolve(root, "locks"))).map(path => ({
+      path,
+      type: "lock" as const,
+    })),
+    ...(await listFiles(resolve(root, "done"))).map(path => ({
+      path,
+      type: "done" as const,
+    })),
+  ]
+  const now = Date.now()
+  const markers = await Promise.all(
+    markerFiles.map(async marker => {
+      const fileStat = await stat(marker.path).catch(() => null)
+      return {
+        ageSeconds:
+          fileStat === null ? null : Math.max(0, Math.round((now - fileStat.mtimeMs) / 1000)),
+        issueRef: issueRefFromQueueMarkerPath(marker.path),
+        markerPath: marker.path,
+        type: marker.type,
+      } satisfies Omit<CodingManagerQueueMarker, "prState">
+    }),
+  )
+  return markers.sort((left, right) => (right.ageSeconds ?? 0) - (left.ageSeconds ?? 0))
+}
+
+const readRecentPrResolverLogs = async (): Promise<
+  readonly { readonly path: string; readonly text: string }[]
+> => {
+  const files = await listFiles(resolve(pylonFableHome(), "pr-resolver-logs"))
+  const withStats = await Promise.all(
+    files
+      .filter(path => /\/pr-review-.*\.log$/.test(path))
+      .map(async path => ({
+        path,
+        modifiedAtMs: (await stat(path).catch(() => null))?.mtimeMs ?? 0,
+      })),
+  )
+  return Promise.all(
+    withStats
+      .sort((left, right) => right.modifiedAtMs - left.modifiedAtMs)
+      .slice(0, 160)
+      .map(async file => ({
+        path: file.path,
+        text: await readTextFile(file.path),
+      })),
+  )
+}
+
+const tokenFailureFromLine = (line: string): CodingManagerTokenFailure | null => {
+  try {
+    const parsed: unknown = JSON.parse(line)
+    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+      return null
+    }
+    const object = parsed as Record<string, unknown>
+    const report =
+      typeof object.report === "object" && object.report !== null && !Array.isArray(object.report)
+        ? object.report as Record<string, unknown>
+        : {}
+    const error = nullableString(object.error)
+    return {
+      assignmentRef: nullableString(report.assignmentRef),
+      error: error === null ? null : error.slice(0, 180),
+      observedAt: nullableString(object.observedAt),
+    }
+  } catch {
+    return null
+  }
+}
+
+const readTokenFailures = async (): Promise<CodingManagerTokenFailures> => {
+  const spoolPath = resolve(pylonFableHome(), "codex-turn-report-failures.jsonl")
+  const [text, fileStat] = await Promise.all([
+    readTextFile(spoolPath),
+    stat(spoolPath).catch(() => null),
+  ])
+  const lines = text.split("\n").filter(line => line.trim() !== "")
+  return {
+    byteLength: fileStat?.size ?? 0,
+    failureCount: lines.length,
+    latestFailures: lines
+      .slice(-6)
+      .map(tokenFailureFromLine)
+      .filter((failure): failure is CodingManagerTokenFailure => failure !== null)
+      .reverse(),
+    spoolPath,
+  }
+}
+
+const spawnJson = async (cmd: readonly string[]): Promise<unknown | null> => {
+  try {
+    const text = await spawnText(cmd)
+    return text.trim() === "" ? null : JSON.parse(text)
+  } catch {
+    return null
+  }
+}
+
+type GithubPrRecord = {
+  readonly closedAt?: string | null
+  readonly mergedAt?: string | null
+  readonly number: number
+  readonly title?: string | null
+}
+
+const githubPrRecords = (value: unknown): readonly GithubPrRecord[] =>
+  Array.isArray(value)
+    ? value
+        .filter((item): item is Record<string, unknown> =>
+          typeof item === "object" && item !== null && !Array.isArray(item),
+        )
+        .map(item => ({
+          closedAt: nullableString(item.closedAt),
+          mergedAt: nullableString(item.mergedAt),
+          number: numberValue(item.number) ?? 0,
+          title: nullableString(item.title),
+        }))
+        .filter(item => item.number > 0)
+    : []
+
+let githubStateCache:
+  | {
+      readonly readAtMs: number
+      readonly state: {
+        readonly counts: CodingManagerGithubCounts
+        readonly prStates: Readonly<Record<string, CodingManagerPrState>>
+      }
+    }
+  | null = null
+
+const readGithubState = async (): Promise<{
+  readonly counts: CodingManagerGithubCounts
+  readonly prStates: Readonly<Record<string, CodingManagerPrState>>
+}> => {
+  if (githubStateCache !== null && Date.now() - githubStateCache.readAtMs <= 60_000) {
+    return githubStateCache.state
+  }
+  const [openValue, mergedValue, closedValue] = await Promise.all([
+    spawnJson([
+      "gh",
+      "pr",
+      "list",
+      "--repo",
+      "OpenAgentsInc/openagents",
+      "--state",
+      "open",
+      "--json",
+      "number,title",
+      "--limit",
+      "500",
+    ]),
+    spawnJson([
+      "gh",
+      "pr",
+      "list",
+      "--repo",
+      "OpenAgentsInc/openagents",
+      "--state",
+      "merged",
+      "--json",
+      "number,mergedAt,title",
+      "--limit",
+      "150",
+    ]),
+    spawnJson([
+      "gh",
+      "pr",
+      "list",
+      "--repo",
+      "OpenAgentsInc/openagents",
+      "--state",
+      "closed",
+      "--json",
+      "number,closedAt,title",
+      "--limit",
+      "150",
+    ]),
+  ])
+  const open = githubPrRecords(openValue)
+  const merged = githubPrRecords(mergedValue)
+  const closed = githubPrRecords(closedValue)
+  const sinceMs = Date.parse(OPENAGENTS_DESKTOP_MANAGER_GITHUB_SINCE)
+  const afterSince = (value: string | null | undefined): boolean => {
+    if (!Number.isFinite(sinceMs) || value === null || value === undefined) return false
+    const millis = Date.parse(value)
+    return Number.isFinite(millis) && millis >= sinceMs
+  }
+  const prStates: Record<string, CodingManagerPrState> = {}
+  for (const pr of closed) prStates[String(pr.number)] = "closed"
+  for (const pr of merged) prStates[String(pr.number)] = "merged"
+  for (const pr of open) prStates[String(pr.number)] = "open"
+  const state = {
+    counts: {
+      closedPrsSince: closedValue === null
+        ? null
+        : closed.filter(pr => afterSince(pr.closedAt)).length,
+      mergedPrsSince: mergedValue === null
+        ? null
+        : merged.filter(pr => afterSince(pr.mergedAt)).length,
+      openPrs: openValue === null ? null : open.length,
+      since: OPENAGENTS_DESKTOP_MANAGER_GITHUB_SINCE,
+    },
+    prStates,
+  }
+  githubStateCache = {
+    readAtMs: Date.now(),
+    state,
+  }
+  return state
 }
 
 const countNonEmptyLines = async (path: string): Promise<number | null> => {
@@ -485,7 +784,17 @@ const spawnText = async (cmd: readonly string[]): Promise<string> => {
 const codingStatus = async (): Promise<CodingStatusResult> => {
   const observedAt = new Date().toISOString()
   const home = supervisorHome()
-  const [psOutput, supervisorLog, claimCount, openIssueCount] =
+  const [
+    psOutput,
+    supervisorLog,
+    claimCount,
+    openIssueCount,
+    activeAssignments,
+    queueLocks,
+    prResolverLogs,
+    tokenFailures,
+    githubState,
+  ] =
     await Promise.all([
       spawnText([
         "/bin/ps",
@@ -504,12 +813,27 @@ const codingStatus = async (): Promise<CodingStatusResult> => {
       readTextFile(resolve(home, "supervisor.log")),
       countDirectoryEntries(resolve(home, "claims")),
       countNonEmptyLines(resolve(home, "open-issues.set")),
+      readActiveAssignmentMarkers(),
+      readQueueMarkers(),
+      readRecentPrResolverLogs(),
+      readTokenFailures(),
+      readGithubState(),
     ])
 
   const processes = parseCodingProcesses(psOutput)
   const sessions = await readCodexSessions(processes)
   const processSummary = summarizeCodingProcesses(processes)
   const logSummary = parseSupervisorLog(supervisorLog)
+  const managerResume = buildManagerResumeSnapshot({
+    activeAssignments,
+    github: githubState.counts,
+    liveProcesses: processes,
+    logs: summarizeManagerAssignmentLogs(prResolverLogs),
+    observedAt,
+    prStates: githubState.prStates,
+    queueLocks,
+    tokenFailures,
+  })
   const summary: CodingStatusSummary = {
     ...emptyCodingStatusSummary(),
     ...processSummary,
@@ -526,6 +850,7 @@ const codingStatus = async (): Promise<CodingStatusResult> => {
   return {
     ok: true,
     events: logSummary.events,
+    managerResume,
     observedAt,
     processes,
     sessions,

--- a/clients/openagents-desktop/src/shared/coding-status.ts
+++ b/clients/openagents-desktop/src/shared/coding-status.ts
@@ -96,10 +96,94 @@ export type CodingStatusSummary = {
   readonly vertexBurnCount: number
 }
 
+export type CodingManagerAssignmentMarker = {
+  readonly accountRef: string | null
+  readonly accountRefHash: string | null
+  readonly assignmentRef: string | null
+  readonly issueRef: string | null
+  readonly markerPath: string
+  readonly updatedAt: string | null
+}
+
+export type CodingManagerPrState = "closed" | "merged" | "open" | "unknown"
+
+export type CodingManagerQueueMarker = {
+  readonly ageSeconds: number | null
+  readonly issueRef: string | null
+  readonly markerPath: string
+  readonly prState: CodingManagerPrState
+  readonly type: "done" | "lock"
+}
+
+export type CodingManagerCandidate = {
+  readonly issueRef: string
+  readonly prState: CodingManagerPrState
+  readonly priority: number
+  readonly title: string
+}
+
+export type CodingManagerLatestBlocker = {
+  readonly blocker: string
+  readonly count: number
+  readonly latestLogPath: string | null
+}
+
+export type CodingManagerLogSummary = {
+  readonly acceptedRunningOrUnknown: number
+  readonly completedAccepted: number
+  readonly completedRejected: number
+  readonly empty: number
+  readonly failedBeforeAccept: number
+  readonly latestBlockers: readonly CodingManagerLatestBlocker[]
+  readonly pendingOutput: number
+  readonly scannedLogCount: number
+}
+
+export type CodingManagerTokenFailure = {
+  readonly assignmentRef: string | null
+  readonly error: string | null
+  readonly observedAt: string | null
+}
+
+export type CodingManagerTokenFailures = {
+  readonly byteLength: number
+  readonly failureCount: number
+  readonly latestFailures: readonly CodingManagerTokenFailure[]
+  readonly spoolPath: string
+}
+
+export type CodingManagerGithubCounts = {
+  readonly closedPrsSince: number | null
+  readonly mergedPrsSince: number | null
+  readonly openPrs: number | null
+  readonly since: string
+}
+
+export type CodingManagerMismatchWarning = {
+  readonly code: string
+  readonly message: string
+  readonly severity: "info" | "warning"
+}
+
+export type CodingManagerResumeSnapshot = {
+  readonly activeAssignments: readonly CodingManagerAssignmentMarker[]
+  readonly candidateLane: readonly CodingManagerCandidate[]
+  readonly github: CodingManagerGithubCounts
+  readonly latestBlockers: readonly CodingManagerLatestBlocker[]
+  readonly liveProcesses: readonly CodingProcess[]
+  readonly logs: CodingManagerLogSummary
+  readonly observedAt: string
+  readonly queueLocks: readonly CodingManagerQueueMarker[]
+  readonly statusBlock: string
+  readonly tokenFailures: CodingManagerTokenFailures
+  readonly warnings: readonly CodingManagerMismatchWarning[]
+}
+
 export type CodingStatusResult =
   | {
       readonly ok: true
       readonly events: readonly CodingSupervisorEvent[]
+      readonly managerResume: CodingManagerResumeSnapshot
       readonly observedAt: string
       readonly processes: readonly CodingProcess[]
       readonly sessions: readonly CodingCodexSession[]
@@ -109,6 +193,7 @@ export type CodingStatusResult =
       readonly ok: false
       readonly error: string
       readonly events: readonly CodingSupervisorEvent[]
+      readonly managerResume: CodingManagerResumeSnapshot
       readonly observedAt: string
       readonly processes: readonly CodingProcess[]
       readonly sessions: readonly CodingCodexSession[]
@@ -124,6 +209,32 @@ const processKindLabel: Record<CodingProcessKind, string> = {
   supervisor: "Supervisor",
   vertex_burn: "Vertex burn",
 }
+
+export const OPENAGENTS_DESKTOP_MANAGER_GITHUB_SINCE =
+  "2026-06-29T13:45:00Z"
+
+export const OPENAGENTS_DESKTOP_MANAGER_CANDIDATE_LANE: readonly Omit<
+  CodingManagerCandidate,
+  "prState"
+>[] = [
+  { issueRef: "7557", priority: 1, title: "Expose Codex fleet quota cooldown state" },
+  { issueRef: "7579", priority: 2, title: "Expose Codex quota reset policy status" },
+  { issueRef: "7560", priority: 3, title: "fix(pylon): update account reset status" },
+  { issueRef: "7523", priority: 4, title: "fix(pylon): parse provider quota reset hints" },
+  { issueRef: "7558", priority: 5, title: "fix(pylon): classify codex account execution refusals" },
+  { issueRef: "7246", priority: 6, title: "fix(pylon): surface Codex execution refusal reasons" },
+  { issueRef: "7221", priority: 7, title: "fix(pylon): surface codex execution refusal reasons" },
+  { issueRef: "7510", priority: 8, title: "fix(khala-desktop): add Codex account readiness controls" },
+  { issueRef: "7279", priority: 9, title: "fix(codex-supervisor): GC orphan claims and fast-retry gate refusals" },
+  { issueRef: "7104", priority: 10, title: "fix(codex-supervisor): GC stale claims and fast-retry gate flakes" },
+  { issueRef: "7073", priority: 11, title: "feat(operator): surface live Pylon runtime progress" },
+  { issueRef: "7283", priority: 12, title: "fix(operator): register fleet state observability route" },
+  { issueRef: "7230", priority: 13, title: "feat(operator): surface fleet assignment progress" },
+  { issueRef: "7336", priority: 14, title: "feat(operator): surface fleet assignment progress" },
+  { issueRef: "7589", priority: 15, title: "Align Pylon coordinator with runner registry" },
+  { issueRef: "7571", priority: 16, title: "Harden Pylon agent runner resolution" },
+  { issueRef: "7486", priority: 17, title: "Harden Pylon agent runner registry contract" },
+]
 
 const processKindFromCommand = (command: string): CodingProcessKind | null => {
   if (/codex\/vendor.*bin\/codex exec|(^|\s)codex exec(\s|$)/i.test(command)) {
@@ -275,6 +386,252 @@ export const summarizeCodingProcesses = (
   vertexBurnCount: processes.filter(process => process.kind === "vertex_burn")
     .length,
 })
+
+type CodingManagerLogInput = {
+  readonly path: string
+  readonly text: string
+}
+
+const blockerPattern = /\bblocker\.[a-z0-9_.-]+/gi
+
+export const summarizeManagerAssignmentLogs = (
+  logs: readonly CodingManagerLogInput[],
+): CodingManagerLogSummary => {
+  let acceptedRunningOrUnknown = 0
+  let completedAccepted = 0
+  let completedRejected = 0
+  let empty = 0
+  let failedBeforeAccept = 0
+  let pendingOutput = 0
+  const blockers = new Map<string, CodingManagerLatestBlocker>()
+
+  for (const log of logs) {
+    const text = log.text
+    const trimmed = text.trim()
+    const matches = text.match(blockerPattern) ?? []
+    for (const blocker of matches) {
+      const key = blocker.toLowerCase()
+      const existing = blockers.get(key)
+      blockers.set(key, {
+        blocker: key,
+        count: (existing?.count ?? 0) + 1,
+        latestLogPath: existing?.latestLogPath ?? log.path,
+      })
+    }
+
+    if (trimmed === "") {
+      empty += 1
+    } else if (
+      /"event"\s*:\s*"assignment_run\.completed"/.test(text) &&
+      /"status"\s*:\s*"accepted"/.test(text)
+    ) {
+      completedAccepted += 1
+    } else if (
+      /"event"\s*:\s*"assignment_run\.completed"/.test(text) &&
+      /"status"\s*:\s*"rejected"/.test(text)
+    ) {
+      completedRejected += 1
+    } else if (/"event"\s*:\s*"assignment_run\.accepted"/.test(text)) {
+      acceptedRunningOrUnknown += 1
+    } else if (/"ok"\s*:\s*false/.test(text) || /"error"\s*:/.test(text)) {
+      failedBeforeAccept += 1
+    } else {
+      pendingOutput += 1
+    }
+  }
+
+  return {
+    acceptedRunningOrUnknown,
+    completedAccepted,
+    completedRejected,
+    empty,
+    failedBeforeAccept,
+    latestBlockers: [...blockers.values()]
+      .sort((left, right) => right.count - left.count)
+      .slice(0, 8),
+    pendingOutput,
+    scannedLogCount: logs.length,
+  }
+}
+
+const processCount = (
+  processes: readonly CodingProcess[],
+  kind: CodingProcessKind,
+): number => processes.filter(process => process.kind === kind).length
+
+const stateForIssue = (
+  issueRef: string | null,
+  prStates: Readonly<Record<string, CodingManagerPrState>>,
+): CodingManagerPrState =>
+  issueRef === null ? "unknown" : prStates[issueRef] ?? "unknown"
+
+export const candidateLaneWithStates = (
+  prStates: Readonly<Record<string, CodingManagerPrState>>,
+): readonly CodingManagerCandidate[] =>
+  OPENAGENTS_DESKTOP_MANAGER_CANDIDATE_LANE.map(candidate => ({
+    ...candidate,
+    prState: stateForIssue(candidate.issueRef, prStates),
+  }))
+
+const compactManagerLine = (value: string | null): string =>
+  value === null || value.trim() === "" ? "-" : value.trim()
+
+export const formatManagerResumeStatusBlock = (
+  snapshot: Omit<CodingManagerResumeSnapshot, "statusBlock">,
+): string => {
+  const assigned = snapshot.activeAssignments.length
+  const executing = processCount(snapshot.liveProcesses, "codex_exec")
+  const khalaRequests = processCount(snapshot.liveProcesses, "khala_request")
+  const locks = snapshot.queueLocks.filter(marker => marker.type === "lock")
+  const done = snapshot.queueLocks.filter(marker => marker.type === "done")
+  const nextCandidate =
+    snapshot.candidateLane.find(candidate => candidate.prState === "open") ??
+    snapshot.candidateLane[0] ??
+    null
+  const blockers = snapshot.latestBlockers
+    .slice(0, 3)
+    .map(blocker => `${blocker.blocker} x${blocker.count}`)
+    .join(", ")
+  const warnings = snapshot.warnings
+    .slice(0, 5)
+    .map(warning => `${warning.severity}:${warning.code}`)
+    .join(", ")
+
+  return [
+    "OPENAGENTS MANAGER RESUME",
+    `observed_at: ${snapshot.observedAt}`,
+    `assigned_markers: ${assigned}`,
+    `live_codex_exec: ${executing}`,
+    `khala_requests: ${khalaRequests}`,
+    `queue_locks: ${locks.length}`,
+    `queue_done_markers: ${done.length}`,
+    `token_failures: ${snapshot.tokenFailures.failureCount}`,
+    `open_prs: ${snapshot.github.openPrs ?? "unknown"}`,
+    `merged_prs_since_${snapshot.github.since}: ${
+      snapshot.github.mergedPrsSince ?? "unknown"
+    }`,
+    `closed_prs_since_${snapshot.github.since}: ${
+      snapshot.github.closedPrsSince ?? "unknown"
+    }`,
+    `recent_logs: accepted=${snapshot.logs.completedAccepted} rejected=${
+      snapshot.logs.completedRejected
+    } running_or_unknown=${snapshot.logs.acceptedRunningOrUnknown}`,
+    `candidate_lane: ${compactManagerLine(
+      nextCandidate === null
+        ? null
+        : `#${nextCandidate.issueRef} ${nextCandidate.prState} ${nextCandidate.title}`,
+    )}`,
+    `latest_blockers: ${compactManagerLine(blockers)}`,
+    `warnings: ${compactManagerLine(warnings)}`,
+  ].join("\n")
+}
+
+export const buildManagerResumeSnapshot = (input: {
+  readonly activeAssignments: readonly CodingManagerAssignmentMarker[]
+  readonly github: CodingManagerGithubCounts
+  readonly liveProcesses: readonly CodingProcess[]
+  readonly logs: CodingManagerLogSummary
+  readonly observedAt: string
+  readonly prStates: Readonly<Record<string, CodingManagerPrState>>
+  readonly queueLocks: readonly Omit<CodingManagerQueueMarker, "prState">[]
+  readonly tokenFailures: CodingManagerTokenFailures
+}): CodingManagerResumeSnapshot => {
+  const queueLocks = input.queueLocks.map(marker => ({
+    ...marker,
+    prState: stateForIssue(marker.issueRef, input.prStates),
+  }))
+  const candidateLane = candidateLaneWithStates(input.prStates)
+  const warnings: CodingManagerMismatchWarning[] = []
+  const codexExecCount = processCount(input.liveProcesses, "codex_exec")
+  const khalaRequestCount = processCount(input.liveProcesses, "khala_request")
+  const activeMarkerCount = input.activeAssignments.length
+
+  if (activeMarkerCount !== codexExecCount) {
+    warnings.push({
+      code: "markers_codex_process_mismatch",
+      message: `Active assignment markers (${activeMarkerCount}) differ from live codex exec processes (${codexExecCount}).`,
+      severity: "warning",
+    })
+  }
+  if (input.logs.acceptedRunningOrUnknown > activeMarkerCount + khalaRequestCount) {
+    warnings.push({
+      code: "accepted_logs_without_local_runtime",
+      message: `Recent logs contain ${input.logs.acceptedRunningOrUnknown} accepted runs but only ${activeMarkerCount} markers and ${khalaRequestCount} Khala request wrappers.`,
+      severity: "warning",
+    })
+  }
+  if (input.tokenFailures.failureCount > 0 || input.tokenFailures.byteLength > 0) {
+    warnings.push({
+      code: "token_usage_failure_spool_nonempty",
+      message: `${input.tokenFailures.failureCount} token usage reports are waiting in the local failure spool.`,
+      severity: "warning",
+    })
+  }
+  if (
+    input.github.openPrs === null ||
+    input.github.mergedPrsSince === null ||
+    input.github.closedPrsSince === null
+  ) {
+    warnings.push({
+      code: "github_state_unavailable",
+      message: "GitHub PR counts were unavailable, so queue and marker state may be stale.",
+      severity: "warning",
+    })
+  }
+
+  const staleLocks = queueLocks.filter(
+    marker => marker.type === "lock" && marker.prState !== "open" && marker.prState !== "unknown",
+  )
+  if (staleLocks.length > 0) {
+    warnings.push({
+      code: "queue_lock_github_state_mismatch",
+      message: `${staleLocks.length} queue locks point at merged or closed PRs.`,
+      severity: "warning",
+    })
+  }
+
+  const snapshotWithoutBlock = {
+    activeAssignments: input.activeAssignments,
+    candidateLane,
+    github: input.github,
+    latestBlockers: input.logs.latestBlockers,
+    liveProcesses: input.liveProcesses,
+    logs: input.logs,
+    observedAt: input.observedAt,
+    queueLocks,
+    tokenFailures: input.tokenFailures,
+    warnings,
+  }
+
+  return {
+    ...snapshotWithoutBlock,
+    statusBlock: formatManagerResumeStatusBlock(snapshotWithoutBlock),
+  }
+}
+
+export const emptyManagerResumeSnapshot = (
+  observedAt: string,
+): CodingManagerResumeSnapshot =>
+  buildManagerResumeSnapshot({
+    activeAssignments: [],
+    github: {
+      closedPrsSince: null,
+      mergedPrsSince: null,
+      openPrs: null,
+      since: OPENAGENTS_DESKTOP_MANAGER_GITHUB_SINCE,
+    },
+    liveProcesses: [],
+    logs: summarizeManagerAssignmentLogs([]),
+    observedAt,
+    prStates: {},
+    queueLocks: [],
+    tokenFailures: {
+      byteLength: 0,
+      failureCount: 0,
+      latestFailures: [],
+      spoolPath: "",
+    },
+  })
 
 export const parseSupervisorLog = (
   logText: string,

--- a/clients/openagents-desktop/src/ui/index.html
+++ b/clients/openagents-desktop/src/ui/index.html
@@ -98,6 +98,23 @@
               <strong id="coding-metric-ready">-</strong>
             </span>
           </div>
+          <section class="coding-manager" aria-label="Manager resume checks">
+            <div class="coding-manager-heading">
+              <div>
+                <h3>Manager Resume</h3>
+                <span id="coding-manager-summary">No snapshot</span>
+              </div>
+              <div class="coding-manager-actions">
+                <button id="coding-copy-status" type="button">Copy Status</button>
+                <button id="coding-copy-json" type="button">Copy JSON</button>
+              </div>
+            </div>
+            <pre id="coding-manager-status" class="coding-manager-status"></pre>
+            <div
+              id="coding-manager-warnings"
+              class="coding-manager-warnings"
+            ></div>
+          </section>
           <div id="coding-active-list" class="coding-active-list"></div>
           <div class="coding-workspace">
             <div class="coding-session-column">

--- a/clients/openagents-desktop/src/ui/main.ts
+++ b/clients/openagents-desktop/src/ui/main.ts
@@ -2,6 +2,7 @@ import { Electroview } from "electrobun/view"
 
 import {
   type CodingCodexSession,
+  emptyManagerResumeSnapshot,
   OPENAGENTS_DESKTOP_CODING_POLL_INTERVAL_MS,
   type CodingStatusResult,
   type CodingSupervisorEvent,
@@ -55,6 +56,17 @@ const codingMetricCodex = requireElement<HTMLElement>("#coding-metric-codex")
 const codingMetricBurning = requireElement<HTMLElement>("#coding-metric-burning")
 const codingMetricKhala = requireElement<HTMLElement>("#coding-metric-khala")
 const codingMetricReady = requireElement<HTMLElement>("#coding-metric-ready")
+const codingManagerSummary = requireElement<HTMLElement>(
+  "#coding-manager-summary",
+)
+const codingManagerStatus = requireElement<HTMLElement>(
+  "#coding-manager-status",
+)
+const codingManagerWarnings = requireElement<HTMLElement>(
+  "#coding-manager-warnings",
+)
+const codingCopyStatus = requireElement<HTMLButtonElement>("#coding-copy-status")
+const codingCopyJson = requireElement<HTMLButtonElement>("#coding-copy-json")
 const codingActiveList = requireElement<HTMLElement>("#coding-active-list")
 const codingList = requireElement<HTMLElement>("#coding-list")
 const codingTranscriptTitle = requireElement<HTMLElement>(
@@ -450,9 +462,24 @@ const eventRow = (event: CodingSupervisorEvent): HTMLElement => {
   return row
 }
 
+const copyText = async (value: string, button: HTMLButtonElement): Promise<void> => {
+  const original = button.textContent ?? "Copy"
+  try {
+    await globalThis.navigator.clipboard.writeText(value)
+    button.textContent = "Copied"
+  } catch {
+    button.textContent = "Copy Failed"
+  } finally {
+    globalThis.setTimeout(() => {
+      button.textContent = original
+    }, 1_200)
+  }
+}
+
 const renderCodingStatus = (result: CodingStatusResult): void => {
   latestCodingResult = result
   const summary = result.summary
+  const manager = result.managerResume
   codingCount.textContent = `Coding: ${formatCount(summary.codexExecCount)}`
   codingStatus.dataset.state =
     summary.codexExecCount > 0
@@ -469,6 +496,35 @@ const renderCodingStatus = (result: CodingStatusResult): void => {
   codingMetricKhala.textContent = formatCount(summary.khalaRequestCount)
   codingMetricReady.textContent =
     summary.readyCodex === null ? "-" : formatCount(summary.readyCodex)
+
+  codingManagerSummary.textContent = [
+    `Assigned ${formatCount(manager.activeAssignments.length)}`,
+    `Locks ${formatCount(manager.queueLocks.filter(lock => lock.type === "lock").length)}`,
+    `Token failures ${formatCount(manager.tokenFailures.failureCount)}`,
+    `Warnings ${formatCount(manager.warnings.length)}`,
+  ].join(" · ")
+  codingManagerStatus.textContent = manager.statusBlock
+  codingManagerWarnings.replaceChildren()
+  if (manager.warnings.length === 0) {
+    const empty = document.createElement("div")
+    empty.className = "coding-empty coding-manager-empty"
+    empty.textContent = "No mismatch warnings."
+    codingManagerWarnings.append(empty)
+  } else {
+    codingManagerWarnings.append(
+      ...manager.warnings.slice(0, 6).map(warning => {
+        const row = document.createElement("article")
+        row.className = "coding-manager-warning"
+        row.dataset.severity = warning.severity
+        const code = document.createElement("strong")
+        code.textContent = warning.code
+        const message = document.createElement("span")
+        message.textContent = warning.message
+        row.append(code, message)
+        return row
+      }),
+    )
+  }
 
   renderCodingSessions(result.sessions)
 
@@ -529,6 +585,7 @@ const loadCodingStatus = async (): Promise<void> => {
     renderCodingStatus({
       ok: false,
       events: [],
+      managerResume: emptyManagerResumeSnapshot(new Date().toISOString()),
       processes: [],
       sessions: [],
       summary: {
@@ -591,6 +648,17 @@ codingStatus.addEventListener("click", () => navigateTo("coding"))
 pylonStatus.addEventListener("click", () => navigateTo("pylons"))
 codingBack.addEventListener("click", () => navigateTo("landing"))
 pylonsBack.addEventListener("click", () => navigateTo("landing"))
+codingCopyStatus.addEventListener("click", () => {
+  if (latestCodingResult === null) return
+  void copyText(latestCodingResult.managerResume.statusBlock, codingCopyStatus)
+})
+codingCopyJson.addEventListener("click", () => {
+  if (latestCodingResult === null) return
+  void copyText(
+    JSON.stringify(latestCodingResult.managerResume, null, 2),
+    codingCopyJson,
+  )
+})
 globalThis.addEventListener("hashchange", () => applyRoute(routeFromLocation()))
 globalThis.addEventListener("popstate", () => applyRoute(routeFromLocation()))
 

--- a/clients/openagents-desktop/src/ui/styles.css
+++ b/clients/openagents-desktop/src/ui/styles.css
@@ -170,6 +170,7 @@ button {
 .coding-status:focus-visible,
 .pylons-back:focus-visible,
 .create-pylon:focus-visible,
+.coding-manager-actions button:focus-visible,
 .coding-active-session:focus-visible,
 .coding-session-row:focus-visible {
   outline: 2px solid rgba(79, 208, 255, 0.84);
@@ -461,6 +462,115 @@ button {
   color: #fff;
   font-size: 1.1rem;
   line-height: 1;
+}
+
+.coding-manager {
+  display: grid;
+  gap: 10px;
+  margin: 4px 16px 10px;
+  padding: 12px;
+  background: rgba(4, 9, 18, 0.88);
+  border: 1px solid rgba(79, 208, 255, 0.16);
+  border-radius: 8px;
+}
+
+.coding-manager-heading {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.coding-manager-heading div:first-child {
+  display: grid;
+  min-width: 0;
+  gap: 5px;
+}
+
+.coding-manager-heading h3 {
+  margin: 0;
+  color: #f4f8ff;
+  font-size: 0.86rem;
+  line-height: 1;
+}
+
+.coding-manager-heading span {
+  overflow: hidden;
+  color: #9bb8e8;
+  font-size: 0.72rem;
+  line-height: 1.35;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.coding-manager-actions {
+  display: flex;
+  flex: 0 0 auto;
+  gap: 8px;
+}
+
+.coding-manager-actions button {
+  min-height: 30px;
+  padding: 0 10px;
+  color: #dbe8ff;
+  background: rgba(7, 11, 18, 0.82);
+  border: 1px solid rgba(58, 123, 255, 0.42);
+  border-radius: 8px;
+  font-size: 0.66rem;
+  font-weight: 700;
+  line-height: 1;
+  text-transform: uppercase;
+  cursor: pointer;
+}
+
+.coding-manager-status {
+  max-height: 190px;
+  margin: 0;
+  overflow: auto;
+  padding: 10px;
+  color: #d7e2f0;
+  background: rgba(0, 0, 0, 0.24);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 6px;
+  font-size: 0.7rem;
+  line-height: 1.5;
+  white-space: pre-wrap;
+}
+
+.coding-manager-warnings {
+  display: grid;
+  gap: 7px;
+}
+
+.coding-manager-warning {
+  display: grid;
+  grid-template-columns: minmax(120px, 0.32fr) minmax(0, 1fr);
+  gap: 10px;
+  padding: 9px 10px;
+  background: rgba(28, 18, 8, 0.62);
+  border: 1px solid rgba(255, 184, 77, 0.22);
+  border-radius: 6px;
+}
+
+.coding-manager-warning[data-severity="info"] {
+  background: rgba(7, 18, 31, 0.72);
+  border-color: rgba(143, 182, 255, 0.22);
+}
+
+.coding-manager-warning strong {
+  overflow: hidden;
+  color: #ffdca8;
+  font-size: 0.66rem;
+  line-height: 1.4;
+  text-overflow: ellipsis;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.coding-manager-warning span {
+  color: #dbe8ff;
+  font-size: 0.7rem;
+  line-height: 1.45;
 }
 
 .coding-active-list {
@@ -942,6 +1052,20 @@ pre.coding-message-body {
   }
 
   .coding-metrics {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .coding-manager-heading,
+  .coding-manager-warning {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .coding-manager-heading {
+    display: grid;
+  }
+
+  .coding-manager-actions {
+    display: grid;
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 

--- a/clients/openagents-desktop/tests/coding-status.test.ts
+++ b/clients/openagents-desktop/tests/coding-status.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, test } from "bun:test"
 
 import {
+  buildManagerResumeSnapshot,
   parseCodexSessionRollout,
   parseCodingProcesses,
   parseSupervisorLog,
+  summarizeManagerAssignmentLogs,
   summarizeCodingProcesses,
 } from "../src/shared/coding-status.js"
 
@@ -138,5 +140,121 @@ Pylon presence failed: OpenAgents presence request failed (401): {"error":"unaut
 `)
 
     expect(parsed.title).toBe("fix(operator): accept account ref hash")
+  })
+
+  test("classifies manager assignment logs by final lifecycle state", () => {
+    const summary = summarizeManagerAssignmentLogs([
+      {
+        path: "/logs/accepted.log",
+        text: '{"event":"assignment_run.completed","status":"accepted"}',
+      },
+      {
+        path: "/logs/rejected.log",
+        text: '{"event":"assignment_run.accepted"}\n{"event":"assignment_run.completed","status":"rejected","blocker":"blocker.assignment.codex_agent_execution_refused"}',
+      },
+      {
+        path: "/logs/running.log",
+        text: '{"event":"assignment_run.accepted"}',
+      },
+      {
+        path: "/logs/error.log",
+        text: '{"ok": false, "error": "capacity unavailable"}',
+      },
+      {
+        path: "/logs/pending.log",
+        text: "launching",
+      },
+      {
+        path: "/logs/empty.log",
+        text: "",
+      },
+    ])
+
+    expect(summary).toMatchObject({
+      acceptedRunningOrUnknown: 1,
+      completedAccepted: 1,
+      completedRejected: 1,
+      empty: 1,
+      failedBeforeAccept: 1,
+      pendingOutput: 1,
+      scannedLogCount: 6,
+    })
+    expect(summary.latestBlockers[0]).toMatchObject({
+      blocker: "blocker.assignment.codex_agent_execution_refused",
+      count: 1,
+      latestLogPath: "/logs/rejected.log",
+    })
+  })
+
+  test("builds manager resume JSON and mismatch warnings", () => {
+    const processes = parseCodingProcesses(`
+  200     1  0.1      04:00 bun apps/pylon/src/index.ts khala request --prompt Resolve PR #7557 --account-ref codex-3
+`)
+    const snapshot = buildManagerResumeSnapshot({
+      activeAssignments: [
+        {
+          accountRef: "codex-3",
+          accountRefHash: "hash-3",
+          assignmentRef: "assignment.public.test",
+          issueRef: "7557",
+          markerPath: "/active/one.json",
+          updatedAt: "2026-06-29T14:00:00Z",
+        },
+      ],
+      github: {
+        closedPrsSince: 97,
+        mergedPrsSince: 19,
+        openPrs: 267,
+        since: "2026-06-29T13:45:00Z",
+      },
+      liveProcesses: processes,
+      logs: summarizeManagerAssignmentLogs([
+        {
+          path: "/logs/running.log",
+          text: '{"event":"assignment_run.accepted"}',
+        },
+      ]),
+      observedAt: "2026-06-29T15:00:00Z",
+      prStates: {
+        "7486": "merged",
+        "7557": "open",
+      },
+      queueLocks: [
+        {
+          ageSeconds: 120,
+          issueRef: "7486",
+          markerPath: "/locks/pr.7486",
+          type: "lock",
+        },
+      ],
+      tokenFailures: {
+        byteLength: 128,
+        failureCount: 1,
+        latestFailures: [
+          {
+            assignmentRef: "assignment.public.test",
+            error: "D1 timeout",
+            observedAt: "2026-06-29T14:10:00Z",
+          },
+        ],
+        spoolPath: "/spool.jsonl",
+      },
+    })
+
+    expect(snapshot.candidateLane[0]).toMatchObject({
+      issueRef: "7557",
+      prState: "open",
+    })
+    expect(snapshot.queueLocks[0]).toMatchObject({
+      issueRef: "7486",
+      prState: "merged",
+    })
+    expect(snapshot.warnings.map(warning => warning.code)).toEqual([
+      "markers_codex_process_mismatch",
+      "token_usage_failure_spool_nonempty",
+      "queue_lock_github_state_mismatch",
+    ])
+    expect(snapshot.statusBlock).toContain("OPENAGENTS MANAGER RESUME")
+    expect(snapshot.statusBlock).toContain("candidate_lane: #7557 open")
   })
 })


### PR DESCRIPTION
## Summary

Closes #7597.

- Adds a deterministic OpenAgents Desktop manager resume snapshot to the Coding status RPC, including active assignment markers, live processes, queue locks/done markers, candidate lane state, token failure spool details, GitHub PR counts, recent log lifecycle classification, latest blockers, and mismatch warnings.
- Exposes a copyable Manager Resume status block and machine-readable JSON from the desktop Coding view.
- Adds focused shared-status tests for lifecycle classification, blocker extraction, candidate/lock GitHub-state mapping, and mismatch warnings.

## Validation

- `bun run typecheck` in `clients/openagents-desktop`
- `bun test tests/*.test.ts` in `clients/openagents-desktop`
- `bun scripts/check-conflict-markers.mjs` was the command resolved from `command.public.pylon_khala.verify.4e3e82daa9d3450372aa61a2`, but that root path is absent on current `origin/main` and failed with `Module not found`.
- `bun apps/openagents.com/scripts/check-conflict-markers.mjs` passed as the current in-repo conflict-marker verifier path.