### PR TITLE
desktop: show Khala Code worker details

### DIFF
--- a/clients/openagents-desktop/src/bun/index.ts
+++ b/clients/openagents-desktop/src/bun/index.ts
@@ -5,8 +5,11 @@ import { homedir } from "node:os"
 import { dirname, join, resolve } from "node:path"
 
 import {
+  type CodingAssignmentRun,
   type CodingCodexSession,
   emptyCodingStatusSummary,
+  mergeAssignmentRuns,
+  parseAssignmentRunLifecycleLog,
   parseCodexSessionRollout,
   parseCodingProcesses,
   parseSupervisorLog,
@@ -109,6 +112,7 @@ const pylonHomeCandidates = (): readonly string[] => {
   return [
     ...(Bun.env.PYLON_HOME ? [Bun.env.PYLON_HOME] : []),
     join(home, ".openagents", "pylon"),
+    join(home, ".pylon-fable"),
     join(home, ".pylon"),
   ]
 }
@@ -254,6 +258,85 @@ const countNonEmptyLines = async (path: string): Promise<number | null> => {
   const text = await readTextFile(path)
   if (text === "") return null
   return text.split("\n").filter(line => line.trim() !== "").length
+}
+
+const activeAssignmentRunDirectories = (): readonly string[] => [
+  resolve(resolvePylonHome(), "active-assignment-runs"),
+  join(homedir(), ".pylon-fable", "active-assignment-runs"),
+  join(homedir(), ".openagents", "pylon", "active-assignment-runs"),
+  join(homedir(), ".pylon", "active-assignment-runs"),
+]
+
+const assignmentLogDirectories = (): readonly string[] => [
+  join(homedir(), ".pylon-fable", "pr-resolver-logs"),
+  resolve(supervisorHome(), "pr-resolver-logs"),
+]
+
+const readActiveAssignmentRuns = async (): Promise<readonly CodingAssignmentRun[]> => {
+  const runs: CodingAssignmentRun[] = []
+  const seen = new Set<string>()
+
+  for (const directory of activeAssignmentRunDirectories()) {
+    if (seen.has(directory)) continue
+    seen.add(directory)
+    let entries
+    try {
+      entries = await readdir(directory, { withFileTypes: true })
+    } catch {
+      continue
+    }
+    await Promise.all(
+      entries.map(async entry => {
+        if (!entry.isFile() || !entry.name.endsWith(".json")) return
+        const text = await readTextFile(resolve(directory, entry.name))
+        runs.push(...parseAssignmentRunLifecycleLog(text))
+      }),
+    )
+  }
+
+  return mergeAssignmentRuns(runs)
+}
+
+const readRecentAssignmentLifecycleRuns = async (): Promise<readonly CodingAssignmentRun[]> => {
+  const files: Array<{ modifiedAtMs: number; path: string }> = []
+
+  for (const directory of assignmentLogDirectories()) {
+    let entries
+    try {
+      entries = await readdir(directory, { withFileTypes: true })
+    } catch {
+      continue
+    }
+    await Promise.all(
+      entries.map(async entry => {
+        if (!entry.isFile() || !entry.name.endsWith(".log")) return
+        const path = resolve(directory, entry.name)
+        try {
+          const fileStat = await stat(path)
+          files.push({ modifiedAtMs: fileStat.mtimeMs, path })
+        } catch {
+          // Ignore logs that disappear during scan.
+        }
+      }),
+    )
+  }
+
+  const runs = await Promise.all(
+    files
+      .sort((left, right) => right.modifiedAtMs - left.modifiedAtMs)
+      .slice(0, 96)
+      .map(async file => parseAssignmentRunLifecycleLog(await readTextFile(file.path))),
+  )
+
+  return mergeAssignmentRuns(runs.flat())
+}
+
+const readAssignmentRuns = async (): Promise<readonly CodingAssignmentRun[]> => {
+  const [activeRuns, lifecycleRuns] = await Promise.all([
+    readActiveAssignmentRuns(),
+    readRecentAssignmentLifecycleRuns(),
+  ])
+  return mergeAssignmentRuns([...lifecycleRuns, ...activeRuns])
 }
 
 const codexSessionDateSegments = (): readonly string[] => {
@@ -414,11 +497,31 @@ const matchingCodexProcess = (
     )
   }) ?? null
 
+const matchingAssignmentRun = (
+  input: {
+    readonly accountRef: string | null
+    readonly process: CodingProcess | null
+  },
+  runs: readonly CodingAssignmentRun[],
+): CodingAssignmentRun | null => {
+  if (input.process?.assignmentRef !== null && input.process?.assignmentRef !== undefined) {
+    return (
+      runs.find(run => run.assignmentRef === input.process?.assignmentRef) ?? null
+    )
+  }
+
+  const activeRuns = runs.filter(run => run.closeoutRef === null)
+  if (input.process !== null && activeRuns.length === 1) return activeRuns[0] ?? null
+
+  return null
+}
+
 const fallbackSessionTitle = (sessionId: string): string =>
   sessionId.startsWith("rollout-") ? sessionId : `Codex ${sessionId.slice(0, 8)}`
 
 const readCodexSessions = async (
   processes: readonly CodingProcess[],
+  assignmentRuns: readonly CodingAssignmentRun[],
 ): Promise<readonly CodingCodexSession[]> => {
   const files = await recentCodexSessionFiles()
   const sessions = await Promise.all(
@@ -436,11 +539,16 @@ const readCodexSessions = async (
       )
       const isRecent = Date.now() - file.modifiedAtMs <= 10 * 60 * 1_000
       const active = process !== null
+      const assignment = matchingAssignmentRun(
+        { accountRef, process },
+        assignmentRuns,
+      )
       const modifiedAt = new Date(file.modifiedAtMs).toISOString()
 
       return {
         accountRef,
         active,
+        assignment,
         cwd: parsed.cwd,
         issueRef: process?.issueRef ?? null,
         messageCount: parsed.messageCount,
@@ -485,7 +593,7 @@ const spawnText = async (cmd: readonly string[]): Promise<string> => {
 const codingStatus = async (): Promise<CodingStatusResult> => {
   const observedAt = new Date().toISOString()
   const home = supervisorHome()
-  const [psOutput, supervisorLog, claimCount, openIssueCount] =
+  const [psOutput, supervisorLog, claimCount, openIssueCount, assignmentRuns] =
     await Promise.all([
       spawnText([
         "/bin/ps",
@@ -504,10 +612,11 @@ const codingStatus = async (): Promise<CodingStatusResult> => {
       readTextFile(resolve(home, "supervisor.log")),
       countDirectoryEntries(resolve(home, "claims")),
       countNonEmptyLines(resolve(home, "open-issues.set")),
+      readAssignmentRuns(),
     ])
 
   const processes = parseCodingProcesses(psOutput)
-  const sessions = await readCodexSessions(processes)
+  const sessions = await readCodexSessions(processes, assignmentRuns)
   const processSummary = summarizeCodingProcesses(processes)
   const logSummary = parseSupervisorLog(supervisorLog)
   const summary: CodingStatusSummary = {

--- a/clients/openagents-desktop/src/shared/coding-status.ts
+++ b/clients/openagents-desktop/src/shared/coding-status.ts
@@ -12,6 +12,7 @@ export type CodingProcessKind =
 export type CodingProcess = {
   readonly accountRef: string | null
   readonly age: string
+  readonly assignmentRef: string | null
   readonly cpuPercent: number
   readonly issueRef: string | null
   readonly kind: CodingProcessKind
@@ -20,6 +21,22 @@ export type CodingProcess = {
   readonly pid: number
   readonly status: "active" | "idle"
   readonly workspacePath: string | null
+}
+
+export type CodingAssignmentRun = {
+  readonly accountRefHash: string | null
+  readonly assignmentRef: string
+  readonly blockerRefs: readonly string[]
+  readonly closeoutRef: string | null
+  readonly closeoutStatus: string | null
+  readonly elapsedMs: number | null
+  readonly lastEvent: string | null
+  readonly lastEventAt: string | null
+  readonly leaseRef: string | null
+  readonly phase: string | null
+  readonly refreshedAt: string | null
+  readonly runRef: string | null
+  readonly startedAt: string | null
 }
 
 export type CodingSupervisorEvent = {
@@ -55,6 +72,7 @@ export type CodingTranscriptMessage = {
 export type CodingCodexSession = {
   readonly accountRef: string | null
   readonly active: boolean
+  readonly assignment: CodingAssignmentRun | null
   readonly cwd: string | null
   readonly issueRef: string | null
   readonly messageCount: number
@@ -148,6 +166,12 @@ const issueRefFromCommand = (command: string): string | null =>
   command.match(/#(\d{3,})/)?.[1] ??
   null
 
+const assignmentRefFromCommand = (command: string): string | null =>
+  command.match(/(?:^|\s)--assignment-ref\s+((?:"[^"]+")|(?:'[^']+')|\S+)/)?.[1]
+    ?.replace(/^(['"])(.*)\1$/, "$2") ??
+  command.match(/\bassignment\.public\.[a-z0-9_.-]+/i)?.[0] ??
+  null
+
 const unquoteShellToken = (value: string): string =>
   value.replace(/^(['"])(.*)\1$/, "$2")
 
@@ -193,10 +217,12 @@ export const parseCodingProcesses = (
     }
 
     const accountRef = accountRefFromCommand(command)
+    const assignmentRef = assignmentRefFromCommand(command)
     const issueRef = issueRefFromCommand(command)
     rows.push({
       accountRef,
       age,
+      assignmentRef,
       cpuPercent,
       issueRef,
       kind,
@@ -212,14 +238,112 @@ export const parseCodingProcesses = (
   return rows.map(row => {
     const parent = byPid.get(row.parentPid)
     const accountRef = row.accountRef ?? parent?.accountRef ?? null
+    const assignmentRef = row.assignmentRef ?? parent?.assignmentRef ?? null
     const issueRef = row.issueRef ?? parent?.issueRef ?? null
     return {
       ...row,
       accountRef,
+      assignmentRef,
       issueRef,
       label: labelForProcess(row.kind, accountRef, issueRef),
     }
   })
+}
+
+const numberValueFromUnknown = (value: unknown): number | null =>
+  typeof value === "number" && Number.isFinite(value) ? value : null
+
+const stringArrayFromUnknown = (value: unknown): readonly string[] =>
+  Array.isArray(value)
+    ? value.filter((item): item is string => typeof item === "string")
+    : []
+
+const assignmentRunFromUnknown = (value: unknown): CodingAssignmentRun | null => {
+  if (!isJsonObject(value)) return null
+  const assignmentRef = stringValueFromUnknown(value.assignmentRef)
+  if (assignmentRef === null) return null
+  const observedAt = stringValueFromUnknown(value.observedAt)
+  const event = stringValueFromUnknown(value.event)
+  const status = stringValueFromUnknown(value.status)
+  const phase = stringValueFromUnknown(value.phase)
+  return {
+    accountRefHash: stringValueFromUnknown(value.accountRefHash),
+    assignmentRef,
+    blockerRefs: stringArrayFromUnknown(value.blockerRefs),
+    closeoutRef: stringValueFromUnknown(value.closeoutRef),
+    closeoutStatus:
+      event === "assignment_run.closeout_submitted" ||
+      event === "assignment_run.completed"
+        ? status
+        : null,
+    elapsedMs: numberValueFromUnknown(value.elapsedMs),
+    lastEvent: event,
+    lastEventAt: observedAt,
+    leaseRef: stringValueFromUnknown(value.leaseRef),
+    phase: phase ?? status,
+    refreshedAt: stringValueFromUnknown(value.refreshedAt),
+    runRef: stringValueFromUnknown(value.runRef),
+    startedAt:
+      event === "assignment_run.accepted" || event === "assignment_run.runtime_started"
+        ? observedAt
+        : stringValueFromUnknown(value.startedAt),
+  }
+}
+
+export const mergeAssignmentRuns = (
+  runs: readonly CodingAssignmentRun[],
+): readonly CodingAssignmentRun[] => {
+  const byAssignment = new Map<string, CodingAssignmentRun>()
+
+  for (const run of runs) {
+    const current = byAssignment.get(run.assignmentRef)
+    byAssignment.set(run.assignmentRef, {
+      accountRefHash: run.accountRefHash ?? current?.accountRefHash ?? null,
+      assignmentRef: run.assignmentRef,
+      blockerRefs:
+        run.blockerRefs.length > 0 ? run.blockerRefs : current?.blockerRefs ?? [],
+      closeoutRef: run.closeoutRef ?? current?.closeoutRef ?? null,
+      closeoutStatus: run.closeoutStatus ?? current?.closeoutStatus ?? null,
+      elapsedMs: Math.max(run.elapsedMs ?? 0, current?.elapsedMs ?? 0) || null,
+      lastEvent: run.lastEvent ?? current?.lastEvent ?? null,
+      lastEventAt: run.lastEventAt ?? current?.lastEventAt ?? null,
+      leaseRef: run.leaseRef ?? current?.leaseRef ?? null,
+      phase: run.phase ?? current?.phase ?? null,
+      refreshedAt: run.refreshedAt ?? current?.refreshedAt ?? null,
+      runRef: run.runRef ?? current?.runRef ?? null,
+      startedAt: current?.startedAt ?? run.startedAt,
+    })
+  }
+
+  return [...byAssignment.values()]
+}
+
+export const parseAssignmentRunLifecycleLog = (
+  logText: string,
+): readonly CodingAssignmentRun[] => {
+  const runs: CodingAssignmentRun[] = []
+
+  for (const line of logText.split("\n")) {
+    const trimmed = line.trim()
+    if (!trimmed.startsWith("{")) continue
+    let record: unknown
+    try {
+      record = JSON.parse(trimmed)
+    } catch {
+      continue
+    }
+    if (!isJsonObject(record)) continue
+    if (
+      record.schema !== "openagents.pylon.assignment_run_lifecycle_event.v0.1" &&
+      record.schema !== "openagents.pylon.active_assignment_run.v0.1"
+    ) {
+      continue
+    }
+    const run = assignmentRunFromUnknown(record)
+    if (run !== null) runs.push(run)
+  }
+
+  return mergeAssignmentRuns(runs)
 }
 
 export const emptyCodingStatusSummary = (): CodingStatusSummary => ({

--- a/clients/openagents-desktop/src/ui/index.html
+++ b/clients/openagents-desktop/src/ui/index.html
@@ -116,6 +116,10 @@
                 <span id="coding-transcript-count">0 messages</span>
               </div>
               <div
+                id="coding-transcript-details"
+                class="coding-transcript-details"
+              ></div>
+              <div
                 id="coding-transcript-messages"
                 class="coding-transcript-messages"
               ></div>

--- a/clients/openagents-desktop/src/ui/main.ts
+++ b/clients/openagents-desktop/src/ui/main.ts
@@ -66,6 +66,9 @@ const codingTranscriptMeta = requireElement<HTMLElement>(
 const codingTranscriptCount = requireElement<HTMLElement>(
   "#coding-transcript-count",
 )
+const codingTranscriptDetails = requireElement<HTMLElement>(
+  "#coding-transcript-details",
+)
 const codingTranscriptMessages = requireElement<HTMLElement>(
   "#coding-transcript-messages",
 )
@@ -128,6 +131,18 @@ const formatAbsoluteTimestamp = (value: string | null): string => {
     minute: "2-digit",
     second: "2-digit",
   }).format(date)
+}
+
+const formatDuration = (value: number | null): string => {
+  if (value === null) return "Unknown"
+  const seconds = Math.max(0, Math.round(value / 1000))
+  if (seconds < 60) return `${formatCount(seconds)}s`
+  const minutes = Math.floor(seconds / 60)
+  const restSeconds = seconds % 60
+  if (minutes < 60) return `${formatCount(minutes)}m ${formatCount(restSeconds)}s`
+  const hours = Math.floor(minutes / 60)
+  const restMinutes = minutes % 60
+  return `${formatCount(hours)}h ${formatCount(restMinutes)}m`
 }
 
 const pylonIsOnline = (pylon: DesktopPylon): boolean =>
@@ -218,14 +233,20 @@ const sessionSubtitle = (session: CodingCodexSession): string => {
   const parts = [
     session.accountRef,
     session.issueRef === null ? null : `#${session.issueRef}`,
+    session.assignment?.closeoutStatus ?? session.assignment?.phase ?? null,
     session.pid === null ? null : `PID ${formatCount(session.pid)}`,
     formatRelativeTimestamp(session.modifiedAt),
   ].filter((value): value is string => value !== null)
   return parts.join(" · ")
 }
 
+const sessionIsActive = (session: CodingCodexSession): boolean =>
+  session.active ||
+  session.status === "active" ||
+  (session.assignment !== null && session.assignment.closeoutRef === null)
+
 const sessionStatusRank = (session: CodingCodexSession): number => {
-  if (session.active || session.status === "active") return 0
+  if (sessionIsActive(session)) return 0
   if (session.status === "recent") return 1
   return 2
 }
@@ -257,7 +278,7 @@ const sessionButton = (
   button.className =
     variant === "chip" ? "coding-active-session" : "coding-session-row"
   button.type = "button"
-  button.dataset.state = session.status
+  button.dataset.state = sessionIsActive(session) ? "active" : session.status
   button.dataset.selected =
     selectedSessionPath === session.path ? "true" : "false"
   button.addEventListener("click", () => selectSession(session))
@@ -270,7 +291,7 @@ const sessionButton = (
 
   const status = document.createElement("span")
   status.className = "coding-session-status"
-  status.textContent = session.status.toUpperCase()
+  status.textContent = (sessionIsActive(session) ? "active" : session.status).toUpperCase()
 
   if (variant === "chip") {
     button.append(title, meta, status)
@@ -354,6 +375,49 @@ const messageRow = (message: CodingTranscriptMessage): HTMLElement => {
   return row
 }
 
+const detailItem = (label: string, value: string | null): HTMLElement => {
+  const item = document.createElement("div")
+  item.className = "coding-detail-item"
+
+  const labelEl = document.createElement("span")
+  labelEl.textContent = label
+
+  const valueEl = document.createElement("strong")
+  valueEl.textContent = value === null || value === "" ? "Unknown" : value
+
+  item.append(labelEl, valueEl)
+  return item
+}
+
+const renderCodingTranscriptDetails = (
+  session: CodingCodexSession | null,
+): void => {
+  codingTranscriptDetails.replaceChildren()
+  if (session === null) return
+
+  const assignment = session.assignment
+  const workspace = compactPath(session.cwd) ?? compactPath(session.path)
+  const issue =
+    session.issueRef === null ? null : `#${session.issueRef}`
+  const blockerRefs =
+    assignment === null || assignment.blockerRefs.length === 0
+      ? null
+      : assignment.blockerRefs.join(", ")
+
+  codingTranscriptDetails.append(
+    detailItem("Assignment", assignment?.assignmentRef ?? null),
+    detailItem("Account", session.accountRef ?? assignment?.accountRefHash ?? null),
+    detailItem("Issue/PR", issue),
+    detailItem("Workspace", workspace),
+    detailItem("PID", session.pid === null ? null : String(session.pid)),
+    detailItem("Elapsed", formatDuration(assignment?.elapsedMs ?? null)),
+    detailItem("Last event", assignment?.lastEvent ?? null),
+    detailItem("Last event age", formatRelativeTimestamp(assignment?.lastEventAt ?? null)),
+    detailItem("Closeout", assignment?.closeoutRef ?? assignment?.closeoutStatus ?? null),
+    detailItem("Blockers", blockerRefs),
+  )
+}
+
 const renderCodingTranscript = (
   session: CodingCodexSession | null,
 ): void => {
@@ -362,6 +426,7 @@ const renderCodingTranscript = (
     codingTranscriptTitle.textContent = "No session selected"
     codingTranscriptMeta.textContent = "Click a Codex instance"
     codingTranscriptCount.textContent = "0 messages"
+    renderCodingTranscriptDetails(null)
     const empty = document.createElement("div")
     empty.className = "coding-empty"
     empty.textContent = "No Codex session transcript loaded."
@@ -377,6 +442,7 @@ const renderCodingTranscript = (
     .filter((value): value is string => value !== null && value !== "")
     .join(" · ")
   codingTranscriptCount.textContent = `${formatCount(session.messageCount)} messages`
+  renderCodingTranscriptDetails(session)
 
   if (session.messages.length === 0) {
     const empty = document.createElement("div")

--- a/clients/openagents-desktop/src/ui/styles.css
+++ b/clients/openagents-desktop/src/ui/styles.css
@@ -606,13 +606,51 @@ button {
 
 .coding-transcript {
   display: grid;
-  grid-template-rows: auto minmax(0, 1fr);
+  grid-template-rows: auto auto minmax(0, 1fr);
   min-width: 0;
   max-height: 460px;
   overflow: hidden;
   background: rgba(4, 9, 18, 0.88);
   border: 1px solid rgba(255, 255, 255, 0.08);
   border-radius: 8px;
+}
+
+.coding-transcript-details {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1px;
+  padding: 1px;
+  background: rgba(255, 255, 255, 0.08);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.coding-detail-item {
+  display: grid;
+  min-width: 0;
+  gap: 5px;
+  padding: 9px 10px;
+  background: rgba(5, 11, 22, 0.9);
+}
+
+.coding-detail-item span {
+  overflow: hidden;
+  color: #7189b4;
+  font-size: 0.58rem;
+  font-weight: 700;
+  line-height: 1;
+  text-overflow: ellipsis;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.coding-detail-item strong {
+  overflow: hidden;
+  color: #dbe8ff;
+  font-size: 0.68rem;
+  font-weight: 700;
+  line-height: 1.3;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .coding-transcript-heading {
@@ -972,6 +1010,10 @@ pre.coding-message-body {
   .coding-message-heading {
     align-items: stretch;
     flex-direction: column;
+  }
+
+  .coding-transcript-details {
+    grid-template-columns: minmax(0, 1fr);
   }
 }
 

--- a/clients/openagents-desktop/tests/coding-status.test.ts
+++ b/clients/openagents-desktop/tests/coding-status.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test"
 
 import {
+  parseAssignmentRunLifecycleLog,
   parseCodexSessionRollout,
   parseCodingProcesses,
   parseSupervisorLog,
@@ -32,10 +33,12 @@ describe("openagents desktop coding status", () => {
     })
     expect(processes[1]).toMatchObject({
       accountRef: "codex-6",
+      assignmentRef: null,
       issueRef: "6932",
     })
     expect(processes[2]).toMatchObject({
       accountRef: "codex-6",
+      assignmentRef: null,
       issueRef: "6932",
       parentPid: 101,
       workspacePath: "/tmp/workspace-one",
@@ -46,6 +49,44 @@ describe("openagents desktop coding status", () => {
       khalaRequestCount: 1,
       supervisorCount: 1,
       vertexBurnCount: 1,
+    })
+  })
+
+  test("inherits assignment refs from parent assignment runners", () => {
+    const processes = parseCodingProcesses(`
+  200     1  0.4      01:20 bun apps/pylon/src/index.ts assignment run-no-spend --assignment-ref assignment.public.khala_coding.chatcmpl_abc --json
+  201   200  9.2      00:44 /Users/me/node_modules/@openai/codex/vendor/aarch64-apple-darwin/bin/codex exec --cd /tmp/workspace-two
+`)
+
+    expect(processes[0]).toMatchObject({
+      assignmentRef: "assignment.public.khala_coding.chatcmpl_abc",
+      kind: "assignment_runner",
+    })
+    expect(processes[1]).toMatchObject({
+      assignmentRef: "assignment.public.khala_coding.chatcmpl_abc",
+      kind: "codex_exec",
+      status: "active",
+    })
+  })
+
+  test("parses assignment lifecycle progress and closeout details", () => {
+    const runs = parseAssignmentRunLifecycleLog(`
+{"schema":"openagents.pylon.assignment_run_lifecycle_event.v0.1","observedAt":"2026-06-29T14:26:41.222Z","event":"assignment_run.runtime_started","assignmentRef":"assignment.public.khala_coding.chatcmpl_abc","accountRefHash":"account.pylon.codex.aaaa","leaseRef":"assignment.public.khala_coding.chatcmpl_abc"}
+{"schema":"openagents.pylon.assignment_run_lifecycle_event.v0.1","observedAt":"2026-06-29T14:27:12.557Z","event":"assignment_run.runtime_progress","assignmentRef":"assignment.public.khala_coding.chatcmpl_abc","accountRefHash":"account.pylon.codex.aaaa","leaseRef":"assignment.public.khala_coding.chatcmpl_abc","phase":"runtime_active","elapsedMs":31335,"lastProgressEvent":"assignment_run.runtime_started"}
+{"schema":"openagents.pylon.assignment_run_lifecycle_event.v0.1","observedAt":"2026-06-29T14:28:09.654Z","event":"assignment_run.completed","assignmentRef":"assignment.public.khala_coding.chatcmpl_abc","leaseRef":"assignment.public.khala_coding.chatcmpl_abc","status":"rejected","closeoutRef":"assignment.closeout.abc","blockerRefs":["blocker.assignment.codex_agent_test_failed"]}
+`)
+
+    expect(runs).toHaveLength(1)
+    expect(runs[0]).toMatchObject({
+      accountRefHash: "account.pylon.codex.aaaa",
+      assignmentRef: "assignment.public.khala_coding.chatcmpl_abc",
+      blockerRefs: ["blocker.assignment.codex_agent_test_failed"],
+      closeoutRef: "assignment.closeout.abc",
+      closeoutStatus: "rejected",
+      elapsedMs: 31335,
+      lastEvent: "assignment_run.completed",
+      lastEventAt: "2026-06-29T14:28:09.654Z",
+      phase: "rejected",
     })
   })
 


### PR DESCRIPTION
Closes #7596.

## Summary
- read local Khala Code active-assignment markers and recent Pylon lifecycle logs into the openagents desktop coding status model
- attach assignment/account/elapsed/last-event/closeout metadata to selected Codex worker transcripts
- render a bounded worker detail grid above the existing ordered user/assistant/tool transcript and keep active workers sorted first

## Verification
- `bun run --cwd clients/openagents-desktop typecheck`
- `bun run --cwd clients/openagents-desktop test`
- `bun run --cwd clients/openagents-desktop verify`
- required ref `command.public.pylon_khala.verify.4e3e82daa9d3450372aa61a2` maps to `bun scripts/check-conflict-markers.mjs`; literal repo-root command currently fails because that script is not present at `./scripts/check-conflict-markers.mjs` on current `origin/main`; equivalent existing script passed from `apps/openagents.com`: `bun scripts/check-conflict-markers.mjs`
