### PR TITLE
Show Khala worker transcript details in desktop

### DIFF
--- a/clients/openagents-desktop/src/bun/index.ts
+++ b/clients/openagents-desktop/src/bun/index.ts
@@ -5,9 +5,11 @@ import { homedir } from "node:os"
 import { dirname, join, resolve } from "node:path"
 
 import {
+  type CodingAssignmentDetail,
   type CodingCodexSession,
   emptyCodingStatusSummary,
   parseCodexSessionRollout,
+  parseCodingAssignmentDetails,
   parseCodingProcesses,
   parseSupervisorLog,
   type CodingProcess,
@@ -414,11 +416,62 @@ const matchingCodexProcess = (
     )
   }) ?? null
 
+const recentAssignmentLogs = async (): Promise<readonly string[]> => {
+  const dirs = [
+    resolve(resolvePylonHome(), "pr-resolver-logs"),
+    join(homedir(), ".pylon-fable", "pr-resolver-logs"),
+  ]
+  const entries: Array<{ modifiedAtMs: number; path: string }> = []
+  for (const dir of [...new Set(dirs)]) {
+    let files
+    try {
+      files = await readdir(dir, { withFileTypes: true })
+    } catch {
+      continue
+    }
+    await Promise.all(
+      files.map(async file => {
+        if (!file.isFile() || !file.name.endsWith(".log")) return
+        const path = resolve(dir, file.name)
+        try {
+          const fileStat = await stat(path)
+          entries.push({ modifiedAtMs: fileStat.mtimeMs, path })
+        } catch {
+          // Logs can rotate while the desktop poll is running.
+        }
+      }),
+    )
+  }
+  entries.sort((left, right) => right.modifiedAtMs - left.modifiedAtMs)
+  return Promise.all(entries.slice(0, 160).map(entry => readTextFile(entry.path)))
+}
+
+const matchingAssignmentDetail = (
+  session: {
+    readonly cwd: string | null
+    readonly issueRef: string | null
+  },
+  details: readonly CodingAssignmentDetail[],
+): CodingAssignmentDetail | null => {
+  const workspaceMatch = details.find(detail =>
+    session.cwd !== null &&
+      detail.workspacePath !== null &&
+      session.cwd === detail.workspacePath,
+  )
+  if (workspaceMatch !== undefined) return workspaceMatch
+  return details.find(detail =>
+    (session.issueRef !== null &&
+      detail.issueRef !== null &&
+      session.issueRef === detail.issueRef),
+  ) ?? null
+}
+
 const fallbackSessionTitle = (sessionId: string): string =>
   sessionId.startsWith("rollout-") ? sessionId : `Codex ${sessionId.slice(0, 8)}`
 
 const readCodexSessions = async (
   processes: readonly CodingProcess[],
+  assignmentDetails: readonly CodingAssignmentDetail[],
 ): Promise<readonly CodingCodexSession[]> => {
   const files = await recentCodexSessionFiles()
   const sessions = await Promise.all(
@@ -437,12 +490,39 @@ const readCodexSessions = async (
       const isRecent = Date.now() - file.modifiedAtMs <= 10 * 60 * 1_000
       const active = process !== null
       const modifiedAt = new Date(file.modifiedAtMs).toISOString()
+      const issueRef = process?.issueRef ?? null
+      const assignment = matchingAssignmentDetail(
+        { cwd: parsed.cwd, issueRef },
+        assignmentDetails,
+      )
+      const lastMessage = parsed.messages.at(-1)
+      const lastEventAt = assignment?.lastEventAt ?? lastMessage?.timestamp ?? modifiedAt
+      const lastEventAtMs = Date.parse(lastEventAt)
 
       return {
         accountRef,
         active,
+        assignmentRef: assignment?.assignmentRef ?? null,
+        closeout: {
+          blockerRefs: assignment?.blockerRefs ?? [],
+          closeoutRef: assignment?.closeoutRef ?? null,
+          status: assignment?.closeoutStatus ?? null,
+        },
         cwd: parsed.cwd,
-        issueRef: process?.issueRef ?? null,
+        elapsed:
+          assignment?.elapsedMs === null || assignment?.elapsedMs === undefined
+            ? process?.age ?? null
+            : `${Math.max(0, Math.floor(assignment.elapsedMs / 1000))}s`,
+        issueRef: issueRef ?? assignment?.issueRef ?? null,
+        lastEvent: {
+          ageSeconds: Number.isFinite(lastEventAtMs)
+            ? Math.max(0, Math.floor((Date.now() - lastEventAtMs) / 1000))
+            : null,
+          name: assignment?.lastEvent ?? lastMessage?.kind ?? null,
+          timestamp: lastEventAt,
+        },
+        leaseRef: assignment?.leaseRef ?? null,
+        pullRequestRef: assignment?.pullRequestRef ?? null,
         messageCount: parsed.messageCount,
         messages: parsed.messages,
         modifiedAt,
@@ -451,7 +531,11 @@ const readCodexSessions = async (
         sessionId,
         source: parsed.source,
         status: active ? "active" : isRecent ? "recent" : "idle",
-        title: parsed.title ?? process?.label ?? fallbackSessionTitle(sessionId),
+        title:
+          parsed.title ??
+          process?.label ??
+          assignment?.assignmentRef ??
+          fallbackSessionTitle(sessionId),
       } satisfies CodingCodexSession
     }),
   )
@@ -507,7 +591,10 @@ const codingStatus = async (): Promise<CodingStatusResult> => {
     ])
 
   const processes = parseCodingProcesses(psOutput)
-  const sessions = await readCodexSessions(processes)
+  const assignmentDetails = (await recentAssignmentLogs()).flatMap(log =>
+    parseCodingAssignmentDetails(log),
+  )
+  const sessions = await readCodexSessions(processes, assignmentDetails)
   const processSummary = summarizeCodingProcesses(processes)
   const logSummary = parseSupervisorLog(supervisorLog)
   const summary: CodingStatusSummary = {

--- a/clients/openagents-desktop/src/shared/coding-status.ts
+++ b/clients/openagents-desktop/src/shared/coding-status.ts
@@ -55,8 +55,22 @@ export type CodingTranscriptMessage = {
 export type CodingCodexSession = {
   readonly accountRef: string | null
   readonly active: boolean
+  readonly assignmentRef: string | null
+  readonly closeout: {
+    readonly blockerRefs: readonly string[]
+    readonly closeoutRef: string | null
+    readonly status: string | null
+  }
   readonly cwd: string | null
+  readonly elapsed: string | null
   readonly issueRef: string | null
+  readonly lastEvent: {
+    readonly ageSeconds: number | null
+    readonly name: string | null
+    readonly timestamp: string | null
+  }
+  readonly leaseRef: string | null
+  readonly pullRequestRef: string | null
   readonly messageCount: number
   readonly messages: readonly CodingTranscriptMessage[]
   readonly modifiedAt: string
@@ -66,6 +80,20 @@ export type CodingCodexSession = {
   readonly source: string | null
   readonly status: "active" | "idle" | "recent"
   readonly title: string
+}
+
+export type CodingAssignmentDetail = {
+  readonly assignmentRef: string
+  readonly blockerRefs: readonly string[]
+  readonly closeoutRef: string | null
+  readonly closeoutStatus: string | null
+  readonly elapsedMs: number | null
+  readonly issueRef: string | null
+  readonly lastEvent: string | null
+  readonly lastEventAt: string | null
+  readonly leaseRef: string | null
+  readonly pullRequestRef: string | null
+  readonly workspacePath: string | null
 }
 
 export type ParsedCodexSessionRollout = {
@@ -365,7 +393,7 @@ const stringValueFromUnknown = (value: unknown): string | null =>
 
 const truncateTranscriptText = (value: string): string => {
   const trimmed = value.replace(/\s+$/g, "")
-  return trimmed.length > 2_400 ? `${trimmed.slice(0, 2_397)}...` : trimmed
+  return trimmed.length > 1_200 ? `${trimmed.slice(0, 1_197)}...` : trimmed
 }
 
 const transcriptMessage = (
@@ -669,4 +697,120 @@ export const parseCodexSessionRollout = (
     source,
     title,
   }
+}
+
+const numberValueFromUnknown = (value: unknown): number | null =>
+  typeof value === "number" && Number.isFinite(value) ? value : null
+
+const stringArrayFromUnknown = (value: unknown): readonly string[] =>
+  Array.isArray(value)
+    ? value.filter((item): item is string => typeof item === "string")
+    : []
+
+const valueMentionsAssignment = (value: unknown, assignmentRef: string): boolean => {
+  if (typeof value === "string") return value === assignmentRef
+  if (Array.isArray(value)) return value.some(item => valueMentionsAssignment(item, assignmentRef))
+  if (!isJsonObject(value)) return false
+  return Object.values(value).some(item => valueMentionsAssignment(item, assignmentRef))
+}
+
+const assignmentRefFromRecord = (record: JsonObject): string | null =>
+  stringValueFromUnknown(record.assignmentRef) ??
+  (isJsonObject(record.assignmentRun)
+    ? assignmentRefFromRecord(record.assignmentRun)
+    : null) ??
+  (isJsonObject(record.closeout)
+    ? stringValueFromUnknown(record.closeout.assignmentRef)
+    : null)
+
+export const parseCodingAssignmentDetails = (
+  logText: string,
+): readonly CodingAssignmentDetail[] => {
+  const byAssignment = new Map<string, CodingAssignmentDetail>()
+  const ensure = (assignmentRef: string): CodingAssignmentDetail => {
+    const current = byAssignment.get(assignmentRef)
+    if (current !== undefined) return current
+    const next: CodingAssignmentDetail = {
+      assignmentRef,
+      blockerRefs: [],
+      closeoutRef: null,
+      closeoutStatus: null,
+      elapsedMs: null,
+      issueRef: null,
+      lastEvent: null,
+      lastEventAt: null,
+      leaseRef: null,
+      pullRequestRef: null,
+      workspacePath: null,
+    }
+    byAssignment.set(assignmentRef, next)
+    return next
+  }
+  const merge = (assignmentRef: string, patch: Partial<CodingAssignmentDetail>) => {
+    const current = ensure(assignmentRef)
+    byAssignment.set(assignmentRef, {
+      ...current,
+      ...Object.fromEntries(
+        Object.entries(patch).filter(([, value]) =>
+          Array.isArray(value) ? value.length > 0 : value !== null && value !== undefined,
+        ),
+      ),
+    })
+  }
+
+  for (const line of logText.split("\n")) {
+    const trimmed = line.trim()
+    if (!trimmed.startsWith("{")) continue
+    let parsed: unknown
+    try {
+      parsed = JSON.parse(trimmed)
+    } catch {
+      continue
+    }
+    if (!isJsonObject(parsed)) continue
+    const assignmentRef = assignmentRefFromRecord(parsed)
+    if (assignmentRef === null || !valueMentionsAssignment(parsed, assignmentRef)) continue
+
+    const nestedRun = isJsonObject(parsed.assignmentRun) ? parsed.assignmentRun : null
+    const nestedCloseout = nestedRun !== null && isJsonObject(nestedRun.closeout)
+      ? nestedRun.closeout
+      : isJsonObject(parsed.closeout)
+        ? parsed.closeout
+        : null
+    const closeoutReceipt =
+      nestedRun !== null && isJsonObject(nestedRun.closeoutReceipt)
+        ? nestedRun.closeoutReceipt
+        : null
+    const issueNumber = numberValueFromUnknown(parsed.issueNumber)
+    const pullRequestNumber = numberValueFromUnknown(parsed.pullRequestNumber)
+    merge(assignmentRef, {
+      blockerRefs:
+        stringArrayFromUnknown(parsed.blockerRefs).length > 0
+          ? stringArrayFromUnknown(parsed.blockerRefs)
+          : nestedCloseout === null
+            ? []
+            : stringArrayFromUnknown(nestedCloseout.blockerRefs),
+      closeoutRef:
+        stringValueFromUnknown(parsed.closeoutRef) ??
+        stringValueFromUnknown(closeoutReceipt?.closeoutRef),
+      closeoutStatus:
+        stringValueFromUnknown(parsed.status) ??
+        (nestedCloseout === null ? null : stringValueFromUnknown(nestedCloseout.status)),
+      elapsedMs: numberValueFromUnknown(parsed.elapsedMs),
+      issueRef:
+        stringValueFromUnknown(parsed.issueRef) ??
+        (issueNumber === null ? null : String(issueNumber)),
+      lastEvent: stringValueFromUnknown(parsed.event),
+      lastEventAt: stringValueFromUnknown(parsed.observedAt),
+      leaseRef: stringValueFromUnknown(parsed.leaseRef),
+      pullRequestRef:
+        stringValueFromUnknown(parsed.pullRequestRef) ??
+        (pullRequestNumber === null ? null : String(pullRequestNumber)),
+      workspacePath:
+        stringValueFromUnknown(parsed.workspacePath) ??
+        stringValueFromUnknown(parsed.localWorkspacePath),
+    })
+  }
+
+  return [...byAssignment.values()]
 }

--- a/clients/openagents-desktop/src/ui/main.ts
+++ b/clients/openagents-desktop/src/ui/main.ts
@@ -218,7 +218,9 @@ const sessionSubtitle = (session: CodingCodexSession): string => {
   const parts = [
     session.accountRef,
     session.issueRef === null ? null : `#${session.issueRef}`,
+    session.assignmentRef === null ? null : session.assignmentRef.slice(-12),
     session.pid === null ? null : `PID ${formatCount(session.pid)}`,
+    session.elapsed === null ? null : `elapsed ${session.elapsed}`,
     formatRelativeTimestamp(session.modifiedAt),
   ].filter((value): value is string => value !== null)
   return parts.join(" · ")
@@ -354,6 +356,53 @@ const messageRow = (message: CodingTranscriptMessage): HTMLElement => {
   return row
 }
 
+const detailChip = (label: string, value: string | null): HTMLElement => {
+  const chip = document.createElement("span")
+  chip.className = "coding-detail-chip"
+  const name = document.createElement("strong")
+  name.textContent = label
+  const body = document.createElement("code")
+  body.textContent = value === null || value.trim() === "" ? "unknown" : value
+  chip.append(name, body)
+  return chip
+}
+
+const sessionDetailChips = (session: CodingCodexSession): readonly HTMLElement[] => {
+  const lastEvent =
+    session.lastEvent.name === null
+      ? null
+      : `${session.lastEvent.name}${
+          session.lastEvent.ageSeconds === null
+            ? ""
+            : ` · ${formatCount(session.lastEvent.ageSeconds)}s ago`
+        }`
+  const closeout =
+    session.closeout.closeoutRef ??
+    session.closeout.status ??
+    (session.closeout.blockerRefs.length === 0
+      ? null
+      : session.closeout.blockerRefs.join(", "))
+  const pullIssue = [
+    session.pullRequestRef === null ? null : `PR #${session.pullRequestRef}`,
+    session.issueRef === null ? null : `issue #${session.issueRef}`,
+  ].filter((value): value is string => value !== null).join(" · ")
+  const workspace =
+    session.cwd ??
+    (session.assignmentRef === null
+      ? session.path
+      : `pylon khala status --assignment-ref ${session.assignmentRef} --json`)
+  return [
+    detailChip("assignment", session.assignmentRef),
+    detailChip("account", session.accountRef),
+    detailChip("PR/issue", pullIssue === "" ? null : pullIssue),
+    detailChip("workspace", workspace),
+    detailChip("PID", session.pid === null ? null : String(session.pid)),
+    detailChip("elapsed", session.elapsed),
+    detailChip("last event", lastEvent),
+    detailChip("closeout", closeout),
+  ]
+}
+
 const renderCodingTranscript = (
   session: CodingCodexSession | null,
 ): void => {
@@ -377,6 +426,11 @@ const renderCodingTranscript = (
     .filter((value): value is string => value !== null && value !== "")
     .join(" · ")
   codingTranscriptCount.textContent = `${formatCount(session.messageCount)} messages`
+
+  const details = document.createElement("div")
+  details.className = "coding-session-details"
+  details.append(...sessionDetailChips(session))
+  codingTranscriptMessages.append(details)
 
   if (session.messages.length === 0) {
     const empty = document.createElement("div")

--- a/clients/openagents-desktop/src/ui/styles.css
+++ b/clients/openagents-desktop/src/ui/styles.css
@@ -673,6 +673,42 @@ button {
   );
 }
 
+.coding-session-details {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 7px;
+  margin-left: 10px;
+}
+
+.coding-detail-chip {
+  display: inline-flex;
+  align-items: center;
+  max-width: 100%;
+  min-width: 0;
+  gap: 6px;
+  padding: 6px 8px;
+  background: rgba(255, 255, 255, 0.055);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 6px;
+}
+
+.coding-detail-chip strong {
+  flex: 0 0 auto;
+  color: #9bb8e8;
+  font-size: 0.64rem;
+  text-transform: uppercase;
+}
+
+.coding-detail-chip code {
+  overflow: hidden;
+  color: #e8f0ff;
+  font-size: 0.68rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .coding-message {
   position: relative;
   display: grid;

--- a/clients/openagents-desktop/tests/coding-status.test.ts
+++ b/clients/openagents-desktop/tests/coding-status.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test"
 
 import {
   parseCodexSessionRollout,
+  parseCodingAssignmentDetails,
   parseCodingProcesses,
   parseSupervisorLog,
   summarizeCodingProcesses,
@@ -127,6 +128,28 @@ Pylon presence failed: OpenAgents presence request failed (401): {"error":"unaut
       title: "tool error",
     })
     expect(parsed.messages.at(-1)?.text).toBe("Done.")
+  })
+
+  test("parses assignment lifecycle details for selected worker panels", () => {
+    const details = parseCodingAssignmentDetails(`
+{"event":"assignment_run.runtime_started","assignmentRef":"assignment.public.khala_coding.one","leaseRef":"lease.one","observedAt":"2026-06-29T16:00:00.000Z","workspacePath":"/tmp/openagents-one","issueNumber":7596}
+{"event":"assignment_run.runtime_progress","assignmentRef":"assignment.public.khala_coding.one","leaseRef":"lease.one","observedAt":"2026-06-29T16:00:10.000Z","elapsedMs":10234,"lastProgressEvent":"turn.completed"}
+{"event":"assignment_run.completed","assignmentRef":"assignment.public.khala_coding.one","leaseRef":"lease.one","observedAt":"2026-06-29T16:00:20.000Z","status":"accepted","closeoutRef":"assignment.closeout.one","pullRequestNumber":7612,"blockerRefs":[]}
+`)
+
+    expect(details).toHaveLength(1)
+    expect(details[0]).toMatchObject({
+      assignmentRef: "assignment.public.khala_coding.one",
+      closeoutRef: "assignment.closeout.one",
+      closeoutStatus: "accepted",
+      elapsedMs: 10234,
+      issueRef: "7596",
+      lastEvent: "assignment_run.completed",
+      lastEventAt: "2026-06-29T16:00:20.000Z",
+      leaseRef: "lease.one",
+      pullRequestRef: "7612",
+      workspacePath: "/tmp/openagents-one",
+    })
   })
 
   test("uses task-like rollout text instead of injected AGENTS context as title", () => {


### PR DESCRIPTION
Closes #7596

## Summary
- Parse recent Khala assignment lifecycle logs into desktop worker session metadata.
- Show assignment/account/PR+issue/workspace or safe lookup/PID/elapsed/last-event/closeout chips when a worker is selected.
- Keep transcript tool text bounded and preserve active-first worker ordering.

## Verification
- `bun test tests/coding-status.test.ts` from `clients/openagents-desktop`
- `bun run typecheck` from `clients/openagents-desktop`
- `bun scripts/check-conflict-markers.mjs` from `apps/openagents.com` for `command.public.pylon_khala.verify.4e3e82daa9d3450372aa61a2`

Note: the command ref resolves to `bun scripts/check-conflict-markers.mjs`; at repository root that path is absent in this checkout, so I ran the same argv from the app directory where the script exists.