### PR TITLE
fix(pylon): gate Codex assignments on account auth health

### DIFF
--- a/apps/pylon/src/account-connect.test.ts
+++ b/apps/pylon/src/account-connect.test.ts
@@ -251,19 +251,19 @@ describe("classifyCodexAuthProbeOutput", () => {
         stdout: "",
         stderr: "Your access token could not be refreshed because your refresh token was revoked.",
       }),
-    ).toEqual({ valid: false, reason: "credentials_revoked" })
+    ).toMatchObject({ valid: false, reason: "credentials_revoked", failure: { reason: "credentials_revoked" } })
   })
 
   test("classifies a usage limit as usage_limited", () => {
     expect(
       classifyCodexAuthProbeOutput({ exitCode: 1, stdout: "", stderr: "You have hit your usage limit." }),
-    ).toEqual({ valid: false, reason: "usage_limited" })
+    ).toMatchObject({ valid: false, reason: "usage_limited", failure: { reason: "usage_limited" } })
   })
 
   test("classifies a 401/unauthorized as auth_error", () => {
     expect(
       classifyCodexAuthProbeOutput({ exitCode: 1, stdout: "", stderr: "http 401 Unauthorized" }),
-    ).toEqual({ valid: false, reason: "auth_error" })
+    ).toMatchObject({ valid: false, reason: "auth_error" })
   })
 
   test("treats a clean exit as valid", () => {

--- a/apps/pylon/src/account-connect.ts
+++ b/apps/pylon/src/account-connect.ts
@@ -12,6 +12,7 @@ import { recordAccountLinkInPresence } from "./presence.js"
 import { assertPublicProjectionSafe } from "./state.js"
 import {
   classifyCodexAccountFailure,
+  type PylonCodexAccountFailure,
   type PylonCodexAccountHealthReason,
 } from "./codex-account-health.js"
 import { clearCodexAccountHealthFailure } from "./codex-account-health-ledger.js"
@@ -51,7 +52,7 @@ export type PylonCodexAuthInvalidReason = Exclude<PylonCodexAccountHealthReason,
  */
 export type PylonCodexAuthValidity =
   | { valid: true; reason?: string }
-  | { valid: false; reason: PylonCodexAuthInvalidReason }
+  | { valid: false; reason: PylonCodexAuthInvalidReason; failure?: PylonCodexAccountFailure }
 
 /**
  * Injectable probe that classifies a stored Codex credential as valid or
@@ -323,14 +324,14 @@ export function classifyCodexAuthProbeOutput(input: {
 }): PylonCodexAuthValidity {
   const text = `${input.stdout}\n${input.stderr}`
   const failure = classifyCodexAccountFailure(text)
-  if (failure.reason === "credentials_revoked") return { valid: false, reason: "credentials_revoked" }
-  if (failure.reason === "usage_limited" || failure.reason === "rate_limited") return { valid: false, reason: failure.reason }
+  if (failure.reason === "credentials_revoked") return { valid: false, reason: "credentials_revoked", failure }
+  if (failure.reason === "usage_limited" || failure.reason === "rate_limited") return { valid: false, reason: failure.reason, failure }
   if (
     /could not be refreshed|refresh token|token (?:has )?expired|expired token|unauthorized|\b401\b|not logged in|please (?:sign in|log ?in)|sign in again|authentication (?:failed|error)|invalid (?:token|credential)/.test(
       text.toLowerCase(),
     )
   ) {
-    return { valid: false, reason: "auth_error" }
+    return { valid: false, reason: "auth_error", failure }
   }
   if (input.exitCode === 0) {
     return { valid: true }

--- a/apps/pylon/src/agent-runner-registry.ts
+++ b/apps/pylon/src/agent-runner-registry.ts
@@ -1,6 +1,7 @@
 import type { AgentRuntimeAdapterKind } from "@openagentsinc/agent-runtime-schema"
 
 import type { ResolvedPylonAccountSelection } from "./account-registry.js"
+import type { PylonCodexAuthValidityProbe } from "./account-connect.js"
 import {
   CLAUDE_AGENT_SDK_PACKAGE,
   CLAUDE_AGENT_CAPABILITY_REF,
@@ -101,6 +102,7 @@ export type AgentRunnerExecutionOptions = {
   claudeAgentRunner?: ClaudeAgentRunner
   codexAgentProbe?: CodexAgentProbeOptions
   codexAgentRunner?: CodexAgentRunner
+  codexAuthValidityProbe?: PylonCodexAuthValidityProbe
   onCodexProgress?: (progress: CodexAgentRuntimeProgress) => void | Promise<void>
   fetch?: typeof fetch
 }
@@ -215,6 +217,9 @@ export const AGENT_RUNNER_REGISTRY: ReadonlyArray<AgentRunnerDescriptor> = [
         ...commonExecutionOptions(options),
         ...(options.codexAgentProbe === undefined ? {} : { codexAgentProbe: options.codexAgentProbe }),
         ...(options.codexAgentRunner === undefined ? {} : { codexAgentRunner: options.codexAgentRunner }),
+        ...(options.codexAuthValidityProbe === undefined
+          ? {}
+          : { codexAuthValidityProbe: options.codexAuthValidityProbe }),
         ...(options.onCodexProgress === undefined ? {} : { onProgress: options.onCodexProgress }),
       } satisfies CodexAgentExecutionOptions),
   },

--- a/apps/pylon/src/assignment.ts
+++ b/apps/pylon/src/assignment.ts
@@ -24,6 +24,8 @@ import {
   probeCodexAgentReadiness,
   type CodexAgentProbeOptions,
 } from "./codex-agent.js"
+import type { PylonCodexAuthValidityProbe } from "./account-connect.js"
+import { probeAndRecordCodexAccountAuthHealth } from "./codex-account-auth-health.js"
 import type { CodexAgentRuntimePhase, CodexAgentRunner } from "./codex-agent-executor.js"
 import {
   agentRunnerForLease,
@@ -177,6 +179,7 @@ export type AssignmentClientOptions = {
   claudeAgentProbe?: ClaudeAgentProbeOptions
   codexAgentRunner?: CodexAgentRunner
   codexAgentProbe?: CodexAgentProbeOptions
+  codexAuthValidityProbe?: PylonCodexAuthValidityProbe
   localAssignmentHeartbeatStaleAfterMs?: number
   localProcessIsAlive?: (processId: number) => boolean
   onLifecycleEvent?: (event: AssignmentRunLifecycleEvent) => void | Promise<void>
@@ -1590,6 +1593,15 @@ async function resolveAgentAccountForAssignment(
             env: targetEnv,
           })
     if (readiness.state !== "ready") continue
+    if (provider === "codex") {
+      const authHealth = await probeAndRecordCodexAccountAuthHealth(summary, {
+        account: target.account,
+        env,
+        now,
+        ...(options.codexAuthValidityProbe === undefined ? {} : { probe: options.codexAuthValidityProbe }),
+      })
+      if (authHealth.state !== "valid") continue
+    }
     readyTargets.push(target)
   }
   if (readyTargets.length === 0) return { account: null }
@@ -1828,6 +1840,9 @@ export async function runNoSpendAssignment(summary: BootstrapSummary, options: A
           ...(options.claudeAgentProbe === undefined ? {} : { claudeAgentProbe: options.claudeAgentProbe }),
           ...(options.claudeAgentRunner === undefined ? {} : { claudeAgentRunner: options.claudeAgentRunner }),
           ...(options.codexAgentRunner === undefined ? {} : { codexAgentRunner: options.codexAgentRunner }),
+          ...(options.codexAuthValidityProbe === undefined
+            ? {}
+            : { codexAuthValidityProbe: options.codexAuthValidityProbe }),
           ...(options.codexAgentProbe === undefined ? {} : { codexAgentProbe: options.codexAgentProbe }),
           ...(options.fetch === undefined ? {} : { fetch: options.fetch }),
           onCodexProgress: async (progress) => {

--- a/apps/pylon/src/codex-account-auth-health.ts
+++ b/apps/pylon/src/codex-account-auth-health.ts
@@ -1,0 +1,58 @@
+import {
+  defaultCodexAuthValidityProbe,
+  type PylonCodexAuthValidity,
+  type PylonCodexAuthValidityProbe,
+} from "./account-connect.js"
+import {
+  pylonAccountEnvironment,
+  type ResolvedPylonAccountSelection,
+} from "./account-registry.js"
+import type { BootstrapSummary } from "./bootstrap.js"
+import {
+  classifyCodexAccountFailure,
+  type PylonCodexAccountFailure,
+} from "./codex-account-health.js"
+import { recordCodexAccountHealthFailure } from "./codex-account-health-ledger.js"
+
+type Summary = Pick<BootstrapSummary, "paths">
+
+type InvalidCodexAuthValidity = Extract<PylonCodexAuthValidity, { valid: false }>
+
+export type PylonCodexAccountAuthHealthResult =
+  | { state: "valid" }
+  | { state: "invalid"; failure: PylonCodexAccountFailure }
+
+export function codexFailureFromAuthValidity(
+  validity: InvalidCodexAuthValidity,
+): PylonCodexAccountFailure {
+  if (validity.failure !== undefined) {
+    return validity.reason === "auth_error" && validity.failure.reason === "other"
+      ? { ...validity.failure, reason: "credentials_revoked" }
+      : validity.failure
+  }
+  return classifyCodexAccountFailure(validity.reason)
+}
+
+export async function probeAndRecordCodexAccountAuthHealth(
+  summary: Summary,
+  input: {
+    account: ResolvedPylonAccountSelection | null | undefined
+    env: Record<string, string | undefined>
+    now: Date
+    probe?: PylonCodexAuthValidityProbe
+  },
+): Promise<PylonCodexAccountAuthHealthResult> {
+  if (input.account === null || input.account === undefined) return { state: "valid" }
+  const validity = await (input.probe ?? defaultCodexAuthValidityProbe)({
+    env: pylonAccountEnvironment(input.env, input.account),
+    home: input.account.home,
+  })
+  if (validity.valid) return { state: "valid" }
+  const failure = codexFailureFromAuthValidity(validity)
+  await recordCodexAccountHealthFailure(summary, {
+    accountRefHash: input.account.accountRefHash,
+    failure,
+    now: input.now,
+  }).catch(() => undefined)
+  return { state: "invalid", failure }
+}

--- a/apps/pylon/src/codex-agent-executor.ts
+++ b/apps/pylon/src/codex-agent-executor.ts
@@ -23,6 +23,8 @@ import {
   pylonAccountEnvironment,
   type ResolvedPylonAccountSelection,
 } from "./account-registry.js"
+import type { PylonCodexAuthValidityProbe } from "./account-connect.js"
+import { probeAndRecordCodexAccountAuthHealth } from "./codex-account-auth-health.js"
 import {
   publishAssignmentPullRequest,
   type AssignmentPrTitleBody,
@@ -165,6 +167,7 @@ export type CodexAgentExecutionOptions = {
   checkoutRunner?: CodexAgentCheckoutRunner
   codexAgentRunner?: CodexAgentRunner
   codexAgentProbe?: CodexAgentProbeOptions
+  codexAuthValidityProbe?: PylonCodexAuthValidityProbe
   codexEventChunkReporter?: CodexEventChunkReporter
   codexTurnReporter?: CodexTurnReporter
   dependencyInstaller?: LocalCommandRunner
@@ -1269,6 +1272,26 @@ export async function executeCodexAgentAssignment(
       resultRef: "result.public.pylon.codex_agent_task.unavailable",
       summaryRef: "summary.public.pylon.codex_agent_task.unavailable",
       message: `Local Codex lane is not ready on this device (${probed.state}).`,
+    })
+  }
+  const authHealth = await probeAndRecordCodexAccountAuthHealth(state, {
+    account: options.account,
+    env,
+    now,
+    ...(options.codexAuthValidityProbe === undefined ? {} : { probe: options.codexAuthValidityProbe }),
+  })
+  if (authHealth.state !== "valid") {
+    return refusalRecord({
+      lease,
+      runRef,
+      blockerRefs: [
+        "blocker.assignment.codex_agent_execution_refused",
+        ...codexAccountFailureBlockerRefs(authHealth.failure.reason),
+        authHealth.failure.sourceDigestRef,
+      ],
+      resultRef: `result.public.pylon.codex_agent_task.execution_refused.${authHealth.failure.reason}`,
+      summaryRef: `summary.public.pylon.codex_agent_task.execution_refused.${authHealth.failure.reason}`,
+      message: `Local Codex account failed pre-dispatch auth health with ${authHealth.failure.reason}: ${authHealth.failure.publicMessage || "no public error message available"}.`,
     })
   }
 

--- a/apps/pylon/src/codex-agent-task-smoke.ts
+++ b/apps/pylon/src/codex-agent-task-smoke.ts
@@ -220,6 +220,7 @@ export async function runCodexAgentTaskCiSmoke(): Promise<CodexAgentTaskSmokeRes
           return {}
         },
       },
+      codexAuthValidityProbe: async () => ({ valid: true }),
     })
 
     const closeout = "closeout" in run ? run.closeout : {}

--- a/apps/pylon/tests/assignment.test.ts
+++ b/apps/pylon/tests/assignment.test.ts
@@ -30,6 +30,7 @@ import {
   type CodexAgentRunner,
 } from "../src/codex-agent-executor"
 import { hashPylonAccountRef } from "../src/account-registry"
+import { loadCodexAccountHealthRecord } from "../src/codex-account-health-ledger"
 
 const INDEX = join(import.meta.dir, "..", "src", "index.ts")
 const CWD = join(import.meta.dir, "..")
@@ -530,6 +531,7 @@ describe("Pylon assignment lease flow", () => {
           importer: async () => ({}),
           platform: "darwin",
         },
+        codexAuthValidityProbe: async () => ({ valid: true }),
         codexAgentRunner: fixingCodexRunner,
         now: () => new Date("2026-06-09T00:00:30.000Z"),
       })
@@ -541,6 +543,83 @@ describe("Pylon assignment lease flow", () => {
       expect(result.closeout.resultRefs).toContain(
         "result.public.pylon.codex_agent_task.fixture_repair_passed",
       )
+    })
+  })
+
+  test("skips revoked Codex accounts during no-spend account selection", async () => {
+    await withTempHome(async (home) => {
+      const codexLease = lease({
+        assignmentRef: "assignment.public.no_spend.codex_health_gate",
+        leaseRef: "lease.public.no_spend.codex_health_gate",
+        capabilityRefs: ["capability.pylon.local_codex"],
+        codingAssignment: {
+          codex: {
+            agentKind: "codex_sdk",
+            fixtureRef: CODEX_AGENT_SUM_REPAIR_FIXTURE_REF,
+            schema: CODEX_AGENT_TASK_SCHEMA,
+          },
+        },
+      })
+      const fake = fakeAssignmentServer({ leases: [codexLease] })
+      const summary = await readySummary(home, ["capability.pylon.local_codex"])
+      const state = await ensurePylonLocalState(summary)
+      const revokedHome = join(home, "accounts/codex/codex-revoked")
+      const goodHome = join(home, "accounts/codex/codex-good")
+      await mkdir(revokedHome, { recursive: true })
+      await mkdir(goodHome, { recursive: true })
+      await writeFile(join(revokedHome, "auth.json"), "{}\n")
+      await writeFile(join(goodHome, "auth.json"), "{}\n")
+      await writeFile(
+        state.paths.config,
+        `${JSON.stringify(
+          {
+            dev: {
+              accounts: [
+                { provider: "codex", ref: "codex-revoked", home: revokedHome },
+                { provider: "codex", ref: "codex-good", home: goodHome },
+              ],
+            },
+          },
+          null,
+          2,
+        )}\n`,
+      )
+      await sendHeartbeat(summary, { baseUrl: fake.baseUrl, now: () => new Date("2026-06-09T00:00:00.000Z") })
+
+      let seenAccountRef: string | null = null
+      const fixingCodexRunner: CodexAgentRunner = async (input) => {
+        seenAccountRef = input.account?.accountRef ?? null
+        await writeFile(
+          join(input.cwd, "sum.ts"),
+          "export const sum = (left: number, right: number) => left + right\n",
+        )
+        return { commandCount: 1, editedFileCount: 1, outcome: "completed", sessionRef: null, turnCount: 1 }
+      }
+
+      const result = await runNoSpendAssignment(summary, {
+        baseUrl: fake.baseUrl,
+        codexAgentProbe: {
+          env: {},
+          importer: async () => ({}),
+          platform: "darwin",
+        },
+        codexAuthValidityProbe: async input =>
+          input.home === revokedHome
+            ? { valid: false, reason: "credentials_revoked" }
+            : { valid: true },
+        codexAgentRunner: fixingCodexRunner,
+        now: () => new Date("2026-06-09T00:00:30.000Z"),
+      })
+
+      expect(result.ok).toBe(true)
+      if (!result.ok) throw new Error("expected Codex assignment to run")
+      expect(seenAccountRef).toBe("codex-good")
+      expect(
+        (await loadCodexAccountHealthRecord(
+          summary,
+          hashPylonAccountRef("codex", "codex-revoked"),
+        ))?.reason,
+      ).toBe("credentials_revoked")
     })
   })
 
@@ -599,6 +678,7 @@ describe("Pylon assignment lease flow", () => {
           importer: async () => ({}),
           platform: "darwin",
         },
+        codexAuthValidityProbe: async () => ({ valid: true }),
         codexAgentRunner: slowFixingCodexRunner,
         now: () => new Date("2026-06-09T00:00:30.000Z"),
         runtimeProgressIntervalMs: 1,

--- a/apps/pylon/tests/codex-agent-executor.test.ts
+++ b/apps/pylon/tests/codex-agent-executor.test.ts
@@ -28,6 +28,7 @@ import {
 } from "../src/account-registry"
 import { loadCodexAccountHealthRecord } from "../src/codex-account-health-ledger"
 import { loadQuotaRecord } from "../src/account-quota-ledger"
+import { classifyCodexAccountFailure } from "../src/codex-account-health"
 import {
   WorkspaceCheckoutError,
   workspaceLeaseRecordFor,
@@ -88,6 +89,8 @@ const idleRunner: CodexAgentRunner = async () => ({
   commandCount: 0,
   sessionRef: null,
 })
+
+const validCodexAuthProbe = async () => ({ valid: true as const })
 
 async function withState<T>(fn: (state: Awaited<ReturnType<typeof ensurePylonLocalState>>) => Promise<T>) {
   const home = await mkdtemp(join(tmpdir(), "pylon-codex-exec-test-"))
@@ -241,6 +244,7 @@ describe("codex agent task recognition", () => {
         account,
         codexAgentRunner: revokedRunner,
         codexAgentProbe: readyProbe,
+        codexAuthValidityProbe: validCodexAuthProbe,
       })
 
       expect(revoked?.status).toBe("rejected")
@@ -264,12 +268,47 @@ describe("codex agent task recognition", () => {
         account: limitedAccount,
         codexAgentRunner: limitedRunner,
         codexAgentProbe: readyProbe,
+        codexAuthValidityProbe: validCodexAuthProbe,
       })
 
       expect(limited?.blockerRefs).toContain("blocker.assignment.codex_agent_execution_usage_limited")
       expect((await loadCodexAccountHealthRecord(state, limitedAccountRefHash))?.reason).toBe("usage_limited")
       expect((await loadQuotaRecord(state, limitedAccountRefHash))?.retryAtIso).toBe("2026-06-28T22:00:00.000Z")
       assertPublicProjectionSafe(limited)
+    })
+  })
+
+  test("pre-dispatch Codex auth health refuses revoked accounts before starting the runner", async () => {
+    await withState(async (state) => {
+      const accountRefHash = hashPylonAccountRef("codex", "codex-revoked")
+      const account: ResolvedPylonAccountSelection = {
+        provider: "codex",
+        selector: "registry_ref",
+        accountRef: "codex-revoked",
+        accountRefHash,
+        home: join(state.paths.home, "accounts", "codex", "codex-revoked"),
+      }
+      let runnerStarted = false
+      const record = await executeCodexAgentAssignment(state, lease, now, {
+        account,
+        codexAgentRunner: async () => {
+          runnerStarted = true
+          return { outcome: "completed", turnCount: 1, editedFileCount: 0, commandCount: 0, sessionRef: null }
+        },
+        codexAgentProbe: readyProbe,
+        codexAuthValidityProbe: async () => ({
+          valid: false,
+          reason: "credentials_revoked",
+          failure: classifyCodexAccountFailure("Your access token could not be refreshed because your refresh token was revoked."),
+        }),
+      })
+
+      expect(runnerStarted).toBe(false)
+      expect(record?.status).toBe("rejected")
+      expect(record?.blockerRefs).toContain("blocker.assignment.codex_agent_execution_credentials_revoked")
+      expect(record?.blockerRefs).toContain("blocker.assignment.codex_account_credentials_revoked_needs_owner_reauth")
+      expect((await loadCodexAccountHealthRecord(state, accountRefHash))?.reason).toBe("credentials_revoked")
+      assertPublicProjectionSafe(record)
     })
   })
 

--- a/apps/pylon/tests/codex-agent-task-smoke.test.ts
+++ b/apps/pylon/tests/codex-agent-task-smoke.test.ts
@@ -131,6 +131,7 @@ describe("codex agent task smoke (CI-safe leg)", () => {
           },
           platform: "darwin",
         },
+        codexAuthValidityProbe: async () => ({ valid: true }),
       })
 
       expect(run.ok).toBe(true)

--- a/apps/pylon/tests/khala-mcp-end-to-end.test.ts
+++ b/apps/pylon/tests/khala-mcp-end-to-end.test.ts
@@ -609,6 +609,7 @@ describe("Khala MCP end-to-end smoke", () => {
           },
           platform: "darwin",
         },
+        codexAuthValidityProbe: async () => ({ valid: true }),
         codexAgentRunner: async input => {
           expect(input.cwd).toContain("codex-agent-tasks")
           expect(input.instructions).toContain("bounded fixture workspace")


### PR DESCRIPTION
Closes #6902.

## Summary
- add a shared Codex account auth-health helper that reuses the bounded Codex auth validity probe and records public-safe health failures
- validate selected Codex accounts before no-spend assignment dispatch and again before executor materialization, returning typed blockers for revoked/limited credentials instead of opaque execution refusals
- preserve CI-safe smoke tests by injecting deterministic auth-health probes instead of touching local Codex credentials

## Verification
- `bun run --cwd apps/pylon typecheck`
- `bun scripts/check-conflict-markers.mjs` (`command.public.pylon_khala.verify.4e3e82daa9d3450372aa61a2`)
- `bun test apps/pylon/tests/codex-agent-executor.test.ts apps/pylon/tests/assignment.test.ts apps/pylon/src/account-connect.test.ts apps/pylon/src/presence-codex-account-capacity.test.ts apps/pylon/src/account-status.test.ts apps/pylon/tests/codex-agent-task-smoke.test.ts apps/pylon/tests/khala-mcp-end-to-end.test.ts`
- `bun run --cwd apps/pylon test` (1930 pass, 3 skip)