### PR TITLE
feat(khala-code-desktop): write the ADR + tests for the Khala Code on-d…

### DIFF
--- a/clients/khala-code-desktop/src/shared/on-device-decider.ts
+++ b/clients/khala-code-desktop/src/shared/on-device-decider.ts
@@ -1,0 +1,182 @@
+export const KHALA_CODE_ON_DEVICE_DECIDER_INTERFACE_VERSION =
+  "khala-code-on-device-decider-v1" as const
+
+export const KHALA_CODE_APPLE_FM_DECIDER_BACKEND_ID =
+  "khala-code-apple-fm-decider" as const
+
+export const KHALA_CODE_GPT_OSS_DECIDER_BACKEND_ID =
+  "khala-code-gpt-oss-decider" as const
+
+export type KhalaCodeOnDeviceDeciderPlatform =
+  | "macos"
+  | "ios"
+  | "linux"
+  | "windows"
+  | "unsupported"
+
+export type KhalaCodeOnDeviceDeciderBackendKind =
+  | "apple_fm"
+  | "self_hosted_gpt_oss"
+
+export type KhalaCodeOnDeviceDeciderRequest = {
+  readonly prompt: string
+  readonly workspaceSummary?: string
+  readonly candidateActions: ReadonlyArray<string>
+}
+
+export type KhalaCodeOnDeviceDeciderDecision = {
+  readonly selectedAction: string | null
+  readonly confidence: number
+  readonly reason: string
+}
+
+export type KhalaCodeOnDeviceDeciderBackend = {
+  readonly id: string
+  readonly kind: KhalaCodeOnDeviceDeciderBackendKind
+  readonly interfaceVersion: typeof KHALA_CODE_ON_DEVICE_DECIDER_INTERFACE_VERSION
+  decide(
+    request: KhalaCodeOnDeviceDeciderRequest,
+  ): Promise<KhalaCodeOnDeviceDeciderDecision>
+}
+
+export type KhalaCodeOnDeviceDeciderSelectionInput = {
+  readonly enabled?: boolean
+  readonly platform: KhalaCodeOnDeviceDeciderPlatform | NodeJS.Platform | string
+  readonly appleFmAvailable?: boolean
+  readonly gptOssAvailable?: boolean
+}
+
+export type KhalaCodeOnDeviceDeciderBackendSelection = {
+  readonly id:
+    | typeof KHALA_CODE_APPLE_FM_DECIDER_BACKEND_ID
+    | typeof KHALA_CODE_GPT_OSS_DECIDER_BACKEND_ID
+  readonly kind: KhalaCodeOnDeviceDeciderBackendKind
+  readonly interfaceVersion: typeof KHALA_CODE_ON_DEVICE_DECIDER_INTERFACE_VERSION
+}
+
+export type KhalaCodeOnDeviceDeciderSelection =
+  | {
+      readonly status: "disabled"
+      readonly enabled: false
+      readonly platform: KhalaCodeOnDeviceDeciderPlatform
+      readonly backend: null
+      readonly failSoft: true
+      readonly blockerRefs: ReadonlyArray<string>
+    }
+  | {
+      readonly status: "ready"
+      readonly enabled: true
+      readonly platform: KhalaCodeOnDeviceDeciderPlatform
+      readonly backend: KhalaCodeOnDeviceDeciderBackendSelection
+      readonly failSoft: true
+      readonly blockerRefs: ReadonlyArray<string>
+    }
+  | {
+      readonly status: "unavailable"
+      readonly enabled: true
+      readonly platform: KhalaCodeOnDeviceDeciderPlatform
+      readonly backend: null
+      readonly failSoft: true
+      readonly blockerRefs: ReadonlyArray<string>
+    }
+
+export function normalizeKhalaCodeOnDeviceDeciderPlatform(
+  platform: KhalaCodeOnDeviceDeciderSelectionInput["platform"],
+): KhalaCodeOnDeviceDeciderPlatform {
+  switch (platform) {
+    case "darwin":
+    case "macos":
+      return "macos"
+    case "ios":
+      return "ios"
+    case "linux":
+      return "linux"
+    case "win32":
+    case "windows":
+      return "windows"
+    default:
+      return "unsupported"
+  }
+}
+
+export function selectKhalaCodeOnDeviceDecider(
+  input: KhalaCodeOnDeviceDeciderSelectionInput,
+): KhalaCodeOnDeviceDeciderSelection {
+  const platform = normalizeKhalaCodeOnDeviceDeciderPlatform(input.platform)
+
+  if (input.enabled !== true) {
+    return {
+      status: "disabled",
+      enabled: false,
+      platform,
+      backend: null,
+      failSoft: true,
+      blockerRefs: ["blocker.khala_code.on_device_decider.disabled"],
+    }
+  }
+
+  if (platform === "macos" || platform === "ios") {
+    if (input.appleFmAvailable === true) {
+      return {
+        status: "ready",
+        enabled: true,
+        platform,
+        backend: {
+          id: KHALA_CODE_APPLE_FM_DECIDER_BACKEND_ID,
+          kind: "apple_fm",
+          interfaceVersion: KHALA_CODE_ON_DEVICE_DECIDER_INTERFACE_VERSION,
+        },
+        failSoft: true,
+        blockerRefs: [],
+      }
+    }
+
+    return {
+      status: "unavailable",
+      enabled: true,
+      platform,
+      backend: null,
+      failSoft: true,
+      blockerRefs: [
+        "blocker.khala_code.on_device_decider.apple_fm_unavailable",
+      ],
+    }
+  }
+
+  if (platform === "linux" || platform === "windows") {
+    if (input.gptOssAvailable === true) {
+      return {
+        status: "ready",
+        enabled: true,
+        platform,
+        backend: {
+          id: KHALA_CODE_GPT_OSS_DECIDER_BACKEND_ID,
+          kind: "self_hosted_gpt_oss",
+          interfaceVersion: KHALA_CODE_ON_DEVICE_DECIDER_INTERFACE_VERSION,
+        },
+        failSoft: true,
+        blockerRefs: [],
+      }
+    }
+
+    return {
+      status: "unavailable",
+      enabled: true,
+      platform,
+      backend: null,
+      failSoft: true,
+      blockerRefs: [
+        "blocker.khala_code.on_device_decider.gpt_oss_unavailable",
+      ],
+    }
+  }
+
+  return {
+    status: "unavailable",
+    enabled: true,
+    platform,
+    backend: null,
+    failSoft: true,
+    blockerRefs: ["blocker.khala_code.on_device_decider.unsupported_platform"],
+  }
+}

--- a/clients/khala-code-desktop/tests/on-device-decider.test.ts
+++ b/clients/khala-code-desktop/tests/on-device-decider.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, test } from "bun:test"
+
+import {
+  KHALA_CODE_APPLE_FM_DECIDER_BACKEND_ID,
+  KHALA_CODE_GPT_OSS_DECIDER_BACKEND_ID,
+  KHALA_CODE_ON_DEVICE_DECIDER_INTERFACE_VERSION,
+  normalizeKhalaCodeOnDeviceDeciderPlatform,
+  selectKhalaCodeOnDeviceDecider,
+} from "../src/shared/on-device-decider"
+
+describe("Khala Code on-device decider selection", () => {
+  test("is off by default and fails soft without selecting a backend", () => {
+    const selection = selectKhalaCodeOnDeviceDecider({
+      platform: "darwin",
+      appleFmAvailable: true,
+    })
+
+    expect(selection).toEqual({
+      status: "disabled",
+      enabled: false,
+      platform: "macos",
+      backend: null,
+      failSoft: true,
+      blockerRefs: ["blocker.khala_code.on_device_decider.disabled"],
+    })
+  })
+
+  test("normalizes host platform signals into the public contract", () => {
+    expect(normalizeKhalaCodeOnDeviceDeciderPlatform("darwin")).toBe("macos")
+    expect(normalizeKhalaCodeOnDeviceDeciderPlatform("macos")).toBe("macos")
+    expect(normalizeKhalaCodeOnDeviceDeciderPlatform("ios")).toBe("ios")
+    expect(normalizeKhalaCodeOnDeviceDeciderPlatform("linux")).toBe("linux")
+    expect(normalizeKhalaCodeOnDeviceDeciderPlatform("win32")).toBe("windows")
+    expect(normalizeKhalaCodeOnDeviceDeciderPlatform("freebsd")).toBe(
+      "unsupported",
+    )
+  })
+
+  test("selects Apple FM only for opted-in Mac and iOS hosts", () => {
+    for (const platform of ["macos", "ios"] as const) {
+      const selection = selectKhalaCodeOnDeviceDecider({
+        enabled: true,
+        platform,
+        appleFmAvailable: true,
+        gptOssAvailable: true,
+      })
+
+      expect(selection.status).toBe("ready")
+      expect(selection.backend).toEqual({
+        id: KHALA_CODE_APPLE_FM_DECIDER_BACKEND_ID,
+        kind: "apple_fm",
+        interfaceVersion: KHALA_CODE_ON_DEVICE_DECIDER_INTERFACE_VERSION,
+      })
+      expect(selection.blockerRefs).toEqual([])
+    }
+  })
+
+  test("selects self-hosted GPT-OSS only for opted-in non-Mac desktop hosts", () => {
+    for (const platform of ["linux", "windows"] as const) {
+      const selection = selectKhalaCodeOnDeviceDecider({
+        enabled: true,
+        platform,
+        appleFmAvailable: true,
+        gptOssAvailable: true,
+      })
+
+      expect(selection.status).toBe("ready")
+      expect(selection.backend).toEqual({
+        id: KHALA_CODE_GPT_OSS_DECIDER_BACKEND_ID,
+        kind: "self_hosted_gpt_oss",
+        interfaceVersion: KHALA_CODE_ON_DEVICE_DECIDER_INTERFACE_VERSION,
+      })
+      expect(selection.blockerRefs).toEqual([])
+    }
+  })
+
+  test("fails soft when the platform backend is unavailable", () => {
+    expect(
+      selectKhalaCodeOnDeviceDecider({
+        enabled: true,
+        platform: "macos",
+        appleFmAvailable: false,
+        gptOssAvailable: true,
+      }),
+    ).toMatchObject({
+      status: "unavailable",
+      backend: null,
+      failSoft: true,
+      blockerRefs: [
+        "blocker.khala_code.on_device_decider.apple_fm_unavailable",
+      ],
+    })
+
+    expect(
+      selectKhalaCodeOnDeviceDecider({
+        enabled: true,
+        platform: "linux",
+        gptOssAvailable: false,
+      }),
+    ).toMatchObject({
+      status: "unavailable",
+      backend: null,
+      failSoft: true,
+      blockerRefs: [
+        "blocker.khala_code.on_device_decider.gpt_oss_unavailable",
+      ],
+    })
+  })
+
+  test("does not hard fail unsupported platforms", () => {
+    expect(
+      selectKhalaCodeOnDeviceDecider({
+        enabled: true,
+        platform: "freebsd",
+      }),
+    ).toEqual({
+      status: "unavailable",
+      enabled: true,
+      platform: "unsupported",
+      backend: null,
+      failSoft: true,
+      blockerRefs: [
+        "blocker.khala_code.on_device_decider.unsupported_platform",
+      ],
+    })
+  })
+})

--- a/docs/adr/0013-adopt-optional-khala-code-on-device-decider.md
+++ b/docs/adr/0013-adopt-optional-khala-code-on-device-decider.md
@@ -1,0 +1,126 @@
+---
+status: "accepted"
+date: 2026-06-29
+decision-makers: OpenAgents maintainers
+consulted: AGENTS.md, docs/adr/0011-ship-khala-mobile-as-native-swiftui-with-local-apple-tooling.md, docs/adr/0012-adopt-khala-native-terminal-tool-runtime.md, docs/desktop/2026-06-28-khala-desktop-spec.md, clients/khala-macos/src/launch-plan.ts, clients/khala-code-desktop/src/shared/on-device-decider.ts
+informed: OpenAgents contributors, Khala Code desktop operators, Khala macOS/iOS operators, and Pylon operators
+---
+
+# Adopt an optional Khala Code on-device decider
+
+## Context and Problem Statement
+
+Khala Code needs a small local decision layer for low-risk routing choices such
+as picking between native tool actions, classifying simple coding intents, or
+deciding when a request should stay in the normal Khala/Codex path. Separate
+backend work is adding Apple Foundation Models and self-hosted GPT-OSS lanes.
+This ADR records the decision boundary for using those lanes as an optional
+on-device decider without making Khala Code depend on either backend.
+
+This decision is only about the decider contract and platform selection. It
+does not implement Apple FM serving, GPT-OSS serving, model downloads,
+evaluation claims, or coding-agent parity.
+
+## Decision Drivers
+
+* Keep Khala Code usable when no local small-model backend is installed.
+* Preserve Apple FM as the local Apple-platform backend without claiming Codex
+  parity.
+* Preserve self-hosted GPT-OSS as the non-Mac local backend without making it a
+  public model alias or spend path.
+* Make platform selection testable and explicit.
+* Keep backend implementations pluggable behind a narrow interface.
+* Fail soft to the normal Khala Code path when the decider is disabled,
+  unsupported, unavailable, or unhealthy.
+
+## Considered Options
+
+* Optional on-device decider with platform-selected pluggable backends.
+* Always require a local decider before Khala Code can run.
+* Use one backend family on every platform.
+* Let each backend invent its own platform detection and request interface.
+
+## Decision Outcome
+
+Chosen option: "Optional on-device decider with platform-selected pluggable
+backends", because it lets Khala Code use local small-model help where it is
+available while keeping the product path independent from Apple FM and GPT-OSS
+availability.
+
+The accepted contract is:
+
+* The decider is off by default. Operators must explicitly opt in before any
+  local small-model backend is selected.
+* Apple platforms select the Apple FM decider backend when Apple FM is
+  available. Bun/Node `darwin` normalizes to `macos`; native iOS clients pass
+  `ios` explicitly.
+* Non-Mac desktop platforms select a self-hosted GPT-OSS decider backend when
+  the local GPT-OSS service is available.
+* Unsupported platforms, disabled flags, missing helpers, failed health checks,
+  and backend errors are soft unavailability states. They must fall back to the
+  normal Khala Code route.
+* Backend adapters implement the pluggable
+  `khala-code-on-device-decider-v1` interface. The selector returns a backend
+  identity and kind; it does not construct or call backend services.
+
+### Consequences
+
+* Good, because Khala Code can opportunistically use local compute without a
+  hard dependency.
+* Good, because Apple FM and GPT-OSS backend PRs can implement adapters behind
+  the same interface.
+* Good, because platform behavior is covered by focused tests before any model
+  serving code is wired in.
+* Bad, because an opt-in decider adds another readiness state operators must
+  surface and diagnose.
+* Bad, because decider quality remains bounded by the backend and eval gates;
+  this ADR does not prove model quality.
+
+### Confirmation
+
+Compliance is confirmed by code review and focused tests for
+`clients/khala-code-desktop/src/shared/on-device-decider.ts`. Future backend PRs
+must preserve the same default-off, platform-selection, and fail-soft behavior
+when adding Apple FM or GPT-OSS adapters.
+
+## Pros and Cons of the Options
+
+### Optional on-device decider with platform-selected pluggable backends
+
+* Good, because it matches the repository posture for local Apple FM readiness
+  and native Khala tooling.
+* Good, because it lets each platform use the local backend that naturally fits
+  that environment.
+* Good, because the selector is pure and testable without model spend.
+* Bad, because it requires the UI/control plane to represent disabled,
+  unsupported, unavailable, and ready as separate states.
+
+### Always require a local decider before Khala Code can run
+
+* Good, because every run would have one uniform local preflight path.
+* Bad, because it would break Khala Code on machines without Apple FM or a
+  self-hosted GPT-OSS service.
+* Bad, because it would turn an optimization into a product dependency.
+
+### Use one backend family on every platform
+
+* Good, because the routing table would be smaller.
+* Bad, because Apple FM is the native Apple-platform path and self-hosted
+  GPT-OSS is the portable non-Mac path.
+* Bad, because forcing either backend everywhere would increase setup burden
+  and make unsupported states less truthful.
+
+### Let each backend invent its own platform detection and request interface
+
+* Good, because backend implementers could move quickly in isolation.
+* Bad, because Khala Code would have duplicated detection, inconsistent
+  fallback behavior, and more ways to accidentally create a hard dependency.
+
+## More Information
+
+* `clients/khala-code-desktop/src/shared/on-device-decider.ts`
+* `clients/khala-code-desktop/tests/on-device-decider.test.ts`
+* `clients/khala-macos/src/launch-plan.ts`
+* `docs/desktop/2026-06-28-khala-desktop-spec.md`
+* `docs/adr/0011-ship-khala-mobile-as-native-swiftui-with-local-apple-tooling.md`
+* `docs/adr/0012-adopt-khala-native-terminal-tool-runtime.md`

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -35,3 +35,4 @@ records. They provide a stable decision log that links those sources together.
 * [ADR-0010: Separate Spark agent payments from MDK checkouts](0010-separate-spark-agent-payments-from-mdk-checkouts.md)
 * [ADR-0011: Ship Khala mobile as native SwiftUI with local Apple tooling](0011-ship-khala-mobile-as-native-swiftui-with-local-apple-tooling.md)
 * [ADR-0012: Adopt a native Khala terminal tool runtime](0012-adopt-khala-native-terminal-tool-runtime.md)
+* [ADR-0013: Adopt an optional Khala Code on-device decider](0013-adopt-optional-khala-code-on-device-decider.md)


### PR DESCRIPTION
Automated OpenAgents Pylon Codex assignment change.

### Changes
- `clients/khala-code-desktop/src/shared/on-device-decider.ts`
- `clients/khala-code-desktop/tests/on-device-decider.test.ts`
- `docs/adr/0013-adopt-optional-khala-code-on-device-decider.md`
- `docs/adr/README.md`

### Verification
```
bun scripts/check-conflict-markers.mjs
```
Passed locally (exit 0).