### PR TITLE
feat(forge): add GitHub mirror receipts

### DIFF
--- a/apps/forge/src/index.test.ts
+++ b/apps/forge/src/index.test.ts
@@ -29,7 +29,7 @@ describe("Forge UI Worker", () => {
     expect(html).toContain("--forge-energy")
   })
 
-  it("defines shell routes for dogfood, work, changes, verification, queue, and refs", () => {
+  it("defines shell routes for dogfood, work, changes, verification, queue, mirrors, and refs", () => {
     expect(forgeShellRoutes.map(route => route.path)).toEqual([
       "/",
       "/dogfood",
@@ -37,6 +37,7 @@ describe("Forge UI Worker", () => {
       "/changes",
       "/verification",
       "/queue",
+      "/mirrors",
       "/refs",
     ])
     expect(forgeShellRoutes.map(route => route.apiPath)).toEqual([
@@ -46,6 +47,7 @@ describe("Forge UI Worker", () => {
       "/api/forge/changes",
       "/api/forge/verification-receipts",
       "/api/forge/queue",
+      "/api/forge/github-mirror",
       "/api/forge/refs",
     ])
     expect(resolveForgeShellRoute("/work/")?.id).toBe("work")
@@ -84,6 +86,9 @@ describe("Forge UI Worker", () => {
     expect(body.preview.apiBasePath).toBe("/api/forge")
     expect(body.preview.dogfoodLanes).toHaveLength(1)
     expect(body.preview.dogfoodLanes[0]?.issueRef).toBe("#6797")
+    expect(body.preview.mirrors[0]?.mirrorRef).toBe(
+      "mirror.github.openagents.main.su6",
+    )
   })
 
   it("renders a direct route shell without the old logged-in Forge page", () => {
@@ -117,6 +122,15 @@ describe("Forge UI Worker", () => {
     expect(html).toContain(OPENAGENTS_FORGE_DEFAULT_BRANCH_REF)
     expect(html).toContain("OpenAgentsInc/openagents default branch")
     expect(html).toContain("/api/forge/refs live canonical store")
+  })
+
+  it("renders the GitHub mirror receipt surface", () => {
+    const html = renderForgeShellHtml("mirrors")
+
+    expect(html).toContain('data-forge-route="mirrors"')
+    expect(html).toContain("GitHub Mirror Receipts")
+    expect(html).toContain("mirror.github.openagents.main.su6")
+    expect(html).toContain("/api/forge/github-mirror surfaces refused or failed receipts")
   })
 
   it("reports health without claiming any coordination authority", async () => {

--- a/apps/forge/src/index.ts
+++ b/apps/forge/src/index.ts
@@ -41,6 +41,7 @@ export const ForgeShellRouteId = Schema.Literals([
   "changes",
   "verification",
   "queue",
+  "mirrors",
   "refs",
 ])
 export type ForgeShellRouteId = typeof ForgeShellRouteId.Type
@@ -96,6 +97,13 @@ export const forgeShellRoutes: ReadonlyArray<ForgeShellRoute> = [
     label: "Merge Queue",
     summary: "virtual heads, gate state, and next promotion",
     apiPath: "/api/forge/queue",
+  },
+  {
+    id: "mirrors",
+    path: "/mirrors",
+    label: "Mirrors",
+    summary: "GitHub mirror receipts and attention state",
+    apiPath: "/api/forge/github-mirror",
   },
   {
     id: "refs",
@@ -157,6 +165,16 @@ export const ForgeShellRefItem = Schema.Struct({
 })
 export type ForgeShellRefItem = typeof ForgeShellRefItem.Type
 
+export const ForgeShellMirrorItem = Schema.Struct({
+  mirrorRef: Schema.String,
+  promotionRef: Schema.String,
+  commit: Schema.String,
+  destination: Schema.String,
+  status: Schema.String,
+  attention: Schema.String,
+})
+export type ForgeShellMirrorItem = typeof ForgeShellMirrorItem.Type
+
 export const ForgeShellDogfoodLane = Schema.Struct({
   laneRef: Schema.String,
   issueRef: Schema.String,
@@ -188,6 +206,7 @@ export const ForgeShellSnapshot = Schema.Struct({
   changes: Schema.Array(ForgeShellChangeItem),
   verification: Schema.Array(ForgeShellVerificationItem),
   mergeQueue: Schema.Array(ForgeShellQueueItem),
+  mirrors: Schema.Array(ForgeShellMirrorItem),
   refs: Schema.Array(ForgeShellRefItem),
 })
 export type ForgeShellSnapshot = typeof ForgeShellSnapshot.Type
@@ -337,6 +356,16 @@ export const forgeShellPreviewState: ForgeShellSnapshot = {
       actualHead: "refs/heads/main",
       gate: "awaiting SU-2 implementation",
       state: "not-promotable",
+    },
+  ],
+  mirrors: [
+    {
+      mirrorRef: "mirror.github.openagents.main.su6",
+      promotionRef: "promotion.forge.su7.su4-blueprint-gated",
+      commit: "pending-first-promoted-head",
+      destination: "OpenAgentsInc/openagents refs/heads/main",
+      status: "waiting-for-approved-promotion",
+      attention: "GET /api/forge/github-mirror surfaces refused or failed receipts",
     },
   ],
   refs: [
@@ -920,6 +949,10 @@ const renderOverview = (): string => `<section class="forge-grid">
     <span class="forge-metric-label">ref namespaces split between Forge authority and GitHub mirror projection</span>
   </article>
   <article class="forge-metric">
+    <span class="forge-metric-value">${forgeShellPreviewState.mirrors.length}</span>
+    <span class="forge-metric-label">GitHub mirror receipt surface wired downstream of Forge promotion</span>
+  </article>
+  <article class="forge-metric">
     <span class="forge-metric-value">${forgeShellPreviewState.dogfoodLanes.length}</span>
     <span class="forge-metric-label">SU-7 Codex/Pylon dogfood lane prepared for Forge-only coordination</span>
   </article>
@@ -1200,6 +1233,41 @@ const renderQueue = (): string => `<section class="forge-panel" data-span="wide"
   </div>
 </section>`
 
+const renderMirrors = (): string => `<section class="forge-panel" data-span="wide">
+  <div class="forge-panel-head">
+    <h3 class="forge-panel-title">GitHub Mirror Receipts</h3>
+    <span class="forge-table-caption">${forgeShellPreviewState.mirrors.length} receipts</span>
+  </div>
+  <div class="forge-table-wrap">
+    <table class="forge-table">
+      <thead>
+        <tr>
+          <th>Mirror</th>
+          <th>Promotion</th>
+          <th>Commit</th>
+          <th>Destination</th>
+          <th>Status</th>
+          <th>Attention</th>
+        </tr>
+      </thead>
+      <tbody>
+        ${forgeShellPreviewState.mirrors
+          .map(
+            item => `<tr>
+              <td class="forge-code">${escapeHtml(item.mirrorRef)}</td>
+              <td>${escapeHtml(item.promotionRef)}</td>
+              <td class="forge-code">${escapeHtml(item.commit)}</td>
+              <td>${escapeHtml(item.destination)}</td>
+              <td>${renderStatus(item.status)}</td>
+              <td class="forge-muted">${escapeHtml(item.attention)}</td>
+            </tr>`,
+          )
+          .join("\n")}
+      </tbody>
+    </table>
+  </div>
+</section>`
+
 const renderRefs = (): string => `<section class="forge-panel" data-span="wide">
   <div class="forge-panel-head">
     <h3 class="forge-panel-title">Canonical Refs</h3>
@@ -1245,6 +1313,8 @@ const renderRouteContent = (routeId: ForgeShellRouteId): string => {
       return renderVerification()
     case "queue":
       return renderQueue()
+    case "mirrors":
+      return renderMirrors()
     case "refs":
       return renderRefs()
     case "overview":

--- a/apps/openagents.com/workers/api/migrations/0260_forge_github_mirror_receipts.sql
+++ b/apps/openagents.com/workers/api/migrations/0260_forge_github_mirror_receipts.sql
@@ -1,0 +1,44 @@
+-- FORGE SU-6 (#6796): GitHub mirror receipts for Forge-promoted commits.
+--
+-- GitHub is a downstream read-only mirror. These rows record the mirror worker's
+-- one-way attempt from a Forge promotion/canonical ref to the configured GitHub
+-- branch. They carry refs, bounded status, public commit ids, and redacted
+-- refusal/error reasons only; they never contain GitHub tokens, raw packfiles,
+-- raw source, private repository contents, local paths, provider payloads,
+-- prompts, wallet material, or payment material.
+
+CREATE TABLE IF NOT EXISTS forge_github_mirror_receipts (
+  tenant_ref TEXT NOT NULL,
+  mirror_ref TEXT NOT NULL,
+  promotion_ref TEXT NOT NULL,
+  change_ref TEXT NOT NULL,
+  repository_ref TEXT NOT NULL,
+  source_canonical_ref TEXT NOT NULL,
+  destination_github_repository TEXT NOT NULL,
+  destination_github_ref TEXT NOT NULL,
+  commit_id TEXT NOT NULL,
+  status TEXT NOT NULL CHECK (status IN ('mirrored', 'refused', 'failed')),
+  attempt_count INTEGER NOT NULL DEFAULT 1 CHECK (attempt_count >= 1),
+  first_attempted_at TEXT NOT NULL,
+  last_attempted_at TEXT NOT NULL,
+  completed_at TEXT,
+  refusal_reason TEXT,
+  error_reason TEXT,
+  source_refs_json TEXT NOT NULL DEFAULT '[]',
+  redacted INTEGER NOT NULL DEFAULT 1 CHECK (redacted = 1),
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  PRIMARY KEY (tenant_ref, mirror_ref),
+  UNIQUE (
+    tenant_ref,
+    promotion_ref,
+    destination_github_repository,
+    destination_github_ref
+  )
+);
+
+CREATE INDEX IF NOT EXISTS idx_forge_github_mirror_receipts_promotion
+  ON forge_github_mirror_receipts (tenant_ref, promotion_ref, updated_at);
+
+CREATE INDEX IF NOT EXISTS idx_forge_github_mirror_receipts_status
+  ON forge_github_mirror_receipts (tenant_ref, status, updated_at);

--- a/apps/openagents.com/workers/api/src/config.ts
+++ b/apps/openagents.com/workers/api/src/config.ts
@@ -428,6 +428,7 @@ export type OpenAgentsWorkerConfigEnv = Readonly<{
   OPENAGENTS_SPARK_API_KEY?: string | undefined
   OPENAGENTS_ADMIN_API_TOKEN?: string | undefined
   OPENAGENTS_FORGE_CONTROL_PLANE_TOKEN?: string | undefined
+  OPENAGENTS_FORGE_GITHUB_MIRROR_TOKEN?: string | undefined
   OPENAGENTS_APP_URL?: string | undefined
   OPENAUTH_CLIENT_ID?: string | undefined
   OPENAUTH_ISSUER_URL?: string | undefined
@@ -616,6 +617,7 @@ export type OpenAgentsWorkerConfigShape = Readonly<{
   }>
   exa: ExaConfig
   forgeControlPlaneToken?: Redacted.Redacted<WorkerSecret> | undefined
+  forgeGithubMirrorToken?: Redacted.Redacted<WorkerSecret> | undefined
   github: Readonly<{
     clientId: GitHubClientId
     clientSecret: Redacted.Redacted<WorkerSecret>
@@ -1340,6 +1342,10 @@ export const decodeOpenAgentsWorkerConfig = (
       forgeControlPlaneToken: optionalRedacted(
         env,
         'OPENAGENTS_FORGE_CONTROL_PLANE_TOKEN',
+      ),
+      forgeGithubMirrorToken: optionalRedacted(
+        env,
+        'OPENAGENTS_FORGE_GITHUB_MIRROR_TOKEN',
       ),
       github: {
         clientId: GitHubClientId.make(

--- a/apps/openagents.com/workers/api/src/forge-control-plane-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/forge-control-plane-routes.test.ts
@@ -13,6 +13,10 @@ import {
   type ForgeCoordinationStore,
 } from './forge-coordination-store'
 import {
+  makeD1ForgeGitHubMirrorStore,
+  type ForgeGitHubMirrorStore,
+} from './forge-github-mirror-store'
+import {
   makeD1ForgeGitCanonicalStore,
   type ForgeGitCanonicalStore,
 } from './forge-git-canonical-store'
@@ -70,6 +74,13 @@ const promotionDecisionGateResultsMigration = readFileSync(
   ),
   'utf8',
 )
+const githubMirrorReceiptsMigration = readFileSync(
+  new URL(
+    '../migrations/0260_forge_github_mirror_receipts.sql',
+    import.meta.url,
+  ),
+  'utf8',
+)
 const canonicalGitMigration = readFileSync(
   new URL('../migrations/0255_forge_git_canonical_store.sql', import.meta.url),
   'utf8',
@@ -78,17 +89,20 @@ const canonicalGitMigration = readFileSync(
 const makeStores = (): Readonly<{
   canonicalStore: ForgeGitCanonicalStore
   coordinationStore: ForgeCoordinationStore
+  mirrorStore: ForgeGitHubMirrorStore
 }> => {
   const db = new DatabaseSync(':memory:')
   db.exec('PRAGMA foreign_keys = ON')
   db.exec(coordinationMigration)
   db.exec(controlPlaneReceiptsMigration)
   db.exec(promotionDecisionGateResultsMigration)
+  db.exec(githubMirrorReceiptsMigration)
   db.exec(canonicalGitMigration)
   const d1 = new SqliteD1(db) as unknown as D1Database
   return {
     canonicalStore: makeD1ForgeGitCanonicalStore(d1),
     coordinationStore: makeD1ForgeCoordinationStore(d1),
+    mirrorStore: makeD1ForgeGitHubMirrorStore(d1),
   }
 }
 
@@ -118,6 +132,43 @@ const makeGitHubFetch = (sha: string = githubMainSha): typeof fetch =>
       },
     })) as typeof fetch
 
+const makeMirrorGitHubFetch = (
+  input: Readonly<{ currentSha?: string; updateStatus?: number }> = {},
+) => {
+  const calls: Array<Readonly<{ body: string | null; method: string; url: string }>> =
+    []
+  const fetchMock = (async (url: RequestInfo | URL, init?: RequestInit) => {
+    const target = String(url)
+    const method = init?.method ?? 'GET'
+    calls.push({
+      body: typeof init?.body === 'string' ? init.body : null,
+      method,
+      url: target,
+    })
+
+    if (method === 'PATCH') {
+      return Response.json(
+        {
+          ref: 'refs/heads/main',
+          object: { sha: headB, type: 'commit' },
+        },
+        { status: input.updateStatus ?? 200 },
+      )
+    }
+
+    return Response.json({
+      ref: 'refs/heads/main',
+      object: {
+        sha: input.currentSha ?? headA,
+        type: 'commit',
+        url: `https://api.github.com/repos/OpenAgentsInc/openagents/git/commits/${input.currentSha ?? headA}`,
+      },
+    })
+  }) as typeof fetch
+
+  return { calls, fetchMock }
+}
+
 type JsonRequestInit = Omit<RequestInit, 'body'> & Readonly<{ json?: unknown }>
 
 const requestJson = (
@@ -133,14 +184,24 @@ const requestJson = (
     },
   })
 
-const makeHarness = () => {
-  const { canonicalStore, coordinationStore } = makeStores()
+const makeHarness = (
+  input: Readonly<{
+    fetch?: typeof fetch
+    mirrorGitHubToken?: string | undefined
+  }> = {},
+) => {
+  const { canonicalStore, coordinationStore, mirrorStore } = makeStores()
   const routes = makeForgeControlPlaneRoutes({
     authorizeControlPlaneBearer: (request, _env, scope) =>
       authorizeForgeControlPlaneBearer(request, controlPlaneToken, scope),
-    fetch: makeGitHubFetch(),
+    fetch: input.fetch ?? makeGitHubFetch(),
     makeCanonicalStore: () => canonicalStore,
+    makeGitHubMirrorStore: () => mirrorStore,
     makeStore: () => coordinationStore,
+    mirrorGitHubToken: () =>
+      Object.prototype.hasOwnProperty.call(input, 'mirrorGitHubToken')
+        ? input.mirrorGitHubToken
+        : 'github-mirror-token',
     nowIso: () => now,
     requireAdminApiToken: () => Promise.resolve(false),
   })
@@ -154,7 +215,7 @@ const makeHarness = () => {
     return Effect.runPromise(effect)
   }
 
-  return { canonicalStore, run, store: coordinationStore }
+  return { canonicalStore, mirrorStore, run, store: coordinationStore }
 }
 
 const createForgeWork = async (
@@ -252,6 +313,86 @@ const createPassingVerification = async (
     }),
   )
   expect(response.status).toBe(201)
+}
+
+const createPromotionDecision = async (
+  run: (request: Request) => Promise<Response>,
+  input: Readonly<{
+    baseHead: string
+    decision?: 'approved' | 'blocked'
+    headHead: string
+    issueNumber: number
+    scopes: string
+    verificationRef?: string | null
+  }>,
+): Promise<void> => {
+  const response = await run(
+    requestJson('/api/forge/promotion-decisions', {
+      json: {
+        schema: 'openagents.forge.promotion.decision.v0.1',
+        tenant_ref: 'tenant.openagents',
+        promotion_ref: `promotion.forge.${input.issueNumber}`,
+        queue_ref: 'queue.forge.openagents.main',
+        queue_position: 0,
+        change_ref: `change.forge.${input.issueNumber}`,
+        decision: input.decision ?? 'approved',
+        target_ref: 'refs/heads/main',
+        base_head: input.baseHead,
+        candidate_head: input.headHead,
+        promoted_head:
+          (input.decision ?? 'approved') === 'approved' ? input.headHead : null,
+        verification_ref: Object.prototype.hasOwnProperty.call(
+          input,
+          'verificationRef',
+        )
+          ? input.verificationRef
+          : `verification.forge.${input.issueNumber}`,
+        gate_refs: ['gate.tests'],
+        gate_results: [
+          {
+            gate_ref: 'gate.tests',
+            verdict: (input.decision ?? 'approved') === 'approved' ? 'passed' : 'blocked',
+            evidence_refs: [`verification.forge.${input.issueNumber}`],
+            blocker_refs:
+              (input.decision ?? 'approved') === 'approved'
+                ? []
+                : ['blocker.forge.test'],
+            decided_at: '2026-06-28T17:03:00.000Z',
+          },
+        ],
+        blocker_refs:
+          (input.decision ?? 'approved') === 'approved'
+            ? []
+            : ['blocker.forge.test'],
+        decided_by_ref: 'agent.public.forge',
+        decided_at: '2026-06-28T17:03:00.000Z',
+        source_refs: [`github:OpenAgentsInc/openagents#${input.issueNumber}`],
+        redacted: true,
+      },
+      headers: authHeaders(input.scopes),
+      method: 'POST',
+    }),
+  )
+  expect(response.status).toBe(201)
+}
+
+const importCanonicalMain = async (
+  canonicalStore: ForgeGitCanonicalStore,
+  objectId: string,
+): Promise<void> => {
+  await canonicalStore.importExternalRef({
+    changeRef: `change.forge.promoted.${objectId.slice(0, 12)}`,
+    objectFormat: 'sha1',
+    objectId,
+    packfileRef: `packfile.forge.promoted.${objectId.slice(0, 12)}`,
+    receivePackRef: `receive-pack.forge.promoted.${objectId.slice(0, 12)}`,
+    refName: 'refs/heads/main',
+    repositoryRef: 'repo.openagents.openagents',
+    sourceDigestSha256: `digest.${objectId}`,
+    sourceRefs: ['github:OpenAgentsInc/openagents#6796'],
+    tenantRef: 'tenant.openagents',
+    nowIso: now,
+  })
 }
 
 describe('Forge control-plane routes', () => {
@@ -509,6 +650,222 @@ describe('Forge control-plane routes', () => {
       promotionDecisions: ReadonlyArray<unknown>
     }
     expect(decisionsBody.promotionDecisions).toHaveLength(1)
+  })
+
+  test('mirrors only a Forge-approved canonical promotion to GitHub and reruns idempotently', async () => {
+    const github = makeMirrorGitHubFetch({ currentSha: headA })
+    const { canonicalStore, run } = makeHarness({ fetch: github.fetchMock })
+    const scopes = [
+      'forge:work:write',
+      'forge:change:write',
+      'forge:receipt:write',
+      'forge:promotion:decide',
+      'forge:mirror:read',
+      'forge:mirror:write',
+    ].join(' ')
+
+    await createForgeWork(run, 6796, scopes)
+    await createForgeChange(run, {
+      baseHead: headA,
+      issueNumber: 6796,
+      patchHead: headB,
+      scopes,
+      verificationRef: 'verification.forge.6796',
+    })
+    await createPassingVerification(run, {
+      baseHead: headA,
+      changeRef: 'change.forge.6796',
+      headHead: headB,
+      scopes,
+      verificationRef: 'verification.forge.6796',
+    })
+    await createPromotionDecision(run, {
+      baseHead: headA,
+      headHead: headB,
+      issueNumber: 6796,
+      scopes,
+    })
+    await importCanonicalMain(canonicalStore, headB)
+
+    const response = await run(
+      requestJson('/api/forge/github-mirror/run', {
+        json: {
+          tenantRef: 'tenant.openagents',
+          promotionRef: 'promotion.forge.6796',
+        },
+        headers: authHeaders(scopes),
+        method: 'POST',
+      }),
+    )
+    const body = (await response.json()) as {
+      attention: { state: string }
+      mirrorReceipts: ReadonlyArray<{
+        attempt_count: number
+        commit_id: string
+        destination_github_ref: string
+        status: string
+      }>
+      mirroredCount: number
+    }
+
+    expect(response.status).toBe(200)
+    expect(body.mirroredCount).toBe(1)
+    expect(body.attention.state).toBe('clear')
+    expect(body.mirrorReceipts[0]).toMatchObject({
+      attempt_count: 1,
+      commit_id: headB,
+      destination_github_ref: 'refs/heads/main',
+      status: 'mirrored',
+    })
+    expect(github.calls.map(call => call.method)).toEqual(['GET', 'PATCH'])
+    expect(github.calls.find(call => call.method === 'PATCH')?.body).toBe(
+      JSON.stringify({ force: false, sha: headB }),
+    )
+
+    const rerunResponse = await run(
+      requestJson('/api/forge/github-mirror/run', {
+        json: {
+          tenantRef: 'tenant.openagents',
+          promotionRef: 'promotion.forge.6796',
+        },
+        headers: authHeaders(scopes),
+        method: 'POST',
+      }),
+    )
+    const rerunBody = (await rerunResponse.json()) as {
+      mirrorReceipts: ReadonlyArray<{ attempt_count: number; status: string }>
+    }
+
+    expect(rerunResponse.status).toBe(200)
+    expect(rerunBody.mirrorReceipts[0]).toMatchObject({
+      attempt_count: 1,
+      status: 'mirrored',
+    })
+    expect(github.calls.map(call => call.method)).toEqual(['GET', 'PATCH'])
+
+    const listResponse = await run(
+      new Request(
+        'https://openagents.com/api/forge/github-mirror?tenantRef=tenant.openagents&promotionRef=promotion.forge.6796',
+        { headers: authHeaders(scopes) },
+      ),
+    )
+    const listBody = (await listResponse.json()) as {
+      mirrorReceipts: ReadonlyArray<unknown>
+    }
+    expect(listResponse.status).toBe(200)
+    expect(listBody.mirrorReceipts).toHaveLength(1)
+  })
+
+  test('refuses non-promoted changes without touching GitHub', async () => {
+    const github = makeMirrorGitHubFetch()
+    const { run } = makeHarness({ fetch: github.fetchMock })
+    const scopes = [
+      'forge:promotion:decide',
+      'forge:mirror:write',
+    ].join(' ')
+
+    await createPromotionDecision(run, {
+      baseHead: headA,
+      decision: 'blocked',
+      headHead: headB,
+      issueNumber: 6796,
+      scopes,
+      verificationRef: null,
+    })
+
+    const response = await run(
+      requestJson('/api/forge/github-mirror/run', {
+        json: {
+          tenantRef: 'tenant.openagents',
+          promotionRef: 'promotion.forge.6796',
+        },
+        headers: authHeaders(scopes),
+        method: 'POST',
+      }),
+    )
+    const body = (await response.json()) as {
+      attention: { reasonRefs: ReadonlyArray<string>; state: string }
+      mirrorReceipts: ReadonlyArray<{ refusal_reason: string; status: string }>
+      refusedCount: number
+    }
+
+    expect(response.status).toBe(200)
+    expect(body.refusedCount).toBe(1)
+    expect(body.attention.state).toBe('needs_attention')
+    expect(body.attention.reasonRefs).toContain(
+      'forge_github_mirror_requires_approved_promotion',
+    )
+    expect(body.mirrorReceipts[0]).toMatchObject({
+      refusal_reason: 'forge_github_mirror_requires_approved_promotion',
+      status: 'refused',
+    })
+    expect(github.calls).toHaveLength(0)
+  })
+
+  test('records failed mirror attempts without advancing GitHub state', async () => {
+    const github = makeMirrorGitHubFetch({
+      currentSha: headA,
+      updateStatus: 422,
+    })
+    const { canonicalStore, run } = makeHarness({ fetch: github.fetchMock })
+    const scopes = [
+      'forge:work:write',
+      'forge:change:write',
+      'forge:receipt:write',
+      'forge:promotion:decide',
+      'forge:mirror:write',
+    ].join(' ')
+
+    await createForgeWork(run, 6796, scopes)
+    await createForgeChange(run, {
+      baseHead: headA,
+      issueNumber: 6796,
+      patchHead: headB,
+      scopes,
+      verificationRef: 'verification.forge.6796',
+    })
+    await createPassingVerification(run, {
+      baseHead: headA,
+      changeRef: 'change.forge.6796',
+      headHead: headB,
+      scopes,
+      verificationRef: 'verification.forge.6796',
+    })
+    await createPromotionDecision(run, {
+      baseHead: headA,
+      headHead: headB,
+      issueNumber: 6796,
+      scopes,
+    })
+    await importCanonicalMain(canonicalStore, headB)
+
+    const response = await run(
+      requestJson('/api/forge/github-mirror/run', {
+        json: {
+          tenantRef: 'tenant.openagents',
+          promotionRef: 'promotion.forge.6796',
+        },
+        headers: authHeaders(scopes),
+        method: 'POST',
+      }),
+    )
+    const body = (await response.json()) as {
+      attention: { reasonRefs: ReadonlyArray<string>; state: string }
+      failedCount: number
+      mirrorReceipts: ReadonlyArray<{ error_reason: string; status: string }>
+    }
+
+    expect(response.status).toBe(200)
+    expect(body.failedCount).toBe(1)
+    expect(body.attention.state).toBe('needs_attention')
+    expect(body.attention.reasonRefs).toContain(
+      'forge_github_mirror_ref_update_http_422',
+    )
+    expect(body.mirrorReceipts[0]).toMatchObject({
+      error_reason: 'forge_github_mirror_ref_update_http_422',
+      status: 'failed',
+    })
+    expect(github.calls.map(call => call.method)).toEqual(['GET', 'PATCH'])
   })
 
   test('derives nextActualPromotion from live Forge rows and serializes concurrent changes', async () => {

--- a/apps/openagents.com/workers/api/src/forge-control-plane-routes.ts
+++ b/apps/openagents.com/workers/api/src/forge-control-plane-routes.ts
@@ -2,6 +2,8 @@ import {
   ForgeCoordinationChangeState,
   ForgeCoordinationIssueState,
   ForgeCoordinationStatusState,
+  ForgeGitHubMirrorReceipt,
+  ForgeGitHubMirrorStatus,
   ForgeMergeQueueLedgerState,
   ForgePromotionDecisionReceipt,
   ForgeVerificationReceipt,
@@ -14,6 +16,9 @@ import { timingSafeEqual } from './agent-registration'
 import {
   type ForgeCoordinationStore,
 } from './forge-coordination-store'
+import type {
+  ForgeGitHubMirrorStore,
+} from './forge-github-mirror-store'
 import type {
   ForgeGitCanonicalStore,
 } from './forge-git-canonical-store'
@@ -32,6 +37,8 @@ const OPENAGENTS_GITHUB_OWNER = 'OpenAgentsInc'
 const OPENAGENTS_GITHUB_REPO = 'openagents'
 const OPENAGENTS_DEFAULT_BRANCH_REF = 'refs/heads/main'
 
+const OPENAGENTS_GITHUB_REPOSITORY = `${OPENAGENTS_GITHUB_OWNER}/${OPENAGENTS_GITHUB_REPO}`
+
 export type ForgeControlPlaneAuth = Readonly<{
   mode: 'admin' | 'control_plane'
   subjectRef: string
@@ -49,7 +56,9 @@ type ForgeControlPlaneRouteDependencies<Bindings> = Readonly<{
   authorizeControlPlaneBearer?: ForgeControlPlaneAuthorize<Bindings> | undefined
   fetch?: typeof fetch
   makeCanonicalStore: (env: Bindings) => ForgeGitCanonicalStore
+  makeGitHubMirrorStore: (env: Bindings) => ForgeGitHubMirrorStore
   makeStore: (env: Bindings) => ForgeCoordinationStore
+  mirrorGitHubToken?: (env: Bindings) => string | undefined
   nowIso?: () => string
   requireAdminApiToken?: (request: Request, env: Bindings) => Promise<boolean>
 }>
@@ -126,6 +135,11 @@ const ForgeMergeQueueDeriveRequest = S.Struct({
   queueRef: S.String,
   actualHead: S.String,
   sourceRefs: S.optionalKey(S.Array(S.String)),
+})
+
+const ForgeGitHubMirrorRunRequest = S.Struct({
+  tenantRef: S.String,
+  promotionRef: S.optionalKey(S.String),
 })
 
 const ForgeOpenAgentsImportRequest = S.Struct({
@@ -958,6 +972,68 @@ const routePromotionDecisions = async <Bindings>(
   return noStoreJsonResponse({ promotionDecision }, { status: 201 })
 }
 
+const forgeGitHubMirrorStatusFromQuery = (
+  url: URL,
+): typeof ForgeGitHubMirrorStatus.Type | undefined => {
+  const status = optionalQuery(url, 'status')
+
+  if (status === undefined) {
+    return undefined
+  }
+
+  try {
+    return decodeUnknownWithSchema(ForgeGitHubMirrorStatus, status)
+  } catch {
+    throw new ForgeControlPlaneHttpError(
+      400,
+      'forge_github_mirror_bad_status_filter',
+    )
+  }
+}
+
+const forgeGitHubMirrorAttention = (
+  receipts: ReadonlyArray<ForgeGitHubMirrorReceipt>,
+) => {
+  const reasonRefs = receipts
+    .filter(receipt => receipt.status === 'failed' || receipt.status === 'refused')
+    .map(receipt => receipt.refusal_reason ?? receipt.error_reason)
+    .filter((reason): reason is string => reason !== null)
+
+  return {
+    receiptRefs: receipts.map(receipt => receipt.mirror_ref),
+    reasonRefs,
+    state: reasonRefs.length > 0 ? 'needs_attention' : 'clear',
+  }
+}
+
+const routeGitHubMirrorReceipts = async <Bindings>(
+  dependencies: ForgeControlPlaneRouteDependencies<Bindings>,
+  request: Request,
+  env: Bindings,
+  url: URL,
+) => {
+  if (request.method !== 'GET') {
+    return methodNotAllowed(['GET'])
+  }
+
+  const tenantRef = tenantRefFromQuery(url)
+  await requireScope(dependencies, request, env, 'forge:mirror:read', tenantRef)
+  const mirrorReceipts = await dependencies
+    .makeGitHubMirrorStore(env)
+    .listReceipts(tenantRef, {
+      limit: limitFromQuery(url),
+      promotionRef: optionalQuery(url, 'promotionRef'),
+      status: forgeGitHubMirrorStatusFromQuery(url),
+    })
+
+  return noStoreJsonResponse({
+    attention: forgeGitHubMirrorAttention(mirrorReceipts),
+    limit: limitFromQuery(url),
+    mirrorReceipts,
+    tenantRef,
+  })
+}
+
 const sha256Hex = async (value: string): Promise<string> => {
   const bytes = await crypto.subtle.digest(
     'SHA-256',
@@ -1001,6 +1077,389 @@ const readGitHubMainTip = async <Bindings>(
     objectId,
     sourceUrl: typeof body.object?.url === 'string' ? body.object.url : url,
   }
+}
+
+class ForgeGitHubMirrorApiError extends Error {
+  constructor(readonly errorCode: string) {
+    super(errorCode)
+    this.name = 'ForgeGitHubMirrorApiError'
+  }
+}
+
+type ForgeGitHubMirrorDestination = Readonly<{
+  branchApiRef: string
+  githubRepository: string
+  githubRef: string
+  owner: string
+  repo: string
+}>
+
+const openAgentsGitHubMirrorDestination = (): ForgeGitHubMirrorDestination => ({
+  branchApiRef: 'heads/main',
+  githubRepository: OPENAGENTS_GITHUB_REPOSITORY,
+  githubRef: OPENAGENTS_DEFAULT_BRANCH_REF,
+  owner: OPENAGENTS_GITHUB_OWNER,
+  repo: OPENAGENTS_GITHUB_REPO,
+})
+
+const githubMirrorHeaders = (
+  token: string,
+  contentType: boolean = false,
+): HeadersInit => ({
+  accept: 'application/vnd.github+json',
+  authorization: `Bearer ${token}`,
+  ...(contentType ? { 'content-type': 'application/json' } : {}),
+  'user-agent': 'openagents-forge-github-mirror',
+  'x-github-api-version': '2022-11-28',
+})
+
+const readGitHubDestinationHead = async <Bindings>(
+  dependencies: ForgeControlPlaneRouteDependencies<Bindings>,
+  destination: ForgeGitHubMirrorDestination,
+  token: string,
+): Promise<string> => {
+  const response = await (dependencies.fetch ?? fetch)(
+    `https://api.github.com/repos/${encodeURIComponent(destination.owner)}/${encodeURIComponent(destination.repo)}/git/ref/${destination.branchApiRef}`,
+    { headers: githubMirrorHeaders(token) },
+  )
+
+  if (!response.ok) {
+    throw new ForgeGitHubMirrorApiError(
+      `forge_github_mirror_destination_lookup_http_${response.status}`,
+    )
+  }
+
+  const body = (await response.json()) as { object?: { sha?: unknown } }
+  const sha = typeof body.object?.sha === 'string' ? body.object.sha : ''
+
+  if (!commitShaPattern.test(sha)) {
+    throw new ForgeGitHubMirrorApiError(
+      'forge_github_mirror_destination_lookup_bad_ref',
+    )
+  }
+
+  return sha.toLowerCase()
+}
+
+const updateGitHubDestinationHead = async <Bindings>(
+  dependencies: ForgeControlPlaneRouteDependencies<Bindings>,
+  destination: ForgeGitHubMirrorDestination,
+  token: string,
+  commitId: string,
+): Promise<void> => {
+  const response = await (dependencies.fetch ?? fetch)(
+    `https://api.github.com/repos/${encodeURIComponent(destination.owner)}/${encodeURIComponent(destination.repo)}/git/refs/${destination.branchApiRef}`,
+    {
+      body: JSON.stringify({ force: false, sha: commitId }),
+      headers: githubMirrorHeaders(token, true),
+      method: 'PATCH',
+    },
+  )
+
+  if (!response.ok) {
+    throw new ForgeGitHubMirrorApiError(
+      `forge_github_mirror_ref_update_http_${response.status}`,
+    )
+  }
+}
+
+const mirrorRefForPromotion = async (
+  promotionRef: string,
+  destination: ForgeGitHubMirrorDestination,
+): Promise<string> =>
+  `mirror.github.openagents.main.${(await sha256Hex(
+    `${promotionRef}:${destination.githubRepository}:${destination.githubRef}`,
+  )).slice(0, 24)}`
+
+const uniqueSourceRefs = (
+  refs: ReadonlyArray<string>,
+): ReadonlyArray<string> => [...new Set(refs.filter(ref => ref.trim() !== ''))]
+
+const repositoryRefForPromotion = async (
+  store: ForgeCoordinationStore,
+  promotion: ForgePromotionDecisionReceipt,
+): Promise<string> => {
+  if (promotion.verification_ref === null) {
+    return OPENAGENTS_FORGE_REPOSITORY_REF
+  }
+
+  const verification = (
+    await store.listVerificationReceipts(
+      promotion.tenant_ref,
+      100,
+      promotion.change_ref,
+    )
+  ).find(receipt => receipt.verification_ref === promotion.verification_ref)
+
+  return verification?.repository_ref ?? OPENAGENTS_FORGE_REPOSITORY_REF
+}
+
+const recordGitHubMirrorReceipt = async <Bindings>(
+  dependencies: ForgeControlPlaneRouteDependencies<Bindings>,
+  env: Bindings,
+  input: Readonly<{
+    commitId: string
+    destination: ForgeGitHubMirrorDestination
+    errorReason?: string | undefined
+    nowIso: string
+    promotion: ForgePromotionDecisionReceipt
+    refusalReason?: string | undefined
+    repositoryRef: string
+    status: typeof ForgeGitHubMirrorStatus.Type
+  }>,
+): Promise<ForgeGitHubMirrorReceipt> =>
+  dependencies.makeGitHubMirrorStore(env).recordReceipt({
+    change_ref: input.promotion.change_ref,
+    commit_id: input.commitId,
+    completed_at: input.nowIso,
+    destination_github_ref: input.destination.githubRef,
+    destination_github_repository: input.destination.githubRepository,
+    error_reason: input.errorReason ?? null,
+    first_attempted_at: input.nowIso,
+    last_attempted_at: input.nowIso,
+    mirror_ref: await mirrorRefForPromotion(
+      input.promotion.promotion_ref,
+      input.destination,
+    ),
+    promotion_ref: input.promotion.promotion_ref,
+    redacted: true,
+    refusal_reason: input.refusalReason ?? null,
+    repository_ref: input.repositoryRef,
+    source_canonical_ref: input.promotion.target_ref,
+    source_refs: uniqueSourceRefs([
+      ...input.promotion.source_refs,
+      input.promotion.promotion_ref,
+      input.promotion.target_ref,
+      `github:${input.destination.githubRepository}#${input.destination.githubRef}`,
+    ]),
+    status: input.status,
+    tenant_ref: input.promotion.tenant_ref,
+  })
+
+const refusalReceipt = async <Bindings>(
+  dependencies: ForgeControlPlaneRouteDependencies<Bindings>,
+  env: Bindings,
+  input: Readonly<{
+    destination: ForgeGitHubMirrorDestination
+    nowIso: string
+    promotion: ForgePromotionDecisionReceipt
+    reason: string
+    repositoryRef: string
+  }>,
+): Promise<ForgeGitHubMirrorReceipt> =>
+  recordGitHubMirrorReceipt(dependencies, env, {
+    commitId: input.promotion.promoted_head ?? input.promotion.candidate_head,
+    destination: input.destination,
+    nowIso: input.nowIso,
+    promotion: input.promotion,
+    refusalReason: input.reason,
+    repositoryRef: input.repositoryRef,
+    status: 'refused',
+  })
+
+const failureReceipt = async <Bindings>(
+  dependencies: ForgeControlPlaneRouteDependencies<Bindings>,
+  env: Bindings,
+  input: Readonly<{
+    commitId: string
+    destination: ForgeGitHubMirrorDestination
+    nowIso: string
+    promotion: ForgePromotionDecisionReceipt
+    reason: string
+    repositoryRef: string
+  }>,
+): Promise<ForgeGitHubMirrorReceipt> =>
+  recordGitHubMirrorReceipt(dependencies, env, {
+    commitId: input.commitId,
+    destination: input.destination,
+    errorReason: input.reason,
+    nowIso: input.nowIso,
+    promotion: input.promotion,
+    repositoryRef: input.repositoryRef,
+    status: 'failed',
+  })
+
+const mirrorPromotionToGitHub = async <Bindings>(
+  dependencies: ForgeControlPlaneRouteDependencies<Bindings>,
+  env: Bindings,
+  promotion: ForgePromotionDecisionReceipt,
+): Promise<ForgeGitHubMirrorReceipt> => {
+  const destination = openAgentsGitHubMirrorDestination()
+  const nowIso = routeNowIso(dependencies)
+  const store = dependencies.makeStore(env)
+  const repositoryRef = await repositoryRefForPromotion(store, promotion)
+  const existing = await dependencies
+    .makeGitHubMirrorStore(env)
+    .readReceiptForPromotion(
+      promotion.tenant_ref,
+      promotion.promotion_ref,
+      destination.githubRepository,
+      destination.githubRef,
+    )
+
+  if (
+    existing?.status === 'mirrored' &&
+    existing.commit_id === promotion.promoted_head
+  ) {
+    return existing
+  }
+
+  if (promotion.decision !== 'approved' || promotion.promoted_head === null) {
+    return refusalReceipt(dependencies, env, {
+      destination,
+      nowIso,
+      promotion,
+      reason: 'forge_github_mirror_requires_approved_promotion',
+      repositoryRef,
+    })
+  }
+
+  if (promotion.target_ref !== destination.githubRef) {
+    return refusalReceipt(dependencies, env, {
+      destination,
+      nowIso,
+      promotion,
+      reason: 'forge_github_mirror_target_ref_not_configured',
+      repositoryRef,
+    })
+  }
+
+  if (repositoryRef !== OPENAGENTS_FORGE_REPOSITORY_REF) {
+    return refusalReceipt(dependencies, env, {
+      destination,
+      nowIso,
+      promotion,
+      reason: 'forge_github_mirror_repository_not_configured',
+      repositoryRef,
+    })
+  }
+
+  const canonicalRef = await dependencies
+    .makeCanonicalStore(env)
+    .readRef(promotion.tenant_ref, repositoryRef, promotion.target_ref)
+
+  if (
+    canonicalRef?.state !== 'active' ||
+    canonicalRef.object_id?.toLowerCase() !== promotion.promoted_head.toLowerCase()
+  ) {
+    return refusalReceipt(dependencies, env, {
+      destination,
+      nowIso,
+      promotion,
+      reason: 'forge_github_mirror_source_canonical_ref_not_promoted',
+      repositoryRef,
+    })
+  }
+
+  const token = dependencies.mirrorGitHubToken?.(env)
+  if (token === undefined || token.trim() === '') {
+    return failureReceipt(dependencies, env, {
+      commitId: promotion.promoted_head,
+      destination,
+      nowIso,
+      promotion,
+      reason: 'forge_github_mirror_token_missing',
+      repositoryRef,
+    })
+  }
+
+  try {
+    const destinationHead = await readGitHubDestinationHead(
+      dependencies,
+      destination,
+      token,
+    )
+    if (destinationHead !== promotion.promoted_head.toLowerCase()) {
+      await updateGitHubDestinationHead(
+        dependencies,
+        destination,
+        token,
+        promotion.promoted_head,
+      )
+    }
+
+    return recordGitHubMirrorReceipt(dependencies, env, {
+      commitId: promotion.promoted_head,
+      destination,
+      nowIso,
+      promotion,
+      repositoryRef,
+      status: 'mirrored',
+    })
+  } catch (error) {
+    return failureReceipt(dependencies, env, {
+      commitId: promotion.promoted_head,
+      destination,
+      nowIso,
+      promotion,
+      reason:
+        error instanceof ForgeGitHubMirrorApiError
+          ? error.errorCode
+          : 'forge_github_mirror_fetch_failed',
+      repositoryRef,
+    })
+  }
+}
+
+const promotionCandidatesForMirrorRun = async (
+  store: ForgeCoordinationStore,
+  tenantRef: string,
+  promotionRef: string | undefined,
+): Promise<ReadonlyArray<ForgePromotionDecisionReceipt>> => {
+  const promotions = await store.listPromotionDecisionReceipts(tenantRef, 100)
+
+  if (promotionRef === undefined) {
+    return promotions.filter(promotion => promotion.decision === 'approved')
+  }
+
+  const promotion = promotions.find(
+    candidate => candidate.promotion_ref === promotionRef,
+  )
+
+  if (promotion === undefined) {
+    throw new ForgeControlPlaneHttpError(
+      404,
+      'forge_github_mirror_promotion_not_found',
+    )
+  }
+
+  return [promotion]
+}
+
+const routeGitHubMirrorRun = async <Bindings>(
+  dependencies: ForgeControlPlaneRouteDependencies<Bindings>,
+  request: Request,
+  env: Bindings,
+) => {
+  if (request.method !== 'POST') {
+    return methodNotAllowed(['POST'])
+  }
+
+  const body = await decodeBody(request, ForgeGitHubMirrorRunRequest)
+  await requireScope(dependencies, request, env, 'forge:mirror:write', body.tenantRef)
+  const store = dependencies.makeStore(env)
+  const promotions = await promotionCandidatesForMirrorRun(
+    store,
+    body.tenantRef,
+    body.promotionRef,
+  )
+  const mirrorReceipts = await Promise.all(
+    promotions.map(promotion =>
+      mirrorPromotionToGitHub(dependencies, env, promotion),
+    ),
+  )
+
+  return noStoreJsonResponse({
+    attention: forgeGitHubMirrorAttention(mirrorReceipts),
+    mirrorReceipts,
+    mirroredCount: mirrorReceipts.filter(receipt => receipt.status === 'mirrored')
+      .length,
+    refusedCount: mirrorReceipts.filter(receipt => receipt.status === 'refused')
+      .length,
+    failedCount: mirrorReceipts.filter(receipt => receipt.status === 'failed')
+      .length,
+    tenantRef: body.tenantRef,
+  })
 }
 
 const routeRefs = async <Bindings>(
@@ -1180,6 +1639,22 @@ export const makeForgeControlPlaneRoutes = <Bindings>(
     if (route.length === 1 && route[0] === 'promotion-decisions') {
       return routeEffect(() =>
         routePromotionDecisions(dependencies, request, env, url),
+      )
+    }
+
+    if (route.length === 1 && route[0] === 'github-mirror') {
+      return routeEffect(() =>
+        routeGitHubMirrorReceipts(dependencies, request, env, url),
+      )
+    }
+
+    if (
+      route.length === 2 &&
+      route[0] === 'github-mirror' &&
+      route[1] === 'run'
+    ) {
+      return routeEffect(() =>
+        routeGitHubMirrorRun(dependencies, request, env),
       )
     }
 

--- a/apps/openagents.com/workers/api/src/forge-github-mirror-store.ts
+++ b/apps/openagents.com/workers/api/src/forge-github-mirror-store.ts
@@ -1,0 +1,270 @@
+import {
+  decodeForgeGitHubMirrorReceipt,
+  type ForgeGitHubMirrorReceipt,
+} from '@openagentsinc/forge-protocol'
+
+import { parseJsonStringArray } from './json-boundary'
+
+export type ForgeGitHubMirrorReceiptInput = Omit<
+  ForgeGitHubMirrorReceipt,
+  'attempt_count' | 'schema'
+>
+
+export type ForgeGitHubMirrorListInput = Readonly<{
+  limit: number
+  promotionRef?: string | undefined
+  status?: ForgeGitHubMirrorReceipt['status'] | undefined
+}>
+
+export type ForgeGitHubMirrorStore = Readonly<{
+  listReceipts: (
+    tenantRef: string,
+    input: ForgeGitHubMirrorListInput,
+  ) => Promise<ReadonlyArray<ForgeGitHubMirrorReceipt>>
+  readReceiptForPromotion: (
+    tenantRef: string,
+    promotionRef: string,
+    destinationGithubRepository: string,
+    destinationGithubRef: string,
+  ) => Promise<ForgeGitHubMirrorReceipt | undefined>
+  recordReceipt: (
+    input: ForgeGitHubMirrorReceiptInput,
+  ) => Promise<ForgeGitHubMirrorReceipt>
+}>
+
+type ForgeGitHubMirrorReceiptRow = Readonly<{
+  tenant_ref: string
+  mirror_ref: string
+  promotion_ref: string
+  change_ref: string
+  repository_ref: string
+  source_canonical_ref: string
+  destination_github_repository: string
+  destination_github_ref: string
+  commit_id: string
+  status: string
+  attempt_count: number
+  first_attempted_at: string
+  last_attempted_at: string
+  completed_at: string | null
+  refusal_reason: string | null
+  error_reason: string | null
+  source_refs_json: string
+  redacted: number | boolean
+}>
+
+class ForgeGitHubMirrorStoreInvariantError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'ForgeGitHubMirrorStoreInvariantError'
+  }
+}
+
+const limitRows = (limit: number): number =>
+  Math.min(Math.max(Math.trunc(limit), 1), 100)
+
+const jsonArray = (values: ReadonlyArray<string>): string =>
+  JSON.stringify([...values])
+
+const receiptFromRow = (
+  row: ForgeGitHubMirrorReceiptRow,
+): ForgeGitHubMirrorReceipt =>
+  decodeForgeGitHubMirrorReceipt({
+    schema: 'openagents.forge.github_mirror.receipt.v0.1',
+    tenant_ref: row.tenant_ref,
+    mirror_ref: row.mirror_ref,
+    promotion_ref: row.promotion_ref,
+    change_ref: row.change_ref,
+    repository_ref: row.repository_ref,
+    source_canonical_ref: row.source_canonical_ref,
+    destination_github_repository: row.destination_github_repository,
+    destination_github_ref: row.destination_github_ref,
+    commit_id: row.commit_id,
+    status: row.status,
+    attempt_count: row.attempt_count,
+    first_attempted_at: row.first_attempted_at,
+    last_attempted_at: row.last_attempted_at,
+    completed_at: row.completed_at,
+    refusal_reason: row.refusal_reason,
+    error_reason: row.error_reason,
+    source_refs: parseJsonStringArray(row.source_refs_json),
+    redacted: row.redacted === true || row.redacted === 1,
+  })
+
+const readByMirrorRef = async (
+  db: D1Database,
+  tenantRef: string,
+  mirrorRef: string,
+): Promise<ForgeGitHubMirrorReceipt> => {
+  const row = await db
+    .prepare(
+      `
+        SELECT *
+        FROM forge_github_mirror_receipts
+        WHERE tenant_ref = ? AND mirror_ref = ?
+      `,
+    )
+    .bind(tenantRef, mirrorRef)
+    .first<ForgeGitHubMirrorReceiptRow>()
+
+  if (row === null) {
+    throw new ForgeGitHubMirrorStoreInvariantError(
+      'forge GitHub mirror receipt was not persisted',
+    )
+  }
+
+  return receiptFromRow(row)
+}
+
+export const makeD1ForgeGitHubMirrorStore = (
+  db: D1Database,
+): ForgeGitHubMirrorStore => ({
+  async listReceipts(tenantRef, input) {
+    const limit = limitRows(input.limit)
+    const rows =
+      input.promotionRef !== undefined
+        ? await db
+            .prepare(
+              `
+                SELECT *
+                FROM forge_github_mirror_receipts
+                WHERE tenant_ref = ? AND promotion_ref = ?
+                ORDER BY updated_at DESC, mirror_ref DESC
+                LIMIT ?
+              `,
+            )
+            .bind(tenantRef, input.promotionRef, limit)
+            .all<ForgeGitHubMirrorReceiptRow>()
+        : input.status !== undefined
+          ? await db
+              .prepare(
+                `
+                  SELECT *
+                  FROM forge_github_mirror_receipts
+                  WHERE tenant_ref = ? AND status = ?
+                  ORDER BY updated_at DESC, mirror_ref DESC
+                  LIMIT ?
+                `,
+              )
+              .bind(tenantRef, input.status, limit)
+              .all<ForgeGitHubMirrorReceiptRow>()
+          : await db
+              .prepare(
+                `
+                  SELECT *
+                  FROM forge_github_mirror_receipts
+                  WHERE tenant_ref = ?
+                  ORDER BY updated_at DESC, mirror_ref DESC
+                  LIMIT ?
+                `,
+              )
+              .bind(tenantRef, limit)
+              .all<ForgeGitHubMirrorReceiptRow>()
+
+    return rows.results.map(receiptFromRow)
+  },
+
+  async readReceiptForPromotion(
+    tenantRef,
+    promotionRef,
+    destinationGithubRepository,
+    destinationGithubRef,
+  ) {
+    const row = await db
+      .prepare(
+        `
+          SELECT *
+          FROM forge_github_mirror_receipts
+          WHERE tenant_ref = ?
+            AND promotion_ref = ?
+            AND destination_github_repository = ?
+            AND destination_github_ref = ?
+          ORDER BY updated_at DESC, mirror_ref DESC
+          LIMIT 1
+        `,
+      )
+      .bind(
+        tenantRef,
+        promotionRef,
+        destinationGithubRepository,
+        destinationGithubRef,
+      )
+      .first<ForgeGitHubMirrorReceiptRow>()
+
+    return row === null ? undefined : receiptFromRow(row)
+  },
+
+  async recordReceipt(input) {
+    const decoded = decodeForgeGitHubMirrorReceipt({
+      schema: 'openagents.forge.github_mirror.receipt.v0.1',
+      ...input,
+      attempt_count: 1,
+    })
+
+    await db
+      .prepare(
+        `
+          INSERT INTO forge_github_mirror_receipts (
+            tenant_ref,
+            mirror_ref,
+            promotion_ref,
+            change_ref,
+            repository_ref,
+            source_canonical_ref,
+            destination_github_repository,
+            destination_github_ref,
+            commit_id,
+            status,
+            attempt_count,
+            first_attempted_at,
+            last_attempted_at,
+            completed_at,
+            refusal_reason,
+            error_reason,
+            source_refs_json,
+            redacted,
+            created_at,
+            updated_at
+          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1, ?, ?, ?, ?, ?, ?, 1, ?, ?)
+          ON CONFLICT (tenant_ref, mirror_ref) DO UPDATE SET
+            change_ref = excluded.change_ref,
+            repository_ref = excluded.repository_ref,
+            source_canonical_ref = excluded.source_canonical_ref,
+            destination_github_repository = excluded.destination_github_repository,
+            destination_github_ref = excluded.destination_github_ref,
+            commit_id = excluded.commit_id,
+            status = excluded.status,
+            attempt_count = forge_github_mirror_receipts.attempt_count + 1,
+            last_attempted_at = excluded.last_attempted_at,
+            completed_at = excluded.completed_at,
+            refusal_reason = excluded.refusal_reason,
+            error_reason = excluded.error_reason,
+            source_refs_json = excluded.source_refs_json,
+            updated_at = excluded.updated_at
+        `,
+      )
+      .bind(
+        decoded.tenant_ref,
+        decoded.mirror_ref,
+        decoded.promotion_ref,
+        decoded.change_ref,
+        decoded.repository_ref,
+        decoded.source_canonical_ref,
+        decoded.destination_github_repository,
+        decoded.destination_github_ref,
+        decoded.commit_id,
+        decoded.status,
+        decoded.first_attempted_at,
+        decoded.last_attempted_at,
+        decoded.completed_at,
+        decoded.refusal_reason,
+        decoded.error_reason,
+        jsonArray(decoded.source_refs),
+        decoded.first_attempted_at,
+        decoded.last_attempted_at,
+      )
+      .run()
+
+    return readByMirrorRef(db, decoded.tenant_ref, decoded.mirror_ref)
+  },
+})

--- a/apps/openagents.com/workers/api/src/index.ts
+++ b/apps/openagents.com/workers/api/src/index.ts
@@ -649,6 +649,7 @@ import { makeD1ForgeCoordinationStore } from './forge-coordination-store'
 import { makeD1ForgeGitCanonicalStore } from './forge-git-canonical-store'
 import { makeForgeGitIntakeRoutes } from './forge-git-intake-routes'
 import { makeD1R2ForgeGitPackfileArchiveStore } from './forge-git-packfile-archive-store'
+import { makeD1ForgeGitHubMirrorStore } from './forge-github-mirror-store'
 import { makeD1ForgeTenantGitAuthStore } from './forge-tenant-git-auth-store'
 import type { KhalaChatStreamClient } from './khala-chat-program'
 import {
@@ -2118,6 +2119,20 @@ const getForgeControlPlaneToken = (
 ): string | undefined => {
   const token = redactedValue(
     getOpenAgentsWorkerConfig(env).forgeControlPlaneToken,
+  )
+
+  if (token === undefined || token.trim() === '') {
+    return undefined
+  }
+
+  return token
+}
+
+const getForgeGitHubMirrorToken = (
+  env: OpenAgentsWorkerConfigEnv,
+): string | undefined => {
+  const token = redactedValue(
+    getOpenAgentsWorkerConfig(env).forgeGithubMirrorToken,
   )
 
   if (token === undefined || token.trim() === '') {
@@ -13555,8 +13570,11 @@ const routeRequest = makeWorkerRouteRequest({
         ),
       makeCanonicalStore: storeEnv =>
         makeD1ForgeGitCanonicalStore(openAgentsDatabase(storeEnv)),
+      makeGitHubMirrorStore: storeEnv =>
+        makeD1ForgeGitHubMirrorStore(openAgentsDatabase(storeEnv)),
       makeStore: storeEnv =>
         makeD1ForgeCoordinationStore(openAgentsDatabase(storeEnv)),
+      mirrorGitHubToken: storeEnv => getForgeGitHubMirrorToken(storeEnv),
       nowIso: currentIsoTimestamp,
       requireAdminApiToken: (authRequest, authEnv) =>
         requireAdminApiToken(authRequest, authEnv),

--- a/packages/forge-protocol/README.md
+++ b/packages/forge-protocol/README.md
@@ -27,11 +27,13 @@ prefix, and optional verification command descriptor. Decisions record Pylon
 accept/reject state. Closeouts return the redacted Pylon result, packfile ref,
 verification ref, artifact/proof/result refs, and settlement status.
 
-Verification and promotion receipts are modeled as
-`ForgeVerificationReceipt` and `ForgePromotionDecisionReceipt`. They carry refs,
-hashes, command metadata, exit/verdict state, queue position, canonical target
-ref, bounded gate results, timestamps, artifact refs, and log digests, but not
-raw logs, raw source, private provider payloads, git tokens, or wallet material.
+Verification, promotion, and GitHub mirror receipts are modeled as
+`ForgeVerificationReceipt`, `ForgePromotionDecisionReceipt`, and
+`ForgeGitHubMirrorReceipt`. They carry refs, hashes, command metadata,
+exit/verdict state, queue position, canonical target ref, bounded gate results,
+mirror source/destination refs, mirror status, timestamps, artifact refs, and
+log digests, but not raw logs, raw source, private provider payloads, git
+tokens, or wallet material.
 
 The package is public-safe by default: records carry refs, bounded state,
 timestamps, and JSON-encoded ref arrays. They do not carry raw prompts, raw

--- a/packages/forge-protocol/src/index.test.ts
+++ b/packages/forge-protocol/src/index.test.ts
@@ -9,6 +9,7 @@ import {
   decodeForgeDispatchLeaseRow,
   decodeForgeGitAccessTokenRow,
   decodeForgeGitAccessTokenScopeRow,
+  decodeForgeGitHubMirrorReceipt,
   decodeForgeGitPackfileArchiveRow,
   decodeForgeDispatchCloseout,
   decodeForgeDispatchDecision,
@@ -42,8 +43,12 @@ describe("@openagentsinc/forge-protocol", () => {
 
   test("keeps control-plane scopes separate from smart Git token scopes", () => {
     expect(forgeControlPlaneScopes).toContain("forge:promotion:decide");
+    expect(forgeControlPlaneScopes).toContain("forge:mirror:write");
     expect(decodeForgeControlPlaneScope("forge:work:write")).toBe(
       "forge:work:write",
+    );
+    expect(decodeForgeControlPlaneScope("forge:mirror:read")).toBe(
+      "forge:mirror:read",
     );
     expect(() => decodeForgeControlPlaneScope("git:receive-pack")).toThrow();
     expect(() => decodeForgeControlPlaneScope("git:admin")).toThrow();
@@ -355,5 +360,33 @@ describe("@openagentsinc/forge-protocol", () => {
       "gate.merge-deploy",
       "gate.issue-close-safe",
     ]);
+    const promotedHead = promotion.promoted_head;
+    if (promotedHead === null) {
+      throw new Error("expected approved promotion to carry promoted_head");
+    }
+
+    const mirror = decodeForgeGitHubMirrorReceipt({
+      schema: "openagents.forge.github_mirror.receipt.v0.1",
+      tenant_ref: "tenant.openagents",
+      mirror_ref: "mirror.github.openagents.main.6768",
+      promotion_ref: promotion.promotion_ref,
+      change_ref: promotion.change_ref,
+      repository_ref: "repo.openagents.openagents",
+      source_canonical_ref: promotion.target_ref,
+      destination_github_repository: "OpenAgentsInc/openagents",
+      destination_github_ref: "refs/heads/main",
+      commit_id: promotedHead,
+      status: "mirrored",
+      attempt_count: 1,
+      first_attempted_at: "2026-06-28T16:03:00.000Z",
+      last_attempted_at: "2026-06-28T16:03:00.000Z",
+      completed_at: "2026-06-28T16:03:02.000Z",
+      refusal_reason: null,
+      error_reason: null,
+      source_refs: [promotion.promotion_ref, promotion.target_ref],
+      redacted: true,
+    });
+    expect(mirror.commit_id).toBe(promotedHead);
+    expect(mirror.status).toBe("mirrored");
   });
 });

--- a/packages/forge-protocol/src/index.ts
+++ b/packages/forge-protocol/src/index.ts
@@ -100,6 +100,8 @@ export const ForgeControlPlaneScope = S.Literals([
   "forge:queue:write",
   "forge:receipt:write",
   "forge:promotion:decide",
+  "forge:mirror:read",
+  "forge:mirror:write",
   "forge:admin",
 ]);
 export type ForgeControlPlaneScope = typeof ForgeControlPlaneScope.Type;
@@ -115,6 +117,8 @@ export const forgeControlPlaneScopes: ReadonlyArray<ForgeControlPlaneScope> = [
   "forge:queue:write",
   "forge:receipt:write",
   "forge:promotion:decide",
+  "forge:mirror:read",
+  "forge:mirror:write",
   "forge:admin",
 ];
 
@@ -166,6 +170,13 @@ export const ForgePromotionDecisionState = S.Literals([
 ]);
 export type ForgePromotionDecisionState =
   typeof ForgePromotionDecisionState.Type;
+
+export const ForgeGitHubMirrorStatus = S.Literals([
+  "mirrored",
+  "refused",
+  "failed",
+]);
+export type ForgeGitHubMirrorStatus = typeof ForgeGitHubMirrorStatus.Type;
 
 export const ForgePromotionGateVerdict = S.Literals([
   "passed",
@@ -483,6 +494,30 @@ export const ForgePromotionDecisionReceipt = S.Struct({
 export type ForgePromotionDecisionReceipt =
   typeof ForgePromotionDecisionReceipt.Type;
 
+export const ForgeGitHubMirrorReceipt = S.Struct({
+  schema: S.Literal("openagents.forge.github_mirror.receipt.v0.1"),
+  tenant_ref: S.String,
+  mirror_ref: S.String,
+  promotion_ref: S.String,
+  change_ref: S.String,
+  repository_ref: S.String,
+  source_canonical_ref: S.String,
+  destination_github_repository: S.String,
+  destination_github_ref: S.String,
+  commit_id: S.String,
+  status: ForgeGitHubMirrorStatus,
+  attempt_count: S.Number,
+  first_attempted_at: S.String,
+  last_attempted_at: S.String,
+  completed_at: S.NullOr(S.String),
+  refusal_reason: S.NullOr(S.String),
+  error_reason: S.NullOr(S.String),
+  source_refs: S.Array(S.String),
+  redacted: S.Literal(true),
+});
+export type ForgeGitHubMirrorReceipt =
+  typeof ForgeGitHubMirrorReceipt.Type;
+
 export const ForgeDispatchMessage = S.Union([
   ForgeDispatchWorkItem,
   ForgeDispatchDecision,
@@ -497,6 +532,7 @@ export const ForgeCoordinationRow = S.Union([
   ForgeDispatchLeaseRow,
   ForgeMergeQueueLedgerRow,
   ForgeGitPackfileArchiveRow,
+  ForgeGitHubMirrorReceipt,
   ForgeTenantRow,
   ForgeGitAccessTokenRow,
   ForgeGitAccessTokenScopeRow,
@@ -547,6 +583,9 @@ export const decodeForgeVerificationReceipt = S.decodeUnknownSync(
 );
 export const decodeForgePromotionDecisionReceipt = S.decodeUnknownSync(
   ForgePromotionDecisionReceipt,
+);
+export const decodeForgeGitHubMirrorReceipt = S.decodeUnknownSync(
+  ForgeGitHubMirrorReceipt,
 );
 
 export const forgeCoordinationStatusStateForNip34Kind = (


### PR DESCRIPTION
Addresses #6796.

### Changes
- Adds the Forge GitHub mirror receipt API surface, configuration token wiring, receipt storage, migration, and route registration for promoted commit mirroring.
- Extends Forge protocol schemas, docs, and tests for GitHub mirror requests and receipts.
- Adds the Forge UI mirrors route and preview table for GitHub mirror receipt status.

### Verification
- `bun scripts/check-conflict-markers.mjs` passed (exit 0).