### PR TITLE
Add Khala BYOK raw-model guard coverage

### DIFF
--- a/apps/openagents.com/workers/api/src/inference/chat-completions-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/chat-completions-routes.test.ts
@@ -1607,6 +1607,50 @@ describe('POST /v1/chat/completions', () => {
     expect(body.error).toBe('invalid_byok_provider_key')
   })
 
+  test('rejects BYOK raw provider model ids before dispatch without echoing the key', async () => {
+    let dispatched = false
+    const registry = new InferenceProviderRegistry()
+    registry.register({
+      complete: () =>
+        Effect.sync(() => {
+          dispatched = true
+          return {
+            content: 'should not dispatch',
+            finishReason: 'stop',
+            servedModel: 'openrouter/test-model',
+            usage: { completionTokens: 1, promptTokens: 1, totalTokens: 2 },
+          }
+        }),
+      id: OPENROUTER_KHALA_FALLBACK_ADAPTER_ID,
+      stream: () => Effect.sync(() => []),
+    })
+
+    const response = await run(
+      handleChatCompletions(
+        chatRequest(
+          {
+            messages: [{ content: 'hello world', role: 'user' }],
+            model: 'openai/gpt-4o',
+          },
+          {
+            headers: {
+              [KHALA_BYOK_PROVIDER_HEADER]: 'openrouter',
+              [KHALA_BYOK_PROVIDER_KEY_HEADER]: 'sk-or-user-owned-key',
+            },
+          },
+        ),
+        baseDeps({ lanePlan: selectAdapterPlan, registry }),
+      ),
+    )
+
+    expect(response.status).toBe(400)
+    expect(response.headers.get(KHALA_BYOK_ACK_HEADER)).toBeNull()
+    expect(dispatched).toBe(false)
+    const text = await response.text()
+    expect(text).toContain('model_unavailable')
+    expect(text).not.toContain('sk-or-user-owned-key')
+  })
+
   test('records served tokens for a completed non-streaming completion (issue #6227)', async () => {
     const recorded: Array<{
       accountRef: string


### PR DESCRIPTION
Problem

Issue #7646 needs hosted Khala BYOK to stay behind the Khala model surface. A caller-owned OpenRouter key must not let hosted `/v1/chat/completions` become a raw provider-model proxy, and the submitted key must not be echoed on rejection.

Change

- Adds a route-level regression test for an OpenRouter BYOK request that asks for `openai/gpt-4o` instead of a Khala model id.
- Verifies the request is rejected before provider dispatch.
- Verifies no BYOK acknowledgement header is set on the rejected raw-model request.
- Verifies the caller-owned provider key is absent from the error response body.

Files touched

- `apps/openagents.com/workers/api/src/inference/chat-completions-routes.test.ts`

Validation

- `bun run test -- src/inference/chat-completions-routes.test.ts src/inference/openrouter-adapter.test.ts`
- `bun run typecheck`

Maintenance / revenue value

This closes a narrow public product-promise/security gate for hosted Khala BYOK: user-paid provider routing remains scoped to Khala, which keeps account billing, product boundaries, and review risk clearer before expanding BYOK storage/UI work.

Intentionally not changed

- No account-attached BYOK storage, rotation, or UI.
- No desktop settings copy.
- No broader `/api/v1/...` route alias work.
- No provider/model expansion beyond the existing Khala BYOK route surface.

Refs #7646
