### PR TITLE
Add Khala tool dispatcher

### DIFF
--- a/clients/khala-code-desktop/src/bun/khala-chat-runtime.ts
+++ b/clients/khala-code-desktop/src/bun/khala-chat-runtime.ts
@@ -2,6 +2,7 @@ import { Effect } from "effect"
 import {
   allowAllKhalaPermissionService,
   applyPatchToolDefinition,
+  createKhalaToolTurnAccounting,
   createApplyPatchTool,
   createEditTool,
   createExecCommandTool,
@@ -10,8 +11,8 @@ import {
   createLsTool,
   createReadTool,
   createWriteTool,
-  executeKhalaTool,
   makeKhalaPrivacyRedactionService,
+  makeKhalaToolDispatcher,
   makeKhalaToolRegistry,
   makeKhalaToolServices,
   redactKhalaPublicText,
@@ -20,6 +21,7 @@ import {
   type KhalaBackendSelection,
   type KhalaPrivacyRedactionServiceShape,
   type KhalaToolDefinition,
+  type KhalaToolDispatcher,
   type KhalaToolRegistry,
   type KhalaToolResult,
   type KhalaToolServices,
@@ -193,10 +195,20 @@ export async function runKhalaCodeDesktopChatTurn(
   const usedTools: string[] = []
   const tools = toOpenAiCompatibleTools(toolDefinitions)
   const turnId = input.request.turnId ?? nextMessageId("turn")
+  const toolTurnAccounting = createKhalaToolTurnAccounting({
+    maxToolCalls: MAX_TOTAL_TOOL_CALLS,
+    turnId,
+  })
+  const toolDispatcher = makeKhalaToolDispatcher({
+    telemetryTags: {
+      surface: "khala_code_desktop",
+      turnId,
+    },
+    turnAccounting: toolTurnAccounting,
+  })
   const emit = (event: KhalaCodeDesktopChatTurnEvent): void => {
     input.onEvent?.(event)
   }
-  let totalToolCalls = 0
   let retriedWithoutTools = false
   let assistantMessagesSinceLastToolResult = 0
   let localFileEvidence = emptyLocalFileEvidenceState()
@@ -236,7 +248,7 @@ export async function runKhalaCodeDesktopChatTurn(
     } catch (error) {
       if (
         !retriedWithoutTools &&
-        totalToolCalls === 0 &&
+        toolTurnAccounting.snapshot().toolCallCount === 0 &&
         assistantStream.streamingAssistant.current === null &&
         shouldRetryWithoutTools(error)
       ) {
@@ -328,14 +340,11 @@ export async function runKhalaCodeDesktopChatTurn(
     }
 
     for (const call of toolCalls) {
-      totalToolCalls += 1
-      if (totalToolCalls > MAX_TOTAL_TOOL_CALLS) {
-        return limitResult(backend, toolNames, usedTools, "Khala requested too many tool calls in one turn.")
-      }
       const toolTranscript = hostMessage("tool", toolTranscriptRunningBody(call.function.name))
       emit({ message: toolTranscript, turnId, type: "message_start" })
       const result = await runToolCall({
         call,
+        dispatcher: toolDispatcher,
         registry,
         services,
         sessionId: input.request.sessionId,
@@ -987,23 +996,28 @@ function parseToolCalls(value: unknown): readonly OpenAiToolCall[] {
 
 async function runToolCall(input: {
   readonly call: OpenAiToolCall
+  readonly dispatcher: KhalaToolDispatcher
   readonly registry: KhalaToolRegistry
   readonly services: KhalaToolServices
   readonly sessionId: string
 }): Promise<KhalaToolResult> {
   const args = parseToolArguments(input.call.function.arguments)
-  return await Effect.runPromise(
-    executeKhalaTool(
-      input.registry,
-      {
+  const dispatched = await Effect.runPromise(
+    input.dispatcher.dispatch({
+      invocation: {
         arguments: args,
         id: input.call.id,
         name: input.call.function.name,
         sessionId: input.sessionId,
       },
-      input.services,
-    ),
+      registry: input.registry,
+      services: input.services,
+      telemetryTags: {
+        openAiToolCallType: input.call.type,
+      },
+    }),
   )
+  return dispatched.result
 }
 
 function parseToolArguments(value: string): Readonly<Record<string, unknown>> {

--- a/packages/khala-tools/src/dispatcher.test.ts
+++ b/packages/khala-tools/src/dispatcher.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, test } from "bun:test"
+import { Effect } from "effect"
+import {
+  createKhalaToolTurnAccounting,
+  executeKhalaTool,
+  khalaToolOk,
+  makeKhalaToolDispatcher,
+  makeKhalaToolRegistry,
+  makeKhalaToolServices,
+  type KhalaToolDefinition,
+  type KhalaToolEvent,
+} from "./index.js"
+
+const echoDefinition: KhalaToolDefinition = {
+  authority: "read",
+  availability: ["inspect", "coding"],
+  description: "Echo input text.",
+  executionMode: "local",
+  inputSchema: {
+    additionalProperties: false,
+    properties: { text: { type: "string" } },
+    required: ["text"],
+    type: "object",
+  },
+  internalId: "khala.test.dispatcher.echo",
+  label: "Echo",
+  name: "echo",
+  permissionMode: "allow",
+  prompt: "Echo text.",
+  promptGuidelines: ["Use for dispatcher tests only."],
+}
+
+describe("KhalaToolDispatcher", () => {
+  test("emits lifecycle events, telemetry tags, and hook callbacks around a successful tool", async () => {
+    const hookOrder: string[] = []
+    const observedEvents: KhalaToolEvent[] = []
+    const dispatcher = makeKhalaToolDispatcher({
+      hooks: {
+        afterTool: context => Effect.sync(() => {
+          hookOrder.push(`after:${context.result.status}:${context.phase}`)
+        }),
+        beforeTool: context => Effect.sync(() => {
+          hookOrder.push(`before:${context.definition?.name}:${context.phase}`)
+        }),
+        onEvent: context => Effect.sync(() => {
+          observedEvents.push(context.event)
+        }),
+      },
+      telemetryTags: { lane: "test" },
+      turnAccounting: createKhalaToolTurnAccounting({ maxToolCalls: 4, turnId: "turn_1" }),
+    })
+
+    const dispatched = await Effect.runPromise(
+      dispatcher.dispatch({
+        invocation: { arguments: { text: "hello" }, id: "call_1", name: "echo", sessionId: "session_1" },
+        registry: makeKhalaToolRegistry([
+          {
+            definition: echoDefinition,
+            execute: input => Effect.succeed(khalaToolOk({ modelText: String(input.text) })),
+          },
+        ]),
+        services: makeKhalaToolServices(),
+        telemetryTags: { surface: "unit" },
+      }),
+    )
+
+    expect(dispatched.result.status).toBe("ok")
+    expect(dispatched.result.modelOutput.text).toBe("hello")
+    expect(dispatched.accounting).toEqual({ maxToolCalls: 4, toolCallCount: 1, turnId: "turn_1" })
+    expect(hookOrder).toEqual(["before:echo:validate", "after:ok:completed"])
+    expect(dispatched.events.map(event => event.kind)).toEqual([
+      "tool_started",
+      "tool_progress",
+      "tool_progress",
+      "tool_completed",
+    ])
+    expect(observedEvents.map(event => event.kind)).toEqual(dispatched.events.map(event => event.kind))
+    expect(dispatched.telemetryTags).toMatchObject({
+      lane: "test",
+      surface: "unit",
+      toolAuthority: "read",
+      toolCallId: "call_1",
+      toolCallIndex: 1,
+      toolName: "echo",
+      turnId: "turn_1",
+    })
+  })
+
+  test("returns typed model-visible errors for dispatcher failures", async () => {
+    const dispatched = await Effect.runPromise(
+      makeKhalaToolDispatcher().dispatch({
+        invocation: { arguments: {}, id: "call_1", name: "missing", sessionId: "session_1" },
+        registry: makeKhalaToolRegistry(),
+        services: makeKhalaToolServices(),
+      }),
+    )
+
+    expect(dispatched.result.status).toBe("failed")
+    expect(dispatched.result.modelOutput.text).toContain("unknown_tool")
+    expect(dispatched.result.ui).toMatchObject({
+      code: "unknown_tool",
+      kind: "khala_tool_error",
+    })
+    expect(dispatched.events.map(event => event.kind)).toContain("tool_failed")
+  })
+
+  test("enforces per-turn tool-call accounting limits", async () => {
+    const dispatcher = makeKhalaToolDispatcher({
+      turnAccounting: createKhalaToolTurnAccounting({ maxToolCalls: 1, turnId: "turn_1" }),
+    })
+    const registry = makeKhalaToolRegistry([
+      {
+        definition: echoDefinition,
+        execute: () => Effect.succeed(khalaToolOk({ modelText: "ok" })),
+      },
+    ])
+    const services = makeKhalaToolServices()
+    const first = await Effect.runPromise(
+      dispatcher.dispatch({
+        invocation: { arguments: { text: "first" }, id: "call_1", name: "echo", sessionId: "session_1" },
+        registry,
+        services,
+      }),
+    )
+    const second = await Effect.runPromise(
+      dispatcher.dispatch({
+        invocation: { arguments: { text: "second" }, id: "call_2", name: "echo", sessionId: "session_1" },
+        registry,
+        services,
+      }),
+    )
+
+    expect(first.result.status).toBe("ok")
+    expect(second.result.status).toBe("failed")
+    expect(second.result.publicSummary).toContain("tool_call_limit_exceeded")
+    expect(second.accounting).toEqual({ maxToolCalls: 1, toolCallCount: 2, turnId: "turn_1" })
+  })
+
+  test("spills oversized model output to a private artifact with a bounded preview", async () => {
+    const result = await Effect.runPromise(
+      executeKhalaTool(
+        makeKhalaToolRegistry([
+          {
+            definition: echoDefinition,
+            execute: () => Effect.succeed(khalaToolOk({ modelText: "abcdefghijklmnopqrstuvwxyz" })),
+          },
+        ]),
+        { arguments: { text: "large" }, id: "call_1", name: "echo", sessionId: "session_1" },
+        makeKhalaToolServices(),
+        { maxModelOutputBytes: 8 },
+      ),
+    )
+
+    expect(result.status).toBe("ok")
+    expect(result.modelOutput.text).toContain("abcdefgh")
+    expect(result.modelOutput.text).toContain("[tool output truncated by dispatcher")
+    expect(result.artifacts).toHaveLength(1)
+    expect(result.privateDataRefs).toEqual([result.artifacts[0]?.artifactRef])
+  })
+})

--- a/packages/khala-tools/src/dispatcher.ts
+++ b/packages/khala-tools/src/dispatcher.ts
@@ -1,0 +1,603 @@
+import { Buffer } from "node:buffer"
+import { Effect } from "effect"
+import { redactKhalaPublicText } from "./redaction.js"
+import type {
+  KhalaPermissionRequest,
+  KhalaPublicSafety,
+  KhalaToolArtifact,
+  KhalaToolDefinition,
+  KhalaToolEvent,
+  KhalaToolEventKind,
+  KhalaToolInvocation,
+  KhalaToolRegistry,
+  KhalaToolResult,
+  KhalaToolResultStatus,
+  KhalaToolRuntimeError,
+  KhalaToolServices,
+  RegisteredKhalaTool,
+} from "./index.js"
+
+export type KhalaToolTelemetryTagValue = string | number | boolean
+export type KhalaToolTelemetryTags = Readonly<Record<string, KhalaToolTelemetryTagValue>>
+
+export type KhalaToolDispatchPhase =
+  | "resolve"
+  | "validate"
+  | "permission"
+  | "execute"
+  | "bound_output"
+  | "completed"
+  | "failed"
+
+export type KhalaToolDispatchHookContext = Readonly<{
+  definition: KhalaToolDefinition | undefined
+  invocation: KhalaToolInvocation
+  phase: KhalaToolDispatchPhase
+  services: KhalaToolServices
+  telemetryTags: KhalaToolTelemetryTags
+  tool: RegisteredKhalaTool | undefined
+}>
+
+export type KhalaToolDispatchAfterHookContext = KhalaToolDispatchHookContext & Readonly<{
+  durationMs: number
+  result: KhalaToolResult
+}>
+
+export type KhalaToolDispatchEventContext = Readonly<{
+  event: KhalaToolEvent
+  telemetryTags: KhalaToolTelemetryTags
+}>
+
+export interface KhalaToolDispatchHooks {
+  readonly afterTool?: (context: KhalaToolDispatchAfterHookContext) => Effect.Effect<void, never>
+  readonly beforeTool?: (context: KhalaToolDispatchHookContext) => Effect.Effect<void, never>
+  readonly onEvent?: (context: KhalaToolDispatchEventContext) => Effect.Effect<void, never>
+}
+
+export interface KhalaToolTurnAccounting {
+  readonly maxToolCalls?: number
+  readonly recordToolCall: (input: Readonly<{
+    invocation: KhalaToolInvocation
+    telemetryTags: KhalaToolTelemetryTags
+  }>) => Effect.Effect<Readonly<{ count: number }>, never>
+  readonly snapshot: () => KhalaToolTurnAccountingSnapshot
+  readonly turnId: string
+}
+
+export type KhalaToolTurnAccountingSnapshot = Readonly<{
+  maxToolCalls?: number
+  toolCallCount: number
+  turnId: string
+}>
+
+export type KhalaToolDispatcherOptions = Readonly<{
+  hooks?: KhalaToolDispatchHooks
+  maxModelOutputBytes?: number
+  maxPublicSummaryBytes?: number
+  telemetryTags?: KhalaToolTelemetryTags
+  turnAccounting?: KhalaToolTurnAccounting
+}>
+
+export type KhalaToolDispatchInput = Readonly<{
+  invocation: KhalaToolInvocation
+  registry: KhalaToolRegistry
+  services: KhalaToolServices
+  telemetryTags?: KhalaToolTelemetryTags
+}>
+
+export type KhalaToolDispatchResult = Readonly<{
+  accounting?: KhalaToolTurnAccountingSnapshot
+  events: ReadonlyArray<KhalaToolEvent>
+  result: KhalaToolResult
+  telemetryTags: KhalaToolTelemetryTags
+}>
+
+export interface KhalaToolDispatcher {
+  readonly dispatch: (input: KhalaToolDispatchInput) => Effect.Effect<KhalaToolDispatchResult, never>
+}
+
+const DEFAULT_MAX_MODEL_OUTPUT_BYTES = 64 * 1024
+const DEFAULT_MAX_PUBLIC_SUMMARY_BYTES = 8 * 1024
+
+export function createKhalaToolTurnAccounting(input: Readonly<{
+  maxToolCalls?: number
+  turnId: string
+}>): KhalaToolTurnAccounting {
+  let toolCallCount = 0
+  return {
+    ...(input.maxToolCalls === undefined ? {} : { maxToolCalls: input.maxToolCalls }),
+    recordToolCall: () =>
+      Effect.sync(() => {
+        toolCallCount += 1
+        return { count: toolCallCount }
+      }),
+    snapshot: () => ({
+      ...(input.maxToolCalls === undefined ? {} : { maxToolCalls: input.maxToolCalls }),
+      toolCallCount,
+      turnId: input.turnId,
+    }),
+    turnId: input.turnId,
+  }
+}
+
+export function makeKhalaToolDispatcher(options: KhalaToolDispatcherOptions = {}): KhalaToolDispatcher {
+  return {
+    dispatch: input => dispatchKhalaTool(input, options),
+  }
+}
+
+function dispatchKhalaTool(
+  input: KhalaToolDispatchInput,
+  options: KhalaToolDispatcherOptions,
+): Effect.Effect<KhalaToolDispatchResult, never> {
+  return Effect.gen(function* () {
+    const startedAt = Date.now()
+    const localEvents: KhalaToolEvent[] = []
+    const baseTelemetryTags = telemetryTagsFor(input, options)
+    const accounting = options.turnAccounting === undefined
+      ? undefined
+      : yield* options.turnAccounting.recordToolCall({
+          invocation: input.invocation,
+          telemetryTags: baseTelemetryTags,
+        })
+    const telemetryTags = {
+      ...baseTelemetryTags,
+      ...(options.turnAccounting === undefined ? {} : { turnId: options.turnAccounting.turnId }),
+      ...(accounting === undefined ? {} : { toolCallIndex: accounting.count }),
+    }
+
+    const fail = (
+      code: string,
+      reason: string,
+      phase: KhalaToolDispatchPhase,
+      definition: KhalaToolDefinition | undefined = undefined,
+    ) =>
+      finalize({
+        definition,
+        durationMs: Date.now() - startedAt,
+        events: localEvents,
+        input,
+        options,
+        phase,
+        result: dispatcherToolError(code, reason),
+        telemetryTags,
+        tool: undefined,
+      })
+
+    if (accounting !== undefined && options.turnAccounting?.maxToolCalls !== undefined) {
+      if (accounting.count > options.turnAccounting.maxToolCalls) {
+        yield* emitToolEvent({
+          events: localEvents,
+          input,
+          kind: "tool_failed",
+          options,
+          payload: {
+            code: "tool_call_limit_exceeded",
+            limit: options.turnAccounting.maxToolCalls,
+            phase: "validate",
+          },
+          telemetryTags,
+        })
+        return yield* fail(
+          "tool_call_limit_exceeded",
+          `Tool call limit exceeded for turn ${options.turnAccounting.turnId}`,
+          "validate",
+        )
+      }
+    }
+
+    yield* emitToolEvent({
+      events: localEvents,
+      input,
+      kind: "tool_started",
+      options,
+      payload: { phase: "resolve" },
+      telemetryTags,
+    })
+
+    const tool = input.registry.resolve(input.invocation.name)
+    if (tool === undefined) {
+      yield* emitToolEvent({
+        events: localEvents,
+        input,
+        kind: "tool_failed",
+        options,
+        payload: { code: "unknown_tool", phase: "resolve" },
+        telemetryTags,
+      })
+      return yield* fail("unknown_tool", `Unknown tool: ${input.invocation.name}`, "resolve")
+    }
+    const definition = tool.definition
+    const definitionTags = telemetryTagsFor(input, options, definition)
+    const taggedTelemetry = { ...definitionTags, ...telemetryTags }
+
+    yield* beforeTool(options, {
+      definition,
+      invocation: input.invocation,
+      phase: "validate",
+      services: input.services,
+      telemetryTags: taggedTelemetry,
+      tool,
+    })
+    if (tool.execute === undefined) {
+      yield* emitToolEvent({
+        events: localEvents,
+        input,
+        kind: "tool_failed",
+        options,
+        payload: { code: "missing_handler", phase: "validate", toolName: definition.name },
+        telemetryTags: taggedTelemetry,
+      })
+      return yield* fail("missing_handler", `Tool has no execute handler: ${input.invocation.name}`, "validate", definition)
+    }
+    if (!isRecord(input.invocation.arguments)) {
+      yield* emitToolEvent({
+        events: localEvents,
+        input,
+        kind: "tool_failed",
+        options,
+        payload: { code: "invalid_arguments", phase: "validate", toolName: definition.name },
+        telemetryTags: taggedTelemetry,
+      })
+      return yield* fail("invalid_arguments", "Invalid tool input: expected an object", "validate", definition)
+    }
+    if (definition.permissionMode === "deny") {
+      const result = dispatcherToolDenied("permission_policy_denied", `${definition.name} is denied by policy`)
+      yield* emitToolEvent({
+        events: localEvents,
+        input,
+        kind: "tool_failed",
+        options,
+        payload: { phase: "permission", status: result.status, toolName: definition.name },
+        telemetryTags: taggedTelemetry,
+      })
+      return yield* finalize({
+        definition,
+        durationMs: Date.now() - startedAt,
+        events: localEvents,
+        input,
+        options,
+        phase: "permission",
+        result,
+        telemetryTags: taggedTelemetry,
+        tool,
+      })
+    }
+
+    yield* emitToolEvent({
+      events: localEvents,
+      input,
+      kind: "tool_progress",
+      options,
+      payload: { phase: "permission", permissionMode: definition.permissionMode, toolName: definition.name },
+      telemetryTags: taggedTelemetry,
+    })
+    const decision = definition.permissionMode === "approval_required"
+      ? yield* requestPermission(input, options, definition, localEvents, taggedTelemetry)
+      : "allow"
+    if (decision === "deny") {
+      const result = dispatcherToolDenied("permission_denied", `${definition.name} denied by permission service`)
+      yield* emitToolEvent({
+        events: localEvents,
+        input,
+        kind: "tool_failed",
+        options,
+        payload: { phase: "permission", status: result.status, toolName: definition.name },
+        telemetryTags: taggedTelemetry,
+      })
+      return yield* finalize({
+        definition,
+        durationMs: Date.now() - startedAt,
+        events: localEvents,
+        input,
+        options,
+        phase: "permission",
+        result,
+        telemetryTags: taggedTelemetry,
+        tool,
+      })
+    }
+
+    yield* emitToolEvent({
+      events: localEvents,
+      input,
+      kind: "tool_progress",
+      options,
+      payload: { phase: "execute", toolName: definition.name },
+      telemetryTags: taggedTelemetry,
+    })
+
+    const rawResult = yield* tool.execute(input.invocation.arguments, {
+      definition,
+      invocation: input.invocation,
+      services: input.services,
+    }).pipe(
+      Effect.map(sanitizeDispatcherToolResult),
+      Effect.catchTag("KhalaToolRuntimeError", (error: KhalaToolRuntimeError) =>
+        Effect.succeed(dispatcherToolError(error.code, error.reason)),
+      ),
+    )
+    const boundedResult = yield* enforceOutputBounds(input, options, definition, rawResult)
+    const phase: KhalaToolDispatchPhase = isFailedStatus(boundedResult.status) ? "failed" : "completed"
+    yield* emitToolEvent({
+      events: localEvents,
+      input,
+      kind: isFailedStatus(boundedResult.status) ? "tool_failed" : "tool_completed",
+      options,
+      payload: {
+        artifactCount: boundedResult.artifacts.length,
+        phase,
+        privateDataRefCount: boundedResult.privateDataRefs.length,
+        status: boundedResult.status,
+        toolName: definition.name,
+      },
+      telemetryTags: taggedTelemetry,
+    })
+    return yield* finalize({
+      definition,
+      durationMs: Date.now() - startedAt,
+      events: localEvents,
+      input,
+      options,
+      phase,
+      result: boundedResult,
+      telemetryTags: taggedTelemetry,
+      tool,
+    })
+  })
+}
+
+function requestPermission(
+  input: KhalaToolDispatchInput,
+  options: KhalaToolDispatcherOptions,
+  definition: KhalaToolDefinition,
+  events: KhalaToolEvent[],
+  telemetryTags: KhalaToolTelemetryTags,
+) {
+  return Effect.gen(function* () {
+    const request = permissionRequestFor(definition, input.invocation, input.services)
+    yield* emitToolEvent({
+      events,
+      input,
+      kind: "approval_requested",
+      options,
+      payload: request,
+      telemetryTags,
+    })
+    const decision = yield* input.services.permission.decide(request)
+    yield* emitToolEvent({
+      events,
+      input,
+      kind: "approval_answered",
+      options,
+      payload: {
+        decision,
+        toolCallId: input.invocation.id,
+        toolName: definition.name,
+      },
+      telemetryTags,
+    })
+    return decision
+  })
+}
+
+function beforeTool(options: KhalaToolDispatcherOptions, context: KhalaToolDispatchHookContext): Effect.Effect<void, never> {
+  return options.hooks?.beforeTool?.(context) ?? Effect.void
+}
+
+function finalize(input: Readonly<{
+  definition: KhalaToolDefinition | undefined
+  durationMs: number
+  events: KhalaToolEvent[]
+  input: KhalaToolDispatchInput
+  options: KhalaToolDispatcherOptions
+  phase: KhalaToolDispatchPhase
+  result: KhalaToolResult
+  telemetryTags: KhalaToolTelemetryTags
+  tool: RegisteredKhalaTool | undefined
+}>): Effect.Effect<KhalaToolDispatchResult, never> {
+  return Effect.gen(function* () {
+    yield* (input.options.hooks?.afterTool?.({
+      definition: input.definition,
+      durationMs: input.durationMs,
+      invocation: input.input.invocation,
+      phase: input.phase,
+      result: input.result,
+      services: input.input.services,
+      telemetryTags: input.telemetryTags,
+      tool: input.tool,
+    }) ?? Effect.void)
+    return {
+      ...(input.options.turnAccounting === undefined ? {} : { accounting: input.options.turnAccounting.snapshot() }),
+      events: input.events,
+      result: input.result,
+      telemetryTags: input.telemetryTags,
+    }
+  })
+}
+
+function emitToolEvent(input: Readonly<{
+  events: KhalaToolEvent[]
+  input: KhalaToolDispatchInput
+  kind: KhalaToolEventKind
+  options: KhalaToolDispatcherOptions
+  payload: unknown
+  telemetryTags: KhalaToolTelemetryTags
+}>): Effect.Effect<void, never> {
+  return Effect.gen(function* () {
+    const event: KhalaToolEvent = {
+      eventId: nextToolEventId(input.kind),
+      invocationId: input.input.invocation.id,
+      kind: input.kind,
+      payload: {
+        ...(isRecord(input.payload) ? input.payload : { value: input.payload }),
+        telemetryTags: input.telemetryTags,
+      },
+      sessionId: input.input.invocation.sessionId,
+    }
+    input.events.push(event)
+    yield* (input.options.hooks?.onEvent?.({ event, telemetryTags: input.telemetryTags }) ?? Effect.void)
+  })
+}
+
+function enforceOutputBounds(
+  input: KhalaToolDispatchInput,
+  options: KhalaToolDispatcherOptions,
+  definition: KhalaToolDefinition,
+  result: KhalaToolResult,
+): Effect.Effect<KhalaToolResult, never> {
+  return Effect.gen(function* () {
+    const maxModelOutputBytes = options.maxModelOutputBytes ?? DEFAULT_MAX_MODEL_OUTPUT_BYTES
+    const maxPublicSummaryBytes = options.maxPublicSummaryBytes ?? DEFAULT_MAX_PUBLIC_SUMMARY_BYTES
+    const modelText = result.modelOutput.text
+    const modelBytes = Buffer.byteLength(modelText, "utf8")
+    const publicSummary = boundUtf8(result.publicSummary, maxPublicSummaryBytes)
+    if (modelBytes <= maxModelOutputBytes) {
+      return publicSummary.truncated
+        ? {
+            ...result,
+            publicSummary: `${publicSummary.text}\n[tool public summary truncated by dispatcher]`,
+          }
+        : result
+    }
+
+    const artifact = yield* input.services.outputStore.writeArtifact({
+      bytes: Buffer.from(modelText, "utf8"),
+      mediaType: "text/plain; charset=utf-8",
+      summary: `dispatcher-bounded model output for ${definition.name}`,
+    }).pipe(
+      Effect.catchTag("KhalaToolRuntimeError", (error: KhalaToolRuntimeError) =>
+        Effect.succeed({
+          artifactRef: `artifact.unavailable.${input.invocation.id}`,
+          private: true,
+          summary: redactKhalaPublicText(`artifact write failed: ${error.reason}`),
+        } satisfies KhalaToolArtifact),
+      ),
+    )
+    const bounded = boundUtf8(modelText, maxModelOutputBytes)
+    return {
+      ...result,
+      artifacts: [...result.artifacts, artifact],
+      modelOutput: {
+        text: `${bounded.text}\n[tool output truncated by dispatcher; full output stored in private artifact ${artifact.artifactRef}]`,
+      },
+      privateDataRefs: [...new Set([...result.privateDataRefs, artifact.artifactRef])],
+      publicSummary: publicSummary.truncated
+        ? `${publicSummary.text}\n[tool public summary truncated by dispatcher]`
+        : result.publicSummary,
+    }
+  })
+}
+
+function telemetryTagsFor(
+  input: KhalaToolDispatchInput,
+  options: KhalaToolDispatcherOptions,
+  definition?: KhalaToolDefinition,
+): KhalaToolTelemetryTags {
+  return {
+    ...options.telemetryTags,
+    ...input.telemetryTags,
+    dispatcher: "khala_tool_dispatcher",
+    schemaVersion: "khala.tool.dispatch.v1",
+    toolCallId: input.invocation.id,
+    toolName: input.invocation.name,
+    ...(definition === undefined
+      ? {}
+      : {
+          toolAuthority: definition.authority,
+          toolExecutionMode: definition.executionMode,
+          toolInternalId: definition.internalId,
+          toolPermissionMode: definition.permissionMode,
+        }),
+  }
+}
+
+function dispatcherToolError(code: string, reason: string): KhalaToolResult {
+  const safe = redactKhalaPublicText(`${code}: ${reason}`)
+  return {
+    artifacts: [],
+    modelOutput: { text: safe },
+    privateDataRefs: [],
+    publicSafety: safe === `${code}: ${reason}` ? "public_safe" : "redacted",
+    publicSummary: safe,
+    redactionRefs: safe === `${code}: ${reason}` ? [] : ["redaction.khala_tool.error"],
+    status: "failed",
+    ui: {
+      code,
+      kind: "khala_tool_error",
+      reason: safe,
+    },
+  }
+}
+
+function dispatcherToolDenied(code: string, reason: string): KhalaToolResult {
+  const error = dispatcherToolError(code, reason)
+  return { ...error, status: "denied" }
+}
+
+function sanitizeDispatcherToolResult(result: KhalaToolResult): KhalaToolResult {
+  const publicSummary = redactKhalaPublicText(result.publicSummary)
+  const modelText = redactKhalaPublicText(result.modelOutput.text)
+  const redacted = publicSummary !== result.publicSummary || modelText !== result.modelOutput.text
+  return {
+    ...result,
+    modelOutput: { text: modelText },
+    publicSafety: redacted ? "redacted" : result.publicSafety,
+    publicSummary,
+    redactionRefs: redacted
+      ? [...new Set([...result.redactionRefs, "redaction.khala_tool.public_text"])]
+      : result.redactionRefs,
+  }
+}
+
+function permissionRequestFor(
+  definition: KhalaToolDefinition,
+  invocation: KhalaToolInvocation,
+  services: KhalaToolServices,
+): KhalaPermissionRequest {
+  const resources = typeof invocation.arguments.path === "string"
+    ? [invocation.arguments.path]
+    : typeof invocation.arguments.url === "string"
+      ? [invocation.arguments.url]
+      : typeof invocation.arguments.query === "string"
+        ? [invocation.arguments.query]
+        : typeof invocation.arguments.selector === "string"
+          ? [invocation.arguments.selector]
+          : typeof invocation.arguments.label === "string"
+            ? [invocation.arguments.label]
+            : typeof invocation.arguments.value === "string"
+              ? [invocation.arguments.value]
+              : []
+  return {
+    action: definition.authority,
+    authorityMode: definition.executionMode,
+    publicSafety: "private" satisfies KhalaPublicSafety,
+    resources,
+    saveScope: "once",
+    sessionId: invocation.sessionId,
+    toolCallId: invocation.id,
+    toolName: definition.name,
+    workingDirectory: services.workspace.workingDirectory,
+  }
+}
+
+function boundUtf8(text: string, maxBytes: number): Readonly<{ text: string; truncated: boolean }> {
+  const bytes = Buffer.from(text, "utf8")
+  if (bytes.byteLength <= maxBytes) return { text, truncated: false }
+  return {
+    text: bytes.subarray(0, Math.max(0, maxBytes)).toString("utf8").replace(/\uFFFD$/u, ""),
+    truncated: true,
+  }
+}
+
+function isFailedStatus(status: KhalaToolResultStatus): boolean {
+  return status === "failed" || status === "denied"
+}
+
+function isRecord(value: unknown): value is Readonly<Record<string, unknown>> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+function nextToolEventId(kind: KhalaToolEventKind): string {
+  return `khala.tool.${kind}.${Date.now().toString(36)}.${Math.random().toString(36).slice(2, 10)}`
+}

--- a/packages/khala-tools/src/index.ts
+++ b/packages/khala-tools/src/index.ts
@@ -1,4 +1,5 @@
 import { Effect, Schema as S } from "effect"
+import { makeKhalaToolDispatcher, type KhalaToolDispatcherOptions } from "./dispatcher.js"
 import { redactKhalaPublicText } from "./redaction.js"
 
 export {
@@ -513,38 +514,10 @@ export function executeKhalaTool(
   registry: KhalaToolRegistry,
   invocation: KhalaToolInvocation,
   services: KhalaToolServices,
+  options: KhalaToolDispatcherOptions = {},
 ): Effect.Effect<KhalaToolResult, never> {
-  const tool = registry.resolve(invocation.name)
-  if (tool === undefined) {
-    return Effect.succeed(khalaToolError("unknown_tool", `Unknown tool: ${invocation.name}`))
-  }
-  if (tool.execute === undefined) {
-    return Effect.succeed(khalaToolError("missing_handler", `Tool has no execute handler: ${invocation.name}`))
-  }
-  if (!isRecord(invocation.arguments)) {
-    return Effect.succeed(khalaToolError("invalid_arguments", "Invalid tool input: expected an object"))
-  }
-  const definition = tool.definition
-  if (definition.permissionMode === "deny") {
-    return Effect.succeed(khalaToolDenied("permission_policy_denied", `${definition.name} is denied by policy`))
-  }
-  const permissionEffect =
-    definition.permissionMode === "approval_required"
-      ? services.permission.decide(permissionRequestFor(definition, invocation, services))
-      : Effect.succeed("allow" as const)
-
-  return permissionEffect.pipe(
-    Effect.flatMap(decision => {
-      if (decision === "deny") {
-        return Effect.succeed(khalaToolDenied("permission_denied", `${definition.name} denied by permission service`))
-      }
-      return tool.execute!(invocation.arguments, { definition, invocation, services }).pipe(
-        Effect.map(sanitizeToolResult),
-        Effect.catchTag("KhalaToolRuntimeError", error =>
-          Effect.succeed(khalaToolError(error.code, error.reason)),
-        ),
-      )
-    }),
+  return makeKhalaToolDispatcher(options).dispatch({ invocation, registry, services }).pipe(
+    Effect.map(dispatched => dispatched.result),
   )
 }
 
@@ -1232,6 +1205,23 @@ export { createViewImageTool, viewImageToolDefinition } from "./view-image.js"
 export { createWebFetchTool, webFetchToolDefinition } from "./web-fetch.js"
 export { createWebSearchTool, webSearchToolDefinition } from "./web-search.js"
 export {
+  createKhalaToolTurnAccounting,
+  makeKhalaToolDispatcher,
+  type KhalaToolDispatcher,
+  type KhalaToolDispatcherOptions,
+  type KhalaToolDispatchAfterHookContext,
+  type KhalaToolDispatchEventContext,
+  type KhalaToolDispatchHookContext,
+  type KhalaToolDispatchHooks,
+  type KhalaToolDispatchInput,
+  type KhalaToolDispatchPhase,
+  type KhalaToolDispatchResult,
+  type KhalaToolTelemetryTags,
+  type KhalaToolTelemetryTagValue,
+  type KhalaToolTurnAccounting,
+  type KhalaToolTurnAccountingSnapshot,
+} from "./dispatcher.js"
+export {
   browserClickToolDefinition,
   browserNavigateToolDefinition,
   browserReadDomToolDefinition,
@@ -1249,38 +1239,3 @@ export {
   createBrowserTypeTool,
   createBrowserWaitForTool,
 } from "./browser.js"
-
-function permissionRequestFor(
-  definition: KhalaToolDefinition,
-  invocation: KhalaToolInvocation,
-  services: KhalaToolServices,
-): KhalaPermissionRequest {
-  const resources = typeof invocation.arguments.path === "string"
-    ? [invocation.arguments.path]
-    : typeof invocation.arguments.url === "string"
-      ? [invocation.arguments.url]
-      : typeof invocation.arguments.query === "string"
-        ? [invocation.arguments.query]
-        : typeof invocation.arguments.selector === "string"
-          ? [invocation.arguments.selector]
-          : typeof invocation.arguments.label === "string"
-            ? [invocation.arguments.label]
-            : typeof invocation.arguments.value === "string"
-              ? [invocation.arguments.value]
-              : []
-  return {
-    action: definition.authority,
-    authorityMode: definition.executionMode,
-    publicSafety: "private",
-    resources,
-    saveScope: "once",
-    sessionId: invocation.sessionId,
-    toolCallId: invocation.id,
-    toolName: definition.name,
-    workingDirectory: services.workspace.workingDirectory,
-  }
-}
-
-function isRecord(value: unknown): value is Readonly<Record<string, unknown>> {
-  return typeof value === "object" && value !== null && !Array.isArray(value)
-}


### PR DESCRIPTION
## Summary

- Add a central `KhalaToolDispatcher` with pre/post hooks, lifecycle `KhalaToolEvent` emission, telemetry tags, per-turn accounting, typed model-visible dispatcher errors, and last-resort output bounding to private artifacts.
- Keep `executeKhalaTool(...)` as the compatibility entrypoint by routing it through the dispatcher.
- Route Khala Code Desktop tool calls through a per-turn dispatcher with shared accounting.
- Add focused dispatcher tests for hooks/events, accounting limits, typed errors, and output bounding.

Closes #7652.

## Verification

- `bun run test:khala-tools` (`command.public.pylon_khala.verify.9265d9586f74dc431fb3b763`)
- `bun run --cwd packages/khala-tools typecheck`
- `bun run test:khala-code-desktop`
- `bun run --cwd clients/khala-code-desktop typecheck`