### PR TITLE
Add Khala durable session rollout resume

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -358,6 +358,7 @@
         "khala": "dist/index.js",
       },
       "dependencies": {
+        "@openagentsinc/khala-tools": "workspace:*",
         "@openai/codex-sdk": "^0.139.0",
       },
       "devDependencies": {

--- a/clients/khala-cli/package.json
+++ b/clients/khala-cli/package.json
@@ -28,6 +28,7 @@
     "access": "public"
   },
   "dependencies": {
+    "@openagentsinc/khala-tools": "workspace:*",
     "@openai/codex-sdk": "^0.139.0"
   },
   "devDependencies": {

--- a/clients/khala-cli/src/cli.test.ts
+++ b/clients/khala-cli/src/cli.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test"
 import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { dirname, join } from "node:path"
+import { khalaSessionModelItems, readKhalaSessionRollout } from "@openagentsinc/khala-tools"
 
 import { formatKhalaSpawnCapabilityAnswer, runKhalaCli } from "./cli.js"
 import { normalizeTerminalMarkdownSpacing } from "./terminal.js"
@@ -376,6 +377,100 @@ describe("Khala CLI info diagnostics", () => {
 
     expect(authHeaders).toContain("Bearer oa_agent_stored_api_test")
     expect(JSON.parse(stdout).text).toBe("stored api token ok")
+  })
+
+  test("persists headless sessions and resumes or forks them with prior context", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "khala-session-cli-test-"))
+    const sessionDir = join(dir, "state")
+    const requests: Array<ReadonlyArray<{ readonly content?: string; readonly role?: string }>> = []
+    const server = Bun.serve({
+      port: 0,
+      fetch: async request => {
+        expect(new URL(request.url).pathname).toBe("/api/khala/chat")
+        const body = await request.json() as { readonly messages?: ReadonlyArray<{ readonly content?: string; readonly role?: string }> }
+        requests.push(body.messages ?? [])
+        const newest = String(body.messages?.at(-1)?.content ?? "")
+        const text = `answer:${newest}`
+        return new Response([
+          `event: delta\ndata: ${JSON.stringify({ text })}`,
+          'event: done\ndata: {"done":true}',
+          "",
+        ].join("\n\n"), {
+          headers: { "content-type": "text/event-stream" },
+        })
+      },
+    })
+
+    const originalWrite = process.stdout.write
+    let stdout = ""
+    process.stdout.write = ((chunk: string | Uint8Array) => {
+      stdout += String(chunk)
+      return true
+    }) as typeof process.stdout.write
+    try {
+      const firstExit = await runKhalaCli([
+        "--headless",
+        "--json",
+        "--base-url",
+        `http://127.0.0.1:${server.port}`,
+        "--session-dir",
+        sessionDir,
+        "--prompt",
+        "first",
+      ], { KHALA_CODEX_AUTO: "off" })
+      expect(firstExit).toBe(0)
+      const first = JSON.parse(stdout) as { readonly sessionId: string; readonly text: string }
+      expect(first.text).toBe("answer:first")
+
+      stdout = ""
+      const resumeExit = await runKhalaCli([
+        "--json",
+        "--base-url",
+        `http://127.0.0.1:${server.port}`,
+        "--session-dir",
+        sessionDir,
+        "--prompt",
+        "second",
+        "resume",
+        first.sessionId,
+      ], { KHALA_CODEX_AUTO: "off" })
+      expect(resumeExit).toBe(0)
+      const resumed = JSON.parse(stdout) as { readonly sessionId: string; readonly text: string }
+      expect(resumed.sessionId).toBe(first.sessionId)
+      expect(resumed.text).toBe("answer:second")
+
+      stdout = ""
+      const forkExit = await runKhalaCli([
+        "--json",
+        "--base-url",
+        `http://127.0.0.1:${server.port}`,
+        "--session-dir",
+        sessionDir,
+        "fork",
+        first.sessionId,
+      ], { KHALA_CODEX_AUTO: "off" })
+      expect(forkExit).toBe(0)
+      const forked = JSON.parse(stdout) as { readonly parentSessionId: string; readonly sessionId: string }
+      expect(forked.parentSessionId).toBe(first.sessionId)
+      expect(forked.sessionId).not.toBe(first.sessionId)
+
+      const loaded = await readKhalaSessionRollout(sessionDir, first.sessionId)
+      expect(khalaSessionModelItems(loaded).map(item => `${item.role}:${item.body}`)).toEqual([
+        "user:first",
+        "assistant:answer:first",
+        "user:second",
+        "assistant:answer:second",
+      ])
+    } finally {
+      process.stdout.write = originalWrite
+      server.stop(true)
+    }
+
+    expect(requests[1]).toEqual([
+      { content: "first", role: "user" },
+      { content: "answer:first", role: "assistant" },
+      { content: "second", role: "user" },
+    ])
   })
 
   test("uses the stored login token for pylon spawn when no env or flag token is present", async () => {

--- a/clients/khala-cli/src/cli.ts
+++ b/clients/khala-cli/src/cli.ts
@@ -1,4 +1,15 @@
 import { Effect } from "effect"
+import { homedir } from "node:os"
+import { join } from "node:path"
+import {
+  appendKhalaSessionModelItem,
+  createKhalaSessionRollout,
+  forkKhalaSessionRollout,
+  khalaSessionModelItems,
+  listKhalaSessionRollouts,
+  readKhalaSessionRollout,
+  type KhalaSessionRolloutLoaded,
+} from "@openagentsinc/khala-tools"
 import { appendAssistantTurn, prepareUserTurn } from "./bounds.js"
 import { KHALA_CLI_VERSION, formatKhalaChangelog } from "./changelog.js"
 import {
@@ -102,6 +113,8 @@ type ParsedCommand =
     }
   | { readonly kind: "login" }
   | { readonly kind: "logout" }
+  | { readonly kind: "resume"; readonly sessionId: string | undefined }
+  | { readonly kind: "fork"; readonly sessionId: string | undefined }
   | { readonly kind: "spawn"; readonly text: string | undefined }
   | { readonly kind: "spawnCancel"; readonly targetRef: string | undefined }
   | { readonly kind: "spawnJoin"; readonly runRef: string | undefined }
@@ -119,6 +132,7 @@ interface ParsedArgs {
   readonly baseUrl: string
   readonly token: string | undefined
   readonly prompt: string | undefined
+  readonly sessionDir: string | undefined
   readonly headless: boolean
   readonly json: boolean
   readonly models: boolean
@@ -322,6 +336,16 @@ export async function runKhalaCli(argv: ReadonlyArray<string>, env: Record<strin
       )
       return 0
     }
+    if (args.command.kind === "resume") {
+      const result = await runResumeCommand(args, env, args.command.sessionId)
+      process.stdout.write(args.json ? `${JSON.stringify(result, null, 2)}\n` : `${formatSessionCommandResult(result)}\n`)
+      return 0
+    }
+    if (args.command.kind === "fork") {
+      const result = await runForkCommand(args, env, args.command.sessionId)
+      process.stdout.write(args.json ? `${JSON.stringify(result, null, 2)}\n` : `${formatSessionCommandResult(result)}\n`)
+      return 0
+    }
     if (args.command.kind === "tokens") {
       const tokens = await Effect.runPromise(fetchTokensServed({ baseUrl: args.baseUrl }))
       process.stdout.write(args.json ? `${JSON.stringify(tokens)}\n` : `${formatTokensServed(tokens)}\n`)
@@ -352,6 +376,11 @@ export async function runKhalaCli(argv: ReadonlyArray<string>, env: Record<strin
 
     if (shouldRunHeadless(args)) {
       const prompt = args.prompt ?? await readStdinPrompt()
+      const session = await createKhalaSessionRollout({
+        sessionId: createCliSessionId(),
+        stateDir: khalaSessionStateDir(args, env),
+      })
+      await appendCliModelItem(args, env, session.sessionId, "user", prompt)
       const text = await runOneTurn(
         args,
         env,
@@ -360,8 +389,9 @@ export async function runKhalaCli(argv: ReadonlyArray<string>, env: Record<strin
         args.json ? undefined : (delta) => process.stdout.write(delta),
         args.json ? undefined : (delta) => process.stderr.write(renderReasoningMarkdownDeltaForTerminal(delta)),
       )
+      await appendCliModelItem(args, env, session.sessionId, "assistant", text)
       if (args.json) {
-        process.stdout.write(`${JSON.stringify({ text })}\n`)
+        process.stdout.write(`${JSON.stringify({ sessionId: session.sessionId, sessionPath: session.path, text })}\n`)
       } else {
         process.stdout.write("\n")
       }
@@ -395,6 +425,7 @@ function parseArgs(argv: ReadonlyArray<string>, env: Record<string, string | und
   let baseUrl = env.KHALA_BASE_URL ?? DEFAULT_BASE_URL
   let token = env.OPENAGENTS_AGENT_TOKEN
   let prompt: string | undefined
+  let sessionDir: string | undefined
   let headless = false
   let json = false
   let models = false
@@ -528,6 +559,11 @@ function parseArgs(argv: ReadonlyArray<string>, env: Record<string, string | und
       index += 1
     } else if (arg.startsWith("--prompt=")) {
       prompt = arg.slice("--prompt=".length)
+    } else if (arg === "--session-dir") {
+      sessionDir = requireValue(argv, index, arg)
+      index += 1
+    } else if (arg.startsWith("--session-dir=")) {
+      sessionDir = arg.slice("--session-dir=".length)
     } else if (arg === "--account") {
       fleetAccount = requireValue(argv, index, arg)
       index += 1
@@ -611,6 +647,10 @@ function parseArgs(argv: ReadonlyArray<string>, env: Record<string, string | und
     command = { kind: "login" }
   } else if (maybeCommand === "logout") {
     command = { kind: "logout" }
+  } else if (maybeCommand === "resume") {
+    command = { kind: "resume", sessionId: positional[1] }
+  } else if (maybeCommand === "fork") {
+    command = { kind: "fork", sessionId: positional[1] }
   } else if (maybeCommand === "spawn") {
     command = {
       kind: "spawn",
@@ -641,6 +681,7 @@ function parseArgs(argv: ReadonlyArray<string>, env: Record<string, string | und
     baseUrl,
     token,
     prompt,
+    sessionDir,
     headless,
     json,
     models,
@@ -675,6 +716,7 @@ async function runInteractive(args: ParsedArgs, env: Record<string, string | und
   // transcript so the two personas never share conversation context.
   let channel: Channel = args.channel
   const sessionId = createCliSessionId()
+  await createKhalaSessionRollout({ sessionId, stateDir: khalaSessionStateDir(args, env) })
   process.stdout.write(`${welcomeBanner()}\n\n`)
   if (channel === "artanis") {
     process.stdout.write(`${artanisBanner()}\n\n`)
@@ -731,6 +773,7 @@ async function runInteractive(args: ParsedArgs, env: Record<string, string | und
 
     if (channel === "artanis") {
       const prepared = prepareUserTurn(messages, prompt)
+      await appendCliModelItem(args, env, sessionId, "user", prompt)
       const waitingDots = startWaitingDots()
       try {
         const token = await ensureStoredAgentToken({
@@ -746,6 +789,7 @@ async function runInteractive(args: ParsedArgs, env: Record<string, string | und
         waitingDots.stop()
         process.stdout.write(`${terminalStyle.assistant("Artanis:")} ${renderMarkdownForTerminal(result.text)}\n\n`)
         messages = appendAssistantTurn(prepared, result.text)
+        await appendCliModelItem(args, env, sessionId, "assistant", result.text)
         lastTraceRef = result.traceRef ?? lastTraceRef
       } catch (error) {
         waitingDots.stop()
@@ -759,6 +803,8 @@ async function runInteractive(args: ParsedArgs, env: Record<string, string | und
     const resolvedArgs = await withStoredApiToken(args, env)
     const routed = await maybeRunLocalCodexTurn(resolvedArgs, env, messages, prompt)
     if (routed.handled) {
+      await appendCliModelItem(args, env, sessionId, "user", prompt)
+      await appendCliModelItem(args, env, sessionId, "assistant", routed.text)
       messages = appendAssistantTurn(
         prepareUserTurn(messages, prompt),
         routed.text,
@@ -767,6 +813,7 @@ async function runInteractive(args: ParsedArgs, env: Record<string, string | und
     }
 
     const prepared = prepareUserTurn(messages, prompt)
+    await appendCliModelItem(args, env, sessionId, "user", prompt)
     // Resolve BYOK per-turn so /key add and /key remove take effect live.
     // Built on resolvedArgs so a stored `khala login` token is still honored.
     const exec = await resolveChatExecution(resolvedArgs, env)
@@ -827,6 +874,7 @@ async function runInteractive(args: ParsedArgs, env: Record<string, string | und
         process.stdout.write(`${terminalStyle.assistant("Khala:")} ${renderMarkdownForTerminal(result.text)}\n\n`)
       }
       messages = appendAssistantTurn(prepared, result.text)
+      await appendCliModelItem(args, env, sessionId, "assistant", result.text)
       lastTraceRef = result.traceRef ?? lastTraceRef
       lastMessageInfo = result.metadata
     } catch (error) {
@@ -1117,6 +1165,127 @@ async function runOneTurn(
     },
   }))
   return result.text
+}
+
+type KhalaSessionCommandResult = Readonly<{
+  action: "fork" | "resume"
+  modelItemCount: number
+  parentSessionId?: string | undefined
+  recordCount: number
+  sessionId: string
+  sessionPath: string
+  text?: string | undefined
+}>
+
+async function runResumeCommand(
+  args: ParsedArgs,
+  env: Record<string, string | undefined>,
+  requestedSessionId: string | undefined,
+): Promise<KhalaSessionCommandResult> {
+  const stateDir = khalaSessionStateDir(args, env)
+  const sessionId = await resolveSessionCommandTarget(stateDir, requestedSessionId)
+  const loaded = await readKhalaSessionRollout(stateDir, sessionId)
+  const prompt = args.prompt?.trim()
+  if (prompt === undefined || prompt.length === 0) {
+    return sessionCommandResult("resume", loaded)
+  }
+  const history = messagesFromRollout(loaded)
+  await appendCliModelItem(args, env, loaded.sessionId, "user", prompt)
+  const text = await runOneTurn(args, env, history, prompt)
+  await appendCliModelItem(args, env, loaded.sessionId, "assistant", text)
+  return { ...sessionCommandResult("resume", await readKhalaSessionRollout(stateDir, loaded.sessionId)), text }
+}
+
+async function runForkCommand(
+  args: ParsedArgs,
+  env: Record<string, string | undefined>,
+  requestedSessionId: string | undefined,
+): Promise<KhalaSessionCommandResult> {
+  const stateDir = khalaSessionStateDir(args, env)
+  const sourceSessionId = await resolveSessionCommandTarget(stateDir, requestedSessionId)
+  const forked = await forkKhalaSessionRollout({
+    fromSessionId: sourceSessionId,
+    stateDir,
+  })
+  const prompt = args.prompt?.trim()
+  if (prompt === undefined || prompt.length === 0) {
+    return sessionCommandResult("fork", forked, sourceSessionId)
+  }
+  const history = messagesFromRollout(forked)
+  await appendCliModelItem(args, env, forked.sessionId, "user", prompt)
+  const text = await runOneTurn(args, env, history, prompt)
+  await appendCliModelItem(args, env, forked.sessionId, "assistant", text)
+  return { ...sessionCommandResult("fork", await readKhalaSessionRollout(stateDir, forked.sessionId), sourceSessionId), text }
+}
+
+async function resolveSessionCommandTarget(stateDir: string, requestedSessionId: string | undefined): Promise<string> {
+  const explicit = requestedSessionId?.trim()
+  if (explicit !== undefined && explicit.length > 0 && explicit !== "--last") return explicit
+  const [latest] = await listKhalaSessionRollouts(stateDir)
+  if (latest === undefined) {
+    throw new Error("No Khala sessions found. Start a chat or pass a session id.")
+  }
+  return latest.sessionId
+}
+
+function sessionCommandResult(
+  action: "fork" | "resume",
+  loaded: KhalaSessionRolloutLoaded,
+  parentSessionId?: string | undefined,
+): KhalaSessionCommandResult {
+  return {
+    action,
+    modelItemCount: khalaSessionModelItems(loaded).length,
+    ...(parentSessionId === undefined ? {} : { parentSessionId }),
+    recordCount: loaded.records.length,
+    sessionId: loaded.sessionId,
+    sessionPath: loaded.path,
+  }
+}
+
+function formatSessionCommandResult(result: KhalaSessionCommandResult): string {
+  const verb = result.action === "fork" ? "Forked" : "Resumed"
+  const lines = [
+    `${verb} Khala session: ${result.sessionId}`,
+    ...(result.parentSessionId === undefined ? [] : [`parent: ${result.parentSessionId}`]),
+    `records: ${result.recordCount}`,
+    `model items: ${result.modelItemCount}`,
+    `rollout: ${result.sessionPath}`,
+  ]
+  if (result.text !== undefined) {
+    lines.push("")
+    lines.push(result.text)
+  }
+  return lines.join("\n")
+}
+
+function messagesFromRollout(loaded: KhalaSessionRolloutLoaded): ReadonlyArray<KhalaChatMessage> {
+  return khalaSessionModelItems(loaded)
+    .flatMap(item => {
+      if (item.role !== "user" && item.role !== "assistant") return []
+      return [{ role: item.role, content: item.body }]
+    })
+}
+
+async function appendCliModelItem(
+  args: ParsedArgs,
+  env: Record<string, string | undefined>,
+  sessionId: string,
+  role: "assistant" | "user",
+  body: string,
+): Promise<void> {
+  await appendKhalaSessionModelItem(khalaSessionStateDir(args, env), sessionId, {
+    body,
+    id: `msg.${role}.${crypto.randomUUID()}`,
+    role,
+  })
+}
+
+function khalaSessionStateDir(args: ParsedArgs, env: Record<string, string | undefined>): string {
+  const explicit = args.sessionDir?.trim() || env.KHALA_SESSION_DIR?.trim()
+  if (explicit) return explicit
+  const stateHome = env.XDG_STATE_HOME?.trim() || join(homedir(), ".local", "state")
+  return join(stateHome, "khala")
 }
 
 async function withStoredApiToken(
@@ -2104,6 +2273,10 @@ Usage:
   khala help
   khala login
   khala logout
+  khala resume <sessionId>
+  khala resume <sessionId> --prompt "continue"
+  khala fork <sessionId>
+  khala fork <sessionId> --prompt "try another path"
   khala info
   khala key add <provider> <api-key>
   khala key list
@@ -2158,6 +2331,7 @@ Flags:
   --public             Use /api/khala/chat (default, no auth)
   --api                Use /api/v1/chat/completions with openagents/khala
   --artanis            Talk to the owner-only Artanis operator channel
+  --session-dir <dir>  Store/read append-only JSONL sessions in this state dir
                        (POST /api/operator/artanis/chat, owner token required)
   --khala              Use the public Khala channel (default)
   --base-url <url>     Override ${DEFAULT_BASE_URL}

--- a/packages/khala-tools/src/index.ts
+++ b/packages/khala-tools/src/index.ts
@@ -2,6 +2,36 @@ import { Effect, Schema as S } from "effect"
 import { redactKhalaPublicText } from "./redaction.js"
 
 export {
+  appendKhalaSessionModelItem,
+  appendKhalaSessionRolloutRecord,
+  appendKhalaSessionToolEvent,
+  compactKhalaSessionRollout,
+  createKhalaSessionRollout,
+  forkKhalaSessionRollout,
+  KhalaSessionModelItem,
+  KhalaSessionModelItemRole,
+  KhalaSessionRolloutRecord,
+  KhalaSessionRolloutRecordKind,
+  KhalaSessionRolloutSchemaVersion,
+  khalaSessionModelItems,
+  khalaSessionRolloutPath,
+  khalaSessionToolEvents,
+  listKhalaSessionRollouts,
+  parseKhalaSessionRolloutText,
+  readKhalaSessionRollout,
+  type KhalaSessionModelItem as KhalaSessionModelItemType,
+  type KhalaSessionModelItemRole as KhalaSessionModelItemRoleType,
+  type KhalaSessionRolloutAppendInput,
+  type KhalaSessionRolloutAppendOptions,
+  type KhalaSessionRolloutCreateOptions,
+  type KhalaSessionRolloutForkOptions,
+  type KhalaSessionRolloutLoaded,
+  type KhalaSessionRolloutRecord as KhalaSessionRolloutRecordType,
+  type KhalaSessionRolloutRecordKind as KhalaSessionRolloutRecordKindType,
+  type KhalaSessionRolloutSummary,
+} from "./session-rollout.js"
+
+export {
   KhalaPrivacyRedactionLive,
   KhalaPrivacyRedactionService,
   makeKhalaPrivacyRedactionService,

--- a/packages/khala-tools/src/session-rollout.test.ts
+++ b/packages/khala-tools/src/session-rollout.test.ts
@@ -1,0 +1,113 @@
+import { mkdtemp, readFile, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { describe, expect, test } from "bun:test"
+import {
+  appendKhalaSessionModelItem,
+  appendKhalaSessionToolEvent,
+  createKhalaSessionRollout,
+  forkKhalaSessionRollout,
+  khalaSessionModelItems,
+  khalaSessionRolloutPath,
+  khalaSessionToolEvents,
+  parseKhalaSessionRolloutText,
+  readKhalaSessionRollout,
+} from "./index.js"
+
+async function makeStateDir(): Promise<string> {
+  return mkdtemp(join(tmpdir(), "khala-session-rollout-"))
+}
+
+describe("Khala session rollout", () => {
+  test("persists model items and tool events as append-only JSONL", async () => {
+    const stateDir = await makeStateDir()
+    const session = await createKhalaSessionRollout({
+      createdAt: "2026-06-30T00:00:00.000Z",
+      sessionId: "session.test",
+      stateDir,
+    })
+
+    await appendKhalaSessionModelItem(stateDir, session.sessionId, {
+      body: "Inspect README.md",
+      id: "msg.user.1",
+      role: "user",
+    }, { createdAt: "2026-06-30T00:00:01.000Z" })
+    await appendKhalaSessionToolEvent(stateDir, session.sessionId, {
+      eventId: "event.tool.1",
+      invocationId: "call_1",
+      kind: "tool_completed",
+      payload: { publicSummary: "read: ok" },
+      sessionId: session.sessionId,
+    }, { createdAt: "2026-06-30T00:00:02.000Z" })
+
+    const loaded = await readKhalaSessionRollout(stateDir, session.sessionId)
+    const text = await readFile(khalaSessionRolloutPath(stateDir, session.sessionId), "utf8")
+
+    expect(text.trim().split("\n")).toHaveLength(3)
+    expect(loaded.records.map(record => record.sequence)).toEqual([0, 1, 2])
+    expect(khalaSessionModelItems(loaded)).toEqual([
+      { body: "Inspect README.md", id: "msg.user.1", role: "user" },
+    ])
+    expect(khalaSessionToolEvents(loaded)).toEqual([
+      expect.objectContaining({ eventId: "event.tool.1", kind: "tool_completed" }),
+    ])
+  })
+
+  test("tolerates a corrupt trailing line from an interrupted append", async () => {
+    const stateDir = await makeStateDir()
+    await createKhalaSessionRollout({ sessionId: "session.partial", stateDir })
+    await appendKhalaSessionModelItem(stateDir, "session.partial", {
+      body: "hello",
+      id: "msg.user.1",
+      role: "user",
+    })
+    const path = khalaSessionRolloutPath(stateDir, "session.partial")
+    const current = await readFile(path, "utf8")
+    await writeFile(path, `${current}{not-json`)
+
+    const loaded = await readKhalaSessionRollout(stateDir, "session.partial")
+
+    expect(loaded.corruptLineCount).toBe(1)
+    expect(khalaSessionModelItems(loaded).map(item => item.body)).toEqual(["hello"])
+  })
+
+  test("forks into a new session with intact model and tool history", async () => {
+    const stateDir = await makeStateDir()
+    await createKhalaSessionRollout({ sessionId: "session.source", stateDir })
+    await appendKhalaSessionModelItem(stateDir, "session.source", {
+      body: "Read package.json",
+      id: "msg.user.1",
+      role: "user",
+    })
+    await appendKhalaSessionToolEvent(stateDir, "session.source", {
+      eventId: "event.approval.1",
+      invocationId: "call_approval",
+      kind: "approval_answered",
+      payload: { decision: "allow" },
+      sessionId: "session.source",
+    })
+
+    const forked = await forkKhalaSessionRollout({
+      createdAt: "2026-06-30T00:00:03.000Z",
+      fromSessionId: "session.source",
+      newSessionId: "session.fork",
+      stateDir,
+    })
+
+    expect(forked.records.map(record => record.kind)).toEqual([
+      "session_forked",
+      "model_item",
+      "tool_event",
+    ])
+    expect(forked.records.every(record => record.sessionId === "session.fork")).toBe(true)
+    expect(forked.records[0]?.parentSessionId).toBe("session.source")
+    expect(khalaSessionModelItems(forked).map(item => item.body)).toEqual(["Read package.json"])
+    expect(khalaSessionToolEvents(forked).map(event => event.kind)).toEqual(["approval_answered"])
+  })
+
+  test("rejects corrupt non-trailing rollout lines", () => {
+    expect(() => parseKhalaSessionRolloutText("{bad}\n{}\n", "test.jsonl")).toThrow(
+      "Invalid Khala session rollout record",
+    )
+  })
+})

--- a/packages/khala-tools/src/session-rollout.ts
+++ b/packages/khala-tools/src/session-rollout.ts
@@ -1,0 +1,334 @@
+import { randomUUID } from "node:crypto"
+import { mkdir, readFile, readdir, rename, writeFile } from "node:fs/promises"
+import { dirname, join } from "node:path"
+import { Schema as S } from "effect"
+import { KhalaToolEvent } from "./index.js"
+
+export const KhalaSessionRolloutSchemaVersion = "khala.session_rollout.v1" as const
+
+export const KhalaSessionModelItemRole = S.Literals(["system", "user", "assistant", "tool"])
+export type KhalaSessionModelItemRole = typeof KhalaSessionModelItemRole.Type
+
+export const KhalaSessionModelItem = S.Struct({
+  body: S.String,
+  id: S.String,
+  role: KhalaSessionModelItemRole,
+  toolCallId: S.optional(S.String),
+})
+export type KhalaSessionModelItem = typeof KhalaSessionModelItem.Type
+
+export const KhalaSessionRolloutRecordKind = S.Literals([
+  "session_started",
+  "session_resumed",
+  "session_forked",
+  "model_item",
+  "tool_event",
+])
+export type KhalaSessionRolloutRecordKind = typeof KhalaSessionRolloutRecordKind.Type
+
+export const KhalaSessionRolloutRecord = S.Struct({
+  createdAt: S.String,
+  kind: KhalaSessionRolloutRecordKind,
+  parentSessionId: S.optional(S.String),
+  payload: S.Unknown,
+  recordId: S.String,
+  schemaVersion: S.Literal(KhalaSessionRolloutSchemaVersion),
+  sequence: S.Int,
+  sessionId: S.String,
+})
+export type KhalaSessionRolloutRecord = typeof KhalaSessionRolloutRecord.Type
+
+export type KhalaSessionRolloutLoaded = Readonly<{
+  corruptLineCount: number
+  path: string
+  records: ReadonlyArray<KhalaSessionRolloutRecord>
+  sessionId: string
+}>
+
+export type KhalaSessionRolloutSummary = Readonly<{
+  lastUpdatedAt: string
+  modelItemCount: number
+  path: string
+  recordCount: number
+  sessionId: string
+}>
+
+export type KhalaSessionRolloutCreateOptions = Readonly<{
+  createdAt?: string | undefined
+  parentSessionId?: string | undefined
+  sessionId?: string | undefined
+  stateDir: string
+}>
+
+export type KhalaSessionRolloutAppendInput = Readonly<{
+  kind: KhalaSessionRolloutRecordKind
+  parentSessionId?: string | undefined
+  payload: unknown
+}>
+
+export type KhalaSessionRolloutAppendOptions = Readonly<{
+  createdAt?: string | undefined
+  stateDir: string
+}>
+
+export type KhalaSessionRolloutForkOptions = Readonly<{
+  createdAt?: string | undefined
+  fromSessionId: string
+  newSessionId?: string | undefined
+  stateDir: string
+}>
+
+export async function createKhalaSessionRollout(
+  options: KhalaSessionRolloutCreateOptions,
+): Promise<KhalaSessionRolloutLoaded> {
+  const sessionId = normalizeSessionId(options.sessionId ?? createKhalaSessionId())
+  const path = khalaSessionRolloutPath(options.stateDir, sessionId)
+  await mkdir(dirname(path), { mode: 0o700, recursive: true })
+  const record = makeRolloutRecord({
+    createdAt: options.createdAt,
+    kind: options.parentSessionId === undefined ? "session_started" : "session_forked",
+    parentSessionId: options.parentSessionId,
+    payload: options.parentSessionId === undefined
+      ? { sessionId }
+      : { fromSessionId: options.parentSessionId, sessionId },
+    sequence: 0,
+    sessionId,
+  })
+  await writeFile(path, `${JSON.stringify(record)}\n`, { mode: 0o600, flag: "wx" })
+  return { corruptLineCount: 0, path, records: [record], sessionId }
+}
+
+export async function appendKhalaSessionRolloutRecord(
+  stateDir: string,
+  sessionId: string,
+  input: KhalaSessionRolloutAppendInput,
+  options: KhalaSessionRolloutAppendOptions = { stateDir },
+): Promise<KhalaSessionRolloutRecord> {
+  const loaded = await readKhalaSessionRollout(options.stateDir, sessionId)
+  const record = makeRolloutRecord({
+    createdAt: options.createdAt,
+    kind: input.kind,
+    parentSessionId: input.parentSessionId,
+    payload: input.payload,
+    sequence: nextSequence(loaded.records),
+    sessionId: loaded.sessionId,
+  })
+  await writeFile(loaded.path, `${JSON.stringify(record)}\n`, { flag: "a", mode: 0o600 })
+  return record
+}
+
+export async function appendKhalaSessionModelItem(
+  stateDir: string,
+  sessionId: string,
+  item: KhalaSessionModelItem,
+  options: Omit<KhalaSessionRolloutAppendOptions, "stateDir"> = {},
+): Promise<KhalaSessionRolloutRecord> {
+  const payload = S.decodeUnknownSync(KhalaSessionModelItem)(item)
+  return appendKhalaSessionRolloutRecord(stateDir, sessionId, { kind: "model_item", payload }, {
+    ...options,
+    stateDir,
+  })
+}
+
+export async function appendKhalaSessionToolEvent(
+  stateDir: string,
+  sessionId: string,
+  event: typeof KhalaToolEvent.Type,
+  options: Omit<KhalaSessionRolloutAppendOptions, "stateDir"> = {},
+): Promise<KhalaSessionRolloutRecord> {
+  const payload = S.decodeUnknownSync(KhalaToolEvent)(event)
+  return appendKhalaSessionRolloutRecord(stateDir, sessionId, { kind: "tool_event", payload }, {
+    ...options,
+    stateDir,
+  })
+}
+
+export async function readKhalaSessionRollout(
+  stateDir: string,
+  sessionId: string,
+): Promise<KhalaSessionRolloutLoaded> {
+  const normalized = normalizeSessionId(sessionId)
+  const path = khalaSessionRolloutPath(stateDir, normalized)
+  const text = await readFile(path, "utf8")
+  const parsed = parseKhalaSessionRolloutText(text, path)
+  if (parsed.records.length === 0) {
+    throw new Error(`Khala session rollout has no readable records: ${normalized}`)
+  }
+  const firstSessionId = parsed.records[0]?.sessionId
+  if (firstSessionId !== normalized) {
+    throw new Error(`Khala session rollout id mismatch: expected ${normalized}, found ${firstSessionId ?? "unknown"}`)
+  }
+  return {
+    corruptLineCount: parsed.corruptLineCount,
+    path,
+    records: parsed.records,
+    sessionId: normalized,
+  }
+}
+
+export async function forkKhalaSessionRollout(
+  options: KhalaSessionRolloutForkOptions,
+): Promise<KhalaSessionRolloutLoaded> {
+  const source = await readKhalaSessionRollout(options.stateDir, options.fromSessionId)
+  const fork = await createKhalaSessionRollout({
+    createdAt: options.createdAt,
+    parentSessionId: source.sessionId,
+    sessionId: options.newSessionId,
+    stateDir: options.stateDir,
+  })
+  const inherited = source.records
+    .filter(record => record.kind === "model_item" || record.kind === "tool_event")
+    .map((record, index) => makeRolloutRecord({
+      createdAt: options.createdAt,
+      kind: record.kind,
+      parentSessionId: source.sessionId,
+      payload: record.payload,
+      sequence: index + 1,
+      sessionId: fork.sessionId,
+    }))
+  if (inherited.length > 0) {
+    await writeFile(
+      fork.path,
+      `${inherited.map(record => JSON.stringify(record)).join("\n")}\n`,
+      { flag: "a", mode: 0o600 },
+    )
+  }
+  return {
+    corruptLineCount: 0,
+    path: fork.path,
+    records: [...fork.records, ...inherited],
+    sessionId: fork.sessionId,
+  }
+}
+
+export async function listKhalaSessionRollouts(stateDir: string): Promise<ReadonlyArray<KhalaSessionRolloutSummary>> {
+  const dir = join(stateDir, "sessions")
+  let names: string[]
+  try {
+    names = await readdir(dir)
+  } catch {
+    return []
+  }
+  const summaries = await Promise.all(names
+    .filter(name => name.endsWith(".jsonl"))
+    .map(async name => {
+      const sessionId = name.slice(0, -".jsonl".length)
+      try {
+        const loaded = await readKhalaSessionRollout(stateDir, sessionId)
+        const last = loaded.records[loaded.records.length - 1]
+        return {
+          lastUpdatedAt: last?.createdAt ?? new Date(0).toISOString(),
+          modelItemCount: khalaSessionModelItems(loaded).length,
+          path: loaded.path,
+          recordCount: loaded.records.length,
+          sessionId: loaded.sessionId,
+        } satisfies KhalaSessionRolloutSummary
+      } catch {
+        return undefined
+      }
+    }))
+  return summaries
+    .filter((summary): summary is KhalaSessionRolloutSummary => summary !== undefined)
+    .sort((a, b) => b.lastUpdatedAt.localeCompare(a.lastUpdatedAt))
+}
+
+export function khalaSessionModelItems(
+  rollout: Pick<KhalaSessionRolloutLoaded, "records">,
+): ReadonlyArray<KhalaSessionModelItem> {
+  const items: KhalaSessionModelItem[] = []
+  for (const record of rollout.records) {
+    if (record.kind !== "model_item") continue
+    try {
+      items.push(S.decodeUnknownSync(KhalaSessionModelItem)(record.payload))
+    } catch {
+      continue
+    }
+  }
+  return items
+}
+
+export function khalaSessionToolEvents(
+  rollout: Pick<KhalaSessionRolloutLoaded, "records">,
+): ReadonlyArray<typeof KhalaToolEvent.Type> {
+  const events: Array<typeof KhalaToolEvent.Type> = []
+  for (const record of rollout.records) {
+    if (record.kind !== "tool_event") continue
+    try {
+      events.push(S.decodeUnknownSync(KhalaToolEvent)(record.payload))
+    } catch {
+      continue
+    }
+  }
+  return events
+}
+
+export function khalaSessionRolloutPath(stateDir: string, sessionId: string): string {
+  return join(stateDir, "sessions", `${normalizeSessionId(sessionId)}.jsonl`)
+}
+
+export function parseKhalaSessionRolloutText(
+  text: string,
+  path = "<memory>",
+): Readonly<{ corruptLineCount: number; records: ReadonlyArray<KhalaSessionRolloutRecord> }> {
+  const records: KhalaSessionRolloutRecord[] = []
+  let corruptLineCount = 0
+  const lines = text.split(/\n/)
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index]?.trim()
+    if (line === undefined || line.length === 0) continue
+    try {
+      records.push(S.decodeUnknownSync(KhalaSessionRolloutRecord)(JSON.parse(line)))
+    } catch {
+      if (index === lines.length - 1) {
+        corruptLineCount += 1
+        continue
+      }
+      throw new Error(`Invalid Khala session rollout record in ${path} at line ${index + 1}`)
+    }
+  }
+  return { corruptLineCount, records }
+}
+
+export async function compactKhalaSessionRollout(stateDir: string, sessionId: string): Promise<KhalaSessionRolloutLoaded> {
+  const loaded = await readKhalaSessionRollout(stateDir, sessionId)
+  const tempPath = `${loaded.path}.${process.pid}.${Date.now()}.tmp`
+  await writeFile(tempPath, `${loaded.records.map(record => JSON.stringify(record)).join("\n")}\n`, { mode: 0o600 })
+  await rename(tempPath, loaded.path)
+  return { ...loaded, corruptLineCount: 0 }
+}
+
+function makeRolloutRecord(input: {
+  readonly createdAt?: string | undefined
+  readonly kind: KhalaSessionRolloutRecordKind
+  readonly parentSessionId?: string | undefined
+  readonly payload: unknown
+  readonly sequence: number
+  readonly sessionId: string
+}): KhalaSessionRolloutRecord {
+  return S.decodeUnknownSync(KhalaSessionRolloutRecord)({
+    createdAt: input.createdAt ?? new Date().toISOString(),
+    kind: input.kind,
+    ...(input.parentSessionId === undefined ? {} : { parentSessionId: normalizeSessionId(input.parentSessionId) }),
+    payload: input.payload,
+    recordId: `rollout_record.${randomUUID()}`,
+    schemaVersion: KhalaSessionRolloutSchemaVersion,
+    sequence: input.sequence,
+    sessionId: normalizeSessionId(input.sessionId),
+  })
+}
+
+function nextSequence(records: ReadonlyArray<KhalaSessionRolloutRecord>): number {
+  return records.reduce((max, record) => Math.max(max, record.sequence), -1) + 1
+}
+
+function createKhalaSessionId(): string {
+  return `khala_session.${randomUUID()}`
+}
+
+function normalizeSessionId(sessionId: string): string {
+  const trimmed = sessionId.trim()
+  if (!/^[A-Za-z0-9._-]+$/.test(trimmed)) {
+    throw new Error("Khala session id may only contain letters, numbers, dot, underscore, and dash.")
+  }
+  return trimmed
+}


### PR DESCRIPTION
## Summary

- Add `@openagentsinc/khala-tools` append-only JSONL session rollout helpers for model items, tool events, tolerant resume reads, listing, compaction, and forked sessions.
- Wire `khala resume <sessionId>` and `khala fork <sessionId>` in the CLI, with persisted headless/interactive model-item history under the owner-local Khala state dir.
- Add focused khala-tools and khala-cli tests covering append-only persistence, interrupted trailing writes, fork history, and resumed CLI context.

Closes #7655.

## Verification

- `bun run test:khala-tools` — 131 pass
- `bun run test:khala-cli` — 84 pass
- `bun run typecheck:khala-tools`
- `bun run typecheck:khala-cli`