### PR TITLE
feat(api): add credit ledger bond settlement adapter

### DIFF
--- a/apps/openagents.com/workers/api/src/labor-escrow.test.ts
+++ b/apps/openagents.com/workers/api/src/labor-escrow.test.ts
@@ -5,6 +5,7 @@ import {
   type LaborEscrowState,
   assertLaborEscrowPublicSafe,
   buildLaborEscrowPublicProjection,
+  createCreditLedgerBondSettlementAdapter,
   evaluateArtanisLaborBudgetGate,
   evaluateLaborEscrowFundingSource,
   forfeitLaborEscrow,
@@ -593,6 +594,53 @@ describe('labor escrow ledger statements', () => {
 })
 
 describe('labor escrow D1 guards and projections', () => {
+  test('credit-ledger bond settlement adapter preserves fail-closed authority checks', async () => {
+    const adapter = createCreditLedgerBondSettlementAdapter(null as never)
+
+    expect(adapter.adapterKind).toBe('credit_ledger')
+
+    await expect(
+      adapter.hold({
+        ...reserveInput,
+        amountMsat: 0,
+      }),
+    ).resolves.toEqual({
+      kind: 'refused',
+      reason: 'invalid_amount',
+    })
+
+    await expect(
+      adapter.release({
+        acceptanceEventRef: 'nostr.event.' + 'd'.repeat(64),
+        authority: { actorRef: 'agent:provider', kind: 'provider' },
+        escrowId: 'escrow_1',
+        nowIso,
+        providerActorRef: 'agent:provider',
+        releaseReceiptId: 'receipt_row_release_adapter_forbidden',
+        releaseReceiptRef: 'receipt.labor_escrow.release.adapter_forbidden',
+      }),
+    ).resolves.toEqual({
+      kind: 'refused',
+      reason: 'release_authority_forbidden',
+    })
+
+    await expect(
+      adapter.forfeit({
+        authority: { actorRef: 'agent:requester', kind: 'requester' },
+        counterpartyActorRef: 'agent:counterparty',
+        escrowId: 'escrow_1',
+        forfeitConditionRef: 'verdict.public.validator.non_performance',
+        forfeitDestination: 'counterparty',
+        forfeitReceiptId: 'receipt_row_forfeit_adapter_forbidden',
+        forfeitReceiptRef: 'receipt.labor_escrow.forfeit.adapter_forbidden',
+        nowIso,
+      }),
+    ).resolves.toEqual({
+      kind: 'refused',
+      reason: 'forfeit_authority_forbidden',
+    })
+  })
+
   test('provider and worker authority cannot release escrow', async () => {
     await expect(
       releaseLaborEscrow(null as never, {

--- a/apps/openagents.com/workers/api/src/labor-escrow.ts
+++ b/apps/openagents.com/workers/api/src/labor-escrow.ts
@@ -166,6 +166,26 @@ export type LaborEscrowResult =
       currentState?: LaborEscrowState
     }>
 
+export type BondSettlementAdapterResult =
+  | Readonly<{
+      kind: 'ok'
+      escrow: LaborEscrowRecord
+      idempotent: boolean
+      receiptRef: string
+    }>
+  | Extract<LaborEscrowResult, Readonly<{ kind: 'refused' }>>
+
+export type BondSettlementAdapter = Readonly<{
+  adapterKind: 'credit_ledger'
+  hold: (input: ReserveLaborEscrowInput) => Promise<BondSettlementAdapterResult>
+  release: (
+    input: ReleaseLaborEscrowInput,
+  ) => Promise<BondSettlementAdapterResult>
+  forfeit: (
+    input: ForfeitLaborEscrowInput,
+  ) => Promise<BondSettlementAdapterResult>
+}>
+
 export type ArtanisLaborBudgetGateDecision =
   | Readonly<{ kind: 'allowed'; remainingTickBudgetMsat: number }>
   | Readonly<{
@@ -963,6 +983,40 @@ export const forfeitLaborEscrow = async (
   }
   return { escrow: forfeited, idempotent: false, kind: 'ok' }
 }
+
+const bondSettlementResultFromLaborEscrow = (
+  result: LaborEscrowResult,
+  receiptRef: (escrow: LaborEscrowRecord) => string | null,
+): BondSettlementAdapterResult =>
+  result.kind === 'refused'
+    ? result
+    : {
+        escrow: result.escrow,
+        idempotent: result.idempotent,
+        kind: 'ok',
+        receiptRef: receiptRef(result.escrow) ?? result.escrow.reserveReceiptRef,
+      }
+
+export const createCreditLedgerBondSettlementAdapter = (
+  db: D1Database,
+): BondSettlementAdapter => ({
+  adapterKind: 'credit_ledger',
+  forfeit: async input =>
+    bondSettlementResultFromLaborEscrow(
+      await forfeitLaborEscrow(db, input),
+      escrow => escrow.forfeitReceiptRef,
+    ),
+  hold: async input =>
+    bondSettlementResultFromLaborEscrow(
+      await reserveLaborEscrow(db, input),
+      escrow => escrow.reserveReceiptRef,
+    ),
+  release: async input =>
+    bondSettlementResultFromLaborEscrow(
+      await releaseLaborEscrow(db, input),
+      escrow => escrow.releaseReceiptRef,
+    ),
+})
 
 export const reserveInputFromForumWorkRequest = (
   request: ForumWorkRequestRecord,


### PR DESCRIPTION
Addresses (no linked issue).

### Changes
- Adds a `BondSettlementAdapter` interface and result type for credit-ledger-backed bond settlement.
- Adds `createCreditLedgerBondSettlementAdapter` to wrap escrow hold, release, and forfeit operations while preserving refused results and receipt refs.
- Adds coverage for adapter kind and fail-closed authority checks on invalid hold, forbidden release, and forbidden forfeit paths.

### Verification
- `bun run --cwd apps/openagents.com/workers/api typecheck` passed (exit 0).