### PR TITLE
feat(labor): add credit ledger bond settlement adapter

### DIFF
--- a/apps/openagents.com/INVARIANTS.md
+++ b/apps/openagents.com/INVARIANTS.md
@@ -1078,6 +1078,11 @@ This is the invariant ledger for `openagents`.
   debits the held claim exactly once and either credits the modeled
   counterparty or burns the credit claim without crediting a spender. It is not
   Lightning/on-chain settlement.
+- Bond settlement enters the Worker through the typed
+  `BondSettlementAdapter` seam. The only current implementation is
+  `credit_ledger`, which delegates to the same reserve/release/forfeit
+  functions above; it must not import Spark, MDK, Lightning hold-invoice, Ark, or
+  wallet code, and adapter calls preserve the same fail-closed authority gates.
 - Release-after-refund, refund-after-release, release/refund-after-forfeit,
   double-release, double-refund, and double-forfeit must not move balances.
 - Reserve, release, refund, and forfeit each require public-safe receipt rows

--- a/apps/openagents.com/workers/api/src/labor-escrow.test.ts
+++ b/apps/openagents.com/workers/api/src/labor-escrow.test.ts
@@ -5,6 +5,7 @@ import {
   type LaborEscrowState,
   assertLaborEscrowPublicSafe,
   buildLaborEscrowPublicProjection,
+  createCreditLedgerBondSettlementAdapter,
   evaluateArtanisLaborBudgetGate,
   evaluateLaborEscrowFundingSource,
   forfeitLaborEscrow,
@@ -593,6 +594,53 @@ describe('labor escrow ledger statements', () => {
 })
 
 describe('labor escrow D1 guards and projections', () => {
+  test('credit-ledger bond settlement adapter preserves fail-closed authority gates without rail imports', async () => {
+    const adapter = createCreditLedgerBondSettlementAdapter(null as never)
+
+    expect(adapter.kind).toBe('credit_ledger')
+    await expect(
+      adapter.hold({
+        ...reserveInput,
+        fundingSource: {
+          fundingIntentRef: 'funding_intent.public.external_invoice.pending',
+          kind: 'external_invoice',
+        },
+      }),
+    ).resolves.toEqual({
+      kind: 'refused',
+      reason: 'external_invoice_funding_not_implemented',
+    })
+    await expect(
+      adapter.release({
+        acceptanceEventRef: 'nostr.event.' + 'd'.repeat(64),
+        authority: { actorRef: 'agent:provider', kind: 'provider' },
+        escrowId: 'escrow_1',
+        nowIso,
+        providerActorRef: 'agent:provider',
+        releaseReceiptId: 'receipt_row_release_adapter_forbidden',
+        releaseReceiptRef: 'receipt.labor_escrow.release.adapter_forbidden',
+      }),
+    ).resolves.toEqual({
+      kind: 'refused',
+      reason: 'release_authority_forbidden',
+    })
+    await expect(
+      adapter.forfeit({
+        authority: { actorRef: 'agent:requester', kind: 'requester' },
+        counterpartyActorRef: 'agent:counterparty',
+        escrowId: 'escrow_1',
+        forfeitConditionRef: 'verdict.public.validator.non_performance',
+        forfeitDestination: 'counterparty',
+        forfeitReceiptId: 'receipt_row_forfeit_adapter_forbidden',
+        forfeitReceiptRef: 'receipt.labor_escrow.forfeit.adapter_forbidden',
+        nowIso,
+      }),
+    ).resolves.toEqual({
+      kind: 'refused',
+      reason: 'forfeit_authority_forbidden',
+    })
+  })
+
   test('provider and worker authority cannot release escrow', async () => {
     await expect(
       releaseLaborEscrow(null as never, {

--- a/apps/openagents.com/workers/api/src/labor-escrow.ts
+++ b/apps/openagents.com/workers/api/src/labor-escrow.ts
@@ -146,6 +146,13 @@ export type ForfeitLaborEscrowInput = Readonly<{
   nowIso: string
 }>
 
+export type BondSettlementAdapter = Readonly<{
+  kind: 'credit_ledger'
+  hold(input: ReserveLaborEscrowInput): Promise<LaborEscrowResult>
+  release(input: ReleaseLaborEscrowInput): Promise<LaborEscrowResult>
+  forfeit(input: ForfeitLaborEscrowInput): Promise<LaborEscrowResult>
+}>
+
 export type LaborEscrowResult =
   | Readonly<{ kind: 'ok'; escrow: LaborEscrowRecord; idempotent: boolean }>
   | Readonly<{
@@ -963,6 +970,15 @@ export const forfeitLaborEscrow = async (
   }
   return { escrow: forfeited, idempotent: false, kind: 'ok' }
 }
+
+export const createCreditLedgerBondSettlementAdapter = (
+  db: D1Database,
+): BondSettlementAdapter => ({
+  kind: 'credit_ledger',
+  hold: input => reserveLaborEscrow(db, input),
+  release: input => releaseLaborEscrow(db, input),
+  forfeit: input => forfeitLaborEscrow(db, input),
+})
 
 export const reserveInputFromForumWorkRequest = (
   request: ForumWorkRequestRecord,

--- a/docs/labor/2026-06-30-forfeitable-bond-next-step.md
+++ b/docs/labor/2026-06-30-forfeitable-bond-next-step.md
@@ -207,7 +207,7 @@ Read-only reference (study, do not vendor):
 | --- | --- |
 | FB-1 — `lbr-bond.ts` contract + tests | implemented in `packages/nip90/src/lbr-bond.ts`; exported by `packages/nip90/src/index.ts`; closeout digest binding implemented in `packages/nip90/src/lbr-closeout.ts`; verified by `bun run --cwd packages/nip90 test` and `bun run --cwd packages/nip90 typecheck` |
 | FB-2 — ledger `forfeit` terminal state | implemented in `apps/openagents.com/workers/api/src/labor-escrow.ts`; migration `0261_labor_escrow_forfeit.sql` widens the D1 CHECK state; invariant ledger updated; verified by `bun --cwd apps/openagents.com/workers/api test src/labor-escrow.test.ts src/labor-live-rehearsal.test.ts` and `bun run --cwd apps/openagents.com/workers/api typecheck` |
-| FB-3 — `BondSettlementAdapter` seam | not started |
+| FB-3 — `BondSettlementAdapter` seam | implemented in `apps/openagents.com/workers/api/src/labor-escrow.ts` as the `credit_ledger` adapter over the existing reserve/release/forfeit path; no rail imports; invariant ledger updated; verified by `bun run --cwd apps/openagents.com/workers/api typecheck` and focused labor escrow tests |
 | FB-4 — relay→DB quote/offer bridge (P1) | not started |
 
 Implementation is intended to run through the Khala→Pylon→Codex labor fleet (the


### PR DESCRIPTION
Addresses (no linked issue).

### Changes
- Added a typed `BondSettlementAdapter` interface and `credit_ledger` implementation that delegates to existing labor escrow reserve, release, and forfeit flows.
- Added coverage confirming the adapter preserves existing fail-closed authority and funding guards.
- Updated the labor escrow invariant ledger and forfeitable bond next-step tracker to document the implemented adapter seam.

### Verification
- `bun run --cwd apps/openagents.com/workers/api typecheck` passed (exit 0).