### PR TITLE
test(openagents): cover bond settlement adapter seam

### DIFF
--- a/apps/openagents.com/INVARIANTS.md
+++ b/apps/openagents.com/INVARIANTS.md
@@ -1084,6 +1084,11 @@ This is the invariant ledger for `openagents`.
   carrying refs, destinations, and amounts only. Escrowed, credited, or
   forfeited amounts are not settled bitcoin until the later payout path records
   settlement evidence.
+- Bond settlement is addressed through the typed `BondSettlementAdapter` seam.
+  The only current implementation is the credit-ledger adapter over the labor
+  escrow lifecycle; it must not import Spark, MDK, Lightning hold-invoice, Ark,
+  wallet, or payout-rail code. Future rail adapters must preserve the same
+  validator-only forfeit and no-settled-bitcoin-until-receipt invariants.
 - Regression coverage for this policy lives in
   `workers/api/src/artanis-labor-requester.test.ts`,
   `workers/api/src/artanis-studying-labor.test.ts`,

--- a/apps/openagents.com/workers/api/src/bond-settlement-adapter.ts
+++ b/apps/openagents.com/workers/api/src/bond-settlement-adapter.ts
@@ -1,0 +1,31 @@
+import {
+  type ForfeitLaborEscrowInput,
+  type LaborEscrowResult,
+  type ReleaseLaborEscrowInput,
+  type ReserveLaborEscrowInput,
+  forfeitLaborEscrow,
+  releaseLaborEscrow,
+  reserveLaborEscrow,
+} from './labor-escrow'
+
+export type BondSettlementAdapterKind = 'credit_ledger'
+
+export type BondSettlementHoldInput = ReserveLaborEscrowInput
+export type BondSettlementReleaseInput = ReleaseLaborEscrowInput
+export type BondSettlementForfeitInput = ForfeitLaborEscrowInput
+
+export type BondSettlementAdapter = Readonly<{
+  kind: BondSettlementAdapterKind
+  hold: (input: BondSettlementHoldInput) => Promise<LaborEscrowResult>
+  release: (input: BondSettlementReleaseInput) => Promise<LaborEscrowResult>
+  forfeit: (input: BondSettlementForfeitInput) => Promise<LaborEscrowResult>
+}>
+
+export const createCreditLedgerBondSettlementAdapter = (
+  db: D1Database,
+): BondSettlementAdapter => ({
+  kind: 'credit_ledger',
+  hold: input => reserveLaborEscrow(db, input),
+  release: input => releaseLaborEscrow(db, input),
+  forfeit: input => forfeitLaborEscrow(db, input),
+})

--- a/apps/openagents.com/workers/api/src/labor-escrow.test.ts
+++ b/apps/openagents.com/workers/api/src/labor-escrow.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, test } from 'vitest'
 
 import {
+  type BondSettlementAdapter,
+  createCreditLedgerBondSettlementAdapter,
+} from './bond-settlement-adapter'
+import {
   type LaborEscrowRecord,
   type LaborEscrowState,
   assertLaborEscrowPublicSafe,
@@ -779,6 +783,57 @@ describe('labor escrow D1 guards and projections', () => {
         workRequestId: 'work_request_1',
       }),
     ).not.toThrow()
+  })
+})
+
+describe('bond settlement adapter seam', () => {
+  test('credit ledger adapter exposes the current hold, release, and forfeit operations', async () => {
+    const adapter: BondSettlementAdapter =
+      createCreditLedgerBondSettlementAdapter(null as never)
+
+    expect(adapter.kind).toBe('credit_ledger')
+    await expect(
+      adapter.hold({
+        ...reserveInput,
+        amountMsat: 0,
+        escrowId: 'escrow_invalid_amount',
+        idempotencyKey: 'labor:reserve:invalid_amount',
+      }),
+    ).resolves.toEqual({
+      kind: 'refused',
+      reason: 'invalid_amount',
+    })
+
+    await expect(
+      adapter.release({
+        acceptanceEventRef: 'nostr.event.' + 'f'.repeat(64),
+        authority: { actorRef: 'agent:provider', kind: 'provider' },
+        escrowId: 'escrow_1',
+        nowIso,
+        providerActorRef: 'agent:provider',
+        releaseReceiptId: 'receipt_row_release_adapter_forbidden',
+        releaseReceiptRef: 'receipt.labor_escrow.release.adapter_forbidden',
+      }),
+    ).resolves.toEqual({
+      kind: 'refused',
+      reason: 'release_authority_forbidden',
+    })
+
+    await expect(
+      adapter.forfeit({
+        authority: { actorRef: 'agent:requester', kind: 'requester' },
+        counterpartyActorRef: 'agent:counterparty',
+        escrowId: 'escrow_1',
+        forfeitConditionRef: 'verdict.public.validator.non_performance',
+        forfeitDestination: 'counterparty',
+        forfeitReceiptId: 'receipt_row_forfeit_adapter_forbidden',
+        forfeitReceiptRef: 'receipt.labor_escrow.forfeit.adapter_forbidden',
+        nowIso,
+      }),
+    ).resolves.toEqual({
+      kind: 'refused',
+      reason: 'forfeit_authority_forbidden',
+    })
   })
 })
 

--- a/docs/labor/2026-06-30-forfeitable-bond-next-step.md
+++ b/docs/labor/2026-06-30-forfeitable-bond-next-step.md
@@ -207,7 +207,7 @@ Read-only reference (study, do not vendor):
 | --- | --- |
 | FB-1 — `lbr-bond.ts` contract + tests | implemented in `packages/nip90/src/lbr-bond.ts`; exported by `packages/nip90/src/index.ts`; closeout digest binding implemented in `packages/nip90/src/lbr-closeout.ts`; verified by `bun run --cwd packages/nip90 test` and `bun run --cwd packages/nip90 typecheck` |
 | FB-2 — ledger `forfeit` terminal state | implemented in `apps/openagents.com/workers/api/src/labor-escrow.ts`; migration `0261_labor_escrow_forfeit.sql` widens the D1 CHECK state; invariant ledger updated; verified by `bun --cwd apps/openagents.com/workers/api test src/labor-escrow.test.ts src/labor-live-rehearsal.test.ts` and `bun run --cwd apps/openagents.com/workers/api typecheck` |
-| FB-3 — `BondSettlementAdapter` seam | not started |
+| FB-3 — `BondSettlementAdapter` seam | started 2026-06-30 with `apps/openagents.com/workers/api/src/bond-settlement-adapter.ts`: typed hold/release/forfeit adapter plus credit-ledger implementation over the existing labor escrow lifecycle; no rail import, no Lightning/Ark behavior, no public promise upgrade |
 | FB-4 — relay→DB quote/offer bridge (P1) | not started |
 
 Implementation is intended to run through the Khala→Pylon→Codex labor fleet (the


### PR DESCRIPTION
Addresses (no linked issue).

### Changes
- Documents the `BondSettlementAdapter` invariant boundary for credit-ledger settlement and future rail adapters.
- Adds regression coverage for the credit-ledger bond settlement adapter hold, release, and forfeit behavior.
- Updates the forfeitable bond next-step tracker to mark the adapter seam as started.

### Verification
- `bun run --cwd apps/openagents.com/workers/api typecheck` passed (exit 0).