### PR TITLE
feat(labor): add credit ledger bond settlement adapter

### DIFF
--- a/apps/openagents.com/workers/api/src/labor-escrow.test.ts
+++ b/apps/openagents.com/workers/api/src/labor-escrow.test.ts
@@ -9,6 +9,7 @@ import {
   evaluateLaborEscrowFundingSource,
   forfeitLaborEscrow,
   forfeitLaborEscrowStatements,
+  makeCreditLedgerBondSettlementAdapter,
   refundLaborEscrowStatements,
   releaseLaborEscrow,
   releaseLaborEscrowStatements,
@@ -589,6 +590,96 @@ describe('labor escrow ledger statements', () => {
       heldMsat: 0,
     })
     expect(model.balances.has('agent:counterparty')).toBe(false)
+  })
+})
+
+describe('credit-ledger bond settlement adapter', () => {
+  test('exposes hold, release, and forfeit through the existing no-rail ledger path', async () => {
+    const calls: string[] = []
+    const adapter = makeCreditLedgerBondSettlementAdapter(null as never, {
+      reserve: async (_db, input) => {
+        calls.push(`hold:${input.reserveReceiptRef}`)
+        return {
+          escrow: {
+            ...reserveInput,
+            createdAt: nowIso,
+            forfeitConditionRef: null,
+            forfeitDestination: null,
+            forfeitDestinationActorRef: null,
+            forfeitReceiptRef: null,
+            fundingSource: 'ledger_balance',
+            providerActorRef: null,
+            publicProjection: buildLaborEscrowPublicProjection({
+              amountMsat: reserveInput.amountMsat,
+              escrowId: reserveInput.escrowId,
+              evidenceRef: 'nostr.event.' + jobEventId,
+              jobEventId,
+              providerActorRef: null,
+              receiptRef: reserveInput.reserveReceiptRef,
+              requesterActorRef: reserveInput.requesterActorRef,
+              stateAfter: 'reserved',
+              transitionKind: 'reserve',
+              workRequestId: reserveInput.workRequestId,
+            }),
+            releaseReceiptRef: null,
+            refundReceiptRef: null,
+            state: 'reserved',
+            updatedAt: nowIso,
+          },
+          idempotent: false,
+          kind: 'ok',
+        }
+      },
+      release: async (_db, input) => {
+        calls.push(`release:${input.releaseReceiptRef}`)
+        return { kind: 'refused', reason: 'escrow_not_found' }
+      },
+      forfeit: async (_db, input) => {
+        calls.push(`forfeit:${input.forfeitReceiptRef}`)
+        return { kind: 'refused', reason: 'escrow_not_found' }
+      },
+    })
+
+    const holdResult = await adapter.hold(reserveInput)
+    const releaseResult = await adapter.release({
+      acceptanceEventRef: 'nostr.event.' + 'a'.repeat(64),
+      authority: { actorRef: 'agent:requester', kind: 'requester_acceptance' },
+      escrowId: 'escrow_1',
+      nowIso,
+      providerActorRef: 'agent:provider',
+      releaseReceiptId: 'receipt_row_release_adapter',
+      releaseReceiptRef: 'receipt.labor_escrow.release.adapter',
+    })
+    const forfeitResult = await adapter.forfeit({
+      authority: {
+        actorRef: 'agent:validator',
+        kind: 'validator_non_acceptance',
+      },
+      counterpartyActorRef: 'agent:counterparty',
+      escrowId: 'escrow_1',
+      forfeitConditionRef: 'verdict.public.validator.non_performance',
+      forfeitDestination: 'counterparty',
+      forfeitReceiptId: 'receipt_row_forfeit_adapter',
+      forfeitReceiptRef: 'receipt.labor_escrow.forfeit.adapter',
+      nowIso,
+    })
+
+    expect(adapter.kind).toBe('credit_ledger')
+    expect(holdResult.kind).toBe('ok')
+    expect(releaseResult).toEqual({
+      kind: 'refused',
+      reason: 'escrow_not_found',
+    })
+    expect(forfeitResult).toEqual({
+      kind: 'refused',
+      reason: 'escrow_not_found',
+    })
+    expect(calls).toEqual([
+      'hold:receipt.labor_escrow.reserve.escrow_1',
+      'release:receipt.labor_escrow.release.adapter',
+      'forfeit:receipt.labor_escrow.forfeit.adapter',
+    ])
+    expect(JSON.stringify(adapter)).not.toMatch(/lightning|spark|mdk|ark/i)
   })
 })
 

--- a/apps/openagents.com/workers/api/src/labor-escrow.ts
+++ b/apps/openagents.com/workers/api/src/labor-escrow.ts
@@ -1043,3 +1043,30 @@ export const evaluateArtanisLaborBudgetGate = (input: Readonly<{
     remainingTickBudgetMsat: input.perTickBudgetMsat - tickAfter,
   }
 }
+
+export type BondSettlementAdapter = Readonly<{
+  kind: 'credit_ledger'
+  hold: (input: ReserveLaborEscrowInput) => Promise<LaborEscrowResult>
+  release: (input: ReleaseLaborEscrowInput) => Promise<LaborEscrowResult>
+  forfeit: (input: ForfeitLaborEscrowInput) => Promise<LaborEscrowResult>
+}>
+
+export type CreditLedgerBondSettlementAdapterDependencies = Readonly<{
+  reserve: typeof reserveLaborEscrow
+  release: typeof releaseLaborEscrow
+  forfeit: typeof forfeitLaborEscrow
+}>
+
+export const makeCreditLedgerBondSettlementAdapter = (
+  db: D1Database,
+  dependencies: CreditLedgerBondSettlementAdapterDependencies = {
+    forfeit: forfeitLaborEscrow,
+    release: releaseLaborEscrow,
+    reserve: reserveLaborEscrow,
+  },
+): BondSettlementAdapter => ({
+  forfeit: input => dependencies.forfeit(db, input),
+  hold: input => dependencies.reserve(db, input),
+  kind: 'credit_ledger',
+  release: input => dependencies.release(db, input),
+})

--- a/docs/labor/2026-06-30-forfeitable-bond-next-step.md
+++ b/docs/labor/2026-06-30-forfeitable-bond-next-step.md
@@ -207,7 +207,7 @@ Read-only reference (study, do not vendor):
 | --- | --- |
 | FB-1 — `lbr-bond.ts` contract + tests | implemented in `packages/nip90/src/lbr-bond.ts`; exported by `packages/nip90/src/index.ts`; closeout digest binding implemented in `packages/nip90/src/lbr-closeout.ts`; verified by `bun run --cwd packages/nip90 test` and `bun run --cwd packages/nip90 typecheck` |
 | FB-2 — ledger `forfeit` terminal state | implemented in `apps/openagents.com/workers/api/src/labor-escrow.ts`; migration `0261_labor_escrow_forfeit.sql` widens the D1 CHECK state; invariant ledger updated; verified by `bun --cwd apps/openagents.com/workers/api test src/labor-escrow.test.ts src/labor-live-rehearsal.test.ts` and `bun run --cwd apps/openagents.com/workers/api typecheck` |
-| FB-3 — `BondSettlementAdapter` seam | not started |
+| FB-3 — `BondSettlementAdapter` seam | implemented as a Worker credit-ledger adapter in `apps/openagents.com/workers/api/src/labor-escrow.ts`; verified by `bun --cwd apps/openagents.com/workers/api test src/labor-escrow.test.ts src/labor-live-rehearsal.test.ts` and `bun run --cwd apps/openagents.com/workers/api typecheck`; no Spark/MDK/Lightning/Ark rail imported |
 | FB-4 — relay→DB quote/offer bridge (P1) | not started |
 
 Implementation is intended to run through the Khala→Pylon→Codex labor fleet (the


### PR DESCRIPTION
Addresses (no linked issue).

### Changes

- Added a `BondSettlementAdapter` type and `makeCreditLedgerBondSettlementAdapter` factory for the existing labor escrow credit-ledger reserve, release, and forfeit flow.
- Added coverage proving the adapter delegates hold, release, and forfeit through the no-rail ledger path and does not expose rail-specific terms.
- Updated the forfeitable bond next-step doc to mark the adapter step implemented.

### Verification

- `bun run --cwd apps/openagents.com/workers/api typecheck` passed (exit 0).