### PR TITLE
feat(khala): add spawn status aggregate counts

### DIFF
--- a/apps/openagents.com/workers/api/src/khala-mcp.test.ts
+++ b/apps/openagents.com/workers/api/src/khala-mcp.test.ts
@@ -441,6 +441,13 @@ describe('Khala MCP catalog', () => {
     )
     expect(status.isError).toBeFalsy()
     expect(status.structuredContent).toMatchObject({
+      aggregate: {
+        acceptedCount: 0,
+        activeCount: 2,
+        closeoutRefCount: 0,
+        proofRefCount: 0,
+        rejectedCount: 0,
+      },
       childCount: 2,
       ok: true,
       schema: 'openagents.khala_mcp.spawn_status.v1',

--- a/apps/openagents.com/workers/api/src/khala-mcp.ts
+++ b/apps/openagents.com/workers/api/src/khala-mcp.ts
@@ -799,6 +799,40 @@ const spawnStateFromChildren = (
   return 'active'
 }
 
+const spawnStatusAggregate = (
+  assignments: ReadonlyArray<PylonApiAssignmentRecord>,
+): Record<string, number> =>
+  assignments.reduce(
+    (aggregate, assignment) => ({
+      acceptedCount:
+        aggregate.acceptedCount + (assignment.state === 'accepted' ? 1 : 0),
+      acceptedWorkRefCount:
+        aggregate.acceptedWorkRefCount + assignment.acceptedWorkRefs.length,
+      activeCount:
+        aggregate.activeCount +
+        (assignment.state !== 'accepted' && assignment.state !== 'rejected'
+          ? 1
+          : 0),
+      artifactRefCount: aggregate.artifactRefCount + assignment.artifactRefs.length,
+      closeoutRefCount: aggregate.closeoutRefCount + assignment.closeoutRefs.length,
+      proofRefCount: aggregate.proofRefCount + assignment.proofRefs.length,
+      rejectedCount:
+        aggregate.rejectedCount + (assignment.state === 'rejected' ? 1 : 0),
+      rejectionRefCount:
+        aggregate.rejectionRefCount + assignment.rejectionRefs.length,
+    }),
+    {
+      acceptedCount: 0,
+      acceptedWorkRefCount: 0,
+      activeCount: 0,
+      artifactRefCount: 0,
+      closeoutRefCount: 0,
+      proofRefCount: 0,
+      rejectedCount: 0,
+      rejectionRefCount: 0,
+    },
+  )
+
 const spawnStatusProjection = async (input: Readonly<{
   agentStore: AgentRegistrationStore
   principal: McpPrincipal
@@ -834,6 +868,7 @@ const spawnStatusProjection = async (input: Readonly<{
   }
 
   return {
+    aggregate: spawnStatusAggregate(children),
     childCount: children.length,
     children: children.map(spawnChildStatusProjection),
     ok: true,


### PR DESCRIPTION
Addresses (no linked issue).

### Changes
- Added aggregate spawn status counts for child assignments, including active, accepted, rejected, proof, closeout, artifact, accepted work, and rejection ref totals.
- Included the aggregate summary in the Khala MCP spawn status projection.
- Updated the Khala MCP catalog test to assert aggregate counts for active child assignments.

### Verification
- `bun run --cwd apps/openagents.com/workers/api typecheck` passed (exit 0).