### PR TITLE
fix(pylon): block khala spawn over capacity

### DIFF
--- a/apps/pylon/src/khala-spawn.test.ts
+++ b/apps/pylon/src/khala-spawn.test.ts
@@ -183,6 +183,64 @@ describe("Khala spawn per-account planning", () => {
       accountHashA,
     ])
   })
+
+  test("blocks batches that request more slots than advertised free capacity", () => {
+    const result = buildPylonKhalaSpawnPlan({
+      accounts: {
+        accounts: [
+          {
+            accountRef: "codex-a",
+            accountRefHash: accountHashA,
+            blockerRefs: [],
+            homeState: "present",
+            provider: "codex",
+            readiness: { state: "ready" },
+          },
+          {
+            accountRef: "codex-b",
+            accountRefHash: accountHashB,
+            blockerRefs: [],
+            homeState: "present",
+            provider: "codex",
+            readiness: { state: "ready" },
+          },
+        ],
+      } as never,
+      advertisedCodexAccounts: [
+        {
+          accountKey: "aaaaaaaaaaaa",
+          accountRefHash: accountHashA,
+          available: 1,
+          busy: 4,
+          queued: 0,
+          ready: 5,
+        },
+        {
+          accountKey: "bbbbbbbbbbbb",
+          accountRefHash: accountHashB,
+          available: 1,
+          busy: 4,
+          queued: 0,
+          ready: 5,
+        },
+      ],
+      baseUrl: "https://openagents.example",
+      fixture: true,
+      maxParallel: 5,
+      objectives: repeatedKhalaSpawnObjectives({
+        count: 5,
+        objective: "Run the bounded fixture.",
+      }),
+      targetPylonRef: "pylon.owner.codex",
+    })
+
+    expect(result.advertisedCodexAvailability).toBe(2)
+    expect(result.maxParallel).toBe(0)
+    expect(result.slots).toEqual([])
+    expect(result.blockerRefs).toContain(
+      "blocker.khala_spawn.requested_count_exceeds_advertised_availability",
+    )
+  })
 })
 
 const requestResult: PylonKhalaRequestResult = {

--- a/apps/pylon/src/khala-spawn.ts
+++ b/apps/pylon/src/khala-spawn.ts
@@ -285,18 +285,26 @@ export function buildPylonKhalaSpawnPlan(input: {
       ? accounts.length
       : advertisedCodexAccounts.reduce((sum, account) => sum + account.available, 0),
   )
+  const requestedCount = input.objectives.length
+  const requestedExceedsAdvertisedAvailability =
+    requestedCount > 0 &&
+    advertisedCodexAvailability > 0 &&
+    requestedCount > advertisedCodexAvailability
   const defaultMaxParallel = Math.max(
     1,
     Math.min(
-      input.objectives.length || 1,
+      requestedCount || 1,
       Math.max(accounts.length, advertisedCodexAvailability),
     ),
   )
   const requestedMaxParallel = Math.max(1, Math.floor(input.maxParallel ?? defaultMaxParallel))
   const selectedParallel =
-    accounts.length === 0 || advertisedCodexAvailability === 0 || input.objectives.length === 0
+    accounts.length === 0 ||
+    advertisedCodexAvailability === 0 ||
+    requestedCount === 0 ||
+    requestedExceedsAdvertisedAvailability
       ? 0
-      : Math.min(requestedMaxParallel, advertisedCodexAvailability, input.objectives.length)
+      : Math.min(requestedMaxParallel, advertisedCodexAvailability, requestedCount)
   const selectedAccounts = weightedKhalaAccountPool(
     accounts,
     advertisedAccountCapacity,
@@ -308,7 +316,10 @@ export function buildPylonKhalaSpawnPlan(input: {
       ? [blocker("khala_spawn", "no_ready_codex_account_slots")]
       : []),
     ...(advertisedCodexAvailability === 0 ? [blocker("khala_spawn", "no_advertised_codex_availability")] : []),
-    ...(input.objectives.length === 0 ? [blocker("khala_spawn", "no_objectives")] : []),
+    ...(requestedExceedsAdvertisedAvailability
+      ? [blocker("khala_spawn", "requested_count_exceeds_advertised_availability")]
+      : []),
+    ...(requestedCount === 0 ? [blocker("khala_spawn", "no_objectives")] : []),
   ]
 
   const slots: PylonKhalaSpawnSlot[] = selectedParallel === 0
@@ -359,9 +370,9 @@ export function buildPylonKhalaSpawnPlan(input: {
     baseUrl: input.baseUrl,
     blockerRefs,
     maxParallel: selectedParallel,
-    objectiveCount: input.objectives.length,
+    objectiveCount: requestedCount,
     readyCodexAccountCount: readyAccounts.length,
-    requestedCount: input.objectives.length,
+    requestedCount,
     slots,
     targetPylonRef: input.targetPylonRef,
   }


### PR DESCRIPTION
Addresses (no linked issue).

### Changes
- Added a Khala spawn planning guard that blocks batches when the requested objective count exceeds advertised Codex availability.
- Reused a normalized requested count throughout spawn planning and added a blocker ref for the over-capacity case.
- Added test coverage for batches that request more slots than advertised free capacity.

### Verification
- `bun run --cwd apps/openagents.com/workers/api typecheck` passed (exit 0).