### PR TITLE
fix(pylon): expose latest Codex progress status

### DIFF
--- a/apps/openagents.com/workers/api/src/pylon-codex-turn-ingest-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/pylon-codex-turn-ingest-routes.test.ts
@@ -244,6 +244,8 @@ class MemoryProofStore
       },
       events: {
         count: 2,
+        latestProgressObservedAt: nowIso,
+        latestProgressStatus: 'proof-ready',
         progressCount: 1,
         latestEventKind: 'assignment_progress',
         latestStatus: 'proof-ready',
@@ -1024,6 +1026,10 @@ const makeFakeProofD1 = (): D1Database & {
             latestEventOwnerId,
             latestStatusAssignmentRef,
             latestStatusOwnerId,
+            latestProgressStatusAssignmentRef,
+            latestProgressStatusOwnerId,
+            latestProgressObservedAtAssignmentRef,
+            latestProgressObservedAtOwnerId,
             assignmentRef,
             ownerAgentUserId,
           ] = bound.map(String)
@@ -1049,10 +1055,29 @@ const makeFakeProofD1 = (): D1Database & {
                 row.owner_agent_user_id === latestStatusOwnerId,
             )
             .sort((left, right) => right.created_at.localeCompare(left.created_at))[0]
+          const latestProgressStatus = activeRows
+            .filter(
+              row =>
+                row.assignment_ref === latestProgressStatusAssignmentRef &&
+                row.owner_agent_user_id === latestProgressStatusOwnerId &&
+                row.event_kind === 'assignment_progress',
+            )
+            .sort((left, right) => right.created_at.localeCompare(left.created_at))[0]
+          const latestProgressObservedAt = activeRows
+            .filter(
+              row =>
+                row.assignment_ref === latestProgressObservedAtAssignmentRef &&
+                row.owner_agent_user_id === latestProgressObservedAtOwnerId &&
+                row.event_kind === 'assignment_progress',
+            )
+            .sort((left, right) => right.created_at.localeCompare(left.created_at))[0]
           return {
             event_count: matches.length,
             latest_event_kind: latestEvent?.event_kind ?? null,
             latest_observed_at: matches[0]?.created_at ?? null,
+            latest_progress_observed_at:
+              latestProgressObservedAt?.created_at ?? null,
+            latest_progress_status: latestProgressStatus?.status ?? null,
             latest_status: latestStatus?.status ?? null,
             progress_count: matches.filter(
               row => row.event_kind === 'assignment_progress',
@@ -1575,6 +1600,7 @@ describe('GET /api/pylon/codex/trace-status', () => {
         count: 2,
         latestEventKind: 'assignment_progress',
         latestStatus: 'proof-ready',
+        latestProgressStatus: 'proof-ready',
         progressCount: 1,
       },
       owner: {
@@ -1718,6 +1744,8 @@ describe('GET /api/pylon/codex/trace-status', () => {
       count: 2,
       latestEventKind: 'assignment_progress',
       latestObservedAt: '2026-06-26T12:00:02.000Z',
+      latestProgressObservedAt: '2026-06-26T12:00:02.000Z',
+      latestProgressStatus: 'runtime_active',
       latestStatus: 'runtime_active',
       progressCount: 1,
     })

--- a/apps/openagents.com/workers/api/src/pylon-codex-turn-ingest-routes.ts
+++ b/apps/openagents.com/workers/api/src/pylon-codex-turn-ingest-routes.ts
@@ -268,6 +268,8 @@ export type PylonCodexAssignmentTraceStatus = Readonly<{
     latestEventKind: string | null
     latestStatus: string | null
     latestObservedAt: string | null
+    latestProgressStatus: string | null
+    latestProgressObservedAt: string | null
   }>
   tokenUsage: PylonCodexAssignmentProof['tokenUsage'] &
     Readonly<{ status: 'pending' | 'recorded' }>
@@ -484,6 +486,8 @@ type PylonCodexAssignmentEventAggregateRow = Readonly<{
   latest_event_kind: string | null
   latest_status: string | null
   latest_observed_at: string | null
+  latest_progress_status: string | null
+  latest_progress_observed_at: string | null
 }>
 
 const boundedProofRefs = (
@@ -757,6 +761,26 @@ export const makeD1PylonCodexAssignmentProofStore = (
               ORDER BY created_at DESC
               LIMIT 1
             ) AS latest_status,
+            (
+              SELECT status
+              FROM pylon_api_events
+              WHERE assignment_ref = ?
+                AND owner_agent_user_id = ?
+                AND event_kind = 'assignment_progress'
+                AND archived_at IS NULL
+              ORDER BY created_at DESC
+              LIMIT 1
+            ) AS latest_progress_status,
+            (
+              SELECT created_at
+              FROM pylon_api_events
+              WHERE assignment_ref = ?
+                AND owner_agent_user_id = ?
+                AND event_kind = 'assignment_progress'
+                AND archived_at IS NULL
+              ORDER BY created_at DESC
+              LIMIT 1
+            ) AS latest_progress_observed_at,
             MAX(created_at) AS latest_observed_at
           FROM pylon_api_events
           WHERE assignment_ref = ?
@@ -765,6 +789,10 @@ export const makeD1PylonCodexAssignmentProofStore = (
         `,
       )
       .bind(
+        input.assignment.assignmentRef,
+        input.ownerAgentUserId,
+        input.assignment.assignmentRef,
+        input.ownerAgentUserId,
         input.assignment.assignmentRef,
         input.ownerAgentUserId,
         input.assignment.assignmentRef,
@@ -932,6 +960,9 @@ export const makeD1PylonCodexAssignmentProofStore = (
         count: Number(eventRow?.event_count ?? 0),
         latestEventKind: eventRow?.latest_event_kind ?? null,
         latestObservedAt: eventRow?.latest_observed_at ?? null,
+        latestProgressObservedAt:
+          eventRow?.latest_progress_observed_at ?? null,
+        latestProgressStatus: eventRow?.latest_progress_status ?? null,
         latestStatus: eventRow?.latest_status ?? null,
         progressCount: Number(eventRow?.progress_count ?? 0),
       },


### PR DESCRIPTION
Addresses (no linked issue).

### Changes
- Adds latest assignment progress status and observed timestamp to the Pylon Codex trace status payload.
- Updates the D1 proof aggregate query and in-memory test store to compute progress-specific status fields.
- Extends trace status tests to cover the new progress status and timestamp values.

### Verification
- `bun run --cwd apps/openagents.com/workers/api typecheck` passed (exit 0).