### PR TITLE
feat(operator): expose own-capacity Codex pace

### DIFF
--- a/apps/openagents.com/workers/api/src/operator-fleet-status-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/operator-fleet-status-routes.test.ts
@@ -141,6 +141,13 @@ const rowsForSql = (sql: string): ReadonlyArray<Record<string, unknown>> => {
   }
 
   if (sql.includes('tokens_window')) {
+    if (sql.includes('pylon-codex-own-capacity')) {
+      return [{
+        assignments_window: 2,
+        tokens_window: 900,
+        turns_window: 3,
+      }]
+    }
     return [{ tokens_window: 600 }]
   }
 
@@ -219,7 +226,7 @@ describe('operator fleet status route', () => {
     expect(first.headers.get('x-openagents-cache')).toBe('miss')
     expect(second.headers.get('x-openagents-cache')).toBe('hit')
     expect(log.length).toBeGreaterThan(0)
-    expect(log.length).toBe(10)
+    expect(log.length).toBe(12)
     expect(cachedBody).toEqual(body)
     expect(body).toMatchObject({
       authority: {
@@ -257,6 +264,14 @@ describe('operator fleet status route', () => {
       },
       pace: {
         liveBurnRateTokensPerMinute: 60,
+        ownCapacityCodex: {
+          assignmentsWindow: 2,
+          sourceRefs: ['d1:token_usage_events.pylon_codex_own_capacity_exact'],
+          tokensPerMinute: 90,
+          tokensWindow: 900,
+          turnsWindow: 3,
+          windowSeconds: 600,
+        },
         paceToFloor: 'ahead',
         targetFloorTokens: 1000,
         todayTokens: 1200,
@@ -327,6 +342,11 @@ describe('operator fleet status route', () => {
     expect(log.some(sql => sql.includes('owner_agent_user_id = ?'))).toBe(true)
     expect(log.some(sql => sql.includes('AND user_id = ?'))).toBe(true)
     expect(log.some(sql => sql.includes('FROM pylon_api_events') && sql.includes('pylon_ref IN'))).toBe(true)
+    expect(log.some(sql =>
+      sql.includes('FROM token_usage_events') &&
+      sql.includes("provider = 'pylon-codex-own-capacity'") &&
+      sql.includes('AND actor_user_id = ?'),
+    )).toBe(true)
   })
 
   test('keeps the legacy fleet status path admin-token only', async () => {

--- a/apps/openagents.com/workers/api/src/operator-fleet-status-routes.ts
+++ b/apps/openagents.com/workers/api/src/operator-fleet-status-routes.ts
@@ -75,6 +75,11 @@ type ProviderAccountRow = Readonly<{
 type TokenTodayRow = Readonly<{ tokens_today: number | null }>
 type TokenYesterdayRow = Readonly<{ tokens_yesterday: number | null }>
 type TokenWindowRow = Readonly<{ tokens_window: number | null }>
+type OwnCapacityCodexWindowRow = Readonly<{
+  assignments_window: number | null
+  tokens_window: number | null
+  turns_window: number | null
+}>
 type BrainRow = Readonly<{
   memory_ref: string
   created_at: string
@@ -164,6 +169,7 @@ const buildFleetStatusSnapshot = async (
 ): Promise<unknown> => {
   const registrationOwnerClause =
     scope.kind === 'agent' ? 'AND owner_agent_user_id = ?' : ''
+  const tokenOwnerClause = scope.kind === 'agent' ? 'AND actor_user_id = ?' : ''
   const assignmentOwnerClause =
     scope.kind === 'agent'
       ? `AND pylon_ref IN (
@@ -185,6 +191,7 @@ const buildFleetStatusSnapshot = async (
     today,
     yesterday,
     window,
+    ownCapacityCodexWindow,
     brainRows,
     glmRows,
   ] = await Promise.all([
@@ -275,6 +282,21 @@ const buildFleetStatusSnapshot = async (
       `SELECT COALESCE(SUM(total_tokens), 0) AS tokens_window
          FROM token_usage_events
         WHERE observed_at >= datetime('now', '-10 minutes')`,
+    ),
+    safeFirst<OwnCapacityCodexWindowRow>(
+      db,
+      `SELECT COALESCE(SUM(total_tokens), 0) AS tokens_window,
+              COUNT(*) AS turns_window,
+              COUNT(DISTINCT task_ref) AS assignments_window
+         FROM token_usage_events
+        WHERE observed_at >= datetime('now', '-10 minutes')
+          AND provider = 'pylon-codex-own-capacity'
+          AND model = 'openagents/pylon-codex'
+          AND usage_truth = 'exact'
+          AND demand_kind = 'own_capacity'
+          AND demand_source = 'khala_coding_delegation'
+          ${tokenOwnerClause}`,
+      ...ownerBindings,
     ),
     safeAll<BrainRow>(
       db,
@@ -378,6 +400,18 @@ const buildFleetStatusSnapshot = async (
   const yesterdayTokens = Math.max(0, Math.trunc(yesterday?.tokens_yesterday ?? 0))
   const windowTokens = Math.max(0, Math.trunc(window?.tokens_window ?? 0))
   const burnRateTokensPerMinute = Math.round(windowTokens / 10)
+  const ownCapacityCodexWindowTokens = Math.max(
+    0,
+    Math.trunc(ownCapacityCodexWindow?.tokens_window ?? 0),
+  )
+  const ownCapacityCodexWindowTurns = Math.max(
+    0,
+    Math.trunc(ownCapacityCodexWindow?.turns_window ?? 0),
+  )
+  const ownCapacityCodexWindowAssignments = Math.max(
+    0,
+    Math.trunc(ownCapacityCodexWindow?.assignments_window ?? 0),
+  )
   const targetFloor = yesterdayTokens * 4
   const paceToFloor =
     targetFloor === 0 ? 'no_floor' : todayTokens >= targetFloor ? 'ahead' : 'behind'
@@ -425,6 +459,14 @@ const buildFleetStatusSnapshot = async (
       todayTokens,
       yesterdayTokens,
       targetFloorTokens: targetFloor,
+      ownCapacityCodex: {
+        assignmentsWindow: ownCapacityCodexWindowAssignments,
+        sourceRefs: ['d1:token_usage_events.pylon_codex_own_capacity_exact'],
+        tokensPerMinute: Math.round(ownCapacityCodexWindowTokens / 10),
+        tokensWindow: ownCapacityCodexWindowTokens,
+        turnsWindow: ownCapacityCodexWindowTurns,
+        windowSeconds: 600,
+      },
       sourceRefs: ['d1:token_usage_events'],
     },
     fleet: {


### PR DESCRIPTION
Addresses (no linked issue).

### Changes
- Adds own-capacity Pylon/Codex token, turn, and assignment window metrics to the operator fleet status pace snapshot.
- Scopes own-capacity token usage queries by actor user for agent-owned fleet status requests.
- Updates fleet status route tests to cover the new query and response shape.

### Verification
- `bun run --cwd apps/openagents.com/workers/api typecheck` passed (exit 0).