### PR TITLE
Add relay quote bond offer ingestion

### DIFF
--- a/apps/openagents.com/workers/api/src/forum-routes.ts
+++ b/apps/openagents.com/workers/api/src/forum-routes.ts
@@ -1,4 +1,9 @@
+import {
+  decodeLbrProviderBondEvent,
+  decodeLbrQuoteEvent,
+} from '@openagentsinc/nip90'
 import { Effect, Schema as S } from 'effect'
+import { type Event as NostrEvent, verifyEvent } from 'nostr-effect/pure'
 
 import type { VerifiedPublicIdentityClaim } from './agent-owner-claim-routes'
 import type { AgentRegistrationStore } from './agent-registration'
@@ -104,6 +109,7 @@ import {
 import {
   type ForumWorkRequestAcceptanceRecord,
   type ForumWorkRequestOfferRecord,
+  type ForumWorkRequestOfferProviderBond,
   type ForumWorkRequestResultRecord,
   listForumWorkRequestOffers,
   markForumWorkRequestSettled,
@@ -120,6 +126,7 @@ import {
   decodeCreateForumWorkRequestBody,
   decodeForumWorkRequestLifecycleBody,
   decodeRelayNativeForumWorkRequestBody,
+  decodeRelayNativeForumWorkRequestOfferBody,
   decodeReleaseForumWorkRequestBody,
   decodeSubmitForumWorkRequestOfferBody,
   decodeSubmitForumWorkRequestResultBody,
@@ -2545,6 +2552,171 @@ const listForumWorkRequestOffersResponse = (
     return noStoreJsonResponse({ offers, workRequest })
   }).pipe(Effect.catch(error => Effect.succeed(writeFailureResponse(error))))
 
+const RelayEventHexPattern = /^[0-9a-f]{64}$/i
+
+const throwRelayOfferValidationError = (reason: string): never => {
+  throw new ForumValidationError({ reason })
+}
+
+const relaySignedEvent = (event: unknown, fieldName: string): NostrEvent => {
+  if (event === null || typeof event !== 'object' || Array.isArray(event)) {
+    throwRelayOfferValidationError(`${fieldName} must be a relay event object.`)
+  }
+
+  const candidate = event as Partial<NostrEvent>
+
+  if (
+    !Number.isInteger(candidate.kind) ||
+    !Number.isInteger(candidate.created_at) ||
+    typeof candidate.content !== 'string' ||
+    typeof candidate.id !== 'string' ||
+    typeof candidate.pubkey !== 'string' ||
+    typeof candidate.sig !== 'string' ||
+    !Array.isArray(candidate.tags) ||
+    !candidate.tags.every(
+      tag => Array.isArray(tag) && tag.every(part => typeof part === 'string'),
+    )
+  ) {
+    throwRelayOfferValidationError(`${fieldName} must be a signed Nostr event.`)
+  }
+
+  const signedEvent = candidate as NostrEvent
+
+  if (!verifyEvent(signedEvent)) {
+    throwRelayOfferValidationError(`${fieldName} signature is invalid.`)
+  }
+
+  return signedEvent
+}
+
+const relayEventStringProperty = (
+  event: NostrEvent,
+  propertyName: 'id' | 'pubkey',
+  fieldName: string,
+): string => {
+  const value = event[propertyName]
+
+  if (typeof value === 'string' && RelayEventHexPattern.test(value)) {
+    return value.toLowerCase()
+  }
+
+  throw new ForumValidationError({
+    reason: `${fieldName} must be a 64-char hex value.`,
+  })
+}
+
+const wholeSatsFromMsats = (amountMsats: number): number => {
+  if (!Number.isInteger(amountMsats) || amountMsats <= 0) {
+    throwRelayOfferValidationError('relay quote amountMsats must be positive.')
+  }
+
+  if (amountMsats % 1000 !== 0) {
+    throwRelayOfferValidationError(
+      'relay quote amountMsats must resolve to whole sats.',
+    )
+  }
+
+  return amountMsats / 1000
+}
+
+const decodeRelayOfferForWorkRequest = (
+  workRequest: ForumWorkRequestRecord,
+  body: Readonly<{
+    providerBondEvent?: unknown | null | undefined
+    quoteEvent: unknown
+  }>,
+): Readonly<{
+  amountSats: number
+  capabilityRefs: ReadonlyArray<string>
+  providerActorRef: string
+  providerBond: ForumWorkRequestOfferProviderBond | null
+  providerPubkey: string
+  quoteRef: string
+  relayEventRef: string
+}> => {
+  const quoteEvent = relaySignedEvent(body.quoteEvent, 'quoteEvent')
+  const quote = decodeLbrQuoteEvent(quoteEvent)
+  const quoteEventId = relayEventStringProperty(
+    quoteEvent,
+    'id',
+    'quoteEvent.id',
+  )
+  const quotePubkey = relayEventStringProperty(
+    quoteEvent,
+    'pubkey',
+    'quoteEvent.pubkey',
+  )
+
+  if (quote.requestId !== workRequest.jobEventId.toLowerCase()) {
+    throwRelayOfferValidationError(
+      'relay quote does not target this work request.',
+    )
+  }
+
+  const providerBond =
+    body.providerBondEvent === null || body.providerBondEvent === undefined
+      ? null
+      : (() => {
+          const signedBondEvent = relaySignedEvent(
+            body.providerBondEvent,
+            'providerBondEvent',
+          )
+          const bond = decodeLbrProviderBondEvent(signedBondEvent)
+          const bondEventId = relayEventStringProperty(
+            signedBondEvent,
+            'id',
+            'providerBondEvent.id',
+          )
+          const bondPubkey = relayEventStringProperty(
+            signedBondEvent,
+            'pubkey',
+            'providerBondEvent.pubkey',
+          )
+
+          if (bond.requestId !== quote.requestId) {
+            throwRelayOfferValidationError(
+              'provider bond does not target the quote request.',
+            )
+          }
+
+          if (bond.requesterPubkey !== quote.requesterPubkey) {
+            throwRelayOfferValidationError(
+              'provider bond requester pubkey does not match quote.',
+            )
+          }
+
+          if (bond.providerRef !== quote.providerRef) {
+            throwRelayOfferValidationError(
+              'provider bond ref does not match quote provider.',
+            )
+          }
+
+          if (bondPubkey !== quotePubkey) {
+            throwRelayOfferValidationError(
+              'provider bond signer does not match quote signer.',
+            )
+          }
+
+          return {
+            bondMsats: bond.bondMsats,
+            bondReceiptRef: bond.bondReceiptRef,
+            forfeitConditionRef: bond.forfeitConditionRef,
+            forfeitDestination: bond.forfeitDestination,
+            relayEventRef: forumWorkRequestEventRef(bondEventId),
+          } satisfies ForumWorkRequestOfferProviderBond
+        })()
+
+  return {
+    amountSats: wholeSatsFromMsats(quote.amountMsats),
+    capabilityRefs: quote.capabilityRefs,
+    providerActorRef: quote.providerRef,
+    providerBond,
+    providerPubkey: quotePubkey,
+    quoteRef: quote.quoteRef,
+    relayEventRef: forumWorkRequestEventRef(quoteEventId),
+  }
+}
+
 // Bridge (a): a provider Pylon publishes its kind-7000 quote on the relay,
 // then submits the public quote refs here so the requester can see and accept
 // the live offer. Registered-agent bearer auth; idempotent on quoteRef.
@@ -2595,6 +2767,76 @@ const submitForumWorkRequestOfferResponse = (
         providerPubkey: body.providerPubkey ?? null,
         quoteRef: body.quoteRef,
         relayEventRef: body.relayEventRef ?? null,
+        workRequestId,
+      },
+      nowIso,
+    )
+
+    return noStoreJsonResponse({ idempotent: false, offer }, { status: 201 })
+  }).pipe(Effect.catch(error => Effect.succeed(writeFailureResponse(error))))
+
+// Bridge (a2): bridge-held relay ingestion path. The caller submits the
+// provider's public kind-7000 quote event (and optional provider-bond event),
+// this route decodes the NIP-LBR refs and records the same API offer shape as
+// the manual bridge above.
+const ingestRelayNativeForumWorkRequestOfferResponse = (
+  request: Request,
+  db: D1Database,
+  workRequestId: string,
+  dependencies: ForumRouteDependencies,
+) =>
+  Effect.gen(function* () {
+    const body = yield* decodeJsonBody(
+      request,
+      decodeRelayNativeForumWorkRequestOfferBody,
+    )
+    const workRequest = yield* readForumWorkRequestById(db, workRequestId)
+
+    if (workRequest === null) {
+      return notFound()
+    }
+
+    // Registered-agent auth mirrors the manual offer bridge and keeps relay
+    // ingestion a server-mediated public-ref write, not an unauthenticated
+    // mutation path.
+    yield* actorForRequest(request, dependencies)
+
+    const decoded = yield* Effect.try({
+      catch: error =>
+        error instanceof ForumValidationError
+          ? error
+          : new ForumValidationError({
+              reason:
+                error instanceof Error
+                  ? error.message
+                  : 'Relay offer event is invalid.',
+            }),
+      try: () => decodeRelayOfferForWorkRequest(workRequest, body),
+    })
+
+    const existing = yield* readForumWorkRequestOfferByQuoteRef(
+      db,
+      workRequestId,
+      decoded.quoteRef,
+    )
+
+    if (existing !== null) {
+      return noStoreJsonResponse({ idempotent: true, offer: existing })
+    }
+
+    const makeId = dependencies.makeId ?? randomUuid
+    const nowIso = (dependencies.nowIso ?? currentIsoTimestamp)()
+    const offer = yield* recordForumWorkRequestOffer(
+      db,
+      {
+        amountSats: decoded.amountSats,
+        capabilityRefs: decoded.capabilityRefs,
+        offerId: makeId(),
+        providerActorRef: decoded.providerActorRef,
+        providerBond: decoded.providerBond,
+        providerPubkey: decoded.providerPubkey,
+        quoteRef: decoded.quoteRef,
+        relayEventRef: decoded.relayEventRef,
         workRequestId,
       },
       nowIso,
@@ -5449,6 +5691,28 @@ export const makeForumRoutes = (dependencies: ForumRouteDependencies = {}) => ({
       return request.method === 'GET'
         ? readForumWorkRequestStatusResponse(db, workRequestId)
         : Effect.succeed(methodNotAllowed(['GET']))
+    }
+
+    const workRequestRelayOffersMatch =
+      /^\/api\/forum\/work-requests\/([^/]+)\/offers\/relay-events$/.exec(
+        url.pathname,
+      )
+
+    if (workRequestRelayOffersMatch !== null) {
+      const workRequestId = decodePathSegment(workRequestRelayOffersMatch[1])
+
+      if (workRequestId === undefined) {
+        return Effect.succeed(badRequest('workRequestId is malformed'))
+      }
+
+      return request.method === 'POST'
+        ? ingestRelayNativeForumWorkRequestOfferResponse(
+            request,
+            db,
+            workRequestId,
+            requestDependencies,
+          )
+        : Effect.succeed(methodNotAllowed(['POST']))
     }
 
     const workRequestOffersMatch =

--- a/apps/openagents.com/workers/api/src/forum-work-request-negotiation-live.test.ts
+++ b/apps/openagents.com/workers/api/src/forum-work-request-negotiation-live.test.ts
@@ -1,6 +1,14 @@
 import { DatabaseSync } from 'node:sqlite'
 
+import {
+  lbrProviderBondToDraft,
+  lbrQuoteToDraft,
+  makeLbrProviderBond,
+  makeLbrQuote,
+  type LbrUnsignedEventDraft,
+} from '@openagentsinc/nip90'
 import { Effect } from 'effect'
+import { finalizeEvent, getPublicKey } from 'nostr-effect/pure'
 import { beforeEach, describe, expect, test } from 'vitest'
 
 import type { AgentRegistrationStore } from './agent-registration'
@@ -210,11 +218,16 @@ CREATE TABLE labor_escrows (
   reserve_receipt_ref TEXT NOT NULL UNIQUE,
   release_receipt_ref TEXT UNIQUE,
   refund_receipt_ref TEXT UNIQUE,
+  forfeit_receipt_ref TEXT UNIQUE,
+  forfeit_destination TEXT,
+  forfeit_destination_actor_ref TEXT,
+  forfeit_condition_ref TEXT,
   public_projection_json TEXT NOT NULL DEFAULT '{}',
   created_at TEXT NOT NULL,
   updated_at TEXT NOT NULL,
   released_at TEXT,
   refunded_at TEXT,
+  forfeited_at TEXT,
   archived_at TEXT
 );
 
@@ -230,6 +243,8 @@ CREATE TABLE labor_escrow_receipts (
   receipt_ref TEXT NOT NULL UNIQUE,
   evidence_ref TEXT,
   state_after TEXT NOT NULL,
+  forfeit_destination TEXT,
+  forfeit_destination_actor_ref TEXT,
   public_projection_json TEXT NOT NULL,
   created_at TEXT NOT NULL
 );
@@ -252,9 +267,26 @@ const PUBLIC_PROJECTION_JSON = JSON.stringify({
 
 const NOW = '2026-06-13T18:00:00.000Z'
 const REQUESTER = 'agent:requester-live'
-const PROVIDER_PUBKEY = '2'.repeat(64)
+const REQUESTER_PUBKEY = '1'.repeat(64)
+const PROVIDER_SECRET_KEY = new Uint8Array(32).fill(2)
+const OTHER_PROVIDER_SECRET_KEY = new Uint8Array(32).fill(3)
+const PROVIDER_PUBKEY = getPublicKey(PROVIDER_SECRET_KEY)
 const JOB_EVENT_ID = 'a'.repeat(64)
 const WORK_REQUEST_ID = 'wr_live_1'
+
+const eventFromDraft = (
+  draft: LbrUnsignedEventDraft,
+  secretKey: Uint8Array,
+) =>
+  finalizeEvent(
+    {
+      content: draft.content,
+      created_at: 1_780_000_000,
+      kind: draft.kind,
+      tags: draft.tags.map(tag => [...tag]),
+    },
+    secretKey,
+  )
 
 const seedWorkRequest = (db: DatabaseSync): void => {
   db.prepare(
@@ -480,6 +512,130 @@ describe('live NIP-LBR negotiation route plumbing', () => {
       },
     )
     expect(unauth.status).toBe(401)
+  })
+
+  test('(a2) relay quote plus provider bond event ingests as an API offer', async () => {
+    const quote = makeLbrQuote({
+      amountMsats: 1_000,
+      capabilityRefs: ['capability.pylon.local_claude_agent'],
+      providerRef: 'provider.public.pylon.relay',
+      quoteRef: 'quote.public.live.relay',
+      requestId: JOB_EVENT_ID,
+      requestRelay: 'wss://relay.openagents.com',
+      requesterPubkey: REQUESTER_PUBKEY,
+    })
+    const bond = makeLbrProviderBond({
+      bondMsats: 10_000,
+      bondReceiptRef: 'receipt.public.labor_bond.relay_1',
+      forfeitConditionRef: 'condition.public.validator.non_acceptance',
+      forfeitDestination: 'counterparty',
+      providerRef: quote.providerRef,
+      requestId: JOB_EVENT_ID,
+      requestRelay: 'wss://relay.openagents.com',
+      requesterPubkey: REQUESTER_PUBKEY,
+    })
+    const quoteEvent = eventFromDraft(
+      lbrQuoteToDraft(quote),
+      PROVIDER_SECRET_KEY,
+    )
+    const providerBondEvent = eventFromDraft(
+      lbrProviderBondToDraft(bond),
+      PROVIDER_SECRET_KEY,
+    )
+
+    const first = await harness.route(
+      `/api/forum/work-requests/${WORK_REQUEST_ID}/offers/relay-events`,
+      {
+        authToken: 'oa_agent_live',
+        body: { providerBondEvent, quoteEvent },
+        method: 'POST',
+      },
+    )
+    expect(first.status).toBe(201)
+    const firstBody = (await first.json()) as {
+      idempotent: boolean
+      offer: {
+        amountSats: number
+        providerPubkey: string
+        publicProjection: {
+          providerBond?: {
+            bondMsats: number
+            bondReceiptRef: string
+            forfeitDestination: string
+            relayEventRef: string
+          }
+        }
+        quoteRef: string
+        relayEventRef: string
+      }
+    }
+    expect(firstBody.idempotent).toBe(false)
+    expect(firstBody.offer.quoteRef).toBe('quote.public.live.relay')
+    expect(firstBody.offer.amountSats).toBe(1)
+    expect(firstBody.offer.providerPubkey).toBe(PROVIDER_PUBKEY)
+    expect(firstBody.offer.relayEventRef).toBe(
+      `nostr.event.${quoteEvent.id}`,
+    )
+    expect(firstBody.offer.publicProjection.providerBond).toMatchObject({
+      bondMsats: 10_000,
+      bondReceiptRef: 'receipt.public.labor_bond.relay_1',
+      forfeitDestination: 'counterparty',
+      relayEventRef: `nostr.event.${providerBondEvent.id}`,
+    })
+
+    const repeat = await harness.route(
+      `/api/forum/work-requests/${WORK_REQUEST_ID}/offers/relay-events`,
+      {
+        authToken: 'oa_agent_live',
+        body: { providerBondEvent, quoteEvent },
+        method: 'POST',
+      },
+    )
+    expect(repeat.status).toBe(200)
+    await expect(repeat.json()).resolves.toMatchObject({ idempotent: true })
+  })
+
+  test('(a2) relay offer ingestion rejects a bond signed by a different provider', async () => {
+    const quote = makeLbrQuote({
+      amountMsats: 1_000,
+      capabilityRefs: ['capability.pylon.local_claude_agent'],
+      providerRef: 'provider.public.pylon.relay',
+      quoteRef: 'quote.public.live.relay_bad_bond',
+      requestId: JOB_EVENT_ID,
+      requestRelay: 'wss://relay.openagents.com',
+      requesterPubkey: REQUESTER_PUBKEY,
+    })
+    const bond = makeLbrProviderBond({
+      bondMsats: 10_000,
+      bondReceiptRef: 'receipt.public.labor_bond.relay_bad',
+      forfeitConditionRef: 'condition.public.validator.non_acceptance',
+      forfeitDestination: 'counterparty',
+      providerRef: quote.providerRef,
+      requestId: JOB_EVENT_ID,
+      requestRelay: 'wss://relay.openagents.com',
+      requesterPubkey: REQUESTER_PUBKEY,
+    })
+    const quoteEvent = eventFromDraft(
+      lbrQuoteToDraft(quote),
+      PROVIDER_SECRET_KEY,
+    )
+    const providerBondEvent = eventFromDraft(
+      lbrProviderBondToDraft(bond),
+      OTHER_PROVIDER_SECRET_KEY,
+    )
+
+    const response = await harness.route(
+      `/api/forum/work-requests/${WORK_REQUEST_ID}/offers/relay-events`,
+      {
+        authToken: 'oa_agent_live',
+        body: { providerBondEvent, quoteEvent },
+        method: 'POST',
+      },
+    )
+    expect(response.status).toBe(400)
+    await expect(response.json()).resolves.toMatchObject({
+      error: 'bad_request',
+    })
   })
 
   const submitOffer = async () =>

--- a/apps/openagents.com/workers/api/src/forum-work-request-negotiation.ts
+++ b/apps/openagents.com/workers/api/src/forum-work-request-negotiation.ts
@@ -28,6 +28,14 @@ export type ForumWorkRequestOfferRecord = Readonly<{
   workRequestId: string
 }>
 
+export type ForumWorkRequestOfferProviderBond = Readonly<{
+  bondMsats: number
+  bondReceiptRef: string
+  forfeitConditionRef: string
+  forfeitDestination: 'burn' | 'counterparty' | 'refund_payer'
+  relayEventRef: string
+}>
+
 export type ForumWorkRequestResultRecord = Readonly<{
   artifactRefs: ReadonlyArray<string>
   closeoutRef: string | null
@@ -62,6 +70,7 @@ export type ForumWorkRequestOfferInput = Readonly<{
   amountSats: number
   capabilityRefs: ReadonlyArray<string>
   offerId: string
+  providerBond?: ForumWorkRequestOfferProviderBond | null | undefined
   providerActorRef: string
   providerPubkey?: string | null
   quoteRef: string
@@ -221,6 +230,7 @@ const offerProjection = (
     amountMsats: number
     capabilityRefs: ReadonlyArray<string>
     offerId: string
+    providerBond: ForumWorkRequestOfferProviderBond | null
     providerActorRef: string
     providerPubkey: string | null
     quoteRef: string
@@ -233,6 +243,9 @@ const offerProjection = (
     amountMsats: input.amountMsats,
     capabilityRefs: input.capabilityRefs,
     offerRef: `work_offer.public.${input.offerId}`,
+    ...(input.providerBond === null
+      ? {}
+      : { providerBond: input.providerBond }),
     providerActorRef: input.providerActorRef,
     providerPubkey: input.providerPubkey,
     quoteRef: input.quoteRef,
@@ -372,6 +385,7 @@ export const recordForumWorkRequestOffer = (
 
     const amountMsats = input.amountSats * 1000
     const relayEventRef = input.relayEventRef ?? null
+    const providerBond = input.providerBond ?? null
     const { capabilityRefs, projection, providerPubkey } = yield* Effect.try({
       catch: validationError,
       try: () => {
@@ -386,6 +400,7 @@ export const recordForumWorkRequestOffer = (
             amountMsats,
             capabilityRefs,
             offerId: input.offerId,
+            providerBond,
             providerActorRef: input.providerActorRef,
             providerPubkey,
             quoteRef: input.quoteRef,

--- a/apps/openagents.com/workers/api/src/forum-work-request-route-contract.ts
+++ b/apps/openagents.com/workers/api/src/forum-work-request-route-contract.ts
@@ -37,6 +37,13 @@ const RelayNativeForumWorkRequestBody = S.Struct({
 export type RelayNativeForumWorkRequestBody =
   typeof RelayNativeForumWorkRequestBody.Type
 
+const RelayNativeForumWorkRequestOfferBody = S.Struct({
+  providerBondEvent: S.optionalKey(S.NullOr(S.Unknown)),
+  quoteEvent: S.Unknown,
+})
+export type RelayNativeForumWorkRequestOfferBody =
+  typeof RelayNativeForumWorkRequestOfferBody.Type
+
 const ForumWorkRequestLifecycleBody = S.Struct({
   lifecycleKind: ForumWorkRequestLifecycleKind,
   receiptRef: ForumWorkRequestRef,
@@ -129,6 +136,14 @@ export const decodeRelayNativeForumWorkRequestBody = (
   rejectForbiddenWorkRequestBodyKeys(body)
 
   return S.decodeUnknownSync(RelayNativeForumWorkRequestBody)(body)
+}
+
+export const decodeRelayNativeForumWorkRequestOfferBody = (
+  body: unknown,
+): RelayNativeForumWorkRequestOfferBody => {
+  rejectForbiddenWorkRequestBodyKeys(body)
+
+  return S.decodeUnknownSync(RelayNativeForumWorkRequestOfferBody)(body)
 }
 
 export const decodeForumWorkRequestLifecycleBody = (


### PR DESCRIPTION
Problem

Issue #7664 had FB-1/FB-2/FB-3 landed, but FB-4 still needed a bridge from relay-published kind-7000 quote/provider-bond events into the existing API offer path. Without that bridge, providers could publish public/ref-only LBR quote material but requesters could not see the same offer shape used by the accepted work-request flow.

Claim

Trigger claimed this FB-4 slice publicly: https://openagents.com/forum/t/368c2c7a-3fcc-4c0d-aeb7-f7985ff12e5f#post-34594ca4-f7ae-4194-8df1-cd818ef80baa

Changes

- Adds `POST /api/forum/work-requests/:id/offers/relay-events` for registered-agent relay-offer ingestion.
- Decodes signed NIP-LBR kind-7000 quote events plus optional provider-bond events, verifies Nostr signatures, validates request/provider/signer consistency, and records through `recordForumWorkRequestOffer`.
- Preserves provider-bond public refs/amounts in offer public projection.
- Adds focused real-SQL coverage for successful relay ingestion/idempotency and mismatched provider-bond signer rejection.
- Aligns the live negotiation harness schema with the landed forfeitable-bond escrow columns.

Validation

- `bun --cwd apps/openagents.com/workers/api test src/forum-work-request-negotiation-live.test.ts`
- `bun run --cwd apps/openagents.com/workers/api typecheck`
- `git diff --check`
- `bun run --cwd apps/openagents.com check:architecture`
- `bun run --cwd apps/openagents.com check:deploy` (rerun with network access for live doc-link checks)

Maintenance / Revenue Value

This clears the smallest remaining FB-4 bridge toward A2A forfeitable provider bonds: relay-native quote/bond events can now become requester-visible API offers with DB idempotency and public proof refs, without adding settlement risk.

Intentionally Not Changed

- No Lightning/Ark rail import.
- No live spend or payout settlement.
- No background relay subscriber/poller.
- No public promise-state/copy upgrade.
