### PR TITLE
fix(pylon): report missing Codex trace readiness refs

### DIFF
--- a/apps/openagents.com/workers/api/src/pylon-codex-turn-ingest-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/pylon-codex-turn-ingest-routes.test.ts
@@ -296,6 +296,11 @@ class MemoryProofStore
         hasFinalTrace: false,
         hasLiveChunks: true,
         hasTokenUsage: false,
+        missingReadinessRefs: [
+          'status.pylon_codex.final_trace.pending',
+          'status.pylon_codex.token_usage.pending',
+          'status.pylon_codex.closeout.pending',
+        ],
         state: 'streaming_chunks',
       },
       generatedAt: input.nowIso,
@@ -1731,6 +1736,11 @@ describe('GET /api/pylon/codex/trace-status', () => {
       hasFinalTrace: false,
       hasLiveChunks: true,
       hasTokenUsage: false,
+      missingReadinessRefs: [
+        'status.pylon_codex.final_trace.pending',
+        'status.pylon_codex.token_usage.pending',
+        'status.pylon_codex.closeout.pending',
+      ],
       state: 'streaming_chunks',
     })
     expect(inProgress.rawEventChunks).toMatchObject({
@@ -1807,6 +1817,7 @@ describe('GET /api/pylon/codex/trace-status', () => {
       hasFinalTrace: true,
       hasLiveChunks: true,
       hasTokenUsage: true,
+      missingReadinessRefs: [],
       state: 'closed_out',
     })
     expect(complete.tokenUsage).toMatchObject({

--- a/apps/openagents.com/workers/api/src/pylon-codex-turn-ingest-routes.ts
+++ b/apps/openagents.com/workers/api/src/pylon-codex-turn-ingest-routes.ts
@@ -311,6 +311,7 @@ export type PylonCodexAssignmentTraceStatus = Readonly<{
     hasLiveChunks: boolean
     hasFinalTrace: boolean
     hasTokenUsage: boolean
+    missingReadinessRefs: ReadonlyArray<string>
   }>
   generatedAt: string
 }>
@@ -937,6 +938,12 @@ export const makeD1PylonCodexAssignmentProofStore = (
               : hasLiveChunks
                 ? 'streaming_chunks'
                 : 'assignment_created'
+    const missingReadinessRefs = [
+      hasLiveChunks ? null : 'status.pylon_codex.raw_event_chunks.pending',
+      hasFinalTrace ? null : 'status.pylon_codex.final_trace.pending',
+      hasTokenUsage ? null : 'status.pylon_codex.token_usage.pending',
+      closedOut ? null : 'status.pylon_codex.closeout.pending',
+    ].filter((ref): ref is string => ref !== null)
 
     return {
       schemaVersion: 'openagents.pylon.codex_assignment_trace_status.v1',
@@ -1012,6 +1019,7 @@ export const makeD1PylonCodexAssignmentProofStore = (
         hasFinalTrace,
         hasLiveChunks,
         hasTokenUsage,
+        missingReadinessRefs,
         state: progressState,
       },
       generatedAt: input.nowIso,

--- a/apps/pylon/src/khala-requester.ts
+++ b/apps/pylon/src/khala-requester.ts
@@ -114,6 +114,7 @@ export type PylonKhalaAssignmentTraceStatusResult = {
     hasFinalTrace: boolean
     hasLiveChunks: boolean
     hasTokenUsage: boolean
+    missingReadinessRefs: string[]
     state:
       | "assignment_created"
       | "streaming_chunks"


### PR DESCRIPTION
Addresses (no linked issue).

### Changes
- Added `missingReadinessRefs` to Pylon Codex assignment trace status readiness output.
- Reports pending refs for raw event chunks, final trace, token usage, and closeout based on current assignment proof state.
- Updated API tests and the Pylon requester type to cover the new readiness field.

### Verification
- `bun run --cwd apps/openagents.com/workers/api typecheck` passed (exit 0).