### PR TITLE
Add Basecoat display Foldkit components

### DIFF
--- a/packages/ui/src/basecoat/display.test.ts
+++ b/packages/ui/src/basecoat/display.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, test } from 'bun:test'
+
+import { Basecoat } from '../index'
+import {
+  alert,
+  alertDescription,
+  alertFooter,
+  alertTitle,
+  avatar,
+  avatarBadge,
+  avatarFallback,
+  avatarGroup,
+  avatarGroupCount,
+  avatarImage,
+  skeleton,
+} from './display'
+import { renderHtml } from './test-helpers'
+
+describe('basecoat display components', () => {
+  test('renders Basecoat alerts with shadcn destructive variant slots', () => {
+    const rendered = renderHtml(
+      alert({
+        variant: 'destructive',
+        children: [
+          alertTitle({ level: 4, children: ['Build failed'] }),
+          alertDescription({ children: ['Verification did not pass'] }),
+          alertFooter({ children: ['Retry'] }),
+        ],
+      }),
+    )
+
+    expect(rendered).toContain('<div')
+    expect(rendered).toContain('class="alert"')
+    expect(rendered).toContain('role="alert"')
+    expect(rendered).toContain('data-variant="destructive"')
+    expect(rendered).toContain('<h4>Build failed</h4>')
+    expect(rendered).toContain('<section>Verification did not pass</section>')
+    expect(rendered).toContain('<footer>Retry</footer>')
+  })
+
+  test('renders avatar image, fallback, badge, and group count selectors', () => {
+    const rendered = renderHtml(
+      avatarGroup({
+        children: [
+          avatar({
+            size: 'sm',
+            children: [
+              avatarImage({
+                src: 'https://example.com/avatar.png',
+                alt: 'AtlantisPleb',
+              }),
+              avatarFallback({ children: ['AP'] }),
+              avatarBadge({ children: ['1'] }),
+            ],
+          }),
+          avatarGroupCount({ children: ['+3'] }),
+        ],
+      }),
+    )
+
+    expect(rendered).toContain('class="avatar-group"')
+    expect(rendered).toContain('class="avatar"')
+    expect(rendered).toContain('data-size="sm"')
+    expect(rendered).toContain('src="https://example.com/avatar.png"')
+    expect(rendered).toContain('alt="AtlantisPleb"')
+    expect(rendered).toContain('<span>AP</span>')
+    expect(rendered).toContain('class="avatar-badge"')
+    expect(rendered).toContain('data-count=""')
+    expect(rendered).toContain('+3')
+  })
+
+  test('renders skeleton placeholders', () => {
+    const rendered = renderHtml(
+      skeleton({
+        className: 'h-4 w-24',
+      }),
+    )
+
+    expect(rendered).toContain('<div')
+    expect(rendered).toContain('class="skeleton h-4 w-24"')
+  })
+
+  test('is exported from the Basecoat namespace', () => {
+    expect(Basecoat.alert).toBe(alert)
+    expect(Basecoat.alertTitle).toBe(alertTitle)
+    expect(Basecoat.alertDescription).toBe(alertDescription)
+    expect(Basecoat.alertFooter).toBe(alertFooter)
+    expect(Basecoat.avatar).toBe(avatar)
+    expect(Basecoat.avatarImage).toBe(avatarImage)
+    expect(Basecoat.avatarFallback).toBe(avatarFallback)
+    expect(Basecoat.avatarBadge).toBe(avatarBadge)
+    expect(Basecoat.avatarGroup).toBe(avatarGroup)
+    expect(Basecoat.avatarGroupCount).toBe(avatarGroupCount)
+    expect(Basecoat.skeleton).toBe(skeleton)
+  })
+})

--- a/packages/ui/src/basecoat/display.ts
+++ b/packages/ui/src/basecoat/display.ts
@@ -1,0 +1,204 @@
+import type { Html } from 'foldkit/html'
+import { html } from 'foldkit/html'
+
+import {
+  basecoatAttrs,
+  basecoatClass,
+  dataAttr,
+  type BasecoatAttrs,
+  type BasecoatChildren,
+} from './shared'
+
+export type AlertVariant = 'default' | 'destructive'
+
+export type AlertProps<Message> = BasecoatAttrs<Message> & Readonly<{
+  children: BasecoatChildren
+  variant?: AlertVariant
+}>
+
+export type AlertTitleProps<Message> = BasecoatAttrs<Message> & Readonly<{
+  children: BasecoatChildren
+  level?: 2 | 3 | 4 | 5 | 6
+}>
+
+export type AlertDescriptionProps<Message> =
+  BasecoatAttrs<Message> & Readonly<{
+    children: BasecoatChildren
+  }>
+
+export type AlertFooterProps<Message> = BasecoatAttrs<Message> & Readonly<{
+  children: BasecoatChildren
+}>
+
+export type AvatarSize = 'default' | 'sm' | 'lg'
+
+export type AvatarProps<Message> = BasecoatAttrs<Message> & Readonly<{
+  children: BasecoatChildren
+  size?: AvatarSize
+}>
+
+export type AvatarImageProps<Message> = BasecoatAttrs<Message> & Readonly<{
+  alt: string
+  src: string
+}>
+
+export type AvatarFallbackProps<Message> =
+  BasecoatAttrs<Message> & Readonly<{
+    children: BasecoatChildren
+  }>
+
+export type AvatarBadgeProps<Message> = BasecoatAttrs<Message> & Readonly<{
+  children?: BasecoatChildren
+}>
+
+export type AvatarGroupProps<Message> = BasecoatAttrs<Message> & Readonly<{
+  children: ReadonlyArray<Html>
+}>
+
+export type AvatarGroupCountProps<Message> =
+  BasecoatAttrs<Message> & Readonly<{
+    children: BasecoatChildren
+  }>
+
+export type SkeletonProps<Message> = BasecoatAttrs<Message> & Readonly<{
+  children?: BasecoatChildren
+}>
+
+const alertRoot = basecoatClass('alert')
+const avatarRoot = basecoatClass('avatar')
+const avatarBadgeClass = basecoatClass('avatar-badge')
+const avatarGroupRoot = basecoatClass('avatar-group')
+const skeletonRoot = basecoatClass('skeleton')
+
+export const alert = <Message>(input: AlertProps<Message>): Html => {
+  const h = html<Message>()
+
+  return h.div(
+    [
+      ...basecoatAttrs<Message>(input, alertRoot),
+      h.Role('alert'),
+      ...dataAttr<Message>(
+        'variant',
+        input.variant === 'default' ? undefined : input.variant,
+      ),
+    ],
+    input.children,
+  )
+}
+
+export const alertTitle = <Message>(
+  input: AlertTitleProps<Message>,
+): Html => {
+  const h = html<Message>()
+  const attrs = basecoatAttrs<Message>(input)
+
+  switch (input.level) {
+    case 3:
+      return h.h3(attrs, input.children)
+    case 4:
+      return h.h4(attrs, input.children)
+    case 5:
+      return h.h5(attrs, input.children)
+    case 6:
+      return h.h6(attrs, input.children)
+    case 2:
+    default:
+      return h.h2(attrs, input.children)
+  }
+}
+
+export const alertDescription = <Message>(
+  input: AlertDescriptionProps<Message>,
+): Html => {
+  const h = html<Message>()
+
+  return h.section(basecoatAttrs<Message>(input), input.children)
+}
+
+export const alertFooter = <Message>(
+  input: AlertFooterProps<Message>,
+): Html => {
+  const h = html<Message>()
+
+  return h.footer(basecoatAttrs<Message>(input), input.children)
+}
+
+export const avatar = <Message>(input: AvatarProps<Message>): Html => {
+  const h = html<Message>()
+
+  return h.span(
+    [
+      ...basecoatAttrs<Message>(input, avatarRoot),
+      ...dataAttr<Message>(
+        'size',
+        input.size === 'default' ? undefined : input.size,
+      ),
+    ],
+    input.children,
+  )
+}
+
+export const avatarImage = <Message>(
+  input: AvatarImageProps<Message>,
+): Html => {
+  const h = html<Message>()
+
+  return h.img([
+    ...basecoatAttrs<Message>(input),
+    h.Src(input.src),
+    h.Alt(input.alt),
+  ])
+}
+
+export const avatarFallback = <Message>(
+  input: AvatarFallbackProps<Message>,
+): Html => {
+  const h = html<Message>()
+
+  return h.span(basecoatAttrs<Message>(input), input.children)
+}
+
+export const avatarBadge = <Message>(
+  input: AvatarBadgeProps<Message>,
+): Html => {
+  const h = html<Message>()
+
+  return h.span(
+    basecoatAttrs<Message>(input, avatarBadgeClass),
+    input.children ?? [],
+  )
+}
+
+export const avatarGroup = <Message>(
+  input: AvatarGroupProps<Message>,
+): Html => {
+  const h = html<Message>()
+
+  return h.div(
+    basecoatAttrs<Message>(input, avatarGroupRoot),
+    input.children,
+  )
+}
+
+export const avatarGroupCount = <Message>(
+  input: AvatarGroupCountProps<Message>,
+): Html => {
+  const h = html<Message>()
+
+  return h.span(
+    [
+      ...basecoatAttrs<Message>(input),
+      h.DataAttribute('count', ''),
+    ],
+    input.children,
+  )
+}
+
+export const skeleton = <Message>(input: SkeletonProps<Message>): Html => {
+  const h = html<Message>()
+
+  return h.div(
+    basecoatAttrs<Message>(input, skeletonRoot),
+    input.children ?? [],
+  )
+}

--- a/packages/ui/src/basecoat/index.ts
+++ b/packages/ui/src/basecoat/index.ts
@@ -1,6 +1,7 @@
 export * from './badge'
 export * from './button'
 export * from './card'
+export * from './display'
 export * from './input'
 export {
   basecoatAttrs,


### PR DESCRIPTION
## Summary
- Add Foldkit Basecoat wrappers for alert, avatar, avatar groups, and skeleton in `packages/ui/src/basecoat/display.ts`
- Export the display components from the Basecoat namespace
- Cover alert slots/variant, avatar selectors, skeleton rendering, and namespace exports

Closes #7695.

## Verification
- `bun run test:ui`
- `bun run typecheck:ui`