### PR TITLE
Add Basecoat table and progress Foldkit components

### DIFF
--- a/packages/ui/src/basecoat/data.test.ts
+++ b/packages/ui/src/basecoat/data.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, test } from 'bun:test'
+
+import { Basecoat } from '../index'
+import {
+  progress,
+  table,
+  tableBody,
+  tableCaption,
+  tableCell,
+  tableContainer,
+  tableFooter,
+  tableHead,
+  tableHeader,
+  tableRow,
+} from './data'
+import { renderHtml } from './test-helpers'
+
+describe('basecoat data components', () => {
+  test('renders Basecoat table markup with semantic sections and selected rows', () => {
+    const rendered = renderHtml(
+      tableContainer({
+        children: [
+          table({
+            children: [
+              tableCaption({ children: ['A list of invoices.'] }),
+              tableHeader({
+                children: [
+                  tableRow({
+                    children: [
+                      tableHead({ scope: 'col', children: ['Invoice'] }),
+                      tableHead({ scope: 'col', className: 'text-end', children: ['Amount'] }),
+                    ],
+                  }),
+                ],
+              }),
+              tableBody({
+                children: [
+                  tableRow({
+                    state: 'selected',
+                    children: [
+                      tableCell({ className: 'font-medium', children: ['INV001'] }),
+                      tableCell({ className: 'text-end', children: ['$250.00'] }),
+                    ],
+                  }),
+                ],
+              }),
+              tableFooter({
+                children: [
+                  tableRow({
+                    children: [
+                      tableCell({ colSpan: 1, children: ['Total'] }),
+                      tableCell({ className: 'text-end', children: ['$250.00'] }),
+                    ],
+                  }),
+                ],
+              }),
+            ],
+          }),
+        ],
+      }),
+    )
+
+    expect(rendered).toContain('<div class="table-container">')
+    expect(rendered).toContain('<table class="table">')
+    expect(rendered).toContain('<caption>A list of invoices.</caption>')
+    expect(rendered).toContain('<thead>')
+    expect(rendered).toContain('<th scope="col">Invoice</th>')
+    expect(rendered).toContain('<th scope="col" class="text-end">Amount</th>')
+    expect(rendered).toContain('<tbody>')
+    expect(rendered).toContain('<tr data-state="selected">')
+    expect(rendered).toContain('<td class="font-medium">INV001</td>')
+    expect(rendered).toContain('<tfoot>')
+    expect(rendered).toContain('<td colspan="1">Total</td>')
+  })
+
+  test('renders Basecoat progress markup with ARIA values and indicator width', () => {
+    const rendered = renderHtml(
+      progress({
+        value: 66,
+        label: 'Loading',
+      }),
+    )
+
+    expect(rendered).toContain('<div')
+    expect(rendered).toContain('class="progress"')
+    expect(rendered).toContain('role="progressbar"')
+    expect(rendered).toContain('aria-label="Loading"')
+    expect(rendered).toContain('aria-valuenow="66"')
+    expect(rendered).toContain('aria-valuemin="0"')
+    expect(rendered).toContain('aria-valuemax="100"')
+    expect(rendered).toContain('<span style="width: 66%"></span>')
+  })
+
+  test('clamps progress indicator width while preserving the announced value', () => {
+    const rendered = renderHtml(
+      progress({
+        value: 150,
+        max: 120,
+        labelledBy: 'progress-label',
+      }),
+    )
+
+    expect(rendered).toContain('aria-labelledby="progress-label"')
+    expect(rendered).toContain('aria-valuenow="150"')
+    expect(rendered).toContain('aria-valuemax="120"')
+    expect(rendered).toContain('<span style="width: 100%"></span>')
+  })
+
+  test('is exported from the Basecoat namespace', () => {
+    expect(Basecoat.tableContainer).toBe(tableContainer)
+    expect(Basecoat.table).toBe(table)
+    expect(Basecoat.tableCaption).toBe(tableCaption)
+    expect(Basecoat.tableHeader).toBe(tableHeader)
+    expect(Basecoat.tableBody).toBe(tableBody)
+    expect(Basecoat.tableFooter).toBe(tableFooter)
+    expect(Basecoat.tableRow).toBe(tableRow)
+    expect(Basecoat.tableHead).toBe(tableHead)
+    expect(Basecoat.tableCell).toBe(tableCell)
+    expect(Basecoat.progress).toBe(progress)
+  })
+})

--- a/packages/ui/src/basecoat/data.ts
+++ b/packages/ui/src/basecoat/data.ts
@@ -1,0 +1,218 @@
+import type { Attribute, Html } from 'foldkit/html'
+import { html } from 'foldkit/html'
+
+import {
+  basecoatAttrs,
+  basecoatClass,
+  type BasecoatAttrs,
+  type BasecoatChildren,
+} from './shared'
+
+export type TableContainerProps<Message> = BasecoatAttrs<Message> & Readonly<{
+  children: BasecoatChildren
+}>
+
+export type TableProps<Message> = BasecoatAttrs<Message> & Readonly<{
+  children: BasecoatChildren
+}>
+
+export type TableCaptionProps<Message> = BasecoatAttrs<Message> & Readonly<{
+  children: BasecoatChildren
+}>
+
+export type TableSectionProps<Message> = BasecoatAttrs<Message> & Readonly<{
+  children: BasecoatChildren
+}>
+
+export type TableRowState = 'selected'
+
+export type TableRowProps<Message> = BasecoatAttrs<Message> & Readonly<{
+  children: BasecoatChildren
+  state?: TableRowState
+}>
+
+export type TableHeadProps<Message> = BasecoatAttrs<Message> & Readonly<{
+  children: BasecoatChildren
+  colSpan?: number
+  rowSpan?: number
+  scope?: 'col' | 'row' | 'colgroup' | 'rowgroup'
+}>
+
+export type TableCellProps<Message> = BasecoatAttrs<Message> & Readonly<{
+  children: BasecoatChildren
+  colSpan?: number
+  rowSpan?: number
+}>
+
+export type ProgressProps<Message> = BasecoatAttrs<Message> & Readonly<{
+  value: number
+  min?: number
+  max?: number
+  label?: string
+  labelledBy?: string
+  indicatorAttrs?: BasecoatAttrs<Message>['attrs']
+  indicatorClassName?: string
+}>
+
+const tableContainerRoot = basecoatClass('table-container')
+const tableRoot = basecoatClass('table')
+const progressRoot = basecoatClass('progress')
+
+const numericAttr = <Message>(
+  key: string,
+  value: number | undefined,
+): ReadonlyArray<Attribute<Message>> => {
+  if (value === undefined) {
+    return []
+  }
+
+  return [html<Message>().Attribute(key, String(value))]
+}
+
+const tableSpanAttrs = <Message>(
+  input: Readonly<{ colSpan?: number; rowSpan?: number }>,
+) => [
+  ...numericAttr<Message>('colspan', input.colSpan),
+  ...numericAttr<Message>('rowspan', input.rowSpan),
+]
+
+const progressPercent = (
+  value: number,
+  min: number,
+  max: number,
+): number => {
+  if (!Number.isFinite(value) || !Number.isFinite(min) || !Number.isFinite(max)) {
+    return 0
+  }
+
+  if (max <= min) {
+    return 0
+  }
+
+  const percent = ((value - min) / (max - min)) * 100
+  return Math.min(100, Math.max(0, percent))
+}
+
+const formatPercent = (percent: number): string =>
+  Number.isInteger(percent) ? String(percent) : String(Number(percent.toFixed(4)))
+
+export const tableContainer = <Message>(
+  input: TableContainerProps<Message>,
+): Html => {
+  const h = html<Message>()
+
+  return h.div(
+    basecoatAttrs<Message>(input, tableContainerRoot),
+    input.children,
+  )
+}
+
+export const table = <Message>(input: TableProps<Message>): Html => {
+  const h = html<Message>()
+
+  return h.table(basecoatAttrs<Message>(input, tableRoot), input.children)
+}
+
+export const tableCaption = <Message>(
+  input: TableCaptionProps<Message>,
+): Html => {
+  const h = html<Message>()
+
+  return h.caption(basecoatAttrs<Message>(input), input.children)
+}
+
+export const tableHeader = <Message>(
+  input: TableSectionProps<Message>,
+): Html => {
+  const h = html<Message>()
+
+  return h.thead(basecoatAttrs<Message>(input), input.children)
+}
+
+export const tableBody = <Message>(
+  input: TableSectionProps<Message>,
+): Html => {
+  const h = html<Message>()
+
+  return h.tbody(basecoatAttrs<Message>(input), input.children)
+}
+
+export const tableFooter = <Message>(
+  input: TableSectionProps<Message>,
+): Html => {
+  const h = html<Message>()
+
+  return h.tfoot(basecoatAttrs<Message>(input), input.children)
+}
+
+export const tableRow = <Message>(input: TableRowProps<Message>): Html => {
+  const h = html<Message>()
+
+  return h.tr(
+    [
+      ...basecoatAttrs<Message>(input),
+      ...(input.state === undefined
+        ? []
+        : [h.DataAttribute('state', input.state)]),
+    ],
+    input.children,
+  )
+}
+
+export const tableHead = <Message>(input: TableHeadProps<Message>): Html => {
+  const h = html<Message>()
+
+  return h.th(
+    [
+      ...basecoatAttrs<Message>(input),
+      ...tableSpanAttrs<Message>(input),
+      ...(input.scope === undefined ? [] : [h.Attribute('scope', input.scope)]),
+    ],
+    input.children,
+  )
+}
+
+export const tableCell = <Message>(input: TableCellProps<Message>): Html => {
+  const h = html<Message>()
+
+  return h.td(
+    [
+      ...basecoatAttrs<Message>(input),
+      ...tableSpanAttrs<Message>(input),
+    ],
+    input.children,
+  )
+}
+
+export const progress = <Message>(input: ProgressProps<Message>): Html => {
+  const h = html<Message>()
+  const min = input.min ?? 0
+  const max = input.max ?? 100
+  const width = `${formatPercent(progressPercent(input.value, min, max))}%`
+
+  return h.div(
+    [
+      ...basecoatAttrs<Message>(input, progressRoot),
+      h.Role('progressbar'),
+      h.Attribute('aria-valuenow', String(input.value)),
+      h.Attribute('aria-valuemin', String(min)),
+      h.Attribute('aria-valuemax', String(max)),
+      ...(input.label === undefined ? [] : [h.AriaLabel(input.label)]),
+      ...(input.labelledBy === undefined
+        ? []
+        : [h.Attribute('aria-labelledby', input.labelledBy)]),
+    ],
+    [
+      h.span(
+        [
+          ...(input.indicatorAttrs ?? []),
+          ...(input.indicatorClassName === undefined
+            ? []
+            : [h.Class(input.indicatorClassName)]),
+          h.Style({ width }),
+        ],
+        [],
+      ),
+    ],
+  )
+}

--- a/packages/ui/src/basecoat/index.ts
+++ b/packages/ui/src/basecoat/index.ts
@@ -1,6 +1,7 @@
 export * from './badge'
 export * from './button'
 export * from './card'
+export * from './data'
 export {
   basecoatAttrs,
   basecoatClass,

--- a/packages/ui/src/basecoat/test-helpers.ts
+++ b/packages/ui/src/basecoat/test-helpers.ts
@@ -8,6 +8,7 @@ type VNodeLike = Readonly<{
     attrs?: Record<string, unknown>
     props?: Record<string, unknown>
     class?: Record<string, boolean>
+    style?: Record<string, unknown>
   }
 }>
 
@@ -17,13 +18,20 @@ const isVNodeLike = (value: unknown): value is VNodeLike =>
 const attrsToString = (node: VNodeLike): string => {
   const attrs = node.data?.attrs ?? {}
   const props = node.data?.props ?? {}
+  const style = props.style ?? node.data?.style
+  const normalizedProps = {
+    ...props,
+    ...(style && typeof style === 'object'
+      ? { style: styleToString(style as Record<string, unknown>) }
+      : {}),
+  }
   const classes = Object.entries(node.data?.class ?? {})
     .filter(([, enabled]) => enabled)
     .map(([className]) => className)
     .join(' ')
   const pairs = [
     ...Object.entries(attrs),
-    ...Object.entries(props),
+    ...Object.entries(normalizedProps),
     ...(classes.length === 0 ? [] : [['class', classes] as const]),
   ]
 
@@ -34,6 +42,12 @@ const attrsToString = (node: VNodeLike): string => {
     )
     .join('')
 }
+
+const styleToString = (style: Record<string, unknown>): string =>
+  Object.entries(style)
+    .filter(([, value]) => value !== undefined && value !== null)
+    .map(([name, value]) => `${name}: ${String(value)}`)
+    .join('; ')
 
 export const renderHtml = (html: Html): string => {
   if (html === null || !isVNodeLike(html)) {


### PR DESCRIPTION
Closes #7697.

## Summary
- Add `packages/ui/src/basecoat/data.ts` with typed Foldkit Basecoat table primitives and progress.
- Export the data components from the Basecoat namespace.
- Add Basecoat data component tests and teach the Basecoat test renderer to serialize Foldkit `data.style` for progress indicator assertions.

## Verification
- `bun run test:ui`
- `bun run --cwd packages/ui typecheck`

Verification command ref `command.public.pylon_khala.verify.5fc2b591e599fe078a5a13c8`: `bun run test:ui` passed.