### PR TITLE
[codex] Add Basecoat selection controls

### DIFF
--- a/packages/ui/src/basecoat/index.ts
+++ b/packages/ui/src/basecoat/index.ts
@@ -1,6 +1,7 @@
 export * from './badge'
 export * from './button'
 export * from './card'
+export * from './selection'
 export {
   basecoatAttrs,
   basecoatClass,

--- a/packages/ui/src/basecoat/selection.test.ts
+++ b/packages/ui/src/basecoat/selection.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, test } from 'bun:test'
+
+import { Basecoat } from '../index'
+import {
+  checkbox,
+  checkboxGroup,
+  radio,
+  radioGroup,
+  switch as basecoatSwitch,
+  switchControl,
+} from './selection'
+import { renderHtml } from './test-helpers'
+
+describe('basecoat selection components', () => {
+  test('renders checkbox input markup with Basecoat input class and state attrs', () => {
+    const rendered = renderHtml(
+      checkbox({
+        id: 'terms-checkbox',
+        name: 'terms',
+        checked: true,
+        required: true,
+        invalid: true,
+        describedBy: 'terms-description',
+      }),
+    )
+
+    expect(rendered).toContain('<input')
+    expect(rendered).toContain('class="input"')
+    expect(rendered).toContain('type="checkbox"')
+    expect(rendered).toContain('id="terms-checkbox"')
+    expect(rendered).toContain('name="terms"')
+    expect(rendered).toContain('checked')
+    expect(rendered).toContain('required')
+    expect(rendered).toContain('aria-invalid="true"')
+    expect(rendered).toContain('aria-describedby="terms-description"')
+  })
+
+  test('renders radio group and radio item markup', () => {
+    const rendered = renderHtml(
+      radioGroup({
+        ariaLabel: 'View density',
+        className: 'w-fit',
+        children: [
+          radio({
+            id: 'density-comfortable',
+            name: 'density',
+            value: 'comfortable',
+            checked: true,
+          }),
+        ],
+      }),
+    )
+
+    expect(rendered).toContain('role="radiogroup"')
+    expect(rendered).toContain('aria-label="View density"')
+    expect(rendered).toContain('data-slot="radio-group"')
+    expect(rendered).toContain('class="w-fit"')
+    expect(rendered).toContain('type="radio"')
+    expect(rendered).toContain('value="comfortable"')
+  })
+
+  test('renders switch as a checkbox with role switch and Basecoat size attr', () => {
+    const rendered = renderHtml(
+      switchControl({
+        id: 'airplane-mode',
+        ariaLabel: 'Airplane mode',
+        size: 'sm',
+        disabled: true,
+      }),
+    )
+
+    expect(rendered).toContain('<input')
+    expect(rendered).toContain('class="input"')
+    expect(rendered).toContain('type="checkbox"')
+    expect(rendered).toContain('role="switch"')
+    expect(rendered).toContain('data-size="sm"')
+    expect(rendered).toContain('disabled')
+    expect(rendered).toContain('aria-label="Airplane mode"')
+  })
+
+  test('renders checkbox group slot markup', () => {
+    const rendered = renderHtml(
+      checkboxGroup({
+        ariaLabel: 'Desktop items',
+        children: [
+          checkbox({
+            id: 'finder-hard-disks',
+            name: 'finder-hard-disks',
+            checked: true,
+          }),
+        ],
+      }),
+    )
+
+    expect(rendered).toContain('role="group"')
+    expect(rendered).toContain('aria-label="Desktop items"')
+    expect(rendered).toContain('data-slot="checkbox-group"')
+    expect(rendered).toContain('type="checkbox"')
+  })
+
+  test('is exported from the Basecoat namespace', () => {
+    expect(Basecoat.checkbox).toBe(checkbox)
+    expect(Basecoat.checkboxGroup).toBe(checkboxGroup)
+    expect(Basecoat.radio).toBe(radio)
+    expect(Basecoat.radioGroup).toBe(radioGroup)
+    expect(Basecoat.switch).toBe(basecoatSwitch)
+    expect(Basecoat.switchControl).toBe(switchControl)
+  })
+})

--- a/packages/ui/src/basecoat/selection.ts
+++ b/packages/ui/src/basecoat/selection.ts
@@ -1,0 +1,120 @@
+import type { Attribute, Html } from 'foldkit/html'
+import { html } from 'foldkit/html'
+
+import {
+  basecoatAttrs,
+  basecoatClass,
+  dataAttr,
+  type BasecoatAttrs,
+} from './shared'
+
+export type SelectionInputProps<Message> = BasecoatAttrs<Message> & Readonly<{
+  id?: string
+  name?: string
+  value?: string
+  checked?: boolean
+  disabled?: boolean
+  required?: boolean
+  invalid?: boolean
+  describedBy?: string
+  ariaLabel?: string
+}>
+
+export type CheckboxProps<Message> = SelectionInputProps<Message>
+
+export type RadioProps<Message> = SelectionInputProps<Message>
+
+export type SwitchSize = 'default' | 'sm'
+
+export type SwitchProps<Message> = SelectionInputProps<Message> & Readonly<{
+  size?: SwitchSize
+}>
+
+export type CheckboxGroupProps<Message> = BasecoatAttrs<Message> & Readonly<{
+  children: ReadonlyArray<Html>
+  ariaLabel?: string
+}>
+
+export type RadioGroupProps<Message> = BasecoatAttrs<Message> & Readonly<{
+  children: ReadonlyArray<Html>
+  ariaLabel?: string
+}>
+
+const inputRoot = basecoatClass('input')
+
+const nativeSelectionAttrs = <Message>(
+  input: SelectionInputProps<Message>,
+  type: 'checkbox' | 'radio',
+): ReadonlyArray<Attribute<Message>> => {
+  const h = html<Message>()
+
+  return [
+    ...basecoatAttrs<Message>(input, inputRoot),
+    h.Type(type),
+    ...(input.id === undefined ? [] : [h.Id(input.id)]),
+    ...(input.name === undefined ? [] : [h.Name(input.name)]),
+    ...(input.value === undefined ? [] : [h.Value(input.value)]),
+    ...(input.checked === undefined ? [] : [h.Checked(input.checked)]),
+    ...(input.disabled === true ? [h.Disabled(true)] : []),
+    ...(input.required === true ? [h.Required(true)] : []),
+    ...(input.invalid === true ? [h.AriaInvalid(true)] : []),
+    ...(input.describedBy === undefined
+      ? []
+      : [h.AriaDescribedBy(input.describedBy)]),
+    ...(input.ariaLabel === undefined ? [] : [h.AriaLabel(input.ariaLabel)]),
+  ]
+}
+
+export const checkbox = <Message>(input: CheckboxProps<Message>): Html => {
+  const h = html<Message>()
+
+  return h.input(nativeSelectionAttrs<Message>(input, 'checkbox'))
+}
+
+export const radio = <Message>(input: RadioProps<Message>): Html => {
+  const h = html<Message>()
+
+  return h.input(nativeSelectionAttrs<Message>(input, 'radio'))
+}
+
+export const switchControl = <Message>(input: SwitchProps<Message>): Html => {
+  const h = html<Message>()
+
+  return h.input([
+    ...nativeSelectionAttrs<Message>(input, 'checkbox'),
+    h.Role('switch'),
+    ...dataAttr<Message>('size', input.size === 'sm' ? 'sm' : undefined),
+  ])
+}
+
+export { switchControl as switch }
+
+export const checkboxGroup = <Message>(
+  input: CheckboxGroupProps<Message>,
+): Html => {
+  const h = html<Message>()
+
+  return h.div(
+    [
+      ...basecoatAttrs<Message>(input),
+      h.Role('group'),
+      h.DataAttribute('slot', 'checkbox-group'),
+      ...(input.ariaLabel === undefined ? [] : [h.AriaLabel(input.ariaLabel)]),
+    ],
+    input.children,
+  )
+}
+
+export const radioGroup = <Message>(input: RadioGroupProps<Message>): Html => {
+  const h = html<Message>()
+
+  return h.div(
+    [
+      ...basecoatAttrs<Message>(input),
+      h.Role('radiogroup'),
+      h.DataAttribute('slot', 'radio-group'),
+      ...(input.ariaLabel === undefined ? [] : [h.AriaLabel(input.ariaLabel)]),
+    ],
+    input.children,
+  )
+}


### PR DESCRIPTION
## Summary

Adds Foldkit Basecoat selection controls for checkbox, radio, and switch inputs in `packages/ui/src/basecoat/selection.ts`. The controls emit Basecoat `input` markup, support checked/disabled/required/invalid/accessibility attrs, expose checkbox/radio group helpers with the Basecoat data slots, and export through the Basecoat namespace.

Closes #7694

## Verification

- `bun run test:ui`
- `bun run --cwd packages/ui typecheck`

The requested verification ref `command.public.pylon_khala.verify.5fc2b591e599fe078a5a13c8` resolves to `bun run test:ui`.