### PR TITLE
[codex] Add Basecoat breadcrumb Foldkit components

### DIFF
--- a/packages/ui/src/basecoat/breadcrumb.test.ts
+++ b/packages/ui/src/basecoat/breadcrumb.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, test } from 'bun:test'
+
+import { Basecoat } from '../index'
+import {
+  breadcrumb,
+  breadcrumbEllipsis,
+  breadcrumbItem,
+  breadcrumbLink,
+  breadcrumbList,
+  breadcrumbPage,
+  breadcrumbSeparator,
+} from './breadcrumb'
+import { renderHtml } from './test-helpers'
+
+describe('basecoat breadcrumb components', () => {
+  test('renders Basecoat breadcrumb landmark, list, links, separators, and current page', () => {
+    const rendered = renderHtml(
+      breadcrumb({
+        children: [
+          breadcrumbList({
+            children: [
+              breadcrumbItem({
+                children: [
+                  breadcrumbLink({ href: '/', children: ['Home'] }),
+                ],
+              }),
+              breadcrumbSeparator({}),
+              breadcrumbItem({
+                children: [
+                  breadcrumbLink({
+                    href: '/components',
+                    children: ['Components'],
+                  }),
+                ],
+              }),
+              breadcrumbSeparator({}),
+              breadcrumbItem({
+                children: [
+                  breadcrumbPage({ children: ['Breadcrumb'] }),
+                ],
+              }),
+            ],
+          }),
+        ],
+      }),
+    )
+
+    expect(rendered).toContain('<nav')
+    expect(rendered).toContain('class="breadcrumb"')
+    expect(rendered).toContain('aria-label="Breadcrumb"')
+    expect(rendered).toContain('<ol>')
+    expect(rendered).toContain('<li><a href="/">Home</a></li>')
+    expect(rendered).toContain('href="/components"')
+    expect(rendered).toContain('aria-hidden="true"')
+    expect(rendered).toContain('data-rtl-flip=""')
+    expect(rendered).toContain('class="lucide lucide-chevron-right"')
+    expect(rendered).toContain(
+      '<li><span aria-current="page">Breadcrumb</span></li>',
+    )
+  })
+
+  test('renders custom separators, collapsed ellipsis, and rtl direction', () => {
+    const rendered = renderHtml(
+      breadcrumb({
+        label: 'Ignored when ariaLabel is present',
+        dir: 'rtl',
+        ariaLabel: 'Trail',
+        className: 'text-sm',
+        children: [
+          breadcrumbList({
+            children: [
+              breadcrumbItem({
+                children: [
+                  breadcrumbLink({
+                    href: '/docs',
+                    rel: 'external',
+                    target: '_blank',
+                    children: ['Docs'],
+                  }),
+                ],
+              }),
+              breadcrumbSeparator({ children: ['/'] }),
+              breadcrumbEllipsis({ label: 'More documentation pages' }),
+              breadcrumbSeparator({ rtlFlip: false }),
+              breadcrumbItem({
+                children: [
+                  breadcrumbPage({
+                    className: 'font-medium',
+                    current: 'step',
+                    children: ['API'],
+                  }),
+                ],
+              }),
+            ],
+          }),
+        ],
+      }),
+    )
+
+    expect(rendered).toContain('class="breadcrumb text-sm"')
+    expect(rendered).toContain('aria-label="Trail"')
+    expect(rendered).toContain('dir="rtl"')
+    expect(rendered).toContain('rel="external"')
+    expect(rendered).toContain('target="_blank"')
+    expect(rendered).toContain('<li aria-hidden="true">/</li>')
+    expect(rendered).toContain('<li><span aria-hidden="true">')
+    expect(rendered).toContain('class="lucide lucide-ellipsis"')
+    expect(rendered).toContain(
+      '<span class="sr-only">More documentation pages</span>',
+    )
+    expect(rendered).toContain('<li aria-hidden="true"><svg')
+    expect(rendered).toContain(
+      '<span aria-current="step" class="font-medium">API</span>',
+    )
+  })
+
+  test('is exported from the Basecoat namespace', () => {
+    expect(Basecoat.breadcrumb).toBe(breadcrumb)
+    expect(Basecoat.breadcrumbList).toBe(breadcrumbList)
+    expect(Basecoat.breadcrumbItem).toBe(breadcrumbItem)
+    expect(Basecoat.breadcrumbLink).toBe(breadcrumbLink)
+    expect(Basecoat.breadcrumbPage).toBe(breadcrumbPage)
+    expect(Basecoat.breadcrumbSeparator).toBe(breadcrumbSeparator)
+    expect(Basecoat.breadcrumbEllipsis).toBe(breadcrumbEllipsis)
+  })
+})

--- a/packages/ui/src/basecoat/breadcrumb.ts
+++ b/packages/ui/src/basecoat/breadcrumb.ts
@@ -1,0 +1,207 @@
+import type { Html } from 'foldkit/html'
+import { html } from 'foldkit/html'
+
+import {
+  basecoatAttrs,
+  basecoatClass,
+  type BasecoatAttrs,
+  type BasecoatChildren,
+} from './shared'
+
+export type BreadcrumbProps<Message> = BasecoatAttrs<Message> & Readonly<{
+  children: BasecoatChildren
+  label?: string
+  ariaLabel?: string
+  dir?: 'ltr' | 'rtl' | 'auto'
+}>
+
+export type BreadcrumbListProps<Message> = BasecoatAttrs<Message> & Readonly<{
+  children: BasecoatChildren
+}>
+
+export type BreadcrumbItemProps<Message> = BasecoatAttrs<Message> & Readonly<{
+  children: BasecoatChildren
+}>
+
+export type BreadcrumbLinkProps<Message> = BasecoatAttrs<Message> & Readonly<{
+  children: BasecoatChildren
+  href: string
+  rel?: string
+  target?: string
+}>
+
+export type BreadcrumbCurrent =
+  | 'page'
+  | 'step'
+  | 'location'
+  | 'date'
+  | 'time'
+  | 'true'
+
+export type BreadcrumbPageProps<Message> = BasecoatAttrs<Message> & Readonly<{
+  children: BasecoatChildren
+  current?: BreadcrumbCurrent
+}>
+
+export type BreadcrumbSeparatorProps<Message> =
+  BasecoatAttrs<Message> & Readonly<{
+    children?: BasecoatChildren
+    rtlFlip?: boolean
+  }>
+
+export type BreadcrumbEllipsisProps<Message> =
+  BasecoatAttrs<Message> & Readonly<{
+    children?: BasecoatChildren
+    label?: string
+  }>
+
+const breadcrumbRoot = basecoatClass('breadcrumb')
+
+const chevronRight = <Message>(rtlFlip: boolean): Html => {
+  const h = html<Message>()
+
+  return h.svg(
+    [
+      ...(rtlFlip ? [h.DataAttribute('rtl-flip', '')] : []),
+      h.Class('lucide lucide-chevron-right'),
+      h.Attribute('xmlns', 'http://www.w3.org/2000/svg'),
+      h.Attribute('width', '24'),
+      h.Attribute('height', '24'),
+      h.ViewBox('0 0 24 24'),
+      h.Fill('none'),
+      h.Attribute('stroke', 'currentColor'),
+      h.Attribute('stroke-width', '2'),
+      h.Attribute('stroke-linecap', 'round'),
+      h.Attribute('stroke-linejoin', 'round'),
+    ],
+    [h.path([h.D('m9 18 6-6-6-6')], [])],
+  )
+}
+
+const ellipsisIcon = <Message>(): Html => {
+  const h = html<Message>()
+
+  return h.svg(
+    [
+      h.Class('lucide lucide-ellipsis'),
+      h.Attribute('xmlns', 'http://www.w3.org/2000/svg'),
+      h.Attribute('width', '24'),
+      h.Attribute('height', '24'),
+      h.ViewBox('0 0 24 24'),
+      h.Fill('none'),
+      h.Attribute('stroke', 'currentColor'),
+      h.Attribute('stroke-width', '2'),
+      h.Attribute('stroke-linecap', 'round'),
+      h.Attribute('stroke-linejoin', 'round'),
+    ],
+    [
+      h.circle([
+        h.Attribute('cx', '12'),
+        h.Attribute('cy', '12'),
+        h.Attribute('r', '1'),
+      ], []),
+      h.circle([
+        h.Attribute('cx', '19'),
+        h.Attribute('cy', '12'),
+        h.Attribute('r', '1'),
+      ], []),
+      h.circle([
+        h.Attribute('cx', '5'),
+        h.Attribute('cy', '12'),
+        h.Attribute('r', '1'),
+      ], []),
+    ],
+  )
+}
+
+export const breadcrumb = <Message>(
+  input: BreadcrumbProps<Message>,
+): Html => {
+  const h = html<Message>()
+
+  return h.nav(
+    [
+      ...basecoatAttrs<Message>(input, breadcrumbRoot),
+      h.AriaLabel(input.ariaLabel ?? input.label ?? 'Breadcrumb'),
+      ...(input.dir === undefined ? [] : [h.Attribute('dir', input.dir)]),
+    ],
+    input.children,
+  )
+}
+
+export const breadcrumbList = <Message>(
+  input: BreadcrumbListProps<Message>,
+): Html => {
+  const h = html<Message>()
+
+  return h.ol(basecoatAttrs<Message>(input), input.children)
+}
+
+export const breadcrumbItem = <Message>(
+  input: BreadcrumbItemProps<Message>,
+): Html => {
+  const h = html<Message>()
+
+  return h.li(basecoatAttrs<Message>(input), input.children)
+}
+
+export const breadcrumbLink = <Message>(
+  input: BreadcrumbLinkProps<Message>,
+): Html => {
+  const h = html<Message>()
+
+  return h.a(
+    [
+      ...basecoatAttrs<Message>(input),
+      h.Href(input.href),
+      ...(input.rel === undefined ? [] : [h.Rel(input.rel)]),
+      ...(input.target === undefined ? [] : [h.Target(input.target)]),
+    ],
+    input.children,
+  )
+}
+
+export const breadcrumbPage = <Message>(
+  input: BreadcrumbPageProps<Message>,
+): Html => {
+  const h = html<Message>()
+
+  return h.span(
+    [
+      ...basecoatAttrs<Message>(input),
+      h.AriaCurrent(input.current ?? 'page'),
+    ],
+    input.children,
+  )
+}
+
+export const breadcrumbSeparator = <Message>(
+  input: BreadcrumbSeparatorProps<Message> = {},
+): Html => {
+  const h = html<Message>()
+
+  return h.li(
+    [
+      ...basecoatAttrs<Message>(input),
+      h.AriaHidden(true),
+    ],
+    input.children ?? [chevronRight<Message>(input.rtlFlip !== false)],
+  )
+}
+
+export const breadcrumbEllipsis = <Message>(
+  input: BreadcrumbEllipsisProps<Message> = {},
+): Html => {
+  const h = html<Message>()
+
+  return h.li(
+    basecoatAttrs<Message>(input),
+    [
+      h.span(
+        [h.AriaHidden(true)],
+        input.children ?? [ellipsisIcon<Message>()],
+      ),
+      h.span([h.Class('sr-only')], [input.label ?? 'More pages']),
+    ],
+  )
+}

--- a/packages/ui/src/basecoat/index.ts
+++ b/packages/ui/src/basecoat/index.ts
@@ -1,4 +1,5 @@
 export * from './badge'
+export * from './breadcrumb'
 export * from './button'
 export * from './card'
 export * from './containers'


### PR DESCRIPTION
## Summary

Adds Foldkit Basecoat breadcrumb helpers under `packages/ui/src/basecoat/`, matching the documented Basecoat landmark/list/link/separator/current-page markup. The API covers root, list, item, link, page, separator, and collapsed ellipsis helpers, including accessible labels, current-page state, optional link attrs, RTL direction, and separator RTL flipping.

Closes #7698

## Validation

- `bun run test:ui` (`command.public.pylon_khala.verify.5fc2b591e599fe078a5a13c8`)
- `bun run --cwd packages/ui typecheck`