### PR TITLE
[codex] Add Basecoat item and empty components

### DIFF
--- a/packages/ui/src/basecoat/containers.test.ts
+++ b/packages/ui/src/basecoat/containers.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, test } from 'bun:test'
+
+import { Basecoat } from '../index'
+import { button } from './button'
+import {
+  empty,
+  emptyContent,
+  emptyDescription,
+  emptyFigure,
+  emptyFooter,
+  emptyHeader,
+  emptyMedia,
+  emptySection,
+  emptyTitle,
+  item,
+  itemAside,
+  itemContent,
+  itemDescription,
+  itemFigure,
+  itemFooter,
+  itemGroup,
+  itemHeader,
+  itemMedia,
+  itemSection,
+  itemSeparator,
+  itemTitle,
+} from './containers'
+import { renderHtml } from './test-helpers'
+
+describe('basecoat container components', () => {
+  test('renders item groups, variants, sizes, and semantic item children', () => {
+    const rendered = renderHtml(
+      itemGroup({
+        className: 'gap-4',
+        children: [
+          item({
+            variant: 'outline',
+            role: 'listitem',
+            children: [
+              itemMedia({ children: ['Icon'] }),
+              itemContent({
+                children: [
+                  itemTitle({ children: ['Security Alert'] }),
+                  itemDescription({
+                    children: ['New login detected from unknown device.'],
+                  }),
+                ],
+              }),
+              itemAside({
+                children: [
+                  button({
+                    variant: 'outline',
+                    size: 'sm',
+                    children: ['Review'],
+                  }),
+                ],
+              }),
+            ],
+          }),
+          itemSeparator(),
+          item({
+            href: '/profile',
+            size: 'sm',
+            role: 'listitem',
+            children: [
+              itemContent({
+                children: [
+                  itemTitle({ level: 4, children: ['Profile verified'] }),
+                ],
+              }),
+              itemAside({ children: ['Next'] }),
+            ],
+          }),
+        ],
+      }),
+    )
+
+    expect(rendered).toContain('<div role="list" class="item-group gap-4">')
+    expect(rendered).toContain('<article')
+    expect(rendered).toContain('role="listitem"')
+    expect(rendered).toContain('class="item"')
+    expect(rendered).toContain('data-variant="outline"')
+    expect(rendered).toContain('<figure>Icon</figure>')
+    expect(rendered).toContain('<section><h3>Security Alert</h3><p>New login detected from unknown device.</p></section>')
+    expect(rendered).toContain('<aside><button')
+    expect(rendered).toContain('<hr></hr>')
+    expect(rendered).toContain('<a')
+    expect(rendered).toContain('href="/profile"')
+    expect(rendered).toContain('data-size="sm"')
+    expect(rendered).toContain('<h4>Profile verified</h4>')
+  })
+
+  test('renders item header and footer regions', () => {
+    const rendered = renderHtml(
+      item({
+        variant: 'muted',
+        size: 'xs',
+        children: [
+          itemHeader({ children: ['Preview'] }),
+          itemContent({
+            children: [itemTitle({ level: 2, children: ['v0-2.0-mini'] })],
+          }),
+          itemFooter({ children: ['Open Source model for everyone.'] }),
+        ],
+      }),
+    )
+
+    expect(rendered).toContain('data-variant="muted"')
+    expect(rendered).toContain('data-size="xs"')
+    expect(rendered).toContain('<header>Preview</header>')
+    expect(rendered).toContain('<h2>v0-2.0-mini</h2>')
+    expect(rendered).toContain('<footer>Open Source model for everyone.</footer>')
+  })
+
+  test('renders empty states with header, media, content, and footer', () => {
+    const rendered = renderHtml(
+      empty({
+        className: 'border border-dashed',
+        children: [
+          emptyHeader({
+            children: [
+              emptyMedia({ children: ['Folder'] }),
+              emptyTitle({ children: ['No Projects Yet'] }),
+              emptyDescription({
+                children: ['Create your first project to get started.'],
+              }),
+            ],
+          }),
+          emptyContent({
+            children: ['Search existing projects before creating one.'],
+          }),
+          emptyFooter({
+            children: [
+              button({ children: ['Create Project'] }),
+              button({
+                variant: 'outline',
+                children: ['Import Project'],
+              }),
+            ],
+          }),
+        ],
+      }),
+    )
+
+    expect(rendered).toContain('<section class="empty border border-dashed">')
+    expect(rendered).toContain('<header><figure>Folder</figure><h3>No Projects Yet</h3><p>Create your first project to get started.</p></header>')
+    expect(rendered).toContain('<section>Search existing projects before creating one.</section>')
+    expect(rendered).toContain('<footer><button')
+    expect(rendered).toContain('Create Project')
+    expect(rendered).toContain('data-variant="outline"')
+  })
+
+  test('is exported from the Basecoat namespace', () => {
+    expect(Basecoat.itemGroup).toBe(itemGroup)
+    expect(Basecoat.item).toBe(item)
+    expect(Basecoat.itemMedia).toBe(itemMedia)
+    expect(Basecoat.itemFigure).toBe(itemFigure)
+    expect(Basecoat.itemContent).toBe(itemContent)
+    expect(Basecoat.itemSection).toBe(itemSection)
+    expect(Basecoat.itemTitle).toBe(itemTitle)
+    expect(Basecoat.itemDescription).toBe(itemDescription)
+    expect(Basecoat.itemAside).toBe(itemAside)
+    expect(Basecoat.itemHeader).toBe(itemHeader)
+    expect(Basecoat.itemFooter).toBe(itemFooter)
+    expect(Basecoat.itemSeparator).toBe(itemSeparator)
+    expect(Basecoat.empty).toBe(empty)
+    expect(Basecoat.emptyHeader).toBe(emptyHeader)
+    expect(Basecoat.emptyMedia).toBe(emptyMedia)
+    expect(Basecoat.emptyFigure).toBe(emptyFigure)
+    expect(Basecoat.emptyTitle).toBe(emptyTitle)
+    expect(Basecoat.emptyDescription).toBe(emptyDescription)
+    expect(Basecoat.emptyContent).toBe(emptyContent)
+    expect(Basecoat.emptySection).toBe(emptySection)
+    expect(Basecoat.emptyFooter).toBe(emptyFooter)
+  })
+})

--- a/packages/ui/src/basecoat/containers.ts
+++ b/packages/ui/src/basecoat/containers.ts
@@ -1,0 +1,302 @@
+import type { Attribute, Html } from 'foldkit/html'
+import { html } from 'foldkit/html'
+
+import {
+  basecoatAttrs,
+  basecoatClass,
+  dataAttr,
+  type BasecoatAttrs,
+  type BasecoatChildren,
+} from './shared'
+
+export type ItemVariant = 'default' | 'outline' | 'muted'
+export type ItemSize = 'default' | 'sm' | 'xs'
+export type ItemElement = 'article' | 'a' | 'span'
+export type ItemTitleLevel = 2 | 3 | 4
+
+export type ItemGroupProps<Message> = BasecoatAttrs<Message> & Readonly<{
+  children: ReadonlyArray<Html>
+  role?: 'list' | 'group'
+}>
+
+export type ItemProps<Message> = BasecoatAttrs<Message> & Readonly<{
+  children: BasecoatChildren
+  element?: ItemElement
+  href?: string
+  rel?: string
+  role?: 'listitem' | 'link' | 'menuitem'
+  size?: ItemSize
+  target?: string
+  variant?: ItemVariant
+}>
+
+export type ItemMediaProps<Message> = BasecoatAttrs<Message> & Readonly<{
+  children: BasecoatChildren
+}>
+
+export type ItemFigureProps<Message> = ItemMediaProps<Message>
+
+export type ItemContentProps<Message> = BasecoatAttrs<Message> & Readonly<{
+  children: BasecoatChildren
+}>
+
+export type ItemSectionProps<Message> = ItemContentProps<Message>
+
+export type ItemTitleProps<Message> = BasecoatAttrs<Message> & Readonly<{
+  children: BasecoatChildren
+  level?: ItemTitleLevel
+}>
+
+export type ItemDescriptionProps<Message> =
+  BasecoatAttrs<Message> & Readonly<{
+    children: BasecoatChildren
+  }>
+
+export type ItemAsideProps<Message> = BasecoatAttrs<Message> & Readonly<{
+  children: BasecoatChildren
+}>
+
+export type ItemHeaderProps<Message> = BasecoatAttrs<Message> & Readonly<{
+  children: BasecoatChildren
+}>
+
+export type ItemFooterProps<Message> = BasecoatAttrs<Message> & Readonly<{
+  children: BasecoatChildren
+}>
+
+export type ItemSeparatorProps<Message> = BasecoatAttrs<Message>
+
+export type EmptyTitleLevel = 2 | 3 | 4
+
+export type EmptyProps<Message> = BasecoatAttrs<Message> & Readonly<{
+  children: BasecoatChildren
+}>
+
+export type EmptyHeaderProps<Message> = BasecoatAttrs<Message> & Readonly<{
+  children: BasecoatChildren
+}>
+
+export type EmptyMediaProps<Message> = BasecoatAttrs<Message> & Readonly<{
+  children: BasecoatChildren
+}>
+
+export type EmptyFigureProps<Message> = EmptyMediaProps<Message>
+
+export type EmptyTitleProps<Message> = BasecoatAttrs<Message> & Readonly<{
+  children: BasecoatChildren
+  level?: EmptyTitleLevel
+}>
+
+export type EmptyDescriptionProps<Message> =
+  BasecoatAttrs<Message> & Readonly<{
+    children: BasecoatChildren
+  }>
+
+export type EmptyContentProps<Message> = BasecoatAttrs<Message> & Readonly<{
+  children: BasecoatChildren
+}>
+
+export type EmptySectionProps<Message> = EmptyContentProps<Message>
+
+export type EmptyFooterProps<Message> = BasecoatAttrs<Message> & Readonly<{
+  children: BasecoatChildren
+}>
+
+const itemGroupRoot = basecoatClass('item-group')
+const itemRoot = basecoatClass('item')
+const emptyRoot = basecoatClass('empty')
+
+const optionalStringAttr = <Message>(
+  value: string | undefined,
+  attr: (value: string) => Attribute<Message>,
+): ReadonlyArray<Attribute<Message>> => value === undefined ? [] : [attr(value)]
+
+export const itemGroup = <Message>(
+  input: ItemGroupProps<Message>,
+): Html => {
+  const h = html<Message>()
+
+  return h.div(
+    [
+      ...basecoatAttrs<Message>(input, itemGroupRoot),
+      h.Role(input.role ?? 'list'),
+    ],
+    input.children,
+  )
+}
+
+export const item = <Message>(input: ItemProps<Message>): Html => {
+  const h = html<Message>()
+  const attrs = [
+    ...basecoatAttrs<Message>(input, itemRoot),
+    ...dataAttr<Message>(
+      'variant',
+      input.variant === 'default' ? undefined : input.variant,
+    ),
+    ...dataAttr<Message>(
+      'size',
+      input.size === 'default' ? undefined : input.size,
+    ),
+    ...(input.role === undefined ? [] : [h.Role(input.role)]),
+  ]
+
+  if (input.href !== undefined || input.element === 'a') {
+    return h.a(
+      [
+        ...attrs,
+        ...optionalStringAttr<Message>(input.href, h.Href),
+        ...optionalStringAttr<Message>(input.target, h.Target),
+        ...optionalStringAttr<Message>(input.rel, h.Rel),
+      ],
+      input.children,
+    )
+  }
+
+  return input.element === 'span'
+    ? h.span(attrs, input.children)
+    : h.article(attrs, input.children)
+}
+
+export const itemMedia = <Message>(
+  input: ItemMediaProps<Message>,
+): Html => {
+  const h = html<Message>()
+
+  return h.figure(basecoatAttrs<Message>(input), input.children)
+}
+
+export const itemFigure = itemMedia
+
+export const itemContent = <Message>(
+  input: ItemContentProps<Message>,
+): Html => {
+  const h = html<Message>()
+
+  return h.section(basecoatAttrs<Message>(input), input.children)
+}
+
+export const itemSection = itemContent
+
+export const itemTitle = <Message>(
+  input: ItemTitleProps<Message>,
+): Html => {
+  const h = html<Message>()
+  const attrs = basecoatAttrs<Message>(input)
+
+  switch (input.level) {
+    case 2:
+      return h.h2(attrs, input.children)
+    case 4:
+      return h.h4(attrs, input.children)
+    case 3:
+    default:
+      return h.h3(attrs, input.children)
+  }
+}
+
+export const itemDescription = <Message>(
+  input: ItemDescriptionProps<Message>,
+): Html => {
+  const h = html<Message>()
+
+  return h.p(basecoatAttrs<Message>(input), input.children)
+}
+
+export const itemAside = <Message>(
+  input: ItemAsideProps<Message>,
+): Html => {
+  const h = html<Message>()
+
+  return h.aside(basecoatAttrs<Message>(input), input.children)
+}
+
+export const itemHeader = <Message>(
+  input: ItemHeaderProps<Message>,
+): Html => {
+  const h = html<Message>()
+
+  return h.header(basecoatAttrs<Message>(input), input.children)
+}
+
+export const itemFooter = <Message>(
+  input: ItemFooterProps<Message>,
+): Html => {
+  const h = html<Message>()
+
+  return h.footer(basecoatAttrs<Message>(input), input.children)
+}
+
+export const itemSeparator = <Message>(
+  input: ItemSeparatorProps<Message> = {},
+): Html => {
+  const h = html<Message>()
+
+  return h.hr(basecoatAttrs<Message>(input))
+}
+
+export const empty = <Message>(input: EmptyProps<Message>): Html => {
+  const h = html<Message>()
+
+  return h.section(basecoatAttrs<Message>(input, emptyRoot), input.children)
+}
+
+export const emptyHeader = <Message>(
+  input: EmptyHeaderProps<Message>,
+): Html => {
+  const h = html<Message>()
+
+  return h.header(basecoatAttrs<Message>(input), input.children)
+}
+
+export const emptyMedia = <Message>(
+  input: EmptyMediaProps<Message>,
+): Html => {
+  const h = html<Message>()
+
+  return h.figure(basecoatAttrs<Message>(input), input.children)
+}
+
+export const emptyFigure = emptyMedia
+
+export const emptyTitle = <Message>(
+  input: EmptyTitleProps<Message>,
+): Html => {
+  const h = html<Message>()
+  const attrs = basecoatAttrs<Message>(input)
+
+  switch (input.level) {
+    case 2:
+      return h.h2(attrs, input.children)
+    case 4:
+      return h.h4(attrs, input.children)
+    case 3:
+    default:
+      return h.h3(attrs, input.children)
+  }
+}
+
+export const emptyDescription = <Message>(
+  input: EmptyDescriptionProps<Message>,
+): Html => {
+  const h = html<Message>()
+
+  return h.p(basecoatAttrs<Message>(input), input.children)
+}
+
+export const emptyContent = <Message>(
+  input: EmptyContentProps<Message>,
+): Html => {
+  const h = html<Message>()
+
+  return h.section(basecoatAttrs<Message>(input), input.children)
+}
+
+export const emptySection = emptyContent
+
+export const emptyFooter = <Message>(
+  input: EmptyFooterProps<Message>,
+): Html => {
+  const h = html<Message>()
+
+  return h.footer(basecoatAttrs<Message>(input), input.children)
+}

--- a/packages/ui/src/basecoat/index.ts
+++ b/packages/ui/src/basecoat/index.ts
@@ -1,6 +1,7 @@
 export * from './badge'
 export * from './button'
 export * from './card'
+export * from './containers'
 export * from './display'
 export * from './input'
 export * from './selection'


### PR DESCRIPTION
## Summary

Adds Foldkit Basecoat wrappers for the `item` and `empty` container components under `packages/ui/src/basecoat/containers.ts`. The new helpers emit the documented Basecoat markup for item roots, groups, separators, item slots, empty state roots, and empty state slots, including the Basecoat item `data-variant` and `data-size` attributes.

Closes #7696.

## Validation

- `bun run test:ui`
- `bun run typecheck:ui`