### PR TITLE
Cover Basecoat display default attributes

### DIFF
--- a/packages/ui/src/basecoat/display.test.ts
+++ b/packages/ui/src/basecoat/display.test.ts
@@ -80,6 +80,21 @@ describe('basecoat display components', () => {
     expect(rendered).toContain('class="skeleton h-4 w-24"')
   })
 
+  test('omits default Basecoat variant and size data attributes', () => {
+    const rendered = renderHtml(
+      alert({
+        variant: 'default',
+        children: [
+          alertTitle({ children: ['Heads up'] }),
+          avatar({ size: 'default', children: [avatarFallback({ children: ['OA'] })] }),
+        ],
+      }),
+    )
+
+    expect(rendered).not.toContain('data-variant="default"')
+    expect(rendered).not.toContain('data-size="default"')
+  })
+
   test('is exported from the Basecoat namespace', () => {
     expect(Basecoat.alert).toBe(alert)
     expect(Basecoat.alertTitle).toBe(alertTitle)


### PR DESCRIPTION
## Summary
- Rebase on the mainline Basecoat display implementation from #7717.
- Add regression coverage that `variant: 'default'` and `size: 'default'` omit Basecoat data attributes for alert/avatar defaults.

Closes #7695.

## Verification
- `bun run test:ui`
- `bun run typecheck:ui`