### PR TITLE
Add Basecoat form Foldkit components

### DIFF
--- a/packages/ui/src/basecoat/form.test.ts
+++ b/packages/ui/src/basecoat/form.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, test } from 'bun:test'
+import { html } from 'foldkit/html'
+
+import { Basecoat } from '../index'
+import { button } from './button'
+import {
+  form,
+  formDescription,
+  formField,
+  formFieldGroup,
+  formOptionLabel,
+  formSection,
+  formSectionTitle,
+  formSwitchContent,
+  formSwitchField,
+  formSwitchLabel,
+} from './form'
+import { input, label, textarea } from './input'
+import { renderHtml } from './test-helpers'
+
+describe('basecoat form components', () => {
+  test('renders the Basecoat form root with native form attributes', () => {
+    const rendered = renderHtml(
+      form({
+        id: 'profile-form',
+        name: 'profile',
+        action: '/profile',
+        method: 'post',
+        target: '_self',
+        ariaLabel: 'Profile settings',
+        className: 'max-w-sm',
+        children: [
+          formField({
+            children: [
+              label({ for: 'username', children: ['Username'] }),
+              input({
+                id: 'username',
+                name: 'username',
+                placeholder: 'hunvreus',
+              }),
+              formDescription({
+                id: 'username-help',
+                children: ['This is your public display name.'],
+              }),
+            ],
+          }),
+          button({ type: 'submit', children: ['Submit'] }),
+        ],
+      }),
+    )
+
+    expect(rendered).toContain('<form')
+    expect(rendered).toContain('id="profile-form"')
+    expect(rendered).toContain('name="profile"')
+    expect(rendered).toContain('action="/profile"')
+    expect(rendered).toContain('method="post"')
+    expect(rendered).toContain('target="_self"')
+    expect(rendered).toContain('aria-label="Profile settings"')
+    expect(rendered).toContain('class="form grid gap-6 max-w-sm"')
+    expect(rendered).toContain('<div class="grid gap-2">')
+    expect(rendered).toContain('<label htmlFor="username" class="label">Username</label>')
+    expect(rendered).toContain('class="input"')
+    expect(rendered).toContain('<p id="username-help" class="text-muted-foreground text-sm">')
+    expect(rendered).toContain('<button type="submit" class="btn">Submit</button>')
+  })
+
+  test('renders Basecoat form sections, option labels, and switch rows', () => {
+    const rendered = renderHtml(
+      form({
+        children: [
+          formField({
+            children: [
+              label({ for: 'bio', children: ['Bio'] }),
+              textarea({ id: 'bio', name: 'bio', rows: 3 }),
+              formDescription({
+                children: ['You can @mention other users and organizations.'],
+              }),
+            ],
+          }),
+          formFieldGroup({
+            children: [
+              label({ for: 'notify', children: ['Notify me about...'] }),
+              formOptionLabel({
+                children: [
+                  input({
+                    id: 'notify-all',
+                    name: 'notify',
+                    type: 'radio',
+                    value: 'all',
+                    checked: true,
+                  }),
+                  'All new messages',
+                ],
+              }),
+            ],
+          }),
+          formSection({
+            children: [
+              formSectionTitle({ children: ['Email Notifications'] }),
+              formSwitchField({
+                children: [
+                  formSwitchContent({
+                    disabled: true,
+                    children: [
+                      formSwitchLabel({
+                        for: 'security-email',
+                        children: ['Security emails'],
+                      }),
+                      formDescription({
+                        children: ['Receive emails about your account security.'],
+                      }),
+                    ],
+                  }),
+                  input({
+                    id: 'security-email',
+                    name: 'security-email',
+                    type: 'checkbox',
+                    disabled: true,
+                    attrs: [html().Role('switch')],
+                  }),
+                ],
+              }),
+            ],
+          }),
+        ],
+      }),
+    )
+
+    expect(rendered).toContain('class="form grid gap-6"')
+    expect(rendered).toContain('<textarea')
+    expect(rendered).toContain('rows="3"')
+    expect(rendered).toContain('<div class="flex flex-col gap-3">')
+    expect(rendered).toContain('<label class="font-normal">')
+    expect(rendered).toContain('type="radio"')
+    expect(rendered).toContain('checked')
+    expect(rendered).toContain('<section class="grid gap-4">')
+    expect(rendered).toContain('<h3 class="text-lg font-medium">Email Notifications</h3>')
+    expect(rendered).toContain('class="gap-2 flex flex-row items-start justify-between rounded-lg border p-4 shadow-xs"')
+    expect(rendered).toContain('class="flex flex-col gap-0.5 opacity-60"')
+    expect(rendered).toContain('<label htmlFor="security-email" class="leading-normal">Security emails</label>')
+    expect(rendered).toContain('role="switch"')
+    expect(rendered).toContain('disabled')
+  })
+
+  test('is exported from the Basecoat namespace', () => {
+    expect(Basecoat.form).toBe(form)
+    expect(Basecoat.formField).toBe(formField)
+    expect(Basecoat.formFieldGroup).toBe(formFieldGroup)
+    expect(Basecoat.formSection).toBe(formSection)
+    expect(Basecoat.formSectionTitle).toBe(formSectionTitle)
+    expect(Basecoat.formDescription).toBe(formDescription)
+    expect(Basecoat.formOptionLabel).toBe(formOptionLabel)
+    expect(Basecoat.formSwitchField).toBe(formSwitchField)
+    expect(Basecoat.formSwitchContent).toBe(formSwitchContent)
+    expect(Basecoat.formSwitchLabel).toBe(formSwitchLabel)
+  })
+})

--- a/packages/ui/src/basecoat/form.ts
+++ b/packages/ui/src/basecoat/form.ts
@@ -1,0 +1,218 @@
+import type { Attribute, Html } from 'foldkit/html'
+import { html } from 'foldkit/html'
+
+import {
+  basecoatAttrs,
+  basecoatClass,
+  type BasecoatAttrs,
+  type BasecoatChildren,
+} from './shared'
+
+export type FormMethod = 'get' | 'post' | 'dialog'
+
+export type FormTarget = '_self' | '_blank' | '_parent' | '_top'
+
+export type FormProps<Message> = BasecoatAttrs<Message> & Readonly<{
+  children: BasecoatChildren
+  id?: string
+  name?: string
+  action?: string
+  method?: FormMethod
+  target?: FormTarget
+  ariaLabel?: string
+}>
+
+export type FormFieldProps<Message> = BasecoatAttrs<Message> & Readonly<{
+  children: BasecoatChildren
+}>
+
+export type FormFieldGroupProps<Message> =
+  BasecoatAttrs<Message> & Readonly<{
+    children: BasecoatChildren
+  }>
+
+export type FormSectionProps<Message> = BasecoatAttrs<Message> & Readonly<{
+  children: BasecoatChildren
+}>
+
+export type FormSectionTitleProps<Message> =
+  BasecoatAttrs<Message> & Readonly<{
+    children: BasecoatChildren
+    level?: 2 | 3
+  }>
+
+export type FormDescriptionProps<Message> =
+  BasecoatAttrs<Message> & Readonly<{
+    children: BasecoatChildren
+    id?: string
+  }>
+
+export type FormOptionLabelProps<Message> =
+  BasecoatAttrs<Message> & Readonly<{
+    children: BasecoatChildren
+    for?: string
+  }>
+
+export type FormSwitchFieldProps<Message> =
+  BasecoatAttrs<Message> & Readonly<{
+    children: BasecoatChildren
+  }>
+
+export type FormSwitchContentProps<Message> =
+  BasecoatAttrs<Message> & Readonly<{
+    children: BasecoatChildren
+    disabled?: boolean
+  }>
+
+export type FormSwitchLabelProps<Message> =
+  BasecoatAttrs<Message> & Readonly<{
+    children: BasecoatChildren
+    for?: string
+  }>
+
+const formRoot = basecoatClass('form')
+const formLayout = basecoatClass('grid gap-6')
+const formFieldLayout = basecoatClass('grid gap-2')
+const formFieldGroupLayout = basecoatClass('flex flex-col gap-3')
+const formSectionLayout = basecoatClass('grid gap-4')
+const formSectionTitleClass = basecoatClass('text-lg font-medium')
+const formDescriptionClass = basecoatClass('text-muted-foreground text-sm')
+const formOptionLabelClass = basecoatClass('font-normal')
+const formSwitchFieldClass = basecoatClass(
+  'gap-2 flex flex-row items-start justify-between rounded-lg border p-4 shadow-xs',
+)
+const formSwitchContentClass = basecoatClass('flex flex-col gap-0.5')
+const formSwitchContentDisabledClass = basecoatClass('opacity-60')
+const formSwitchLabelClass = basecoatClass('leading-normal')
+
+const optionalStringAttr = <Message>(
+  value: string | undefined,
+  attr: (value: string) => Attribute<Message>,
+): ReadonlyArray<Attribute<Message>> =>
+  value === undefined ? [] : [attr(value)]
+
+export const form = <Message>(input: FormProps<Message>): Html => {
+  const h = html<Message>()
+
+  return h.form(
+    [
+      ...basecoatAttrs<Message>(input, formRoot, formLayout),
+      ...optionalStringAttr<Message>(input.id, h.Id),
+      ...optionalStringAttr<Message>(input.name, h.Name),
+      ...optionalStringAttr<Message>(input.action, h.Action),
+      ...(input.method === undefined ? [] : [h.Method(input.method)]),
+      ...optionalStringAttr<Message>(input.target, h.Target),
+      ...optionalStringAttr<Message>(input.ariaLabel, h.AriaLabel),
+    ],
+    input.children,
+  )
+}
+
+export const formField = <Message>(
+  input: FormFieldProps<Message>,
+): Html => {
+  const h = html<Message>()
+
+  return h.div(basecoatAttrs<Message>(input, formFieldLayout), input.children)
+}
+
+export const formFieldGroup = <Message>(
+  input: FormFieldGroupProps<Message>,
+): Html => {
+  const h = html<Message>()
+
+  return h.div(
+    basecoatAttrs<Message>(input, formFieldGroupLayout),
+    input.children,
+  )
+}
+
+export const formSection = <Message>(
+  input: FormSectionProps<Message>,
+): Html => {
+  const h = html<Message>()
+
+  return h.section(
+    basecoatAttrs<Message>(input, formSectionLayout),
+    input.children,
+  )
+}
+
+export const formSectionTitle = <Message>(
+  input: FormSectionTitleProps<Message>,
+): Html => {
+  const h = html<Message>()
+  const attrs = basecoatAttrs<Message>(input, formSectionTitleClass)
+
+  return input.level === 2
+    ? h.h2(attrs, input.children)
+    : h.h3(attrs, input.children)
+}
+
+export const formDescription = <Message>(
+  input: FormDescriptionProps<Message>,
+): Html => {
+  const h = html<Message>()
+
+  return h.p(
+    [
+      ...basecoatAttrs<Message>(input, formDescriptionClass),
+      ...optionalStringAttr<Message>(input.id, h.Id),
+    ],
+    input.children,
+  )
+}
+
+export const formOptionLabel = <Message>(
+  input: FormOptionLabelProps<Message>,
+): Html => {
+  const h = html<Message>()
+
+  return h.label(
+    [
+      ...basecoatAttrs<Message>(input, formOptionLabelClass),
+      ...optionalStringAttr<Message>(input.for, h.For),
+    ],
+    input.children,
+  )
+}
+
+export const formSwitchField = <Message>(
+  input: FormSwitchFieldProps<Message>,
+): Html => {
+  const h = html<Message>()
+
+  return h.div(
+    basecoatAttrs<Message>(input, formSwitchFieldClass),
+    input.children,
+  )
+}
+
+export const formSwitchContent = <Message>(
+  input: FormSwitchContentProps<Message>,
+): Html => {
+  const h = html<Message>()
+
+  return h.div(
+    basecoatAttrs<Message>(
+      input,
+      formSwitchContentClass,
+      input.disabled === true ? formSwitchContentDisabledClass : null,
+    ),
+    input.children,
+  )
+}
+
+export const formSwitchLabel = <Message>(
+  input: FormSwitchLabelProps<Message>,
+): Html => {
+  const h = html<Message>()
+
+  return h.label(
+    [
+      ...basecoatAttrs<Message>(input, formSwitchLabelClass),
+      ...optionalStringAttr<Message>(input.for, h.For),
+    ],
+    input.children,
+  )
+}

--- a/packages/ui/src/basecoat/index.ts
+++ b/packages/ui/src/basecoat/index.ts
@@ -2,6 +2,7 @@ export * from './badge'
 export * from './button'
 export * from './card'
 export * from './display'
+export * from './form'
 export * from './input'
 export {
   basecoatAttrs,


### PR DESCRIPTION
## Summary
- add typed Foldkit Basecoat form components in `packages/ui/src/basecoat/form.ts`
- cover Basecoat form root, field layouts, descriptions, option labels, switch rows, and namespace exports
- export the form components from `packages/ui/src/basecoat/index.ts`

Closes #7699.

## Verification
- `bun run test:ui` (matches `command.public.pylon_khala.verify.5fc2b591e599fe078a5a13c8`)
- `git diff --check`