### PR TITLE
Add Basecoat tooltip scrollbar collapsible components

### DIFF
--- a/packages/ui/src/basecoat/index.ts
+++ b/packages/ui/src/basecoat/index.ts
@@ -5,6 +5,7 @@ export * from './containers'
 export * from './display'
 export * from './input'
 export * from './selection'
+export * from './tooltip'
 export {
   basecoatAttrs,
   basecoatClass,

--- a/packages/ui/src/basecoat/tooltip.test.ts
+++ b/packages/ui/src/basecoat/tooltip.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, test } from 'bun:test'
+
+import { Basecoat } from '../index'
+import {
+  collapsible,
+  collapsibleContent,
+  collapsibleTrigger,
+  scrollbar,
+  tooltip,
+} from './tooltip'
+import { renderHtml } from './test-helpers'
+
+describe('basecoat tooltip, scrollbar, and collapsible components', () => {
+  test('renders tooltip data attributes on the selected element', () => {
+    const rendered = renderHtml(
+      tooltip({
+        element: 'button',
+        tooltip: 'Archive thread',
+        side: 'inline-end',
+        align: 'start',
+        ariaLabel: 'Archive',
+        className: 'inline-flex',
+        children: ['Archive'],
+      }),
+    )
+
+    expect(rendered).toContain('<button')
+    expect(rendered).toContain('type="button"')
+    expect(rendered).toContain('data-tooltip="Archive thread"')
+    expect(rendered).toContain('data-side="inline-end"')
+    expect(rendered).toContain('data-align="start"')
+    expect(rendered).toContain('aria-label="Archive"')
+    expect(rendered).toContain('class="inline-flex"')
+  })
+
+  test('renders scrollbar size classes with semantic container options', () => {
+    const rendered = renderHtml(
+      scrollbar({
+        element: 'section',
+        size: 'sm',
+        role: 'region',
+        ariaLabel: 'Activity',
+        children: ['Scrollable content'],
+      }),
+    )
+
+    expect(rendered).toContain('<section')
+    expect(rendered).toContain('class="scrollbar-sm"')
+    expect(rendered).toContain('role="region"')
+    expect(rendered).toContain('aria-label="Activity"')
+    expect(rendered).toContain('Scrollable content')
+  })
+
+  test('renders native details collapsible with trigger and content slots', () => {
+    const rendered = renderHtml(
+      collapsible({
+        open: true,
+        className: 'group',
+        summaryClassName: 'cursor-pointer',
+        contentClassName: 'pt-2',
+        trigger: ['Advanced'],
+        children: ['Hidden settings'],
+      }),
+    )
+
+    expect(rendered).toContain('<details')
+    expect(rendered).toContain('open=""')
+    expect(rendered).toContain('class="group"')
+    expect(rendered).toContain('<summary')
+    expect(rendered).toContain('data-slot="collapsible-trigger"')
+    expect(rendered).toContain('class="cursor-pointer"')
+    expect(rendered).toContain('Advanced')
+    expect(rendered).toContain('data-slot="collapsible-content"')
+    expect(rendered).toContain('class="pt-2"')
+    expect(rendered).toContain('Hidden settings')
+  })
+
+  test('renders collapsible slots independently', () => {
+    const rendered = renderHtml(
+      collapsibleContent({
+        children: [
+          collapsibleTrigger({
+            children: ['Standalone slot'],
+          }),
+        ],
+      }),
+    )
+
+    expect(rendered).toContain('data-slot="collapsible-content"')
+    expect(rendered).toContain('data-slot="collapsible-trigger"')
+  })
+
+  test('is exported from the Basecoat namespace', () => {
+    expect(Basecoat.tooltip).toBe(tooltip)
+    expect(Basecoat.scrollbar).toBe(scrollbar)
+    expect(Basecoat.collapsible).toBe(collapsible)
+    expect(Basecoat.collapsibleTrigger).toBe(collapsibleTrigger)
+    expect(Basecoat.collapsibleContent).toBe(collapsibleContent)
+  })
+})

--- a/packages/ui/src/basecoat/tooltip.ts
+++ b/packages/ui/src/basecoat/tooltip.ts
@@ -1,0 +1,195 @@
+import type { Attribute, Html } from 'foldkit/html'
+import { html } from 'foldkit/html'
+
+import {
+  basecoatAttrs,
+  basecoatClass,
+  dataAttr,
+  type BasecoatAttrs,
+  type BasecoatChildren,
+} from './shared'
+
+export type TooltipSide =
+  | 'top'
+  | 'right'
+  | 'bottom'
+  | 'left'
+  | 'inline-start'
+  | 'inline-end'
+
+export type TooltipAlign = 'start' | 'center' | 'end'
+
+export type TooltipElement = 'span' | 'button' | 'div' | 'a'
+
+export type TooltipProps<Message> = BasecoatAttrs<Message> & Readonly<{
+  children: BasecoatChildren
+  tooltip: string
+  side?: TooltipSide
+  align?: TooltipAlign
+  element?: TooltipElement
+  href?: string
+  type?: 'button' | 'submit' | 'reset'
+  disabled?: boolean
+  ariaLabel?: string
+}>
+
+export type ScrollbarSize = 'default' | 'sm'
+
+export type ScrollbarElement =
+  | 'div'
+  | 'section'
+  | 'article'
+  | 'main'
+  | 'aside'
+
+export type ScrollbarProps<Message> = BasecoatAttrs<Message> & Readonly<{
+  children: BasecoatChildren
+  size?: ScrollbarSize
+  element?: ScrollbarElement
+  role?: 'region' | 'group'
+  ariaLabel?: string
+}>
+
+export type CollapsibleProps<Message> = BasecoatAttrs<Message> & Readonly<{
+  trigger: BasecoatChildren
+  children: BasecoatChildren
+  open?: boolean
+  summaryAttrs?: ReadonlyArray<Attribute<Message>>
+  summaryClassName?: string
+  contentAttrs?: ReadonlyArray<Attribute<Message>>
+  contentClassName?: string
+}>
+
+export type CollapsibleTriggerProps<Message> = BasecoatAttrs<Message> & Readonly<{
+  children: BasecoatChildren
+}>
+
+export type CollapsibleContentProps<Message> = BasecoatAttrs<Message> & Readonly<{
+  children: BasecoatChildren
+}>
+
+const scrollbarRoot = basecoatClass('scrollbar')
+const scrollbarSmRoot = basecoatClass('scrollbar-sm')
+
+const optionalStringAttr = <Message>(
+  value: string | undefined,
+  attr: (value: string) => Attribute<Message>,
+): ReadonlyArray<Attribute<Message>> => value === undefined ? [] : [attr(value)]
+
+const optionalBooleanAttr = <Message>(
+  enabled: boolean | undefined,
+  attr: (value: true) => Attribute<Message>,
+): ReadonlyArray<Attribute<Message>> => enabled === true ? [attr(true)] : []
+
+export const tooltip = <Message>(input: TooltipProps<Message>): Html => {
+  const h = html<Message>()
+  const attrs = [
+    ...basecoatAttrs<Message>(input),
+    h.DataAttribute('tooltip', input.tooltip),
+    ...dataAttr<Message>('side', input.side),
+    ...dataAttr<Message>('align', input.align),
+    ...optionalStringAttr<Message>(input.ariaLabel, h.AriaLabel),
+  ]
+
+  switch (input.element) {
+    case 'button':
+      return h.button(
+        [
+          ...attrs,
+          h.Type(input.type ?? 'button'),
+          ...optionalBooleanAttr<Message>(input.disabled, h.Disabled),
+        ],
+        input.children,
+      )
+    case 'div':
+      return h.div(attrs, input.children)
+    case 'a':
+      return h.a(
+        [
+          ...attrs,
+          ...optionalStringAttr<Message>(input.href, h.Href),
+        ],
+        input.children,
+      )
+    default:
+      return h.span(attrs, input.children)
+  }
+}
+
+export const scrollbar = <Message>(input: ScrollbarProps<Message>): Html => {
+  const h = html<Message>()
+  const attrs = [
+    ...basecoatAttrs<Message>(
+      input,
+      input.size === 'sm' ? scrollbarSmRoot : scrollbarRoot,
+    ),
+    ...(input.role === undefined ? [] : [h.Role(input.role)]),
+    ...optionalStringAttr<Message>(input.ariaLabel, h.AriaLabel),
+  ]
+
+  switch (input.element) {
+    case 'section':
+      return h.section(attrs, input.children)
+    case 'article':
+      return h.article(attrs, input.children)
+    case 'main':
+      return h.main(attrs, input.children)
+    case 'aside':
+      return h.aside(attrs, input.children)
+    default:
+      return h.div(attrs, input.children)
+  }
+}
+
+export const collapsibleTrigger = <Message>(
+  input: CollapsibleTriggerProps<Message>,
+): Html => {
+  const h = html<Message>()
+
+  return h.summary(
+    [
+      ...basecoatAttrs<Message>(input),
+      h.DataAttribute('slot', 'collapsible-trigger'),
+    ],
+    input.children,
+  )
+}
+
+export const collapsibleContent = <Message>(
+  input: CollapsibleContentProps<Message>,
+): Html => {
+  const h = html<Message>()
+
+  return h.div(
+    [
+      ...basecoatAttrs<Message>(input),
+      h.DataAttribute('slot', 'collapsible-content'),
+    ],
+    input.children,
+  )
+}
+
+export const collapsible = <Message>(
+  input: CollapsibleProps<Message>,
+): Html => {
+  const h = html<Message>()
+
+  return h.details(
+    [
+      ...basecoatAttrs<Message>(input),
+      ...(input.open === true ? [h.Attribute('open', '')] : []),
+    ],
+    [
+      collapsibleTrigger<Message>({
+        attrs: input.summaryAttrs,
+        className: input.summaryClassName,
+        children: input.trigger,
+      }),
+      collapsibleContent<Message>({
+        attrs: input.contentAttrs,
+        className: input.contentClassName,
+        children: input.children,
+      }),
+    ],
+  )
+}


### PR DESCRIPTION
## Summary
- add typed Foldkit Basecoat wrappers for tooltip, scrollbar, and native details collapsible markup
- export the new Basecoat components from `packages/ui/src/basecoat`
- cover tooltip data attributes, scrollbar sizing, collapsible slots, and namespace exports

## Verification
- `bun run test:ui`
- command ref `command.public.pylon_khala.verify.5fc2b591e599fe078a5a13c8`

Closes #7701