### PR TITLE
Add Basecoat native select Foldkit components

### DIFF
--- a/packages/ui/src/basecoat/index.ts
+++ b/packages/ui/src/basecoat/index.ts
@@ -3,6 +3,7 @@ export * from './button'
 export * from './card'
 export * from './display'
 export * from './input'
+export * from './native-select'
 export * from './selection'
 export {
   basecoatAttrs,

--- a/packages/ui/src/basecoat/native-select.test.ts
+++ b/packages/ui/src/basecoat/native-select.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, test } from 'bun:test'
+
+import { Basecoat } from '../index'
+import {
+  nativeSelect,
+  nativeSelectOptgroup,
+  nativeSelectOption,
+} from './native-select'
+import { renderHtml } from './test-helpers'
+
+describe('basecoat native select components', () => {
+  test('renders native select markup with Basecoat class, size, and state attrs', () => {
+    const rendered = renderHtml(
+      nativeSelect({
+        id: 'timezone',
+        name: 'timezone',
+        size: 'sm',
+        required: true,
+        invalid: true,
+        describedBy: 'timezone-description',
+        children: [
+          nativeSelectOption({
+            value: 'utc',
+            selected: true,
+            children: ['UTC'],
+          }),
+          nativeSelectOption({
+            value: 'america-chicago',
+            children: ['America/Chicago'],
+          }),
+        ],
+      }),
+    )
+
+    expect(rendered).toContain('<select')
+    expect(rendered).toContain('class="select"')
+    expect(rendered).toContain('id="timezone"')
+    expect(rendered).toContain('name="timezone"')
+    expect(rendered).toContain('data-size="sm"')
+    expect(rendered).toContain('required')
+    expect(rendered).toContain('aria-invalid="true"')
+    expect(rendered).toContain('aria-describedby="timezone-description"')
+    expect(rendered).toContain('<option value="utc" selected>UTC</option>')
+    expect(rendered).toContain('<option value="america-chicago">America/Chicago</option>')
+  })
+
+  test('renders optgroups, disabled states, and multiple selection', () => {
+    const rendered = renderHtml(
+      nativeSelect({
+        ariaLabel: 'Deployment region',
+        multiple: true,
+        disabled: true,
+        className: 'w-full',
+        children: [
+          nativeSelectOptgroup({
+            label: 'US',
+            children: [
+              nativeSelectOption({
+                value: 'iad',
+                children: ['Washington, DC'],
+              }),
+            ],
+          }),
+          nativeSelectOptgroup({
+            label: 'EU',
+            disabled: true,
+            children: [
+              nativeSelectOption({
+                value: 'fra',
+                disabled: true,
+                children: ['Frankfurt'],
+              }),
+            ],
+          }),
+        ],
+      }),
+    )
+
+    expect(rendered).toContain('class="select w-full"')
+    expect(rendered).toContain('aria-label="Deployment region"')
+    expect(rendered).toContain('multiple')
+    expect(rendered).toContain('disabled')
+    expect(rendered).not.toContain('data-size="default"')
+    expect(rendered).toContain('<optgroup label="US">')
+    expect(rendered).toContain('<optgroup label="EU" disabled>')
+    expect(rendered).toContain('<option value="fra" disabled>Frankfurt</option>')
+  })
+
+  test('is exported from the Basecoat namespace', () => {
+    expect(Basecoat.nativeSelect).toBe(nativeSelect)
+    expect(Basecoat.nativeSelectOption).toBe(nativeSelectOption)
+    expect(Basecoat.nativeSelectOptgroup).toBe(nativeSelectOptgroup)
+  })
+})

--- a/packages/ui/src/basecoat/native-select.ts
+++ b/packages/ui/src/basecoat/native-select.ts
@@ -1,0 +1,95 @@
+import type { Html } from 'foldkit/html'
+import { html } from 'foldkit/html'
+
+import {
+  basecoatAttrs,
+  basecoatClass,
+  dataAttr,
+  type BasecoatAttrs,
+  type BasecoatChildren,
+} from './shared'
+
+export type NativeSelectSize = 'default' | 'sm'
+
+export type NativeSelectProps<Message> = BasecoatAttrs<Message> & Readonly<{
+  children: BasecoatChildren
+  id?: string
+  name?: string
+  size?: NativeSelectSize
+  disabled?: boolean
+  required?: boolean
+  multiple?: boolean
+  invalid?: boolean
+  describedBy?: string
+  ariaLabel?: string
+}>
+
+export type NativeSelectOptionProps<Message> = BasecoatAttrs<Message> & Readonly<{
+  children: BasecoatChildren
+  value?: string
+  disabled?: boolean
+  selected?: boolean
+}>
+
+export type NativeSelectOptgroupProps<Message> = BasecoatAttrs<Message> & Readonly<{
+  children: ReadonlyArray<Html>
+  label: string
+  disabled?: boolean
+}>
+
+const nativeSelectRoot = basecoatClass('select')
+
+export const nativeSelect = <Message>(
+  input: NativeSelectProps<Message>,
+): Html => {
+  const h = html<Message>()
+
+  return h.select(
+    [
+      ...basecoatAttrs<Message>(input, nativeSelectRoot),
+      ...(input.id === undefined ? [] : [h.Id(input.id)]),
+      ...(input.name === undefined ? [] : [h.Name(input.name)]),
+      ...dataAttr<Message>('size', input.size === 'sm' ? 'sm' : undefined),
+      ...(input.disabled === true ? [h.Disabled(true)] : []),
+      ...(input.required === true ? [h.Required(true)] : []),
+      ...(input.multiple === true ? [h.Multiple(true)] : []),
+      ...(input.invalid === true ? [h.AriaInvalid(true)] : []),
+      ...(input.describedBy === undefined
+        ? []
+        : [h.AriaDescribedBy(input.describedBy)]),
+      ...(input.ariaLabel === undefined ? [] : [h.AriaLabel(input.ariaLabel)]),
+    ],
+    input.children,
+  )
+}
+
+export const nativeSelectOption = <Message>(
+  input: NativeSelectOptionProps<Message>,
+): Html => {
+  const h = html<Message>()
+
+  return h.option(
+    [
+      ...basecoatAttrs<Message>(input),
+      ...(input.value === undefined ? [] : [h.Value(input.value)]),
+      ...(input.disabled === true ? [h.Disabled(true)] : []),
+      ...(input.selected === true ? [h.Selected(true)] : []),
+    ],
+    input.children,
+  )
+}
+
+export const nativeSelectOptgroup = <Message>(
+  input: NativeSelectOptgroupProps<Message>,
+): Html => {
+  const h = html<Message>()
+
+  return h.optgroup(
+    [
+      ...basecoatAttrs<Message>(input),
+      h.LabelAttr(input.label),
+      ...(input.disabled === true ? [h.Disabled(true)] : []),
+    ],
+    input.children,
+  )
+}


### PR DESCRIPTION
## Summary
- Add `nativeSelect`, `nativeSelectOption`, and `nativeSelectOptgroup` Foldkit helpers for Basecoat native select markup.
- Export the native-select helpers from `packages/ui/src/basecoat/index.ts`.
- Cover Basecoat class, `data-size="sm"`, native state attrs, options, optgroups, and namespace exports.

Closes #7700.

## Verification
- `bun run test:ui` (`command.public.pylon_khala.verify.5fc2b591e599fe078a5a13c8`)
- `bun run --cwd packages/ui typecheck`