### PR TITLE
Add Basecoat accordion Foldkit component

### DIFF
--- a/packages/ui/src/basecoat/accordion.test.ts
+++ b/packages/ui/src/basecoat/accordion.test.ts
@@ -1,0 +1,236 @@
+import { describe, expect, test } from 'bun:test'
+
+import { Basecoat } from '../index'
+import {
+  accordion,
+  accordionContent,
+  accordionInit,
+  accordionItem,
+  accordionTrigger,
+  accordionUpdate,
+  accordionView,
+  type AccordionMessage,
+} from './accordion'
+import { renderHtml } from './test-helpers'
+
+const message = (input: AccordionMessage): AccordionMessage => input
+
+describe('basecoat accordion component', () => {
+  test('renders Basecoat details and summary markup', () => {
+    const rendered = renderHtml(
+      accordion({
+        children: [
+          accordionItem({
+            value: 'shipping',
+            open: true,
+            children: [
+              accordionTrigger({
+                itemValue: 'shipping',
+                controlsId: 'shipping-content',
+                open: true,
+                tabIndex: 0,
+                children: ['Shipping'],
+              }),
+              accordionContent({
+                id: 'shipping-content',
+                labelledBy: 'shipping-trigger',
+                children: ['Ships in 2 days.'],
+              }),
+            ],
+          }),
+        ],
+      }),
+    )
+
+    expect(rendered).toContain('class="accordion"')
+    expect(rendered).toContain('<details')
+    expect(rendered).toContain('data-value="shipping"')
+    expect(rendered).toContain('open')
+    expect(rendered).toContain('<summary')
+    expect(rendered).toContain('aria-expanded="true"')
+    expect(rendered).toContain('aria-controls="shipping-content"')
+    expect(rendered).toContain('tabIndex="0"')
+    expect(rendered).toContain('<svg')
+    expect(rendered).toContain('id="shipping-content"')
+    expect(rendered).toContain('aria-labelledby="shipping-trigger"')
+  })
+
+  test('adds multiple and disabled Basecoat state attrs', () => {
+    const rendered = renderHtml(
+      accordion({
+        type: 'multiple',
+        children: [
+          accordionItem({
+            value: 'locked',
+            disabled: true,
+            children: [
+              accordionTrigger({
+                itemValue: 'locked',
+                disabled: true,
+                children: ['Locked'],
+              }),
+            ],
+          }),
+        ],
+      }),
+    )
+
+    expect(rendered).toContain('data-multiple="true"')
+    expect(rendered).toContain('aria-disabled="true"')
+    expect(rendered).toContain('data-disabled="true"')
+  })
+
+  test('initializes single accordions with only one enabled open item', () => {
+    const model = accordionInit({
+      items: [
+        { value: 'first' },
+        { value: 'second' },
+        { value: 'disabled', disabled: true },
+      ],
+      defaultOpenValues: ['first', 'second', 'disabled'],
+    })
+
+    expect(model.type).toBe('single')
+    expect(model.openValues).toEqual(['first'])
+    expect(model.focusedValue).toBe('first')
+    expect(model.selectedValue).toBe('first')
+  })
+
+  test('opens one item at a time in single mode and preserves siblings in multiple mode', () => {
+    const single = accordionInit({
+      items: [{ value: 'first' }, { value: 'second' }],
+      defaultOpenValues: ['first'],
+    })
+
+    expect(accordionUpdate(single, {
+      _tag: 'AccordionToggled',
+      value: 'second',
+      open: true,
+    }).openValues).toEqual(['second'])
+
+    const multiple = accordionInit({
+      type: 'multiple',
+      items: [{ value: 'first' }, { value: 'second' }],
+      defaultOpenValues: ['first'],
+    })
+
+    expect(accordionUpdate(multiple, {
+      _tag: 'AccordionToggled',
+      value: 'second',
+      open: true,
+    }).openValues).toEqual(['first', 'second'])
+  })
+
+  test('ignores disabled item toggles and selection', () => {
+    const model = accordionInit({
+      items: [{ value: 'first' }, { value: 'disabled', disabled: true }],
+      defaultOpenValues: ['first'],
+    })
+
+    expect(accordionUpdate(model, {
+      _tag: 'AccordionToggled',
+      value: 'disabled',
+      open: true,
+    })).toEqual(model)
+    expect(accordionUpdate(model, {
+      _tag: 'AccordionSelected',
+      value: 'disabled',
+    })).toEqual(model)
+  })
+
+  test('moves focus with accordion keyboard navigation', () => {
+    const model = accordionInit({
+      items: [
+        { value: 'first' },
+        { value: 'disabled', disabled: true },
+        { value: 'second' },
+      ],
+    })
+
+    const next = accordionUpdate(model, {
+      _tag: 'AccordionKeyDown',
+      value: 'first',
+      key: 'ArrowDown',
+    })
+    expect(next.focusedValue).toBe('second')
+
+    const home = accordionUpdate(next, {
+      _tag: 'AccordionKeyDown',
+      value: 'second',
+      key: 'Home',
+    })
+    expect(home.focusedValue).toBe('first')
+
+    const end = accordionUpdate(home, {
+      _tag: 'AccordionKeyDown',
+      value: 'first',
+      key: 'End',
+    })
+    expect(end.focusedValue).toBe('second')
+  })
+
+  test('keyboard Enter and Space toggle the focused item', () => {
+    const model = accordionInit({
+      items: [{ value: 'first' }, { value: 'second' }],
+    })
+
+    const opened = accordionUpdate(model, {
+      _tag: 'AccordionKeyDown',
+      value: 'second',
+      key: 'Enter',
+    })
+    expect(opened.openValues).toEqual(['second'])
+    expect(opened.focusedValue).toBe('second')
+
+    const closed = accordionUpdate(opened, {
+      _tag: 'AccordionKeyDown',
+      value: 'second',
+      key: ' ',
+    })
+    expect(closed.openValues).toEqual([])
+  })
+
+  test('accordionView wires model state into rendered attrs', () => {
+    const model = accordionInit({
+      type: 'multiple',
+      items: [{ value: 'shipping' }, { value: 'returns' }],
+      defaultOpenValues: ['returns'],
+      focusedValue: 'returns',
+    })
+
+    const rendered = renderHtml(
+      accordionView({
+        model,
+        toMessage: message,
+        items: [
+          {
+            value: 'shipping',
+            trigger: ['Shipping'],
+            content: ['Shipping details'],
+          },
+          {
+            value: 'returns',
+            trigger: ['Returns'],
+            content: ['Return details'],
+          },
+        ],
+      }),
+    )
+
+    expect(rendered).toContain('data-multiple="true"')
+    expect(rendered).toContain('data-value="returns" open')
+    expect(rendered).toContain('aria-expanded="true"')
+    expect(rendered).toContain('tabIndex="0"')
+    expect(rendered).toContain('hidden')
+  })
+
+  test('is exported from the Basecoat namespace', () => {
+    expect(Basecoat.accordion).toBe(accordion)
+    expect(Basecoat.accordionItem).toBe(accordionItem)
+    expect(Basecoat.accordionTrigger).toBe(accordionTrigger)
+    expect(Basecoat.accordionContent).toBe(accordionContent)
+    expect(Basecoat.accordionView).toBe(accordionView)
+    expect(Basecoat.accordionInit).toBe(accordionInit)
+    expect(Basecoat.accordionUpdate).toBe(accordionUpdate)
+  })
+})

--- a/packages/ui/src/basecoat/accordion.ts
+++ b/packages/ui/src/basecoat/accordion.ts
@@ -1,0 +1,400 @@
+import { Option } from 'effect'
+import type { Html } from 'foldkit/html'
+import { html } from 'foldkit/html'
+
+import {
+  basecoatAttrs,
+  basecoatClass,
+  dataAttr,
+  type BasecoatAttrs,
+  type BasecoatChildren,
+} from './shared'
+
+export type AccordionType = 'single' | 'multiple'
+
+export type AccordionItem = Readonly<{
+  value: string
+  disabled?: boolean
+}>
+
+export type AccordionModel = Readonly<{
+  type: AccordionType
+  items: ReadonlyArray<AccordionItem>
+  openValues: ReadonlyArray<string>
+  focusedValue: string | null
+  selectedValue: string | null
+}>
+
+export type AccordionInit = Readonly<{
+  type?: AccordionType
+  items: ReadonlyArray<AccordionItem>
+  defaultOpenValues?: ReadonlyArray<string>
+  focusedValue?: string | null
+  selectedValue?: string | null
+}>
+
+export type AccordionMessage =
+  | Readonly<{ readonly _tag: 'AccordionToggled'; readonly value: string; readonly open: boolean }>
+  | Readonly<{ readonly _tag: 'AccordionFocused'; readonly value: string }>
+  | Readonly<{ readonly _tag: 'AccordionSelected'; readonly value: string }>
+  | Readonly<{ readonly _tag: 'AccordionKeyDown'; readonly key: string; readonly value: string }>
+
+export type AccordionProps<Message> = BasecoatAttrs<Message> & Readonly<{
+  children: ReadonlyArray<Html>
+  type?: AccordionType
+}>
+
+export type AccordionItemProps<Message> = BasecoatAttrs<Message> & Readonly<{
+  value: string
+  open?: boolean
+  disabled?: boolean
+  children: ReadonlyArray<Html>
+  onToggle?: (open: boolean) => Message
+}>
+
+export type AccordionTriggerProps<Message> = BasecoatAttrs<Message> & Readonly<{
+  children: BasecoatChildren
+  itemValue: string
+  open?: boolean
+  disabled?: boolean
+  controlsId?: string
+  tabIndex?: number
+  onClick?: Message
+  onFocus?: Message
+  onKeyDown?: (key: string) => Message | null
+}>
+
+export type AccordionContentProps<Message> = BasecoatAttrs<Message> & Readonly<{
+  children: BasecoatChildren
+  id?: string
+  labelledBy?: string
+  hidden?: boolean
+}>
+
+export type AccordionViewItem<Message> = AccordionItem & Readonly<{
+  trigger: BasecoatChildren
+  content: BasecoatChildren
+  contentId?: string
+  triggerId?: string
+}>
+
+export type AccordionViewProps<Message> = BasecoatAttrs<Message> & Readonly<{
+  model: AccordionModel
+  items: ReadonlyArray<AccordionViewItem<Message>>
+  toMessage: (message: AccordionMessage) => Message
+}>
+
+const accordionRoot = basecoatClass('accordion')
+
+const enabledItems = (model: AccordionModel): ReadonlyArray<AccordionItem> =>
+  model.items.filter(item => item.disabled !== true)
+
+const hasItem = (items: ReadonlyArray<AccordionItem>, value: string): boolean =>
+  items.some(item => item.value === value)
+
+const isDisabled = (model: AccordionModel, value: string): boolean =>
+  model.items.find(item => item.value === value)?.disabled === true
+
+const normalizeOpenValues = (
+  type: AccordionType,
+  items: ReadonlyArray<AccordionItem>,
+  openValues: ReadonlyArray<string>,
+): ReadonlyArray<string> => {
+  const allowed = new Set(items.filter(item => item.disabled !== true).map(item => item.value))
+  const next = openValues.filter((value, index) =>
+    allowed.has(value) && openValues.indexOf(value) === index
+  )
+
+  return type === 'single' ? next.slice(0, 1) : next
+}
+
+export const accordionInit = (input: AccordionInit): AccordionModel => {
+  const type = input.type ?? 'single'
+  const openValues = normalizeOpenValues(
+    type,
+    input.items,
+    input.defaultOpenValues ?? [],
+  )
+  const firstEnabled = input.items.find(item => item.disabled !== true)?.value ?? null
+  const focusedValue =
+    input.focusedValue !== undefined &&
+    input.focusedValue !== null &&
+    hasItem(input.items, input.focusedValue) &&
+    !isDisabled({ type, items: input.items, openValues, focusedValue: null, selectedValue: null }, input.focusedValue)
+      ? input.focusedValue
+      : firstEnabled
+  const selectedValue =
+    input.selectedValue !== undefined && input.selectedValue !== null
+      ? input.selectedValue
+      : openValues[0] ?? null
+
+  return {
+    type,
+    items: input.items,
+    openValues,
+    focusedValue,
+    selectedValue,
+  }
+}
+
+const setOpenValue = (
+  model: AccordionModel,
+  value: string,
+  open: boolean,
+): AccordionModel => {
+  if (isDisabled(model, value) || !hasItem(model.items, value)) {
+    return model
+  }
+
+  const openValues = open
+    ? model.type === 'single'
+      ? [value]
+      : normalizeOpenValues(model.type, model.items, [...model.openValues, value])
+    : model.openValues.filter(candidate => candidate !== value)
+
+  return {
+    ...model,
+    openValues,
+    selectedValue: open ? value : model.selectedValue,
+  }
+}
+
+const focusByOffset = (model: AccordionModel, value: string, offset: number): AccordionModel => {
+  const items = enabledItems(model)
+  const index = items.findIndex(item => item.value === value)
+
+  if (items.length === 0 || index === -1) {
+    return model
+  }
+
+  const next = items[(index + offset + items.length) % items.length]
+
+  return { ...model, focusedValue: next?.value ?? model.focusedValue }
+}
+
+export const accordionUpdate = (
+  model: AccordionModel,
+  message: AccordionMessage,
+): AccordionModel => {
+  switch (message._tag) {
+    case 'AccordionToggled':
+      return setOpenValue(model, message.value, message.open)
+    case 'AccordionFocused':
+      return isDisabled(model, message.value) || !hasItem(model.items, message.value)
+        ? model
+        : { ...model, focusedValue: message.value }
+    case 'AccordionSelected':
+      return setOpenValue(model, message.value, !model.openValues.includes(message.value))
+    case 'AccordionKeyDown': {
+      if (isDisabled(model, message.value)) {
+        return model
+      }
+
+      switch (message.key) {
+        case 'ArrowDown':
+        case 'ArrowRight':
+          return focusByOffset(model, message.value, 1)
+        case 'ArrowUp':
+        case 'ArrowLeft':
+          return focusByOffset(model, message.value, -1)
+        case 'Home': {
+          const first = enabledItems(model)[0]?.value
+          return first === undefined ? model : { ...model, focusedValue: first }
+        }
+        case 'End': {
+          const items = enabledItems(model)
+          const last = items[items.length - 1]?.value
+          return last === undefined ? model : { ...model, focusedValue: last }
+        }
+        case 'Enter':
+        case ' ':
+        case 'Spacebar':
+          return setOpenValue(
+            { ...model, focusedValue: message.value },
+            message.value,
+            !model.openValues.includes(message.value),
+          )
+        default:
+          return model
+      }
+    }
+  }
+}
+
+export const accordion = <Message>(input: AccordionProps<Message>): Html => {
+  const h = html<Message>()
+
+  return h.div(
+    [
+      ...basecoatAttrs<Message>(input, accordionRoot),
+      ...dataAttr<Message>('multiple', input.type === 'multiple' ? 'true' : undefined),
+    ],
+    input.children,
+  )
+}
+
+export const accordionItem = <Message>(
+  input: AccordionItemProps<Message>,
+): Html => {
+  const h = html<Message>()
+
+  return h.details(
+    [
+      ...basecoatAttrs<Message>(input),
+      h.DataAttribute('value', input.value),
+      ...(input.open === true ? [h.Open(true)] : []),
+      ...(input.disabled === true ? [h.AriaDisabled(true)] : []),
+      ...(input.disabled === true ? [h.DataAttribute('disabled', 'true')] : []),
+      ...(input.onToggle === undefined ? [] : [h.OnToggle(input.onToggle)]),
+    ],
+    input.children,
+  )
+}
+
+const chevronDown = <Message>(): Html => {
+  const h = html<Message>()
+
+  return h.svg(
+    [
+      h.Width('16'),
+      h.Height('16'),
+      h.ViewBox('0 0 24 24'),
+      h.Fill('none'),
+      h.Stroke('currentColor'),
+      h.StrokeWidth('2'),
+      h.StrokeLinecap('round'),
+      h.StrokeLinejoin('round'),
+      h.AriaHidden(true),
+    ],
+    [h.path([h.D('m6 9 6 6 6-6')], [])],
+  )
+}
+
+const handledAccordionKeys = new Set([
+  'ArrowDown',
+  'ArrowRight',
+  'ArrowUp',
+  'ArrowLeft',
+  'Home',
+  'End',
+  'Enter',
+  ' ',
+  'Spacebar',
+])
+
+export const accordionTrigger = <Message>(
+  input: AccordionTriggerProps<Message>,
+): Html => {
+  const h = html<Message>()
+
+  return h.summary(
+    [
+      ...basecoatAttrs<Message>(input),
+      h.DataAttribute('value', input.itemValue),
+      h.AriaExpanded(input.open === true),
+      ...(input.controlsId === undefined ? [] : [h.AriaControls(input.controlsId)]),
+      ...(input.disabled === true ? [h.AriaDisabled(true)] : []),
+      ...(input.tabIndex === undefined ? [] : [h.Tabindex(input.tabIndex)]),
+      ...(input.onClick === undefined || input.disabled === true
+        ? []
+        : [h.OnClick(input.onClick)]),
+      ...(input.onFocus === undefined || input.disabled === true
+        ? []
+        : [h.OnFocus(input.onFocus)]),
+      ...(input.onKeyDown === undefined
+        ? []
+        : [
+            h.OnKeyDownPreventDefault(key =>
+              handledAccordionKeys.has(key)
+                ? (() => {
+                    const next = input.onKeyDown?.(key) ?? null
+                    return next === null ? Option.none() : Option.some(next)
+                  })()
+                : Option.none(),
+            ),
+          ]),
+    ],
+    [...input.children, chevronDown<Message>()],
+  )
+}
+
+export const accordionContent = <Message>(
+  input: AccordionContentProps<Message>,
+): Html => {
+  const h = html<Message>()
+
+  return h.div(
+    [
+      ...basecoatAttrs<Message>(input),
+      ...(input.id === undefined ? [] : [h.Id(input.id)]),
+      ...(input.labelledBy === undefined ? [] : [h.AriaLabelledBy(input.labelledBy)]),
+      ...(input.hidden === true ? [h.Hidden(true)] : []),
+    ],
+    input.children,
+  )
+}
+
+export const accordionView = <Message>(
+  input: AccordionViewProps<Message>,
+): Html => {
+  const items = input.items.map((item) => {
+    const open = input.model.openValues.includes(item.value)
+    const triggerId = item.triggerId ?? `${item.value}-trigger`
+    const contentId = item.contentId ?? `${item.value}-content`
+    const triggerInput: AccordionTriggerProps<Message> = {
+      itemValue: item.value,
+      open,
+      controlsId: contentId,
+      tabIndex: input.model.focusedValue === item.value ? 0 : -1,
+      onClick: input.toMessage({
+        _tag: 'AccordionSelected',
+        value: item.value,
+      }),
+      onFocus: input.toMessage({
+        _tag: 'AccordionFocused',
+        value: item.value,
+      }),
+      onKeyDown: key =>
+        input.toMessage({
+          _tag: 'AccordionKeyDown',
+          key,
+          value: item.value,
+        }),
+      attrs: [html<Message>().Id(triggerId)],
+      children: item.trigger,
+      ...(item.disabled === undefined ? {} : { disabled: item.disabled }),
+    }
+
+    return accordionItem<Message>({
+      value: item.value,
+      open,
+      onToggle: toggledOpen =>
+        input.toMessage({
+          _tag: 'AccordionToggled',
+          value: item.value,
+          open: toggledOpen,
+        }),
+      children: [
+        accordionTrigger<Message>(triggerInput),
+        accordionContent<Message>({
+          id: contentId,
+          labelledBy: triggerId,
+          hidden: !open,
+          children: item.content,
+        }),
+      ],
+      ...(item.disabled === undefined ? {} : { disabled: item.disabled }),
+    })
+  })
+
+  const rootInput: AccordionProps<Message> = {
+    type: input.model.type,
+    children: items,
+  }
+
+  return accordion<Message>({
+    ...rootInput,
+    ...(input.attrs === undefined ? {} : { attrs: input.attrs }),
+    ...(input.className === undefined ? {} : { className: input.className }),
+  })
+}

--- a/packages/ui/src/basecoat/index.ts
+++ b/packages/ui/src/basecoat/index.ts
@@ -1,3 +1,4 @@
+export * from './accordion'
 export * from './badge'
 export * from './button'
 export * from './card'


### PR DESCRIPTION
## Summary
- Add `packages/ui/src/basecoat/accordion.ts` with Foldkit model/message/update helpers and Basecoat `details`/`summary` markup helpers.
- Support single and multiple accordion state, disabled guards, selected/open state, roving focus, and keyboard navigation messages.
- Export the accordion API from `packages/ui/src/basecoat/index.ts` and cover markup/update behavior in `accordion.test.ts`.

Closes #7702.

## Verification
- `bun run test:ui` (`command.public.pylon_khala.verify.5fc2b591e599fe078a5a13c8`) — 105 pass, 0 fail
- `bun run typecheck:ui` — passed