### PR TITLE
feat(khala-code-desktop): Foldkit/Effect Basecoat sidebar

### DIFF
--- a/clients/khala-code-desktop/package.json
+++ b/clients/khala-code-desktop/package.json
@@ -21,6 +21,7 @@
     "chromium-bidi": "15.0.0",
     "effect": "catalog:",
     "electrobun": "1.18.1",
+    "foldkit": "^0.102.1",
     "playwright": "^1.61.0",
     "three": "0.184.0"
   },

--- a/clients/khala-code-desktop/src/ui/index.html
+++ b/clients/khala-code-desktop/src/ui/index.html
@@ -8,6 +8,7 @@
   </head>
   <body>
     <main class="khala-code-shell antialiased" aria-label="Khala Code chat">
+      <aside id="sidebar-root" class="khala-code-sidebar" aria-label="Khala Code navigation"></aside>
       <div class="khala-code-scene" aria-hidden="true"></div>
       <section class="khala-code-thread-shell" aria-label="Khala Code transcript">
         <div

--- a/clients/khala-code-desktop/src/ui/main.ts
+++ b/clients/khala-code-desktop/src/ui/main.ts
@@ -42,6 +42,7 @@ import {
   type KhalaCodeDesktopRPCSchema,
 } from "../shared/rpc"
 import { renderMessageBody } from "./transcript-render"
+import { mountKhalaCodeSidebar } from "./sidebar"
 import "./styles.css"
 
 type DesktopRpc = ReturnType<typeof Electroview.defineRPC<KhalaCodeDesktopRPCSchema>>
@@ -1112,5 +1113,13 @@ Object.assign(globalThis, {
 
 void controls.appInfo().catch(() => undefined)
 mountComposerHud()
+
+const sidebarRoot = document.getElementById("sidebar-root")
+if (sidebarRoot !== null) {
+  mountKhalaCodeSidebar(sidebarRoot, {
+    selectedValue: "chat",
+    onActivate: () => {},
+  })
+}
 render()
 requestAnimationFrame(focusComposerInput)

--- a/clients/khala-code-desktop/src/ui/sidebar.ts
+++ b/clients/khala-code-desktop/src/ui/sidebar.ts
@@ -1,0 +1,112 @@
+import { Schema } from "effect"
+import { Runtime } from "foldkit"
+import type { Command } from "foldkit"
+import {
+  sidebarInit,
+  sidebarUpdate,
+  sidebarView,
+  type SidebarPrimitiveMessage,
+  type SidebarPrimitiveModel,
+  type SidebarViewGroup,
+} from "@openagentsinc/ui/basecoat/sidebar"
+
+// The sidebar runs as a small, self-contained Foldkit/Effect island mounted into
+// a dedicated container in the Khala Code Desktop shell. Its state is a Foldkit
+// Model, interactions flow through SidebarPrimitiveMessage + sidebarUpdate, and
+// it renders through sidebarView. No manual DOM, no class-name shim.
+
+export type SidebarNavMessage = SidebarPrimitiveMessage
+
+type SidebarModel = SidebarPrimitiveModel
+
+type SidebarCommands = ReadonlyArray<Command<SidebarNavMessage, never, never>>
+
+const NO_COMMANDS: SidebarCommands = []
+
+// Foldkit requires a Schema codec for the Model (devtools / freeze model).
+const SidebarPrimitiveItemSchema = Schema.Struct({
+  value: Schema.String,
+  disabled: Schema.optional(Schema.Boolean),
+})
+
+const SidebarModelSchema: Schema.Codec<SidebarModel, unknown, unknown, unknown> = Schema.Struct({
+  open: Schema.Boolean,
+  breakpoint: Schema.Number,
+  items: Schema.Array(SidebarPrimitiveItemSchema),
+  focusedValue: Schema.NullOr(Schema.String),
+  selectedValue: Schema.NullOr(Schema.String),
+})
+
+// The desktop has no session-list RPC yet, so the initial sidebar is a small,
+// representative navigation. The app owns the nav data + current selection; the
+// sidebar owns chrome + behavior. Replace these groups when a session list lands.
+const navGroups = (): ReadonlyArray<SidebarViewGroup<SidebarNavMessage>> => [
+  {
+    label: "Khala Code",
+    items: [
+      { value: "chat", children: ["Chat"] },
+      { value: "sessions", children: ["Sessions"] },
+    ],
+  },
+  {
+    label: "Fleet",
+    items: [
+      { value: "fleet", children: ["Fleet status"] },
+      { value: "settings", children: ["Settings"] },
+    ],
+  },
+]
+
+const navItems = (): ReadonlyArray<{ value: string }> =>
+  navGroups().flatMap(group => group.items.map(item => ({ value: item.value })))
+
+export type SidebarMountOptions = Readonly<{
+  readonly selectedValue?: string | null
+  readonly onActivate?: (value: string) => void
+}>
+
+export const mountKhalaCodeSidebar = (
+  container: HTMLElement,
+  options: SidebarMountOptions = {},
+): void => {
+  const init = (): readonly [SidebarModel, SidebarCommands] => [
+    sidebarInit({
+      items: navItems(),
+      initialOpen: true,
+      viewportWidth: window.innerWidth,
+      ...(options.selectedValue === undefined || options.selectedValue === null
+        ? {}
+        : { selectedValue: options.selectedValue }),
+    }),
+    NO_COMMANDS,
+  ]
+
+  const update = (
+    model: SidebarModel,
+    message: SidebarNavMessage,
+  ): readonly [SidebarModel, SidebarCommands] => {
+    if (message._tag === "SidebarItemActivated") {
+      options.onActivate?.(message.value)
+    }
+    return [sidebarUpdate(model, message), NO_COMMANDS]
+  }
+
+  const view = (model: SidebarModel) =>
+    sidebarView<SidebarNavMessage>({
+      model,
+      groups: navGroups(),
+      toMessage: message => message,
+      side: "left",
+      label: "Khala Code navigation",
+    })
+
+  const program = Runtime.makeProgram<SidebarModel, SidebarNavMessage>({
+    Model: SidebarModelSchema,
+    init,
+    update,
+    view,
+    container,
+  })
+
+  Runtime.run(program)
+}

--- a/clients/khala-code-desktop/src/ui/styles.css
+++ b/clients/khala-code-desktop/src/ui/styles.css
@@ -728,3 +728,49 @@ button {
     scroll-behavior: auto;
   }
 }
+
+/* Basecoat sidebar (Foldkit/Effect island) — desktop column, themed to match. */
+.khala-code-shell {
+  grid-template-columns: auto minmax(0, 1fr);
+}
+.khala-code-sidebar {
+  position: relative;
+  z-index: 1;
+  grid-column: 1;
+  grid-row: 1 / 3;
+  min-height: 0;
+}
+.khala-code-thread-shell,
+.composer-dock {
+  grid-column: 2;
+}
+/* Render the Basecoat sidebar as a static column (not a fixed overlay) and
+   resolve its theme variables to the Khala Code dark surface. */
+.khala-code-sidebar .sidebar nav {
+  position: relative;
+  inset: auto;
+  width: 16rem;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.42);
+  border-right: 1px solid rgba(79, 208, 255, 0.14);
+  transform: none;
+  color: #f1efe8;
+}
+.khala-code-sidebar .sidebar nav h3 {
+  color: rgba(241, 239, 232, 0.56);
+  font-size: 0.72rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  padding: 0.75rem 0.75rem 0.35rem;
+}
+.khala-code-sidebar .sidebar nav a,
+.khala-code-sidebar .sidebar nav button {
+  color: #f1efe8;
+  border-radius: 0.4rem;
+  padding: 0.4rem 0.6rem;
+  gap: 0.5rem;
+}
+.khala-code-sidebar .sidebar nav [aria-current="true"],
+.khala-code-sidebar .sidebar nav [data-selected="true"] {
+  background: rgba(79, 208, 255, 0.12);
+}


### PR DESCRIPTION
Closes #7750 (the fully-Foldkit/Effect sidebar).

## What
Mounts the merged `@openagentsinc/ui` Basecoat sidebar into the Khala Code Desktop shell as a **true Foldkit/Effect island** — no manual DOM, no class-name shim.

- **`src/ui/sidebar.ts`** — a Foldkit program via `Runtime.makeProgram` over the sidebar's `SidebarPrimitiveModel`/`SidebarPrimitiveMessage`: `sidebarInit`/`sidebarUpdate`/`sidebarView`, an Effect `Schema` codec for the Model, a representative left nav (Khala Code / Fleet), and an `onActivate` bridge for future routing.
- **`index.html`** — `#sidebar-root` container as the first shell child.
- **`styles.css`** — 2-column grid; the Basecoat sidebar rendered as a static column with its theme variables resolved to the desktop's dark / Berkeley-Mono surface so it matches the composer/transcript.
- **`main.ts`** — mounts the Foldkit sidebar after the composer HUD.
- **`package.json`** — adds `foldkit ^0.102.1` (matches `packages/ui`).

## Verification status (read before merging)
- The Foldkit/Effect wiring is written against the real APIs (`Runtime.makeProgram`'s `ProgramConfig`, the sidebar's `init`/`update`/`view` + `SidebarViewGroup`).
- **Two things need a desktop dev-runtime pass I could not do headless:**
  1. **`bun install`** for the newly-added `foldkit` desktop dep — without it, `tsc` can't resolve `foldkit` / `@openagentsinc/ui/basecoat/sidebar` in my new file (the only typecheck errors that originate from this PR are those two module-resolution errors; the types flow once installed).
  2. **Build + visually confirm** the Electrobun render (the Basecoat sidebar's fixed-overlay model is adapted here to a static desktop column via CSS; the exact layout/theme should be eyeballed in the running app).
- Note: `typecheck:khala-code-desktop` is **already red on `main`** independent of this PR — `src/bun/khala-codex-fleet-tools.ts` references `runKhalaFleetDelegateProgram` / `KhalaFleetDelegate*` exports from `@openagentsinc/khala-tools` that don't exist yet (the in-progress GD-P deterministic-delegation work). A green desktop typecheck depends on that landing too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)