### PR TITLE
Harden codex_spawn live progress replacements

### DIFF
--- a/clients/khala-code-desktop/src/bun/khala-chat-runtime.ts
+++ b/clients/khala-code-desktop/src/bun/khala-chat-runtime.ts
@@ -1394,10 +1394,12 @@ function createLiveToolProgressCard(input: {
   let timer: ReturnType<typeof setTimeout> | null = null
   const emitReplace = () => {
     if (pendingBody === null) return
+    const body = pendingBody
+    pendingBody = null
     input.emit({
       message: {
         ...input.toolTranscript,
-        body: pendingBody,
+        body,
       },
       turnId: input.turnId,
       type: "message_replace",

--- a/clients/khala-code-desktop/tests/khala-chat-runtime.test.ts
+++ b/clients/khala-code-desktop/tests/khala-chat-runtime.test.ts
@@ -62,6 +62,10 @@ async function tempWorkspace(): Promise<string> {
   return dir
 }
 
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
 function jsonResponse(body: unknown, init?: ResponseInit): Response {
   return new Response(JSON.stringify(body), {
     ...init,
@@ -602,15 +606,31 @@ describe("Khala Code desktop chat runtime", () => {
         execute: (_input, context) =>
           Effect.gen(function* () {
             yield* context.emitProgress({
-              events: [{ event: "assignment_run.runtime_progress", phase: "runtime_active" }],
+              events: [{ event: "assignment_run.started", phase: "dispatch" }],
               kind: "codex_spawn_lifecycle",
               lines: [
                 "lifecycle:",
+                "  - assignment_run.started (phase=dispatch)",
+              ],
+              schema: "openagents.khala_code.codex_spawn_progress.v0.1",
+              toolName: "codex_spawn",
+            })
+            yield* Effect.promise(() => sleep(230))
+            yield* context.emitProgress({
+              events: [
+                { event: "assignment_run.started", phase: "dispatch" },
+                { event: "assignment_run.runtime_progress", phase: "runtime_active" },
+              ],
+              kind: "codex_spawn_lifecycle",
+              lines: [
+                "lifecycle:",
+                "  - assignment_run.started (phase=dispatch)",
                 "  - assignment_run.runtime_progress (phase=runtime_active)",
               ],
               schema: "openagents.khala_code.codex_spawn_progress.v0.1",
               toolName: "codex_spawn",
             })
+            yield* Effect.promise(() => sleep(230))
             return khalaToolOk({
               modelText: "Codex spawn: accepted 1/1\n- slot 0: accepted",
               publicSummary: "Codex spawn accepted 1/1 request(s).",
@@ -657,7 +677,16 @@ describe("Khala Code desktop chat runtime", () => {
       event.message.role === "tool" &&
       event.message.id === toolId
     )
-    const progressIndex = toolReplacements.findIndex(event =>
+    const progressReplacements = toolReplacements.filter(event =>
+      event.type === "message_replace" &&
+      event.message.body.includes("codex_spawn: running")
+    )
+    const firstProgressIndex = toolReplacements.findIndex(event =>
+      event.type === "message_replace" &&
+      event.message.body.includes("codex_spawn: running") &&
+      event.message.body.includes("assignment_run.started")
+    )
+    const secondProgressIndex = toolReplacements.findIndex(event =>
       event.type === "message_replace" &&
       event.message.body.includes("codex_spawn: running") &&
       event.message.body.includes("assignment_run.runtime_progress")
@@ -669,8 +698,10 @@ describe("Khala Code desktop chat runtime", () => {
     )
 
     expect(result.ok).toBe(true)
-    expect(progressIndex).toBeGreaterThanOrEqual(0)
-    expect(finalIndex).toBeGreaterThan(progressIndex)
+    expect(progressReplacements).toHaveLength(2)
+    expect(firstProgressIndex).toBeGreaterThanOrEqual(0)
+    expect(secondProgressIndex).toBeGreaterThan(firstProgressIndex)
+    expect(finalIndex).toBeGreaterThan(secondProgressIndex)
     expect(events.some(event =>
       event.type === "tool_event" &&
       event.event.kind === "tool_progress" &&


### PR DESCRIPTION
## Problem

#7762 needs desktop-side confidence that long-running `codex_spawn` progress events update the existing tool card before the final result, rather than only dumping status at completion.

## Change

- Clears the pending live progress body after each same-card `message_replace`, so the completion flush does not duplicate the last progress frame before the final tool result.
- Strengthens the focused `codex_spawn` runtime test to emit two fixture-backed progress frames while the fake tool is still running, then asserts both replacements land on the same tool card before the final `codex_spawn: ok` replacement.

## Files Touched

- `clients/khala-code-desktop/src/bun/khala-chat-runtime.ts`
- `clients/khala-code-desktop/tests/khala-chat-runtime.test.ts`

## Validation

- `bun test clients/khala-code-desktop/tests/khala-chat-runtime.test.ts -t "streams codex_spawn progress"`
- `bun test packages/khala-tools/src/dispatcher.test.ts`
- `bun run --cwd clients/khala-code-desktop typecheck`
- `git diff --check`

Known unrelated current-main failure observed while checking the broader runtime file:

- `bun test clients/khala-code-desktop/tests/khala-chat-runtime.test.ts` fails only at `uses the default Rampart model redaction before hosted provider requests`, expecting `Hello Alice Johnson.` but receiving `Hello [GIVEN_NAME_1] [SURNAME_1].`

## Maintenance / Product Value

This makes the #7762 live-progress path reviewable with a small, deterministic desktop runtime test and removes a duplicate progress-frame edge case from the live tool-card emitter.

## Not Changed

- No Pylon lifecycle schema contract changes.
- No durable-stream alternate transport changes.
- No UI rendering changes.
- No real fleet e2e coverage.
