### PR TITLE
fix(pylon): preserve Khala stream resume evidence

### DIFF
--- a/apps/pylon/src/khala-requester.test.ts
+++ b/apps/pylon/src/khala-requester.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from "bun:test"
 import {
   buildPylonKhalaChatRequestBody,
   issuePylonKhalaRequest,
+  resumePylonKhalaRequest,
 } from "./khala-requester.js"
 
 describe("Pylon Khala requester", () => {
@@ -66,5 +67,93 @@ describe("Pylon Khala requester", () => {
     await expect(result).rejects.toThrow(
       "blocker.public.pylon_dispatch.duplicate_active_assignment",
     )
+  })
+
+  test("parses CRLF SSE frames, public event text, and durable resume metadata", async () => {
+    const fetchMock = (async () =>
+      new Response(
+        [
+          ": keepalive\r\n",
+          "event: delta\r\n",
+          'data: {"text":"Hel"}\r\n',
+          "\r\n",
+          'data: {"choices":[{"delta":{"content":"lo"}}]}\r\n',
+          "\r\n",
+          "data: [DONE]\r\n",
+          "\r\n",
+        ].join(""),
+        {
+          headers: {
+            "openagents-durable-stream-url": "/v1/chat/completions/durable/request.public.123",
+            "stream-closed": "true",
+            "stream-next-offset": "128",
+            "stream-up-to-date": "true",
+          },
+        },
+      )) as unknown as typeof fetch
+
+    const result = await issuePylonKhalaRequest(
+      {
+        agentToken: "oa_agent_test",
+        baseUrl: "https://openagents.example",
+        fetch: fetchMock,
+      },
+      {
+        prompt: "Run the public-safe fixture.",
+        workflow: "codex_agent_task",
+      },
+    )
+
+    expect(result.diagnostics).toEqual([])
+    expect(result.durableRequestId).toBe("request.public.123")
+    expect(result.frames.map((frame) => frame.event ?? null)).toEqual(["delta", null, null])
+    expect(result.nextOffset).toBe("128")
+    expect(result.streamClosed).toBe(true)
+    expect(result.streamUpToDate).toBe(true)
+    expect(result.text).toBe("Hello")
+  })
+
+  test("records malformed SSE JSON as a typed diagnostic instead of silently dropping stream evidence", async () => {
+    const fetchMock = (async () =>
+      new Response(
+        [
+          "event: delta\n",
+          'data: {"text":"ok"}\n',
+          "\n",
+          "event: delta\n",
+          "data: {not-json}\n",
+          "\n",
+        ].join(""),
+        {
+          headers: {
+            "stream-up-to-date": "true",
+          },
+        },
+      )) as unknown as typeof fetch
+
+    const result = await resumePylonKhalaRequest(
+      {
+        agentToken: "oa_agent_test",
+        baseUrl: "https://openagents.example",
+        fetch: fetchMock,
+      },
+      {
+        durableRequestId: "request.public.123",
+        offset: 0,
+      },
+    )
+
+    expect(result.text).toBe("ok")
+    expect(result.diagnostics).toHaveLength(1)
+    expect(result.diagnostics[0]).toMatchObject({
+      code: "malformed_sse_json",
+      event: "delta",
+      frameIndex: 1,
+    })
+    expect(result.frames[1]).toMatchObject({
+      data: "{not-json}",
+      event: "delta",
+      parsed: null,
+    })
   })
 })

--- a/apps/pylon/src/khala-requester.ts
+++ b/apps/pylon/src/khala-requester.ts
@@ -45,10 +45,19 @@ export type PylonKhalaResumeInput = {
 
 export type PylonKhalaSseFrame = {
   data: string
+  event?: string
   parsed: unknown | null
 }
 
+export type PylonKhalaStreamDiagnostic = {
+  code: "malformed_sse_json"
+  event: string | null
+  frameIndex: number
+  reason: string
+}
+
 export type PylonKhalaStreamProjection = {
+  diagnostics: PylonKhalaStreamDiagnostic[]
   durableRequestId: string | null
   durableStreamUrl: string | null
   frames: PylonKhalaSseFrame[]
@@ -57,6 +66,23 @@ export type PylonKhalaStreamProjection = {
   streamClosed: boolean
   streamUpToDate: boolean
   text: string
+}
+
+export class PylonKhalaStreamFrameError extends Error {
+  readonly _tag = "PylonKhalaStreamFrameError"
+  readonly code: "malformed_sse_json"
+  readonly event: string | null
+  readonly frameIndex: number
+  readonly reason: string
+
+  constructor(input: PylonKhalaStreamDiagnostic) {
+    super(`malformed SSE JSON frame ${input.frameIndex}: ${input.reason}`)
+    this.name = "PylonKhalaStreamFrameError"
+    this.code = input.code
+    this.event = input.event
+    this.frameIndex = input.frameIndex
+    this.reason = input.reason
+  }
 }
 
 export type PylonKhalaRequestResult = PylonKhalaStreamProjection & {
@@ -695,27 +721,67 @@ export function buildPylonKhalaChatRequestBody(
   return body
 }
 
-function parseSseFrames(rawSse: string): PylonKhalaSseFrame[] {
-  return rawSse
+function parseSseBlock(block: string): { data: string; event?: string } | null {
+  const data: string[] = []
+  let event: string | undefined
+  for (const line of block.split("\n")) {
+    if (line === "" || line.startsWith(":")) continue
+    const colonIndex = line.indexOf(":")
+    const field = colonIndex >= 0 ? line.slice(0, colonIndex) : line
+    const rawValue = colonIndex >= 0 ? line.slice(colonIndex + 1) : ""
+    const value = rawValue.startsWith(" ") ? rawValue.slice(1) : rawValue
+    if (field === "event") event = value
+    if (field === "data") data.push(value)
+  }
+  if (event === undefined && data.length === 0) return null
+  return event === undefined
+    ? { data: data.join("\n") }
+    : { data: data.join("\n"), event }
+}
+
+function parseSseFrames(rawSse: string): {
+  diagnostics: PylonKhalaStreamDiagnostic[]
+  frames: PylonKhalaSseFrame[]
+} {
+  const diagnostics: PylonKhalaStreamDiagnostic[] = []
+  const frames = rawSse
+    .replace(/\r\n/g, "\n")
+    .replace(/\r/g, "\n")
     .split(/\n\n+/)
-    .map((chunk) =>
-      chunk
-        .split(/\n/)
-        .filter((line) => line.startsWith("data:"))
-        .map((line) => line.slice("data:".length).trimStart())
-        .join("\n"),
-    )
-    .filter((data) => data !== "")
-    .map((data) => {
-      if (data === "[DONE]") {
-        return { data, parsed: null }
+    .flatMap((chunk) => {
+      const frame = parseSseBlock(chunk)
+      return frame === null || frame.data === "" ? [] : [frame]
+    })
+    .map((frame, frameIndex) => {
+      if (frame.data === "[DONE]") {
+        return frame.event === undefined
+          ? { data: frame.data, parsed: null }
+          : { data: frame.data, event: frame.event, parsed: null }
       }
       try {
-        return { data, parsed: JSON.parse(data) }
-      } catch {
-        return { data, parsed: null }
+        const parsed = JSON.parse(frame.data)
+        return frame.event === undefined
+          ? { data: frame.data, parsed }
+          : { data: frame.data, event: frame.event, parsed }
+      } catch (error) {
+        const streamError = new PylonKhalaStreamFrameError({
+          code: "malformed_sse_json",
+          event: frame.event ?? null,
+          frameIndex,
+          reason: error instanceof Error ? error.message : String(error),
+        })
+        diagnostics.push({
+          code: streamError.code,
+          event: streamError.event,
+          frameIndex: streamError.frameIndex,
+          reason: streamError.reason,
+        })
+        return frame.event === undefined
+          ? { data: frame.data, parsed: null }
+          : { data: frame.data, event: frame.event, parsed: null }
       }
     })
+  return { diagnostics, frames }
 }
 
 function textFromFrames(frames: readonly PylonKhalaSseFrame[]): string {
@@ -727,6 +793,10 @@ function textFromFrames(frames: readonly PylonKhalaSseFrame[]): string {
       }
       const choices = (parsed as { choices?: unknown }).choices
       if (!Array.isArray(choices)) {
+        if ((parsed as { text?: unknown }).text !== undefined) {
+          const text = (parsed as { text?: unknown }).text
+          return typeof text === "string" ? text : ""
+        }
         return ""
       }
       return choices
@@ -747,10 +817,11 @@ function streamProjection(input: {
   rawSse: string
   response: Response
 }): PylonKhalaStreamProjection {
-  const frames = parseSseFrames(input.rawSse)
+  const { diagnostics, frames } = parseSseFrames(input.rawSse)
   const durableRequestId =
     durableRequestIdFromUrl(input.durableStreamUrl) ?? input.fallbackRequestId ?? null
   return {
+    diagnostics,
     durableRequestId,
     durableStreamUrl: input.durableStreamUrl,
     frames,

--- a/apps/pylon/src/khala-spawn.test.ts
+++ b/apps/pylon/src/khala-spawn.test.ts
@@ -292,6 +292,7 @@ describe("Khala spawn per-account planning", () => {
 
 const requestResult: PylonKhalaRequestResult = {
   assignmentRef: "assignment.public.khala_coding.test",
+  diagnostics: [],
   durableRequestId: "durable.test",
   durableStreamUrl: null,
   frames: [],


### PR DESCRIPTION
Addresses (no linked issue).

### Changes
- Expanded Khala SSE parsing to handle CRLF frames, `event:` fields, keepalive comments, `[DONE]`, public `text` payloads, and durable stream metadata.
- Added typed diagnostics for malformed SSE JSON so bad frames remain visible instead of being silently dropped.
- Covered request/resume stream parsing behavior with focused tests, including malformed-frame diagnostics.

### Verification
- `bun test clients/khala-code-desktop/tests/khala-codex-fleet-tools.test.ts apps/pylon/src/khala-spawn.test.ts apps/pylon/tests/khala-spawn.test.ts apps/pylon/src/presence-codex-account-capacity.test.ts apps/pylon/tests/presence.test.ts`
- Result: passed (exit 0)