### PR TITLE
feat(composer-state): add collaborative transaction helpers

### DIFF
--- a/docs/adr/0013-adopt-prosemirror-inspired-command-composer.md
+++ b/docs/adr/0013-adopt-prosemirror-inspired-command-composer.md
@@ -220,6 +220,26 @@ The implementation should land as a sequence:
 | No public projection of raw private prompt or file content | Satisfied for v1 artifacts by the new composer privacy fixture guard and the documented metadata-only attachment boundary. |
 | Product-promise records | No new record was added because this work hardens existing input surfaces and does not broaden public product claims. |
 
+## Rich Inline Editing And Collaboration Follow-Up
+
+Issue #7647 keeps the v1 editor substrate as a native textarea. The current
+decision is:
+
+| Adapter | Fit | Decision |
+| --- | --- | --- |
+| Textarea-native source mode | Best reliability for IME, mobile keyboards, browser copy/paste, selection, screen readers, OS shortcuts, and always-writable pending turns. | Remains the default and only shipped editing mode. |
+| Full ProseMirror browser view | Strongest rich inline editing, decorations, search, nested lists, collaborative rebasing, and changesets, but imports the highest-risk `contentEditable` surface and would need broad IME/mobile/accessibility smoke coverage before use. | Not shipped. Reconsider only after a dedicated adapter preserves the textarea path and passes the full input matrix. |
+| Hybrid adapter | Allows textarea source editing plus typed sidecar state for marks, decorations, nested-list intent, search matches, collaboration envelopes, and change summaries. | Accepted follow-up shape. Keep rich UI optional and driven from typed state, not public raw prompt projections. |
+
+`@openagentsinc/composer-state` now includes collaboration-ready transaction
+envelopes, deterministic text-step rebasing over remote steps, typed richer
+inline/search/nested-list sidecar contracts, and public-safe change summaries.
+The summaries count text and structural edits but do not expose inserted prompt
+text, private file names, local paths, or raw attachment content refs. Shared
+editing UI remains deferred until a view adapter can prove textarea parity for
+IME, mobile, copy/paste, shortcuts, focus, and accessibility without breaking
+the current textarea path.
+
 Deferred follow-ups:
 
 * #7647: rich inline editing, contentEditable/ProseMirror-view evaluation, and

--- a/packages/composer-state/README.md
+++ b/packages/composer-state/README.md
@@ -10,9 +10,15 @@ The package intentionally owns only serializable composer state:
 - selections;
 - typed editing steps;
 - transactions and history;
+- collaboration-ready transaction envelopes, rebase mapping, and public-safe
+  change summaries;
 - input-rule and keymap helpers;
 - Markdown parse/serialize helpers for the v1 source-first subset.
 
 It does not render DOM, own uploads, or make routing decisions from user text.
 UI packages and app integrations consume this state layer and keep platform
 editing behavior native.
+
+Collaborative helpers intentionally keep raw draft text inside the private
+transaction payload. Public projections should use `ComposerChangeSummary` or
+attachment upload receipts, not serialized transaction steps.

--- a/packages/composer-state/src/index.test.ts
+++ b/packages/composer-state/src/index.test.ts
@@ -1,12 +1,16 @@
 import { describe, expect, test } from "bun:test"
 
 import {
+  ComposerDecoration,
+  ComposerInlineMark,
+  ComposerListItem,
   DEFAULT_DESKTOP_LOCAL_ATTACHMENT_UPLOAD_POLICY,
   DEFAULT_WEB_HOSTED_ATTACHMENT_UPLOAD_POLICY,
   applyComposerTransaction,
   composerAttachmentContentAddressedRef,
   composerAttachmentId,
   composerBlockId,
+  createComposerCollaborativeTransaction,
   emptyComposerState,
   moveComposerAttachmentSelection,
   offerComposerLargeTextPaste,
@@ -14,6 +18,7 @@ import {
   planComposerAttachmentUpload,
   projectComposerAttachmentUploadReceipt,
   readyComposerAttachmentTransaction,
+  rebaseComposerTransaction,
   redoComposerState,
   retryComposerAttachmentTransaction,
   resolveComposerKeyBinding,
@@ -22,11 +27,13 @@ import {
   stageComposerDroppedFiles,
   stageComposerPastedFiles,
   setComposerAttachmentStatusTransaction,
+  summarizeComposerSteps,
   undoComposerState,
   type ComposerAttachment,
   type ComposerState,
   type ComposerTransaction,
 } from "./index"
+import { Schema as S } from "effect"
 
 const tx = (steps: ComposerTransaction["steps"]): ComposerTransaction => ({
   steps,
@@ -523,5 +530,118 @@ describe("composer state core", () => {
     expect(serialized).toContain("- one\n- two")
     expect(serialized).toContain("```ts\nconst answer = 42\n```")
     expect(serialized).toContain("<custom-widget data-x=\"1\">keep me</custom-widget>")
+  })
+
+  test("rebases local text transactions over remote collaborative steps", () => {
+    const blockId = composerBlockId("block-1")
+    const local = tx([
+      {
+        _tag: "InsertText",
+        at: { blockId, offset: 0 },
+        text: " world",
+      },
+    ])
+    const remote: ComposerTransaction = {
+      steps: [
+        {
+          _tag: "InsertText",
+          at: { blockId, offset: 0 },
+          text: "hello",
+        },
+      ],
+      meta: { source: "program", time: 2, clientId: "remote", baseVersion: 0 },
+    }
+
+    const collaborative = createComposerCollaborativeTransaction({
+      sessionRef: "composer-session.public.fixture",
+      transactionRef: "composer-tx.public.local",
+      clientId: "local",
+      baseVersion: 0,
+      transaction: local,
+    })
+    expect(collaborative.version).toBe(1)
+    expect(collaborative.transaction.meta).toMatchObject({
+      clientId: "local",
+      baseVersion: 0,
+    })
+
+    const rebased = rebaseComposerTransaction({
+      transaction: collaborative.transaction,
+      fromBaseVersion: collaborative.baseVersion,
+      remoteSteps: remote.steps,
+    })
+    expect(rebased.toBaseVersion).toBe(1)
+    expect(rebased.transaction.meta.baseVersion).toBe(1)
+    expect(rebased.transaction.steps[0]).toMatchObject({
+      _tag: "InsertText",
+      at: { blockId, offset: 5 },
+      text: " world",
+    })
+    expect(rebased.changeSummary).toMatchObject({
+      insertedTextChars: 6,
+      deletedTextChars: 0,
+      replacedTextChars: 0,
+    })
+    expect(JSON.stringify(rebased.changeSummary)).not.toContain("world")
+
+    const remoteApplied = apply(emptyComposerState(), remote)
+    const merged = apply(remoteApplied, rebased.transaction)
+    expect(firstText(merged)).toBe("hello world")
+  })
+
+  test("summarizes collaborative attachment and view changes without raw content", () => {
+    const attachment: ComposerAttachment = {
+      id: composerAttachmentId("att-summary"),
+      kind: "text",
+      name: "private-notes.txt",
+      mime: "text/plain",
+      sizeBytes: 123,
+      contentRef: "local-file:/private/tmp/private-notes.txt",
+      status: "staged",
+    }
+    const summary = summarizeComposerSteps([
+      { _tag: "InsertAttachment", attachment },
+      {
+        _tag: "UpdateAttachment",
+        attachmentId: attachment.id,
+        patch: { status: "ready", digest: "sha256:feed" },
+      },
+      { _tag: "ResizeComposer", heightPx: 280 },
+    ])
+    expect(summary).toEqual({
+      insertedTextChars: 0,
+      deletedTextChars: 0,
+      replacedTextChars: 0,
+      blockKindChanges: 0,
+      attachmentsInserted: [attachment.id],
+      attachmentsRemoved: [],
+      attachmentsUpdated: [attachment.id],
+      resizeChanges: 1,
+    })
+    expect(JSON.stringify(summary)).not.toContain("private-notes")
+    expect(JSON.stringify(summary)).not.toContain("/private/tmp")
+  })
+
+  test("keeps rich inline, search decoration, and nested-list follow-up state typed", () => {
+    const mark = S.decodeUnknownSync(ComposerInlineMark)({
+      kind: "link",
+      from: 0,
+      to: 5,
+      href: "https://openagents.com",
+    })
+    expect(mark.kind).toBe("link")
+
+    const decoration = S.decodeUnknownSync(ComposerDecoration)({
+      kind: "searchMatch",
+      range: { from: 6, to: 11 },
+      label: "visible match label",
+    })
+    expect(decoration.kind).toBe("searchMatch")
+
+    const nestedItem = S.decodeUnknownSync(ComposerListItem)({
+      text: "parent",
+      children: ["child one", "child two"],
+    })
+    expect(nestedItem.children).toEqual(["child one", "child two"])
   })
 })

--- a/packages/composer-state/src/index.ts
+++ b/packages/composer-state/src/index.ts
@@ -48,6 +48,33 @@ export const ComposerInlineMark = S.Struct({
 })
 export type ComposerInlineMark = typeof ComposerInlineMark.Type
 
+export const ComposerDecorationKind = S.Literals([
+  "searchMatch",
+  "selectionMirror",
+  "remoteCursor",
+  "syntaxHint",
+])
+export type ComposerDecorationKind = typeof ComposerDecorationKind.Type
+
+export const ComposerDecoration = S.Struct({
+  kind: ComposerDecorationKind,
+  range: S.optional(
+    S.Struct({
+      from: S.Number,
+      to: S.Number,
+    }),
+  ),
+  ref: S.optional(S.String),
+  label: S.optional(S.String),
+})
+export type ComposerDecoration = typeof ComposerDecoration.Type
+
+export const ComposerListItem = S.Struct({
+  text: S.String,
+  children: S.Array(S.String),
+})
+export type ComposerListItem = typeof ComposerListItem.Type
+
 export const ComposerParagraphBlock = S.Struct({
   id: ComposerBlockId,
   kind: S.Literal("paragraph"),
@@ -327,6 +354,9 @@ export const ComposerTransactionMeta = S.Struct({
   source: ComposerTransactionSource,
   time: S.Number,
   addToHistory: S.optional(S.Boolean),
+  clientId: S.optional(S.String),
+  sequence: S.optional(S.Number),
+  baseVersion: S.optional(S.Number),
 })
 export type ComposerTransactionMeta = typeof ComposerTransactionMeta.Type
 
@@ -336,6 +366,39 @@ export const ComposerTransaction = S.Struct({
   meta: ComposerTransactionMeta,
 })
 export type ComposerTransaction = typeof ComposerTransaction.Type
+
+export const ComposerCollaborativeTransaction = S.Struct({
+  schemaVersion: ComposerSchemaVersion,
+  sessionRef: S.String,
+  transactionRef: S.String,
+  clientId: S.String,
+  baseVersion: S.Number,
+  version: S.Number,
+  transaction: ComposerTransaction,
+})
+export type ComposerCollaborativeTransaction =
+  typeof ComposerCollaborativeTransaction.Type
+
+export const ComposerChangeSummary = S.Struct({
+  insertedTextChars: S.Number,
+  deletedTextChars: S.Number,
+  replacedTextChars: S.Number,
+  blockKindChanges: S.Number,
+  attachmentsInserted: S.Array(ComposerAttachmentId),
+  attachmentsRemoved: S.Array(ComposerAttachmentId),
+  attachmentsUpdated: S.Array(ComposerAttachmentId),
+  resizeChanges: S.Number,
+})
+export type ComposerChangeSummary = typeof ComposerChangeSummary.Type
+
+export const ComposerRebasedTransaction = S.Struct({
+  schemaVersion: ComposerSchemaVersion,
+  fromBaseVersion: S.Number,
+  toBaseVersion: S.Number,
+  transaction: ComposerTransaction,
+  changeSummary: ComposerChangeSummary,
+})
+export type ComposerRebasedTransaction = typeof ComposerRebasedTransaction.Type
 
 export const ComposerAttachmentUploadPlan = S.Struct({
   attachmentId: ComposerAttachmentId,
@@ -1176,6 +1239,175 @@ export const mapSelectionThroughStep = (
   return selection.selectedAttachmentId === undefined
     ? { anchor, head }
     : { anchor, head, selectedAttachmentId: selection.selectedAttachmentId }
+}
+
+export const mapComposerStepThroughStep = (
+  step: ComposerStep,
+  remoteStep: ComposerStep,
+): ComposerStep => {
+  switch (step._tag) {
+    case "InsertText":
+      return {
+        ...step,
+        at: mapPositionThroughStep(step.at, remoteStep),
+      }
+    case "DeleteRange":
+      return {
+        ...step,
+        range: {
+          anchor: mapPositionThroughStep(step.range.anchor, remoteStep),
+          head: mapPositionThroughStep(step.range.head, remoteStep),
+        },
+      }
+    case "ReplaceRange":
+      return {
+        ...step,
+        range: {
+          anchor: mapPositionThroughStep(step.range.anchor, remoteStep),
+          head: mapPositionThroughStep(step.range.head, remoteStep),
+        },
+      }
+    case "SetBlockKind":
+    case "InsertAttachment":
+    case "RemoveAttachment":
+    case "UpdateAttachment":
+    case "ResizeComposer":
+      return step
+  }
+}
+
+export const mapComposerTransactionThroughSteps = (
+  transaction: ComposerTransaction,
+  remoteSteps: ReadonlyArray<ComposerStep>,
+): ComposerTransaction => {
+  const steps = transaction.steps.map((step) =>
+    remoteSteps.reduce(
+      (mappedStep, remoteStep) => mapComposerStepThroughStep(mappedStep, remoteStep),
+      step,
+    ),
+  )
+  const selection =
+    transaction.selection === undefined
+      ? undefined
+      : remoteSteps.reduce(
+          (mappedSelection, remoteStep) =>
+            mapSelectionThroughStep(mappedSelection, remoteStep),
+          transaction.selection,
+        )
+  return {
+    ...transaction,
+    steps,
+    ...(selection === undefined ? {} : { selection }),
+  }
+}
+
+const rangeCharLength = (range: ComposerTextRange): number =>
+  Math.abs(Math.trunc(range.head.offset) - Math.trunc(range.anchor.offset))
+
+const uniqueComposerAttachmentIds = (
+  ids: ReadonlyArray<ComposerAttachmentId>,
+): ReadonlyArray<ComposerAttachmentId> => [...new Set(ids)]
+
+export const summarizeComposerSteps = (
+  steps: ReadonlyArray<ComposerStep>,
+): ComposerChangeSummary => {
+  let insertedTextChars = 0
+  let deletedTextChars = 0
+  let replacedTextChars = 0
+  let blockKindChanges = 0
+  let resizeChanges = 0
+  const attachmentsInserted: ComposerAttachmentId[] = []
+  const attachmentsRemoved: ComposerAttachmentId[] = []
+  const attachmentsUpdated: ComposerAttachmentId[] = []
+
+  for (const step of steps) {
+    switch (step._tag) {
+      case "InsertText":
+        insertedTextChars += step.text.length
+        break
+      case "DeleteRange":
+        deletedTextChars += rangeCharLength(step.range)
+        break
+      case "ReplaceRange":
+        replacedTextChars += rangeCharLength(step.range)
+        insertedTextChars += step.text.length
+        break
+      case "SetBlockKind":
+        blockKindChanges += 1
+        break
+      case "InsertAttachment":
+        attachmentsInserted.push(step.attachment.id)
+        break
+      case "RemoveAttachment":
+        attachmentsRemoved.push(step.attachmentId)
+        break
+      case "UpdateAttachment":
+        attachmentsUpdated.push(step.attachmentId)
+        break
+      case "ResizeComposer":
+        resizeChanges += 1
+        break
+    }
+  }
+
+  return {
+    insertedTextChars,
+    deletedTextChars,
+    replacedTextChars,
+    blockKindChanges,
+    attachmentsInserted: uniqueComposerAttachmentIds(attachmentsInserted),
+    attachmentsRemoved: uniqueComposerAttachmentIds(attachmentsRemoved),
+    attachmentsUpdated: uniqueComposerAttachmentIds(attachmentsUpdated),
+    resizeChanges,
+  }
+}
+
+export const createComposerCollaborativeTransaction = (input: {
+  sessionRef: string
+  transactionRef: string
+  clientId: string
+  baseVersion: number
+  transaction: ComposerTransaction
+}): ComposerCollaborativeTransaction => ({
+  schemaVersion: COMPOSER_SCHEMA_VERSION,
+  sessionRef: input.sessionRef,
+  transactionRef: input.transactionRef,
+  clientId: input.clientId,
+  baseVersion: Math.max(0, Math.trunc(input.baseVersion)),
+  version: Math.max(0, Math.trunc(input.baseVersion)) + input.transaction.steps.length,
+  transaction: {
+    ...input.transaction,
+    meta: {
+      ...input.transaction.meta,
+      clientId: input.clientId,
+      baseVersion: Math.max(0, Math.trunc(input.baseVersion)),
+    },
+  },
+})
+
+export const rebaseComposerTransaction = (input: {
+  transaction: ComposerTransaction
+  fromBaseVersion: number
+  remoteSteps: ReadonlyArray<ComposerStep>
+}): ComposerRebasedTransaction => {
+  const fromBaseVersion = Math.max(0, Math.trunc(input.fromBaseVersion))
+  const transaction = mapComposerTransactionThroughSteps(
+    input.transaction,
+    input.remoteSteps,
+  )
+  return {
+    schemaVersion: COMPOSER_SCHEMA_VERSION,
+    fromBaseVersion,
+    toBaseVersion: fromBaseVersion + input.remoteSteps.length,
+    transaction: {
+      ...transaction,
+      meta: {
+        ...transaction.meta,
+        baseVersion: fromBaseVersion + input.remoteSteps.length,
+      },
+    },
+    changeSummary: summarizeComposerSteps(transaction.steps),
+  }
 }
 
 const setSelectionAfterText = (


### PR DESCRIPTION
Addresses (no linked issue).

### Changes
- Adds collaboration-ready composer transaction envelopes, deterministic text-step rebasing, and public-safe change summaries.
- Adds typed sidecar contracts for inline marks, decorations, search matches, nested-list intent, and collaboration metadata.
- Documents the textarea-first rich editing follow-up shape and privacy boundary for collaborative projections.
- Extends composer-state tests for rebasing, summary privacy, and schema validation.

### Verification
- `bun test clients/khala-code-desktop/tests/khala-codex-fleet-tools.test.ts apps/pylon/src/khala-spawn.test.ts apps/pylon/tests/khala-spawn.test.ts apps/pylon/src/presence-codex-account-capacity.test.ts apps/pylon/tests/presence.test.ts`
- Result: passed (exit 0)