### PR TITLE
feat(khala-code): add unified inbox view

### DIFF
--- a/clients/khala-code-desktop/src/ui/gym-proof-loader.ts
+++ b/clients/khala-code-desktop/src/ui/gym-proof-loader.ts
@@ -248,10 +248,10 @@ export const gymPaneStateFromLocation = (
 
 export const initialKhalaCodeViewFromLocation = (
   location: Pick<Location, "search" | "hash">,
-): "chat" | "fleet" | "gym" => {
+): "chat" | "inbox" | "fleet" | "gym" => {
   const params = paramsForLocation(location)
   const view = params.get("view")
-  if (view === "fleet" || view === "gym" || view === "chat") return view
+  if (view === "fleet" || view === "gym" || view === "inbox" || view === "chat") return view
   const proof = params.get("gymProof")
   return proof === "fixture" || proof === "demo" ? "gym" : "chat"
 }

--- a/clients/khala-code-desktop/src/ui/inbox.ts
+++ b/clients/khala-code-desktop/src/ui/inbox.ts
@@ -1,0 +1,416 @@
+import type {
+  KhalaCodeDesktopFleetStatus,
+  KhalaCodeDesktopRuntimeStatus,
+} from "../shared/rpc"
+
+export type UnifiedInboxItemKind =
+  | "approval_required"
+  | "run_blocked"
+  | "ready_for_review"
+  | "mcp_failed"
+  | "missing_credential"
+  | "memory_update_pending"
+
+export type UnifiedInboxItemAction =
+  | "approve"
+  | "reject"
+  | "edit"
+  | "reply"
+  | "rerun"
+  | "open_file"
+  | "resume"
+  | "reconnect"
+  | "open_fleet"
+  | "refresh"
+
+export type UnifiedInboxItem = Readonly<{
+  ref: string
+  kind: UnifiedInboxItemKind
+  title: string
+  summary: string
+  source: "fleet" | "runtime" | "assignment" | "permission" | "mcp" | "memory"
+  severity: "info" | "warning" | "critical"
+  observedAt: string
+  accountRef?: string
+  assignmentRef?: string
+  issueRef?: string
+  resumeCommand?: string
+  actions: readonly UnifiedInboxItemAction[]
+}>
+
+export type UnifiedInboxProjection = Readonly<{
+  ok: boolean
+  observedAt: string
+  items: readonly UnifiedInboxItem[]
+  coverage: readonly {
+    source: string
+    status: "connected" | "not_connected"
+    summary: string
+  }[]
+}>
+
+export type UnifiedInboxSource = Readonly<{
+  fleet: KhalaCodeDesktopFleetStatus
+  pylon: KhalaCodeDesktopRuntimeStatus
+  coding: KhalaCodeDesktopRuntimeStatus
+  tokenAccounting: KhalaCodeDesktopRuntimeStatus
+}>
+
+export type UnifiedInboxPanelHandle = Readonly<{
+  refresh: () => Promise<void>
+  setVisible: (visible: boolean) => void
+}>
+
+export type UnifiedInboxPanelOptions = Readonly<{
+  fetch: () => Promise<UnifiedInboxSource>
+  onOpenFleet: () => void
+  onReconnectAccount: (accountRef: string) => void
+}>
+
+type InboxView =
+  | { readonly phase: "loading" }
+  | { readonly phase: "error"; readonly message: string }
+  | { readonly phase: "ready"; readonly data: UnifiedInboxProjection }
+
+type Handlers = Readonly<{
+  onRefresh: () => void
+  onOpenFleet: () => void
+  onReconnectAccount: (accountRef: string) => void
+}>
+
+const itemPriority: Record<UnifiedInboxItemKind, number> = {
+  approval_required: 0,
+  run_blocked: 1,
+  missing_credential: 2,
+  mcp_failed: 3,
+  ready_for_review: 4,
+  memory_update_pending: 5,
+}
+
+const el = <K extends keyof HTMLElementTagNameMap>(
+  tag: K,
+  className?: string,
+  text?: string,
+): HTMLElementTagNameMap[K] => {
+  const node = document.createElement(tag)
+  if (className !== undefined) node.className = className
+  if (text !== undefined) node.textContent = text
+  return node
+}
+
+const readable = (value: string): string =>
+  value.replace(/[_-]+/g, " ").replace(/\b\w/g, char => char.toUpperCase())
+
+const stableRefText = (value: string | null): string =>
+  value === null || value.trim() === "" ? "unavailable" : value
+
+const readinessNeedsHuman = (readiness: string): boolean => {
+  const value = readiness.toLowerCase()
+  return value.includes("credential") || value.includes("missing") || value.includes("error")
+}
+
+const assignmentResumeCommand = (assignmentRef: string): string =>
+  `khala closeout ${assignmentRef} --json`
+
+export const projectUnifiedInbox = (
+  source: UnifiedInboxSource,
+): UnifiedInboxProjection => {
+  const observedAt = source.fleet.observedAt
+  const items: UnifiedInboxItem[] = []
+
+  if (!source.pylon.available || source.fleet.pylon.status === "unavailable") {
+    items.push({
+      ref: "inbox.runtime.pylon.unavailable",
+      kind: "run_blocked",
+      title: "Pylon unavailable",
+      summary: source.pylon.reason || source.fleet.pylon.message,
+      source: "runtime",
+      severity: "critical",
+      observedAt,
+      actions: ["open_fleet", "refresh"],
+    })
+  }
+
+  for (const account of source.fleet.accounts) {
+    if (!readinessNeedsHuman(account.readiness)) continue
+    items.push({
+      ref: `inbox.credential.${account.accountRef}`,
+      kind: "missing_credential",
+      title: `${account.accountRef} needs reconnect`,
+      summary: account.email === null
+        ? `Codex account ${account.accountRef} is not signed in.`
+        : `${account.email} is not ready: ${account.readiness}.`,
+      source: "fleet",
+      severity: "critical",
+      observedAt,
+      accountRef: account.accountRef,
+      actions: ["reconnect", "open_fleet"],
+    })
+  }
+
+  for (const assignment of source.fleet.activeAssignments) {
+    const assignmentRef = assignment.assignmentRef
+    items.push({
+      ref: `inbox.assignment.${stableRefText(assignmentRef)}.${stableRefText(assignment.issueRef)}`,
+      kind: "ready_for_review",
+      title: assignment.issueRef === null
+        ? "Assignment needs review"
+        : `${assignment.issueRef} needs review`,
+      summary: assignmentRef === null
+        ? "An active assignment was reported without a public assignment ref."
+        : "Review the closeout/proof projection before accepting the next step.",
+      source: "assignment",
+      severity: "info",
+      observedAt: assignment.updatedAt ?? observedAt,
+      ...(assignmentRef === null ? {} : {
+        assignmentRef,
+        resumeCommand: assignmentResumeCommand(assignmentRef),
+      }),
+      ...(assignment.issueRef === null ? {} : { issueRef: assignment.issueRef }),
+      actions: assignmentRef === null
+        ? ["open_fleet", "refresh"]
+        : ["resume", "open_fleet", "refresh"],
+    })
+  }
+
+  if (source.coding.status === "error" || source.coding.status === "unavailable") {
+    items.push({
+      ref: "inbox.runtime.coding.blocked",
+      kind: "run_blocked",
+      title: "Coding runtime blocked",
+      summary: source.coding.reason,
+      source: "runtime",
+      severity: "critical",
+      observedAt: source.coding.observedAt,
+      actions: ["refresh"],
+    })
+  }
+
+  const coverage = [
+    {
+      source: "approval queue",
+      status: "not_connected" as const,
+      summary: "Pylon permission prompts are not exposed through the desktop RPC yet.",
+    },
+    {
+      source: "MCP failures",
+      status: "not_connected" as const,
+      summary: "MCP tool failure routing needs a desktop projection before it can create Inbox items.",
+    },
+    {
+      source: "memory and skill updates",
+      status: "not_connected" as const,
+      summary: "Staged worker memory/skill diffs are not persisted as desktop queue rows yet.",
+    },
+    {
+      source: "fleet readiness",
+      status: "connected" as const,
+      summary: "Codex account readiness, Pylon state, and assignment markers are projected locally.",
+    },
+  ]
+
+  return {
+    ok: source.fleet.ok && source.pylon.ok && source.coding.ok && source.tokenAccounting.ok,
+    observedAt,
+    items: items.sort((left, right) =>
+      itemPriority[left.kind] - itemPriority[right.kind] ||
+      left.title.localeCompare(right.title)
+    ),
+    coverage,
+  }
+}
+
+const countByKind = (
+  items: readonly UnifiedInboxItem[],
+  kind: UnifiedInboxItemKind,
+): number => items.filter(item => item.kind === kind).length
+
+const itemKindLabel = (kind: UnifiedInboxItemKind): string => readable(kind)
+
+const renderAction = (
+  item: UnifiedInboxItem,
+  action: UnifiedInboxItemAction,
+  handlers: Handlers,
+): HTMLButtonElement => {
+  const button = el("button", "khala-inbox-action", readable(action))
+  button.type = "button"
+  button.dataset.action = action
+  button.addEventListener("click", () => {
+    if (action === "open_fleet") handlers.onOpenFleet()
+    if (action === "reconnect" && item.accountRef !== undefined) {
+      handlers.onReconnectAccount(item.accountRef)
+    }
+    if (action === "refresh") handlers.onRefresh()
+    if (action === "resume" && item.resumeCommand !== undefined) {
+      void navigator.clipboard?.writeText(item.resumeCommand)
+      button.textContent = "Copied"
+      window.setTimeout(() => {
+        button.textContent = readable(action)
+      }, 1400)
+    }
+  })
+  if (
+    (action === "reconnect" && item.accountRef === undefined) ||
+    (action === "resume" && item.resumeCommand === undefined)
+  ) {
+    button.disabled = true
+  }
+  return button
+}
+
+const renderItem = (item: UnifiedInboxItem, handlers: Handlers): HTMLElement => {
+  const row = el("article", "khala-inbox-item")
+  row.dataset.kind = item.kind
+  row.dataset.severity = item.severity
+
+  const marker = el("span", "khala-inbox-marker", itemKindLabel(item.kind))
+  const body = el("div", "khala-inbox-item-body")
+  body.append(el("h3", "khala-inbox-item-title", item.title))
+  body.append(el("p", "khala-inbox-item-summary", item.summary))
+
+  const meta = el("div", "khala-inbox-meta")
+  meta.append(el("span", undefined, item.source))
+  if (item.assignmentRef !== undefined) meta.append(el("span", undefined, item.assignmentRef))
+  if (item.accountRef !== undefined) meta.append(el("span", undefined, item.accountRef))
+  body.append(meta)
+
+  if (item.resumeCommand !== undefined) {
+    const command = el("code", "khala-inbox-command", item.resumeCommand)
+    body.append(command)
+  }
+
+  const actions = el("div", "khala-inbox-actions")
+  for (const action of item.actions) {
+    actions.append(renderAction(item, action, handlers))
+  }
+
+  row.append(marker, body, actions)
+  return row
+}
+
+const renderReady = (
+  container: HTMLElement,
+  data: UnifiedInboxProjection,
+  handlers: Handlers,
+): void => {
+  const summary = el("section", "khala-inbox-summary")
+  summary.append(
+    el("span", "khala-inbox-count", String(data.items.length)),
+    el("span", undefined, data.items.length === 1 ? "item needs a human" : "items need a human"),
+  )
+  const chips = el("div", "khala-inbox-chips")
+  for (const kind of [
+    "approval_required",
+    "run_blocked",
+    "missing_credential",
+    "ready_for_review",
+  ] as const) {
+    chips.append(el("span", "khala-inbox-chip", `${readable(kind)} ${countByKind(data.items, kind)}`))
+  }
+  summary.append(chips)
+  container.append(summary)
+
+  if (data.items.length === 0) {
+    container.append(
+      el("p", "khala-inbox-empty", "No projected Inbox items need action right now."),
+    )
+  } else {
+    const list = el("div", "khala-inbox-list")
+    for (const item of data.items) list.append(renderItem(item, handlers))
+    container.append(list)
+  }
+
+  const coverage = el("section", "khala-inbox-coverage")
+  coverage.append(el("h3", "khala-inbox-section-title", "Source coverage"))
+  for (const source of data.coverage) {
+    const row = el("div", "khala-inbox-coverage-row")
+    row.dataset.status = source.status
+    row.append(
+      el("strong", undefined, source.source),
+      el("span", undefined, source.summary),
+    )
+    coverage.append(row)
+  }
+  container.append(coverage)
+}
+
+const render = (
+  container: HTMLElement,
+  view: InboxView,
+  handlers: Handlers,
+): void => {
+  container.replaceChildren()
+
+  const header = el("header", "khala-inbox-header")
+  const title = el("div")
+  title.append(el("h2", "khala-inbox-title", "Unified Inbox"))
+  title.append(
+    el("p", "khala-inbox-subtitle", "Approvals, blockers, review-ready runs, and fleet fixes in one queue."),
+  )
+  header.append(title)
+  const refresh = el("button", "khala-inbox-refresh", view.phase === "loading" ? "Loading..." : "Refresh")
+  refresh.type = "button"
+  refresh.disabled = view.phase === "loading"
+  refresh.addEventListener("click", handlers.onRefresh)
+  header.append(refresh)
+  container.append(header)
+
+  const body = el("div", "khala-inbox-body")
+  if (view.phase === "loading") {
+    body.append(el("p", "khala-inbox-empty", "Projecting queue items..."))
+  } else if (view.phase === "error") {
+    body.append(el("p", "khala-inbox-error", `Could not load Inbox: ${view.message}`))
+  } else {
+    renderReady(body, view.data, handlers)
+  }
+  container.append(body)
+}
+
+export const mountUnifiedInboxPanel = (
+  container: HTMLElement,
+  options: UnifiedInboxPanelOptions,
+): UnifiedInboxPanelHandle => {
+  let inFlight = false
+  let visible = false
+  let pollTimer = 0
+  let lastData: UnifiedInboxProjection | null = null
+
+  const currentView = (): InboxView =>
+    lastData === null ? { phase: "loading" } : { phase: "ready", data: lastData }
+
+  const handlers: Handlers = {
+    onRefresh: () => void refresh(),
+    onOpenFleet: options.onOpenFleet,
+    onReconnectAccount: options.onReconnectAccount,
+  }
+
+  const paint = (): void => render(container, currentView(), handlers)
+
+  const refresh = async (): Promise<void> => {
+    if (inFlight) return
+    inFlight = true
+    if (lastData === null) paint()
+    try {
+      lastData = projectUnifiedInbox(await options.fetch())
+      paint()
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      render(container, { phase: "error", message }, handlers)
+    } finally {
+      inFlight = false
+    }
+  }
+
+  const setVisible = (next: boolean): void => {
+    visible = next
+    window.clearInterval(pollTimer)
+    if (!next) return
+    void refresh()
+    pollTimer = window.setInterval(() => {
+      if (visible && !inFlight) void refresh()
+    }, 5000)
+  }
+
+  paint()
+  return { refresh, setVisible }
+}

--- a/clients/khala-code-desktop/src/ui/index.html
+++ b/clients/khala-code-desktop/src/ui/index.html
@@ -123,6 +123,12 @@
         hidden
       ></section>
       <section
+        id="inbox-panel"
+        class="khala-code-inbox"
+        aria-label="Unified Inbox"
+        hidden
+      ></section>
+      <section
         id="gym-panel"
         class="khala-code-gym"
         aria-label="Gym delegation graph"

--- a/clients/khala-code-desktop/src/ui/main.ts
+++ b/clients/khala-code-desktop/src/ui/main.ts
@@ -43,6 +43,7 @@ import {
 } from "../shared/rpc"
 import { renderMessageBody } from "./transcript-render"
 import { mountFleetPanel } from "./fleet-status"
+import { mountUnifiedInboxPanel } from "./inbox"
 import {
   gymPaneStateFromBridgeProof,
   gymPaneStateFromLocation,
@@ -1175,6 +1176,7 @@ mountComposerHud()
 
 const sidebarRoot = document.getElementById("sidebar-root")
 const fleetPanelEl = document.getElementById("fleet-panel")
+const inboxPanelEl = document.getElementById("inbox-panel")
 const gymPanelEl = document.getElementById("gym-panel")
 const threadShell = document.querySelector<HTMLElement>(".khala-code-thread-shell")
 const composerDock = document.querySelector<HTMLElement>(".composer-dock")
@@ -1191,19 +1193,44 @@ const fleetPanel =
         openExternal: url => controls.openExternalUrl(url),
       })
 
+const showFleetPanel = (): void => {
+  setActiveView("fleet")
+}
+
+const inboxPanel =
+  inboxPanelEl === null
+    ? null
+    : mountUnifiedInboxPanel(inboxPanelEl, {
+        fetch: async () => ({
+          fleet: await controls.codexFleetStatus(),
+          pylon: await controls.pylonStatus(),
+          coding: await controls.codingStatus(),
+          tokenAccounting: await controls.tokenAccountingStatus(),
+        }),
+        onOpenFleet: showFleetPanel,
+        onReconnectAccount: accountRef => {
+          showFleetPanel()
+          void controls.connectCodexAccount(accountRef)
+          void fleetPanel?.refresh()
+        },
+      })
+
 const gymPanel =
   gymPanelEl === null ? null : mountGymPane(gymPanelEl, initialGymState)
 
 const setActiveView = (value: string): void => {
+  const showInbox = value === "inbox"
   const showFleet = value === "fleet"
   const showGym = value === "gym"
+  if (inboxPanelEl !== null) inboxPanelEl.hidden = !showInbox
   if (fleetPanelEl !== null) fleetPanelEl.hidden = !showFleet
   gymPanel?.setVisible(showGym)
-  if (threadShell !== null) threadShell.hidden = showFleet || showGym
-  if (composerDock !== null) composerDock.hidden = showFleet || showGym
+  if (threadShell !== null) threadShell.hidden = showInbox || showFleet || showGym
+  if (composerDock !== null) composerDock.hidden = showInbox || showFleet || showGym
   // setVisible starts/stops the live 5s poll so the panel updates on its own.
+  inboxPanel?.setVisible(showInbox)
   fleetPanel?.setVisible(showFleet)
-  if (!showFleet && !showGym && value === "chat") {
+  if (!showInbox && !showFleet && !showGym && value === "chat") {
     requestAnimationFrame(focusComposerInput)
   }
 }

--- a/clients/khala-code-desktop/src/ui/sidebar.ts
+++ b/clients/khala-code-desktop/src/ui/sidebar.ts
@@ -42,6 +42,7 @@ const navGroups = (): ReadonlyArray<SidebarViewGroup<SidebarNavMessage>> => [
     label: "Khala Code",
     items: [
       { value: "chat", children: ["Chat"] },
+      { value: "inbox", children: ["Inbox"] },
       { value: "fleet", children: ["Fleet status"] },
       { value: "gym", children: ["Gym"] },
     ],

--- a/clients/khala-code-desktop/src/ui/styles.css
+++ b/clients/khala-code-desktop/src/ui/styles.css
@@ -784,6 +784,7 @@ button {
 @media (min-width: 768px) {
   .khala-code-thread-shell,
   .composer-dock,
+  .khala-code-inbox,
   .khala-code-fleet,
   .khala-code-gym {
     margin-left: var(--sidebar-width);
@@ -814,6 +815,230 @@ button {
   background: var(--oa-color-component-surface-active);
   color: var(--oa-color-accent);
   box-shadow: inset 2px 0 0 var(--oa-color-accent);
+}
+
+/* Unified Inbox — one operator queue for human attention items projected from
+   existing local-safe fleet/runtime sources. */
+.khala-code-inbox {
+  grid-column: 1;
+  grid-row: 1 / 3;
+  min-height: 0;
+  overflow-y: auto;
+  padding: 1.4rem 1.6rem 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.15rem;
+  color: var(--oa-color-component-text);
+}
+.khala-inbox-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+}
+.khala-inbox-title {
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 600;
+}
+.khala-inbox-subtitle {
+  max-width: 58ch;
+  margin: 0.35rem 0 0;
+  color: color-mix(in srgb, var(--oa-color-component-text) 62%, transparent);
+  font-size: 0.78rem;
+  line-height: 1.5;
+}
+.khala-inbox-refresh,
+.khala-inbox-action {
+  font: inherit;
+  border: 1px solid var(--oa-color-component-border);
+  background: var(--oa-color-component-surface);
+  color: var(--oa-color-component-text);
+  cursor: pointer;
+  transition: background 120ms ease, border-color 120ms ease, color 120ms ease;
+}
+.khala-inbox-refresh {
+  flex: 0 0 auto;
+  padding: 0.35rem 0.8rem;
+  border-radius: 0.4rem;
+  font-size: 0.78rem;
+}
+.khala-inbox-action {
+  padding: 0.28rem 0.6rem;
+  border-radius: 0.35rem;
+  font-size: 0.72rem;
+}
+.khala-inbox-refresh:hover,
+.khala-inbox-action:hover {
+  border-color: rgba(79, 208, 255, 0.4);
+  background: var(--oa-color-component-surface-active);
+}
+.khala-inbox-refresh:disabled,
+.khala-inbox-action:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+.khala-inbox-body,
+.khala-inbox-list,
+.khala-inbox-coverage {
+  display: flex;
+  flex-direction: column;
+}
+.khala-inbox-body {
+  gap: 1rem;
+}
+.khala-inbox-summary {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.75rem 0.85rem;
+  border: 1px solid rgba(79, 208, 255, 0.22);
+  border-radius: 0.55rem;
+  background: rgba(79, 208, 255, 0.05);
+  color: color-mix(in srgb, var(--oa-color-component-text) 76%, transparent);
+  font-size: 0.78rem;
+}
+.khala-inbox-count {
+  color: #cdeeff;
+  font-size: 1.05rem;
+  font-weight: 700;
+}
+.khala-inbox-chips,
+.khala-inbox-actions,
+.khala-inbox-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+.khala-inbox-chip,
+.khala-inbox-marker,
+.khala-inbox-meta span {
+  border: 1px solid var(--oa-color-component-border);
+  background: var(--oa-color-component-surface);
+  color: color-mix(in srgb, var(--oa-color-component-text) 66%, transparent);
+  font-size: 0.7rem;
+}
+.khala-inbox-chip,
+.khala-inbox-marker {
+  border-radius: 999px;
+  padding: 0.2rem 0.5rem;
+  white-space: nowrap;
+}
+.khala-inbox-list {
+  gap: 0.55rem;
+}
+.khala-inbox-item {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  gap: 0.7rem;
+  align-items: start;
+  padding: 0.75rem 0.85rem;
+  border: 1px solid var(--oa-color-component-border);
+  border-radius: 0.55rem;
+  background: var(--oa-color-component-surface);
+}
+.khala-inbox-item[data-severity="critical"] {
+  border-color: rgba(248, 113, 113, 0.34);
+}
+.khala-inbox-item[data-severity="warning"] {
+  border-color: rgba(251, 191, 36, 0.34);
+}
+.khala-inbox-marker {
+  margin-top: 0.05rem;
+  color: #9be0ff;
+  border-color: rgba(79, 208, 255, 0.28);
+  background: rgba(79, 208, 255, 0.08);
+}
+.khala-inbox-item-body {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+.khala-inbox-item-title {
+  margin: 0;
+  font-size: 0.9rem;
+  font-weight: 600;
+}
+.khala-inbox-item-summary,
+.khala-inbox-empty,
+.khala-inbox-error {
+  margin: 0;
+  font-size: 0.8rem;
+  line-height: 1.5;
+}
+.khala-inbox-item-summary,
+.khala-inbox-empty {
+  color: color-mix(in srgb, var(--oa-color-component-text) 66%, transparent);
+}
+.khala-inbox-error {
+  color: var(--oa-color-danger);
+}
+.khala-inbox-meta span {
+  padding: 0.18rem 0.45rem;
+  border-radius: 0.3rem;
+  font-variant-numeric: tabular-nums;
+}
+.khala-inbox-command {
+  width: fit-content;
+  max-width: 100%;
+  overflow-wrap: anywhere;
+  padding: 0.22rem 0.45rem;
+  border-radius: 0.3rem;
+  border: 1px solid #1d2a44;
+  background: #05080e;
+  color: #d7e2f0;
+  font-size: 0.72rem;
+}
+.khala-inbox-section-title {
+  margin: 0 0 0.25rem;
+  font-size: 0.68rem;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: color-mix(in srgb, var(--oa-color-component-text) 48%, transparent);
+}
+.khala-inbox-coverage {
+  gap: 0.45rem;
+}
+.khala-inbox-coverage-row {
+  display: grid;
+  grid-template-columns: minmax(8rem, 0.28fr) minmax(0, 1fr);
+  gap: 0.75rem;
+  align-items: start;
+  padding: 0.55rem 0.65rem;
+  border: 1px solid var(--oa-color-component-border);
+  border-radius: 0.45rem;
+  background: rgba(255, 255, 255, 0.02);
+  font-size: 0.74rem;
+}
+.khala-inbox-coverage-row strong {
+  color: var(--oa-color-component-text);
+  font-weight: 600;
+}
+.khala-inbox-coverage-row span {
+  color: color-mix(in srgb, var(--oa-color-component-text) 58%, transparent);
+  line-height: 1.45;
+}
+.khala-inbox-coverage-row[data-status="not_connected"] strong {
+  color: #fbbf24;
+}
+@media (max-width: 860px) {
+  .khala-inbox-summary,
+  .khala-inbox-header {
+    align-items: stretch;
+    flex-direction: column;
+  }
+  .khala-inbox-item {
+    grid-template-columns: minmax(0, 1fr);
+  }
+  .khala-inbox-actions {
+    justify-content: flex-start;
+  }
+  .khala-inbox-coverage-row {
+    grid-template-columns: minmax(0, 1fr);
+  }
 }
 
 /* Fleet status panel — occupies the chat content column when "Fleet status" is

--- a/clients/khala-code-desktop/tests/app-shell.test.ts
+++ b/clients/khala-code-desktop/tests/app-shell.test.ts
@@ -10,6 +10,7 @@ import {
   parseMessageSegments,
   parseToolTranscript,
 } from "../src/ui/transcript-render"
+import { projectUnifiedInbox } from "../src/ui/inbox"
 
 describe("khala code desktop app shell", () => {
   test("registers the Khala Code desktop view", () => {
@@ -40,9 +41,99 @@ describe("khala code desktop app shell", () => {
     expect(html).toContain("data-oa-command-composer-native-editing")
     expect(html).toContain("autofocus")
     expect(html).toContain('id="send-button"')
+    expect(html).toContain('id="inbox-panel"')
     expect(html).toContain('id="fleet-panel"')
     expect(html).toContain('id="gym-panel"')
     expect(html).not.toContain("Pylons")
+  })
+
+  test("wires the Unified Inbox shell and local-safe projection", async () => {
+    const html = await Bun.file(new URL("../src/ui/index.html", import.meta.url)).text()
+    const sidebar = await Bun.file(new URL("../src/ui/sidebar.ts", import.meta.url)).text()
+    const main = await Bun.file(new URL("../src/ui/main.ts", import.meta.url)).text()
+    const css = await Bun.file(new URL("../src/ui/styles.css", import.meta.url)).text()
+
+    expect(sidebar).toContain('{ value: "inbox", children: ["Inbox"] }')
+    expect(html).toContain('aria-label="Unified Inbox"')
+    expect(main).toContain("mountUnifiedInboxPanel")
+    expect(main).toContain('const showInbox = value === "inbox"')
+    expect(main).toContain("inboxPanel?.setVisible(showInbox)")
+    expect(css).toContain(".khala-code-inbox")
+    expect(css).toContain(".khala-inbox-coverage-row[data-status=\"not_connected\"]")
+
+    const projection = projectUnifiedInbox({
+      fleet: {
+        ok: false,
+        observedAt: "2026-06-30T00:00:00.000Z",
+        pylon: {
+          status: "unavailable",
+          pylonRef: null,
+          message: "Pylon offline",
+        },
+        availableCodexAssignments: null,
+        maxCodexAssignments: null,
+        accounts: [{
+          accountRef: "codex-2",
+          provider: "codex",
+          readiness: "credentials_missing",
+          quotaState: null,
+          accountKey: null,
+          email: null,
+        }],
+        activeAssignments: [{
+          assignmentRef: "assignment.khala.demo",
+          issueRef: "github.issue.openagents.7760",
+          updatedAt: "2026-06-30T00:01:00.000Z",
+        }],
+        processes: [],
+      },
+      pylon: {
+        ok: true,
+        app: "Khala Code Desktop",
+        available: false,
+        capability: "pylon",
+        observedAt: "2026-06-30T00:00:00.000Z",
+        reason: "Pylon offline",
+        status: "unavailable",
+      },
+      coding: {
+        ok: true,
+        app: "Khala Code Desktop",
+        available: true,
+        capability: "coding",
+        observedAt: "2026-06-30T00:00:00.000Z",
+        reason: "ready",
+        status: "ready",
+      },
+      tokenAccounting: {
+        ok: true,
+        app: "Khala Code Desktop",
+        available: false,
+        capability: "token_accounting",
+        observedAt: "2026-06-30T00:00:00.000Z",
+        reason: "not configured",
+        status: "not_configured",
+      },
+    })
+
+    expect(projection.items.map(item => item.kind)).toEqual([
+      "run_blocked",
+      "missing_credential",
+      "ready_for_review",
+    ])
+    expect(projection.items[1]).toMatchObject({
+      accountRef: "codex-2",
+      actions: ["reconnect", "open_fleet"],
+    })
+    expect(projection.items[2]).toMatchObject({
+      assignmentRef: "assignment.khala.demo",
+      resumeCommand: "khala closeout assignment.khala.demo --json",
+    })
+    expect(projection.coverage).toContainEqual({
+      source: "approval queue",
+      status: "not_connected",
+      summary: "Pylon permission prompts are not exposed through the desktop RPC yet.",
+    })
   })
 
   test("renders a visible Gym pane entry without seeded private proof data", async () => {


### PR DESCRIPTION
Addresses (no linked issue).

### Changes
- Adds an Inbox entry to the Khala Code sidebar and routes `view=inbox` deep links to the new view.
- Mounts a unified inbox panel that aggregates fleet, Pylon, coding, and token accounting status from existing UI controls.
- Adds inbox panel markup, styling, refresh/action states, and tests for the app shell behavior.

### Verification
- `bun test clients/khala-code-desktop/tests/khala-codex-fleet-tools.test.ts apps/pylon/src/khala-spawn.test.ts apps/pylon/tests/khala-spawn.test.ts apps/pylon/src/presence-codex-account-capacity.test.ts apps/pylon/tests/presence.test.ts`
- Result: passed (exit 0)