### PR TITLE
fix(pylon): normalize orchestration runner aliases

### DIFF
--- a/apps/pylon/src/agent-runner-registry.ts
+++ b/apps/pylon/src/agent-runner-registry.ts
@@ -34,6 +34,7 @@ import type { PylonAssignmentLease } from "./assignment.js"
 import type { PylonLocalState } from "./state.js"
 
 export type AgentRunnerKind = "claude_agent" | "codex"
+export type LegacyAgentRunnerKind = "claude"
 export type AgentRunnerTaskAgentKind =
   | typeof CLAUDE_AGENT_TASK_AGENT_KIND
   | typeof CODEX_AGENT_TASK_AGENT_KIND
@@ -224,6 +225,16 @@ export const AGENT_RUNNER_REGISTRY: ReadonlyArray<AgentRunnerDescriptor> = [
       } satisfies CodexAgentExecutionOptions),
   },
 ]
+
+export const AGENT_RUNNER_KINDS = AGENT_RUNNER_REGISTRY.map((runner) => runner.kind) as readonly AgentRunnerKind[]
+
+export function isAgentRunnerKind(kind: string): kind is AgentRunnerKind {
+  return AGENT_RUNNER_KINDS.includes(kind as AgentRunnerKind)
+}
+
+export function normalizeAgentRunnerKind(kind: AgentRunnerKind | LegacyAgentRunnerKind): AgentRunnerKind {
+  return kind === "claude" ? "claude_agent" : kind
+}
 
 export function agentRunnerForAdapterKind(
   adapterKind: AgentRuntimeAdapterKind,

--- a/apps/pylon/src/orchestration/groups.ts
+++ b/apps/pylon/src/orchestration/groups.ts
@@ -1,5 +1,5 @@
 import type { DispatchContext, OrchestrationRunnerKind } from "./store.js"
-import { normalizeOrchestrationRunnerKind } from "./store.js"
+import { isStoredOrchestrationRunnerKind, normalizeOrchestrationRunnerKind } from "./store.js"
 
 export type OrchestrationGroupAddress =
   | { kind: "all" }
@@ -14,7 +14,7 @@ export function parseOrchestrationGroupAddress(address: string): OrchestrationGr
   if (address.startsWith("@runner:")) {
     const rawRunnerKind = address.slice("@runner:".length).trim()
     if (rawRunnerKind.length === 0) throw new Error("empty @runner group address")
-    if (rawRunnerKind !== "codex" && rawRunnerKind !== "claude_agent" && rawRunnerKind !== "claude" && rawRunnerKind !== "generic") {
+    if (!isStoredOrchestrationRunnerKind(rawRunnerKind)) {
       throw new Error(`unsupported @runner group address: ${address}`)
     }
     return { kind: "runner", runnerKind: normalizeOrchestrationRunnerKind(rawRunnerKind) }

--- a/apps/pylon/src/orchestration/store.ts
+++ b/apps/pylon/src/orchestration/store.ts
@@ -1,6 +1,11 @@
 import type { Database } from "bun:sqlite"
 import { createHash } from "node:crypto"
-import type { AgentRunnerKind } from "../agent-runner-registry.js"
+import {
+  isAgentRunnerKind,
+  normalizeAgentRunnerKind,
+  type AgentRunnerKind,
+  type LegacyAgentRunnerKind,
+} from "../agent-runner-registry.js"
 
 export const ORCHESTRATION_SCHEMA_VERSION = 1
 
@@ -63,7 +68,7 @@ export type DispatchContextStatus =
   | "circuit_broken"
 
 export type OrchestrationRunnerKind = AgentRunnerKind | "generic"
-type StoredRunnerKind = OrchestrationRunnerKind | "claude"
+type StoredRunnerKind = OrchestrationRunnerKind | LegacyAgentRunnerKind
 
 export type DispatchContext = {
   id: string
@@ -101,7 +106,7 @@ export type CreateTaskInput = {
 export type CreateDispatchContextInput = {
   id: string
   assigneeHandle: string
-  runnerKind?: OrchestrationRunnerKind | "claude"
+  runnerKind?: OrchestrationRunnerKind | LegacyAgentRunnerKind
   worktreeId?: string | null
   worktreePath?: string | null
   maxConcurrentSlots?: number
@@ -132,8 +137,14 @@ const parseSpec = (value: string): OrchestrationTaskSpec => {
   }
 }
 
-export function normalizeOrchestrationRunnerKind(kind: OrchestrationRunnerKind | "claude"): OrchestrationRunnerKind {
-  return kind === "claude" ? "claude_agent" : kind
+export function normalizeOrchestrationRunnerKind(
+  kind: OrchestrationRunnerKind | LegacyAgentRunnerKind,
+): OrchestrationRunnerKind {
+  return kind === "generic" ? "generic" : normalizeAgentRunnerKind(kind)
+}
+
+export function isStoredOrchestrationRunnerKind(kind: string): kind is StoredRunnerKind {
+  return kind === "generic" || kind === "claude" || isAgentRunnerKind(kind)
 }
 
 type TaskRow = {

--- a/apps/pylon/src/orchestration/supervisor-orchestration.test.ts
+++ b/apps/pylon/src/orchestration/supervisor-orchestration.test.ts
@@ -2,8 +2,12 @@ import { describe, expect, test } from "bun:test"
 import { Database } from "bun:sqlite"
 
 import { dispatchEligibility, dispatchLiveness, dispatchReadySupervisorTasks } from "./coordinator.js"
-import { resolveOrchestrationGroup } from "./groups.js"
-import { createPylonOrchestrationStore } from "./store.js"
+import { parseOrchestrationGroupAddress, resolveOrchestrationGroup } from "./groups.js"
+import {
+  createPylonOrchestrationStore,
+  isStoredOrchestrationRunnerKind,
+  normalizeOrchestrationRunnerKind,
+} from "./store.js"
 
 const baseTaskSpec = {
   title: "Issue #6405",
@@ -133,6 +137,22 @@ describe("Pylon supervisor orchestration store", () => {
     expect(store.getTask("task.claude")?.status).toBe("dispatched")
   })
 
+  test("normalizes legacy runner aliases through the AgentRunner registry vocabulary", () => {
+    const store = createPylonOrchestrationStore(new Database(":memory:"))
+    const context = store.createDispatchContext({
+      id: "ctx.legacy-claude",
+      assigneeHandle: "claude-legacy",
+      runnerKind: "claude",
+      lastHeartbeatAt: new Date("2026-06-27T12:00:00.000Z"),
+    })
+
+    expect(context.runnerKind).toBe("claude_agent")
+    expect(normalizeOrchestrationRunnerKind("claude")).toBe("claude_agent")
+    expect(isStoredOrchestrationRunnerKind("claude_agent")).toBe(true)
+    expect(isStoredOrchestrationRunnerKind("claude")).toBe(true)
+    expect(isStoredOrchestrationRunnerKind("opencode")).toBe(false)
+  })
+
   test("refuses an otherwise healthy idle context when the ready task requires another runner", () => {
     const now = new Date("2026-06-27T12:00:00.000Z")
     const store = createPylonOrchestrationStore(new Database(":memory:"))
@@ -257,5 +277,9 @@ describe("Pylon supervisor group addressing", () => {
     expect(resolveOrchestrationGroup("@runner:claude_agent", contexts).map((context) => context.id)).toEqual(["ctx.b"])
     expect(resolveOrchestrationGroup("@worktree:wt-b", contexts).map((context) => context.id)).toEqual(["ctx.b"])
     expect(resolveOrchestrationGroup("@codex-1", contexts).map((context) => context.id)).toEqual(["ctx.a"])
+    expect(parseOrchestrationGroupAddress("@runner:generic")).toEqual({ kind: "runner", runnerKind: "generic" })
+    expect(() => parseOrchestrationGroupAddress("@runner:opencode")).toThrow(
+      "unsupported @runner group address: @runner:opencode",
+    )
   })
 })

--- a/apps/pylon/tests/agent-runtime-adapter.test.ts
+++ b/apps/pylon/tests/agent-runtime-adapter.test.ts
@@ -20,10 +20,13 @@ import {
   type AgentRuntimeRunRequest,
 } from "../src/agent-runtime-adapter"
 import {
+  AGENT_RUNNER_KINDS,
   AGENT_RUNNER_REGISTRY,
   agentRunnerForLease,
   agentRunnerResolutionForLease,
   agentRunnerServiceForLease,
+  isAgentRunnerKind,
+  normalizeAgentRunnerKind,
 } from "../src/agent-runner-registry"
 import { createBootstrapSummary, parseBootstrapArgs } from "../src/bootstrap"
 import { CLAUDE_AGENT_SDK_PACKAGE } from "../src/claude-agent"
@@ -112,6 +115,12 @@ async function withRequest<T>(
 
 describe("AgentRuntimeAdapter", () => {
   test("Claude and Codex runners are selected from the declarative registry", () => {
+    expect(AGENT_RUNNER_KINDS).toEqual(["claude_agent", "codex"])
+    expect(isAgentRunnerKind("claude_agent")).toBe(true)
+    expect(isAgentRunnerKind("codex")).toBe(true)
+    expect(isAgentRunnerKind("generic")).toBe(false)
+    expect(normalizeAgentRunnerKind("claude")).toBe("claude_agent")
+
     expect(
       AGENT_RUNNER_REGISTRY.map((runner) => ({
         agentKind: runner.agentKind,


### PR DESCRIPTION
Addresses (no linked issue).

### Changes
- Added shared AgentRunner registry helpers for known runner kinds and legacy `claude` normalization.
- Reused the registry vocabulary in orchestration runner normalization and group address validation.
- Added tests for legacy runner alias handling, generic runner group parsing, unsupported runner rejection, and registry helper behavior.

### Verification
- `bun test clients/khala-code-desktop/tests/khala-codex-fleet-tools.test.ts apps/pylon/src/khala-spawn.test.ts apps/pylon/tests/khala-spawn.test.ts apps/pylon/src/presence-codex-account-capacity.test.ts apps/pylon/tests/presence.test.ts`
- Result: passed (exit 0)