### PR TITLE
feat(khala-code): render fleet board in status panel

### DIFF
--- a/clients/khala-code-desktop/src/ui/fleet-board-projection.ts
+++ b/clients/khala-code-desktop/src/ui/fleet-board-projection.ts
@@ -1,0 +1,694 @@
+import {
+  graphLinkStatusForRefs,
+  graphPublicSafetyCheckRefPattern,
+  graphSafeRefPattern,
+  type GraphDatum,
+  type GraphLink,
+  type GraphNode,
+  type GraphNodeStatus,
+  type GraphPin,
+  type GraphPinDirection,
+  type GraphSpec,
+} from "@openagentsinc/arbiter-effect"
+
+import type {
+  KhalaCodeDesktopFleetAccount,
+  KhalaCodeDesktopFleetAssignment,
+  KhalaCodeDesktopFleetProcess,
+  KhalaCodeDesktopFleetStatus,
+} from "../shared/rpc"
+
+export const KhalaFleetBoardProjectionSchemaVersion =
+  "openagents.khala_code.fleet_board_projection.v0"
+
+export type KhalaFleetTimelineEventStatus =
+  | "idle"
+  | "active"
+  | "blocked"
+  | "complete"
+
+export type KhalaFleetTimelineEvent = Readonly<{
+  id: string
+  label: string
+  status: KhalaFleetTimelineEventStatus
+  observedAt: string
+  subjectRef: string
+  detail: string
+  evidenceRefs: ReadonlyArray<string>
+  blockerRefs: ReadonlyArray<string>
+  caveatRefs: ReadonlyArray<string>
+}>
+
+export type KhalaFleetBoardProjection = Readonly<{
+  schemaVersion: typeof KhalaFleetBoardProjectionSchemaVersion
+  generatedAt: string
+  graph: GraphSpec
+  timeline: ReadonlyArray<KhalaFleetTimelineEvent>
+  summary: Readonly<{
+    readyAccounts: number
+    totalAccounts: number
+    activeAssignments: number
+    runningProcesses: number
+    availableCodexAssignments: number | null
+    maxCodexAssignments: number | null
+  }>
+  evidenceRefs: ReadonlyArray<string>
+  blockerRefs: ReadonlyArray<string>
+  caveatRefs: ReadonlyArray<string>
+  sourceRefs: ReadonlyArray<string>
+}>
+
+export type KhalaFleetBoardProjectionInput = Readonly<{
+  status: KhalaCodeDesktopFleetStatus
+  generatedAt?: string
+}>
+
+export class KhalaFleetBoardProjectionUnsafe extends Error {
+  override readonly name = "KhalaFleetBoardProjectionUnsafe"
+
+  constructor(readonly reason: string) {
+    super(reason)
+  }
+}
+
+const unsafePublicProjectionValue =
+  /\/Users\/|\/home\/|access[_-]?token|auth\.json|bearer |authorization:|cookie|credential|customer[_-]?(email|name|value)|email[_-]?(address|body)|gho_[A-Za-z0-9_]+|ghp_[A-Za-z0-9_]+|http:\/\/|https:\/\/|invoice|lnbc|lntb|lnbcrt|lno1|mnemonic|oauth|payment[_-]?(hash|id|preimage|proof)|preimage|private[_-]?(endpoint|repo|source)|provider[_-]?(grant|payload|secret|token)|raw[_-]?(auth|email|fixture|log|payload|prompt|provider|runner|source|trace|traces)|secret|(?:^|[^A-Za-z0-9])sk-[a-z0-9]|scratch[_-]?log|token|wallet/i
+
+const counterOnlyRefPattern = /(^|[.:/-])counter([.:/-]|$)|=\d+$/
+
+const collectStringValues = (value: unknown): ReadonlyArray<string> => {
+  if (typeof value === "string") return [value]
+  if (Array.isArray(value)) return value.flatMap(item => collectStringValues(item))
+  if (value !== null && typeof value === "object") {
+    return Object.values(value).flatMap(item => collectStringValues(item))
+  }
+  return []
+}
+
+const isPublicSafeString = (value: string): boolean =>
+  graphPublicSafetyCheckRefPattern.test(value) ||
+  !unsafePublicProjectionValue.test(value)
+
+const assertProjectionPublicSafe = (
+  projection: KhalaFleetBoardProjection,
+): void => {
+  const unsafe = collectStringValues(projection).find(value => !isPublicSafeString(value))
+  if (unsafe !== undefined) {
+    throw new KhalaFleetBoardProjectionUnsafe(
+      `Fleet board projection leaked private material: ${unsafe}`,
+    )
+  }
+}
+
+const uniqueRefs = (
+  refs: ReadonlyArray<string | null | undefined>,
+): ReadonlyArray<string> =>
+  [
+    ...new Set(
+      refs
+        .flatMap(ref => (ref === undefined || ref === null ? [] : [ref.trim()]))
+        .filter(ref => ref !== ""),
+    ),
+  ].sort()
+
+const isSafeRef = (value: string): boolean =>
+  graphSafeRefPattern.test(value) &&
+  (graphPublicSafetyCheckRefPattern.test(value) ||
+    !unsafePublicProjectionValue.test(value))
+
+const publicRefs = (
+  refs: ReadonlyArray<string | null | undefined>,
+): ReadonlyArray<string> =>
+  uniqueRefs(refs).filter(ref => !counterOnlyRefPattern.test(ref) && isSafeRef(ref))
+
+const refOrFallback = (
+  value: string | null | undefined,
+  fallback: string,
+): string => {
+  const ref = value?.trim()
+  if (ref !== undefined && ref !== "" && isSafeRef(ref)) return ref
+  return fallback
+}
+
+const safeLabel = (value: string | null | undefined, fallback: string): string => {
+  const label = value?.trim()
+  if (
+    label !== undefined &&
+    label !== "" &&
+    label.length <= 64 &&
+    isPublicSafeString(label) &&
+    !label.includes("@") &&
+    !label.includes("/")
+  ) {
+    return label
+  }
+  return fallback
+}
+
+const accountState = (
+  account: KhalaCodeDesktopFleetAccount,
+): "ready" | "missing" | "degraded" => {
+  const value = account.readiness.toLowerCase()
+  if (value === "ready") return "ready"
+  if (value.includes("missing")) return "missing"
+  return "degraded"
+}
+
+const accountStateLabel = (
+  account: KhalaCodeDesktopFleetAccount,
+): "ready" | "missing sign-in" | "needs attention" => {
+  const state = accountState(account)
+  if (state === "ready") return "ready"
+  if (state === "missing") return "missing sign-in"
+  return "needs attention"
+}
+
+const pylonStatusLabel = (
+  status: KhalaCodeDesktopFleetStatus["pylon"]["status"],
+): "online" | "started" | "offline" =>
+  status === "unavailable" ? "offline" : status
+
+const pin = (
+  direction: GraphPinDirection,
+  id: string,
+  name: string,
+  type: string,
+): GraphPin => ({
+  direction,
+  id,
+  name,
+  type,
+})
+
+const datum = (
+  label: string,
+  value: string | number | boolean | null | undefined,
+  evidenceRefs: ReadonlyArray<string> = [],
+  unit?: string,
+): ReadonlyArray<GraphDatum> =>
+  value === undefined || value === null
+    ? []
+    : [{
+        label,
+        value,
+        evidenceRefs,
+        ...(unit === undefined ? {} : { unit }),
+      }]
+
+const node = (input: {
+  id: string
+  label: string
+  kind: string
+  status: GraphNodeStatus
+  inputs?: ReadonlyArray<GraphPin>
+  outputs?: ReadonlyArray<GraphPin>
+  datum?: ReadonlyArray<GraphDatum>
+  evidenceRefs?: ReadonlyArray<string>
+  blockerRefs?: ReadonlyArray<string>
+  caveatRefs?: ReadonlyArray<string>
+  x: number
+  y: number
+}): GraphNode => ({
+  id: input.id,
+  label: input.label,
+  kind: input.kind,
+  status: input.status,
+  inputs: [...(input.inputs ?? [])],
+  outputs: [...(input.outputs ?? [])],
+  datum: [...(input.datum ?? [])],
+  evidenceRefs: [...(input.evidenceRefs ?? [])],
+  blockerRefs: [...(input.blockerRefs ?? [])],
+  caveatRefs: [...(input.caveatRefs ?? [])],
+  position: { x: input.x, y: input.y },
+})
+
+const link = (input: {
+  id: string
+  label: string
+  fromNodeId: string
+  fromPinId: string
+  toNodeId: string
+  toPinId: string
+  evidenceRefs?: ReadonlyArray<string>
+  blockerRefs?: ReadonlyArray<string>
+  caveatRefs?: ReadonlyArray<string>
+}): GraphLink => {
+  const evidenceRefs = [...(input.evidenceRefs ?? [])]
+  const blockerRefs = [...(input.blockerRefs ?? [])]
+  return {
+    id: input.id,
+    label: input.label,
+    status: graphLinkStatusForRefs(evidenceRefs, blockerRefs),
+    from: { nodeId: input.fromNodeId, pinId: input.fromPinId },
+    to: { nodeId: input.toNodeId, pinId: input.toPinId },
+    evidenceRefs,
+    blockerRefs,
+    caveatRefs: [...(input.caveatRefs ?? [])],
+  }
+}
+
+const readyAccounts = (
+  accounts: ReadonlyArray<KhalaCodeDesktopFleetAccount>,
+): number => accounts.filter(account => accountState(account) === "ready").length
+
+const graphStatus = (
+  status: KhalaCodeDesktopFleetStatus,
+  readyAccountCount: number,
+): GraphNodeStatus => {
+  if (status.pylon.status === "unavailable") return "blocked"
+  if (status.accounts.length > 0 && readyAccountCount === 0) return "blocked"
+  if (status.activeAssignments.length > 0 || status.processes.length > 0) {
+    return "active"
+  }
+  return "complete"
+}
+
+const capacityNodeStatus = (
+  status: KhalaCodeDesktopFleetStatus,
+): GraphNodeStatus => {
+  if (status.pylon.status === "unavailable") return "blocked"
+  if (status.availableCodexAssignments === null || status.maxCodexAssignments === null) {
+    return "idle"
+  }
+  if (status.maxCodexAssignments === 0 || status.availableCodexAssignments === 0) {
+    return "blocked"
+  }
+  if (status.availableCodexAssignments < status.maxCodexAssignments) return "active"
+  return "complete"
+}
+
+const accountNodeStatus = (
+  accounts: ReadonlyArray<KhalaCodeDesktopFleetAccount>,
+): GraphNodeStatus => {
+  if (accounts.length === 0) return "idle"
+  if (readyAccounts(accounts) === 0) return "blocked"
+  if (readyAccounts(accounts) < accounts.length) return "active"
+  return "complete"
+}
+
+const activeNodeStatus = (
+  status: KhalaCodeDesktopFleetStatus,
+): GraphNodeStatus =>
+  status.activeAssignments.length > 0 || status.processes.length > 0
+    ? "active"
+    : "idle"
+
+const timelineEvent = (input: {
+  id: string
+  label: string
+  status: KhalaFleetTimelineEventStatus
+  observedAt: string | null | undefined
+  subjectRef: string
+  detail: string
+  evidenceRefs?: ReadonlyArray<string>
+  blockerRefs?: ReadonlyArray<string>
+  caveatRefs?: ReadonlyArray<string>
+}): KhalaFleetTimelineEvent => ({
+  id: input.id,
+  label: input.label,
+  status: input.status,
+  observedAt: input.observedAt ?? "time.khala_fleet_board.local",
+  subjectRef: input.subjectRef,
+  detail: input.detail,
+  evidenceRefs: [...(input.evidenceRefs ?? [])],
+  blockerRefs: [...(input.blockerRefs ?? [])],
+  caveatRefs: [...(input.caveatRefs ?? [])],
+})
+
+const assignmentRef = (
+  assignment: KhalaCodeDesktopFleetAssignment,
+  index: number,
+): string => refOrFallback(assignment.assignmentRef, `assignment.khala_fleet.pending.${index + 1}`)
+
+const issueRef = (
+  assignment: KhalaCodeDesktopFleetAssignment,
+  index: number,
+): string => refOrFallback(assignment.issueRef, `issue.khala_fleet.unset.${index + 1}`)
+
+const accountRef = (
+  account: KhalaCodeDesktopFleetAccount,
+  index: number,
+): string => refOrFallback(account.accountRef, `account.khala_fleet.codex.${index + 1}`)
+
+const processRef = (
+  process: KhalaCodeDesktopFleetProcess,
+  index: number,
+): string => refOrFallback(process.pid, `process.khala_fleet.codex_exec.${index + 1}`)
+
+const buildTimeline = (
+  status: KhalaCodeDesktopFleetStatus,
+  refs: {
+    pylonRef: string
+    capacityRefs: ReadonlyArray<string>
+    accountRefs: ReadonlyArray<string>
+    assignmentRefs: ReadonlyArray<string>
+    processRefs: ReadonlyArray<string>
+    blockerRefs: ReadonlyArray<string>
+    caveatRefs: ReadonlyArray<string>
+  },
+): ReadonlyArray<KhalaFleetTimelineEvent> => {
+  const events: KhalaFleetTimelineEvent[] = [
+    timelineEvent({
+      id: "pylon-status",
+      label: "Pylon status",
+      status: status.pylon.status === "unavailable" ? "blocked" : "complete",
+      observedAt: status.observedAt,
+      subjectRef: refs.pylonRef,
+      detail: `Pylon is ${pylonStatusLabel(status.pylon.status)}.`,
+      evidenceRefs: status.pylon.status === "unavailable" ? [] : [refs.pylonRef],
+      blockerRefs: status.pylon.status === "unavailable" ? refs.blockerRefs : [],
+    }),
+    timelineEvent({
+      id: "capacity",
+      label: "Capacity advertised",
+      status: capacityNodeStatus(status) === "blocked" ? "blocked" : "complete",
+      observedAt: status.observedAt,
+      subjectRef: refs.capacityRefs[0] ?? "capacity.khala_fleet.codex.unknown",
+      detail:
+        status.availableCodexAssignments === null ||
+        status.maxCodexAssignments === null
+          ? "Capacity count is not reported yet."
+          : `${status.availableCodexAssignments}/${status.maxCodexAssignments} Codex slots free.`,
+      evidenceRefs: refs.capacityRefs,
+      blockerRefs: capacityNodeStatus(status) === "blocked" ? refs.blockerRefs : [],
+    }),
+  ]
+
+  status.accounts.forEach((account, index) => {
+    const ref = refs.accountRefs[index] ?? `account.khala_fleet.codex.${index + 1}`
+    const state = accountState(account)
+    events.push(
+      timelineEvent({
+        id: `account-${index + 1}`,
+        label: safeLabel(account.accountRef, `Codex account ${index + 1}`),
+        status: state === "ready" ? "complete" : state === "missing" ? "blocked" : "active",
+        observedAt: status.observedAt,
+        subjectRef: ref,
+        detail: `Readiness is ${accountStateLabel(account)}.`,
+        evidenceRefs: state === "ready" ? [ref] : [],
+        blockerRefs: state === "ready" ? [] : [`blocker.khala_fleet.account.${index + 1}`],
+      }),
+    )
+  })
+
+  status.activeAssignments.forEach((assignment, index) => {
+    const ref = refs.assignmentRefs[index] ?? `assignment.khala_fleet.pending.${index + 1}`
+    const publicIssueRef = issueRef(assignment, index)
+    events.push(
+      timelineEvent({
+        id: `assignment-${index + 1}`,
+        label: "Assignment active",
+        status: "active",
+        observedAt: assignment.updatedAt ?? status.observedAt,
+        subjectRef: ref,
+        detail: `Active run for ${publicIssueRef}.`,
+        evidenceRefs: [ref, publicIssueRef],
+      }),
+    )
+  })
+
+  status.processes.forEach((process, index) => {
+    const ref = refs.processRefs[index] ?? `process.khala_fleet.codex_exec.${index + 1}`
+    events.push(
+      timelineEvent({
+        id: `process-${index + 1}`,
+        label: "Codex process",
+        status: "active",
+        observedAt: status.observedAt,
+        subjectRef: ref,
+        detail: `Process ${ref} has run for ${safeLabel(process.elapsed, "elapsed time unknown")}.`,
+        evidenceRefs: [ref],
+      }),
+    )
+  })
+
+  return events.sort((left, right) => {
+    const byTime = left.observedAt.localeCompare(right.observedAt)
+    return byTime === 0 ? left.id.localeCompare(right.id) : byTime
+  })
+}
+
+export const buildKhalaFleetBoardProjection = (
+  input: KhalaFleetBoardProjectionInput,
+): KhalaFleetBoardProjection => {
+  const { status } = input
+  const generatedAt = input.generatedAt ?? status.observedAt
+  const readyAccountCount = readyAccounts(status.accounts)
+  const pylonRef = refOrFallback(status.pylon.pylonRef, "pylon.khala_fleet.local")
+  const accountRefs = status.accounts.map(accountRef)
+  const assignmentRefs = status.activeAssignments.map(assignmentRef)
+  const processRefs = status.processes.map(processRef)
+  const capacityRefs = publicRefs([
+    pylonRef,
+    status.availableCodexAssignments === null
+      ? undefined
+      : `capacity.khala_fleet.codex.available.${status.availableCodexAssignments}`,
+    status.maxCodexAssignments === null
+      ? undefined
+      : `capacity.khala_fleet.codex.max.${status.maxCodexAssignments}`,
+  ])
+  const blockerRefs = publicRefs([
+    status.pylon.status === "unavailable"
+      ? "blocker.khala_fleet.pylon_unavailable"
+      : undefined,
+    status.accounts.length > 0 && readyAccountCount === 0
+      ? "blocker.khala_fleet.no_ready_codex_accounts"
+      : undefined,
+    status.availableCodexAssignments === 0 && status.maxCodexAssignments !== 0
+      ? "blocker.khala_fleet.no_free_codex_slots"
+      : undefined,
+  ])
+  const caveatRefs = publicRefs([
+    "caveat.khala_fleet.tool_scope_projection_pending",
+    status.maxCodexAssignments === null
+      ? "caveat.khala_fleet.capacity_not_reported"
+      : undefined,
+  ])
+  const allEvidenceRefs = publicRefs([
+    pylonRef,
+    ...accountRefs,
+    ...assignmentRefs,
+    ...status.activeAssignments.map(issueRef),
+    ...processRefs,
+    ...capacityRefs,
+  ])
+  const boardStatus = graphStatus(status, readyAccountCount)
+  const activeCount = status.activeAssignments.length
+  const processCount = status.processes.length
+
+  const nodes: ReadonlyArray<GraphNode> = [
+    node({
+      id: "khala-code",
+      label: "Khala Code",
+      kind: "operator_surface",
+      status: status.ok ? "complete" : "blocked",
+      outputs: [pin("output", "fleet-status", "fleet status", "khala.fleet.status")],
+      datum: datum("observed", generatedAt, [pylonRef]),
+      evidenceRefs: [pylonRef],
+      x: 40,
+      y: 70,
+    }),
+    node({
+      id: "local-pylon",
+      label: "Local Pylon",
+      kind: "capacity_host",
+      status: status.pylon.status === "unavailable" ? "blocked" : "complete",
+      inputs: [pin("input", "fleet-status", "fleet status", "khala.fleet.status")],
+      outputs: [pin("output", "capacity", "capacity", "pylon.capacity")],
+      datum: datum("status", pylonStatusLabel(status.pylon.status), [pylonRef]),
+      evidenceRefs: status.pylon.status === "unavailable" ? [] : [pylonRef],
+      blockerRefs: status.pylon.status === "unavailable" ? blockerRefs : [],
+      x: 255,
+      y: 70,
+    }),
+    node({
+      id: "capacity-gate",
+      label: "Capacity gate",
+      kind: "dispatch_gate",
+      status: capacityNodeStatus(status),
+      inputs: [pin("input", "capacity", "capacity", "pylon.capacity")],
+      outputs: [pin("output", "workers", "workers", "codex.worker.pool")],
+      datum: [
+        ...datum("available", status.availableCodexAssignments, capacityRefs),
+        ...datum("max", status.maxCodexAssignments, capacityRefs),
+      ],
+      evidenceRefs: capacityRefs,
+      blockerRefs: capacityNodeStatus(status) === "blocked" ? blockerRefs : [],
+      caveatRefs,
+      x: 470,
+      y: 70,
+    }),
+    node({
+      id: "codex-workers",
+      label: "Codex workers",
+      kind: "worker_pool",
+      status: accountNodeStatus(status.accounts),
+      inputs: [pin("input", "workers", "workers", "codex.worker.pool")],
+      outputs: [pin("output", "assignments", "assignments", "codex.assignment")],
+      datum: [
+        ...datum("ready", readyAccountCount, accountRefs),
+        ...datum("total", status.accounts.length, accountRefs),
+      ],
+      evidenceRefs: accountRefs,
+      blockerRefs: readyAccountCount === 0 && status.accounts.length > 0 ? blockerRefs : [],
+      caveatRefs,
+      x: 685,
+      y: 70,
+    }),
+    node({
+      id: "active-assignments",
+      label: "Active runs",
+      kind: "assignment_board",
+      status: activeNodeStatus(status),
+      inputs: [pin("input", "assignments", "assignments", "codex.assignment")],
+      outputs: [pin("output", "timeline", "timeline", "khala.fleet.timeline")],
+      datum: datum("active", activeCount, assignmentRefs),
+      evidenceRefs: assignmentRefs,
+      x: 900,
+      y: 70,
+    }),
+    node({
+      id: "codex-processes",
+      label: "Codex exec",
+      kind: "local_processes",
+      status: processCount > 0 ? "active" : "idle",
+      inputs: [pin("input", "assignments", "assignments", "codex.assignment")],
+      outputs: [pin("output", "processes", "processes", "codex.exec.process")],
+      datum: datum("running", processCount, processRefs),
+      evidenceRefs: processRefs,
+      x: 900,
+      y: 250,
+    }),
+    node({
+      id: "run-timeline",
+      label: "Run timeline",
+      kind: "trace_view",
+      status: activeCount > 0 || processCount > 0 ? "active" : "idle",
+      inputs: [
+        pin("input", "timeline", "timeline", "khala.fleet.timeline"),
+        pin("input", "processes", "processes", "codex.exec.process"),
+      ],
+      datum: datum("events", 2 + status.accounts.length + activeCount + processCount, allEvidenceRefs),
+      evidenceRefs: allEvidenceRefs,
+      caveatRefs,
+      x: 1115,
+      y: 160,
+    }),
+  ]
+
+  const links: ReadonlyArray<GraphLink> = [
+    link({
+      id: "khala-to-pylon",
+      label: "status",
+      fromNodeId: "khala-code",
+      fromPinId: "fleet-status",
+      toNodeId: "local-pylon",
+      toPinId: "fleet-status",
+      evidenceRefs: [pylonRef],
+      blockerRefs: status.pylon.status === "unavailable" ? blockerRefs : [],
+    }),
+    link({
+      id: "pylon-to-capacity",
+      label: "advertises",
+      fromNodeId: "local-pylon",
+      fromPinId: "capacity",
+      toNodeId: "capacity-gate",
+      toPinId: "capacity",
+      evidenceRefs: capacityRefs,
+      blockerRefs: status.pylon.status === "unavailable" ? blockerRefs : [],
+    }),
+    link({
+      id: "capacity-to-workers",
+      label: "admits",
+      fromNodeId: "capacity-gate",
+      fromPinId: "workers",
+      toNodeId: "codex-workers",
+      toPinId: "workers",
+      evidenceRefs: accountRefs,
+      blockerRefs: readyAccountCount === 0 && status.accounts.length > 0 ? blockerRefs : [],
+      caveatRefs,
+    }),
+    link({
+      id: "workers-to-assignments",
+      label: "leases",
+      fromNodeId: "codex-workers",
+      fromPinId: "assignments",
+      toNodeId: "active-assignments",
+      toPinId: "assignments",
+      evidenceRefs: assignmentRefs,
+    }),
+    link({
+      id: "workers-to-processes",
+      label: "executes",
+      fromNodeId: "codex-workers",
+      fromPinId: "assignments",
+      toNodeId: "codex-processes",
+      toPinId: "assignments",
+      evidenceRefs: processRefs,
+    }),
+    link({
+      id: "assignments-to-timeline",
+      label: "events",
+      fromNodeId: "active-assignments",
+      fromPinId: "timeline",
+      toNodeId: "run-timeline",
+      toPinId: "timeline",
+      evidenceRefs: assignmentRefs,
+    }),
+    link({
+      id: "processes-to-timeline",
+      label: "activity",
+      fromNodeId: "codex-processes",
+      fromPinId: "processes",
+      toNodeId: "run-timeline",
+      toPinId: "processes",
+      evidenceRefs: processRefs,
+    }),
+  ]
+
+  const graph: GraphSpec = {
+    schemaVersion: "openagents.arbiter.graph_spec.v0",
+    title: "Khala Code Fleet board",
+    generatedAt,
+    status: boardStatus,
+    nodes,
+    links,
+    evidenceRefs: allEvidenceRefs,
+    blockerRefs,
+    caveatRefs,
+    sourceRefs: publicRefs([
+      "doc.khala_code.fleet_management_spec.2026_06_30",
+      "source.khala_code_desktop.codex_fleet_status",
+    ]),
+  }
+
+  const projection: KhalaFleetBoardProjection = {
+    schemaVersion: KhalaFleetBoardProjectionSchemaVersion,
+    generatedAt,
+    graph,
+    timeline: buildTimeline(status, {
+      pylonRef,
+      capacityRefs,
+      accountRefs,
+      assignmentRefs,
+      processRefs,
+      blockerRefs,
+      caveatRefs,
+    }),
+    summary: {
+      readyAccounts: readyAccountCount,
+      totalAccounts: status.accounts.length,
+      activeAssignments: activeCount,
+      runningProcesses: processCount,
+      availableCodexAssignments: status.availableCodexAssignments,
+      maxCodexAssignments: status.maxCodexAssignments,
+    },
+    evidenceRefs: allEvidenceRefs,
+    blockerRefs,
+    caveatRefs,
+    sourceRefs: graph.sourceRefs,
+  }
+
+  assertProjectionPublicSafe(projection)
+  return projection
+}

--- a/clients/khala-code-desktop/src/ui/fleet-board-renderer.ts
+++ b/clients/khala-code-desktop/src/ui/fleet-board-renderer.ts
@@ -1,0 +1,97 @@
+import {
+  renderArbiterGraphHtml,
+  type ArbiterGraphRenderOptions,
+  type ArbiterGraphRenderOutput,
+} from "@openagentsinc/arbiter-effect/foldkit"
+
+import type {
+  KhalaFleetBoardProjection,
+  KhalaFleetTimelineEvent,
+} from "./fleet-board-projection"
+
+export type KhalaFleetBoardRenderOptions = ArbiterGraphRenderOptions
+
+export type KhalaFleetBoardRenderOutput = Readonly<{
+  html: string
+  graph: ArbiterGraphRenderOutput
+  timelineHtml: string
+}>
+
+const escapeHtml = (value: string | number | boolean): string =>
+  String(value)
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;")
+
+const formatSlotSummary = (projection: KhalaFleetBoardProjection): string => {
+  const { availableCodexAssignments, maxCodexAssignments } = projection.summary
+  if (availableCodexAssignments === null || maxCodexAssignments === null) {
+    return "capacity pending"
+  }
+  return `${availableCodexAssignments}/${maxCodexAssignments} slots free`
+}
+
+const renderSummary = (projection: KhalaFleetBoardProjection): string => [
+  '<div class="khala-fleet-board-summary" role="list" aria-label="Fleet board summary">',
+  `<span class="khala-fleet-board-stat" role="listitem"><span>Workers</span><strong>${escapeHtml(projection.summary.readyAccounts)}/${escapeHtml(projection.summary.totalAccounts)}</strong></span>`,
+  `<span class="khala-fleet-board-stat" role="listitem"><span>Capacity</span><strong>${escapeHtml(formatSlotSummary(projection))}</strong></span>`,
+  `<span class="khala-fleet-board-stat" role="listitem"><span>Runs</span><strong>${escapeHtml(projection.summary.activeAssignments)}</strong></span>`,
+  `<span class="khala-fleet-board-stat" role="listitem"><span>Exec</span><strong>${escapeHtml(projection.summary.runningProcesses)}</strong></span>`,
+  "</div>",
+].join("")
+
+const timelineRefs = (event: KhalaFleetTimelineEvent): string => {
+  const refs = event.evidenceRefs.length > 0 ? event.evidenceRefs : event.blockerRefs
+  if (refs.length === 0) return ""
+  return `<span class="khala-fleet-timeline-refs">${escapeHtml(refs.join(" "))}</span>`
+}
+
+const renderTimelineEvent = (event: KhalaFleetTimelineEvent): string => [
+  `<li class="khala-fleet-timeline-event" data-status="${escapeHtml(event.status)}">`,
+  '<span class="khala-fleet-timeline-marker" aria-hidden="true"></span>',
+  '<div class="khala-fleet-timeline-card">',
+  '<div class="khala-fleet-timeline-topline">',
+  `<strong>${escapeHtml(event.label)}</strong>`,
+  `<span class="khala-fleet-timeline-time">${escapeHtml(event.observedAt)}</span>`,
+  "</div>",
+  `<p>${escapeHtml(event.detail)}</p>`,
+  `<span class="khala-fleet-timeline-subject">${escapeHtml(event.subjectRef)}</span>`,
+  timelineRefs(event),
+  "</div>",
+  "</li>",
+].join("")
+
+const renderTimeline = (
+  projection: KhalaFleetBoardProjection,
+): string => [
+  '<section class="khala-fleet-timeline" aria-label="Run timeline">',
+  '<div class="khala-fleet-board-heading">',
+  '<h3 class="khala-fleet-section-title">Run timeline</h3>',
+  `<span class="khala-fleet-section-meta">${escapeHtml(projection.timeline.length)} events</span>`,
+  "</div>",
+  `<ol class="khala-fleet-timeline-list">${projection.timeline.map(renderTimelineEvent).join("")}</ol>`,
+  "</section>",
+].join("")
+
+export const renderKhalaFleetBoardHtml = (
+  projection: KhalaFleetBoardProjection,
+  options: KhalaFleetBoardRenderOptions = {},
+): KhalaFleetBoardRenderOutput => {
+  const graph = renderArbiterGraphHtml(projection.graph, options)
+  const timelineHtml = renderTimeline(projection)
+  const html = [
+    `<section class="khala-fleet-board" data-fleet-board="${escapeHtml(projection.schemaVersion)}" data-status="${escapeHtml(projection.graph.status)}" aria-label="Fleet board graph and run timeline">`,
+    '<div class="khala-fleet-board-heading">',
+    '<h3 class="khala-fleet-section-title">Fleet board</h3>',
+    `<span class="khala-fleet-section-meta">${escapeHtml(projection.generatedAt)}</span>`,
+    "</div>",
+    renderSummary(projection),
+    graph.html,
+    timelineHtml,
+    "</section>",
+  ].join("")
+
+  return { html, graph, timelineHtml }
+}

--- a/clients/khala-code-desktop/src/ui/fleet-status.ts
+++ b/clients/khala-code-desktop/src/ui/fleet-status.ts
@@ -3,6 +3,8 @@ import type {
   KhalaCodeDesktopFleetAccount,
   KhalaCodeDesktopFleetStatus,
 } from "../shared/rpc"
+import { buildKhalaFleetBoardProjection } from "./fleet-board-projection"
+import { renderKhalaFleetBoardHtml } from "./fleet-board-renderer"
 
 // Fleet status panel for Khala Code Desktop: current Codex fleet state — all
 // linked accounts (with signed-in email + readiness), local Pylon health +
@@ -90,6 +92,20 @@ const sectionHeader = (title: string, meta?: string): HTMLElement => {
   return header
 }
 
+const appendFleetBoard = (
+  container: HTMLElement,
+  data: KhalaCodeDesktopFleetStatus,
+): void => {
+  const projection = buildKhalaFleetBoardProjection({ status: data })
+  const template = document.createElement("template")
+  template.innerHTML = renderKhalaFleetBoardHtml(projection, {
+    reducedMotion:
+      typeof matchMedia === "function" &&
+      matchMedia("(prefers-reduced-motion: reduce)").matches,
+  }).html
+  container.append(template.content.cloneNode(true))
+}
+
 const accountCard = (
   account: KhalaCodeDesktopFleetAccount,
   handlers: Handlers,
@@ -157,6 +173,8 @@ const renderReady = (
     data.availableCodexAssignments === null || data.maxCodexAssignments === null
       ? null
       : `${data.availableCodexAssignments}/${data.maxCodexAssignments} Codex slots free`
+
+  appendFleetBoard(container, data)
 
   // Pylon
   const pylonSection = el("section", "khala-fleet-section")

--- a/clients/khala-code-desktop/src/ui/styles.css
+++ b/clients/khala-code-desktop/src/ui/styles.css
@@ -1008,6 +1008,153 @@ button {
   background: var(--oa-color-component-surface);
 }
 
+.khala-fleet-board {
+  display: grid;
+  gap: 0.8rem;
+  padding: 0.85rem 0.95rem;
+  border: 1px solid var(--oa-color-component-border);
+  border-radius: 0.55rem;
+  background:
+    linear-gradient(180deg, rgba(79, 208, 255, 0.035), transparent 44%),
+    var(--oa-color-component-surface);
+}
+.khala-fleet-board-heading {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 1rem;
+  min-width: 0;
+}
+.khala-fleet-board-summary {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  border: 1px solid rgba(147, 164, 189, 0.16);
+  border-radius: 0.45rem;
+  background: rgba(0, 0, 0, 0.16);
+}
+.khala-fleet-board-stat {
+  display: grid;
+  gap: 0.18rem;
+  min-width: 0;
+  padding: 0.55rem 0.7rem;
+  border-left: 1px solid rgba(147, 164, 189, 0.16);
+}
+.khala-fleet-board-stat:first-child {
+  border-left: 0;
+}
+.khala-fleet-board-stat span {
+  overflow: hidden;
+  color: color-mix(in srgb, var(--oa-color-component-text) 48%, transparent);
+  font-size: 0.66rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.khala-fleet-board-stat strong {
+  overflow: hidden;
+  color: #e7f4ff;
+  font-size: 0.88rem;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.khala-fleet-timeline {
+  display: grid;
+  gap: 0.65rem;
+  min-width: 0;
+}
+.khala-fleet-timeline-list {
+  display: grid;
+  gap: 0.55rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+.khala-fleet-timeline-event {
+  display: grid;
+  grid-template-columns: 0.8rem minmax(0, 1fr);
+  gap: 0.55rem;
+  min-width: 0;
+}
+.khala-fleet-timeline-marker {
+  width: 0.55rem;
+  height: 0.55rem;
+  margin-top: 0.55rem;
+  border-radius: 999px;
+  background: currentColor;
+  box-shadow: 0 0 7px currentColor;
+}
+.khala-fleet-timeline-event[data-status="complete"] {
+  color: #4ade80;
+}
+.khala-fleet-timeline-event[data-status="active"] {
+  color: #4fd0ff;
+}
+.khala-fleet-timeline-event[data-status="blocked"] {
+  color: #f87171;
+}
+.khala-fleet-timeline-event[data-status="idle"] {
+  color: #93a4bd;
+}
+.khala-fleet-timeline-card {
+  display: grid;
+  gap: 0.28rem;
+  min-width: 0;
+  padding: 0.55rem 0.65rem;
+  border: 1px solid rgba(147, 164, 189, 0.16);
+  border-radius: 0.45rem;
+  background: rgba(0, 0, 0, 0.14);
+  color: var(--oa-color-component-text);
+}
+.khala-fleet-timeline-topline {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.75rem;
+  min-width: 0;
+}
+.khala-fleet-timeline-topline strong {
+  overflow: hidden;
+  color: #f1efe8;
+  font-size: 0.8rem;
+  font-weight: 600;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.khala-fleet-timeline-time {
+  color: color-mix(in srgb, var(--oa-color-component-text) 45%, transparent);
+  font-size: 0.66rem;
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+.khala-fleet-timeline-card p {
+  margin: 0;
+  color: color-mix(in srgb, var(--oa-color-component-text) 68%, transparent);
+  font-size: 0.74rem;
+  line-height: 1.4;
+}
+.khala-fleet-timeline-subject,
+.khala-fleet-timeline-refs {
+  overflow: hidden;
+  color: color-mix(in srgb, var(--oa-color-component-text) 48%, transparent);
+  font-size: 0.68rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+@media (max-width: 700px) {
+  .khala-fleet-board-summary {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .khala-fleet-board-stat:nth-child(odd) {
+    border-left: 0;
+  }
+
+  .khala-fleet-board-stat:nth-child(n + 3) {
+    border-top: 1px solid rgba(147, 164, 189, 0.16);
+  }
+}
+
 /* Account rows get a delete (✕) button: identity | badge | delete. */
 .khala-fleet-account {
   grid-template-columns: minmax(0, 1fr) auto auto;

--- a/clients/khala-code-desktop/tests/app-shell.test.ts
+++ b/clients/khala-code-desktop/tests/app-shell.test.ts
@@ -45,6 +45,23 @@ describe("khala code desktop app shell", () => {
     expect(html).not.toContain("Pylons")
   })
 
+  test("renders Fleet status with a board graph and run timeline mount", async () => {
+    const main = await Bun.file(new URL("../src/ui/main.ts", import.meta.url)).text()
+    const panel = await Bun.file(new URL("../src/ui/fleet-status.ts", import.meta.url)).text()
+    const projection = await Bun.file(new URL("../src/ui/fleet-board-projection.ts", import.meta.url)).text()
+    const renderer = await Bun.file(new URL("../src/ui/fleet-board-renderer.ts", import.meta.url)).text()
+    const css = await Bun.file(new URL("../src/ui/styles.css", import.meta.url)).text()
+
+    expect(main).toContain("mountFleetPanel")
+    expect(panel).toContain("appendFleetBoard(container, data)")
+    expect(panel).toContain("buildKhalaFleetBoardProjection")
+    expect(panel).toContain("renderKhalaFleetBoardHtml")
+    expect(projection).toContain("openagents.khala_code.fleet_board_projection.v0")
+    expect(renderer).toContain("Fleet board graph and run timeline")
+    expect(css).toContain(".khala-fleet-board-summary")
+    expect(css).toContain(".khala-fleet-timeline-event")
+  })
+
   test("renders a visible Gym pane entry without seeded private proof data", async () => {
     const html = await Bun.file(new URL("../src/ui/index.html", import.meta.url)).text()
     const sidebar = await Bun.file(new URL("../src/ui/sidebar.ts", import.meta.url)).text()

--- a/clients/khala-code-desktop/tests/fleet-board-projection.test.ts
+++ b/clients/khala-code-desktop/tests/fleet-board-projection.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, test } from "bun:test"
+
+import {
+  buildKhalaFleetBoardProjection,
+  KhalaFleetBoardProjectionUnsafe,
+} from "../src/ui/fleet-board-projection"
+import type { KhalaCodeDesktopFleetStatus } from "../src/shared/rpc"
+
+const fleetStatus = (
+  overrides: Partial<KhalaCodeDesktopFleetStatus> = {},
+): KhalaCodeDesktopFleetStatus => ({
+  ok: true,
+  observedAt: "2026-06-30T20:00:00.000Z",
+  pylon: {
+    status: "online",
+    pylonRef: "pylon.local.test",
+    message: "online",
+  },
+  availableCodexAssignments: 1,
+  maxCodexAssignments: 3,
+  accounts: [
+    {
+      accountRef: "codex",
+      provider: "codex",
+      readiness: "ready",
+      quotaState: "available",
+      accountKey: "account_key_public",
+      email: "operator@example.com",
+    },
+    {
+      accountRef: "codex-2",
+      provider: "codex",
+      readiness: "credentials_missing",
+      quotaState: null,
+      accountKey: null,
+      email: null,
+    },
+  ],
+  activeAssignments: [
+    {
+      assignmentRef: "assignment.public.one",
+      issueRef: "github.issue.openagents.7768",
+      updatedAt: "2026-06-30T20:01:00.000Z",
+    },
+  ],
+  processes: [
+    {
+      pid: "200",
+      parentPid: "199",
+      elapsed: "00:02:03",
+    },
+  ],
+  ...overrides,
+})
+
+describe("Khala Code Fleet board projection", () => {
+  test("maps fleet status into a board graph and run timeline", () => {
+    const projection = buildKhalaFleetBoardProjection({
+      status: fleetStatus(),
+      generatedAt: "time.test.fleet_board",
+    })
+
+    expect(projection.schemaVersion).toBe(
+      "openagents.khala_code.fleet_board_projection.v0",
+    )
+    expect(projection.summary).toMatchObject({
+      readyAccounts: 1,
+      totalAccounts: 2,
+      activeAssignments: 1,
+      runningProcesses: 1,
+      availableCodexAssignments: 1,
+      maxCodexAssignments: 3,
+    })
+    expect(projection.graph.status).toBe("active")
+    expect(projection.graph.nodes.map(node => node.id)).toEqual([
+      "khala-code",
+      "local-pylon",
+      "capacity-gate",
+      "codex-workers",
+      "active-assignments",
+      "codex-processes",
+      "run-timeline",
+    ])
+    expect(
+      projection.graph.links.map(link => [link.id, link.status]),
+    ).toContainEqual(["workers-to-assignments", "evidence_backed"])
+    expect(projection.timeline.map(event => event.id)).toEqual([
+      "account-1",
+      "account-2",
+      "capacity",
+      "process-1",
+      "pylon-status",
+      "assignment-1",
+    ])
+    expect(projection.timeline.some(event => event.label === "Assignment active"))
+      .toBe(true)
+    expect(projection.timeline.some(event => event.detail.includes("github.issue.openagents.7768")))
+      .toBe(true)
+  })
+
+  test("does not project signed-in email, local paths, or raw provider fields", () => {
+    const projection = buildKhalaFleetBoardProjection({
+      status: fleetStatus({
+        pylon: {
+          status: "online",
+          pylonRef: "pylon.local.test",
+          message: "/Users/operator/.codex/auth.json bearer sk-local",
+        },
+        accounts: [
+          {
+            accountRef: "/Users/operator/private",
+            provider: "codex",
+            readiness: "ready",
+            quotaState: null,
+            accountKey: "credential.provider.token",
+            email: "operator@example.com",
+          },
+        ],
+        activeAssignments: [
+          {
+            assignmentRef: "raw_prompt.full",
+            issueRef: "https://private.example/issue",
+            updatedAt: "2026-06-30T20:01:00.000Z",
+          },
+        ],
+      }),
+    })
+    const serialized = JSON.stringify(projection)
+
+    expect(serialized).not.toMatch(
+      /operator@example\.com|\/Users\/|auth\.json|bearer|sk-local|credential\.provider\.token|raw_prompt|private\.example/i,
+    )
+    expect(serialized).toContain("account.khala_fleet.codex.1")
+    expect(serialized).toContain("assignment.khala_fleet.pending.1")
+  })
+
+  test("marks missing Pylon capacity as blocked with blocker refs", () => {
+    const projection = buildKhalaFleetBoardProjection({
+      status: fleetStatus({
+        pylon: {
+          status: "unavailable",
+          pylonRef: null,
+          message: "offline",
+        },
+        availableCodexAssignments: 0,
+        maxCodexAssignments: 2,
+        activeAssignments: [],
+        processes: [],
+      }),
+    })
+
+    expect(projection.graph.status).toBe("blocked")
+    expect(projection.blockerRefs).toContain("blocker.khala_fleet.pylon_unavailable")
+    expect(
+      projection.timeline.find(event => event.id === "pylon-status")?.status,
+    ).toBe("blocked")
+  })
+
+  test("rejects unsafe generated timestamps before rendering", () => {
+    expect(() =>
+      buildKhalaFleetBoardProjection({
+        status: fleetStatus(),
+        generatedAt: "Bearer sk-local",
+      }),
+    ).toThrow(KhalaFleetBoardProjectionUnsafe)
+  })
+})

--- a/clients/khala-code-desktop/tests/fleet-board-renderer.test.ts
+++ b/clients/khala-code-desktop/tests/fleet-board-renderer.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, test } from "bun:test"
+
+import { buildKhalaFleetBoardProjection } from "../src/ui/fleet-board-projection"
+import { renderKhalaFleetBoardHtml } from "../src/ui/fleet-board-renderer"
+import type { KhalaCodeDesktopFleetStatus } from "../src/shared/rpc"
+
+const status = (): KhalaCodeDesktopFleetStatus => ({
+  ok: true,
+  observedAt: "2026-06-30T20:00:00.000Z",
+  pylon: {
+    status: "online",
+    pylonRef: "pylon.local.render",
+    message: "online",
+  },
+  availableCodexAssignments: 2,
+  maxCodexAssignments: 4,
+  accounts: [
+    {
+      accountRef: "codex",
+      provider: "codex",
+      readiness: "ready",
+      quotaState: "available",
+      accountKey: null,
+      email: "operator@example.com",
+    },
+  ],
+  activeAssignments: [
+    {
+      assignmentRef: "assignment.public.render",
+      issueRef: "github.issue.openagents.7768",
+      updatedAt: "2026-06-30T20:01:00.000Z",
+    },
+  ],
+  processes: [],
+})
+
+describe("Khala Code Fleet board renderer", () => {
+  test("renders a board graph and accessible run timeline", () => {
+    const projection = buildKhalaFleetBoardProjection({ status: status() })
+    const rendered = renderKhalaFleetBoardHtml(projection, { reducedMotion: true })
+
+    expect(rendered.html).toContain('class="khala-fleet-board"')
+    expect(rendered.html).toContain(
+      'data-fleet-board="openagents.khala_code.fleet_board_projection.v0"',
+    )
+    expect(rendered.graph.svg).toContain('viewBox="0 0 1480 430"')
+    expect(rendered.graph.svg).toContain('data-node-id="codex-workers"')
+    expect(rendered.graph.svg).toContain('data-node-id="run-timeline"')
+    expect(rendered.graph.svg).toContain('data-reduced-motion="true"')
+    expect(rendered.timelineHtml).toContain("Run timeline")
+    expect(rendered.timelineHtml).toContain("Assignment active")
+    expect(rendered.timelineHtml).toContain("assignment.public.render")
+    expect(rendered.html).toContain("2/4 slots free")
+  })
+
+  test("escapes timeline content and keeps private fields out of rendered HTML", () => {
+    const projection = buildKhalaFleetBoardProjection({
+      status: {
+        ...status(),
+        pylon: {
+          status: "online",
+          pylonRef: "pylon.local.render",
+          message: "Bearer sk-local /Users/operator/.codex/auth.json",
+        },
+        accounts: [
+          {
+            accountRef: "<script>alert(1)</script>",
+            provider: "codex",
+            readiness: "ready",
+            quotaState: null,
+            accountKey: null,
+            email: "operator@example.com",
+          },
+        ],
+        activeAssignments: [
+          {
+            assignmentRef: "assignment.public.<render>",
+            issueRef: "github.issue.openagents.7768",
+            updatedAt: "2026-06-30T20:01:00.000Z",
+          },
+        ],
+      },
+    })
+    const rendered = renderKhalaFleetBoardHtml(projection)
+
+    expect(rendered.html).not.toMatch(
+      /operator@example\.com|Bearer|sk-local|\/Users\/|auth\.json|<script>|assignment\.public\.<render>/,
+    )
+    expect(rendered.html).toContain("account.khala_fleet.codex.1")
+    expect(rendered.html).toContain("assignment.khala_fleet.pending.1")
+  })
+
+  test("the Fleet panel mounts the board from live fleet status", async () => {
+    const panel = await Bun.file(new URL("../src/ui/fleet-status.ts", import.meta.url)).text()
+    const css = await Bun.file(new URL("../src/ui/styles.css", import.meta.url)).text()
+
+    expect(panel).toContain("buildKhalaFleetBoardProjection")
+    expect(panel).toContain("renderKhalaFleetBoardHtml")
+    expect(panel).toContain('matchMedia("(prefers-reduced-motion: reduce)")')
+    expect(panel).toContain("appendFleetBoard(container, data)")
+    expect(css).toContain(".khala-fleet-board")
+    expect(css).toContain(".khala-fleet-timeline-list")
+  })
+})


### PR DESCRIPTION
Addresses (no linked issue).

### Changes
- Wires the Fleet status panel to build and render the fleet board projection, including reduced-motion detection.
- Adds styles for the fleet board summary and run timeline, with responsive stats layout on narrow screens.
- Extends the app shell test to assert the Fleet status board/timeline mount and CSS coverage.

### Verification
- `bun test clients/khala-code-desktop/tests/khala-codex-fleet-tools.test.ts apps/pylon/src/khala-spawn.test.ts apps/pylon/tests/khala-spawn.test.ts apps/pylon/src/presence-codex-account-capacity.test.ts apps/pylon/tests/presence.test.ts` passed (exit 0).