### PR TITLE
fix(composer-state): keep attachment receipts public-safe

### DIFF
--- a/packages/composer-state/README.md
+++ b/packages/composer-state/README.md
@@ -16,3 +16,19 @@ The package intentionally owns only serializable composer state:
 It does not render DOM, own uploads, or make routing decisions from user text.
 UI packages and app integrations consume this state layer and keep platform
 editing behavior native.
+
+## Attachment Upload Receipts
+
+Attachments move through `staged`, `uploading`, `ready`, and `error` states.
+Upload plans separate authority by surface:
+
+- `desktop-local` registers a local attachment and keeps local-only refs local.
+- `web-hosted` uploads to hosted storage before scan, parse, and thumbnail work.
+
+`ComposerAttachmentUploadTask` may carry private executor refs such as
+`local-file:` or `browser-file:` so the owning surface can do the work.
+`ComposerAttachmentUploadReceipt` is the public-safe projection boundary: it
+keeps metadata, digests, dimensions, status, and only content-addressed
+`attachment.<surface>.sha256.*` / `attachment_thumbnail.<surface>.sha256.*`
+refs. Raw file bytes, preview URLs, prompt text, local paths, and browser-local
+file handles must stay out of receipts.

--- a/packages/composer-state/src/index.test.ts
+++ b/packages/composer-state/src/index.test.ts
@@ -319,6 +319,12 @@ describe("composer state core", () => {
       sizeBytes: 2048,
     })
     expect(JSON.stringify(planned.plan.receipt)).not.toContain("previewUrl")
+    expect(JSON.stringify(planned.plan.receipt)).not.toContain("browser-file")
+    expect(planned.plan.receipt.contentRef).toBeUndefined()
+    expect(planned.plan.tasks[0]).toMatchObject({
+      kind: "upload_hosted_attachment",
+      contentRef: "browser-file:screen.png",
+    })
 
     const uploading = apply(state, planned.plan.transaction)
     const readyTx = readyComposerAttachmentTransaction(uploading, attachmentId, {
@@ -427,6 +433,14 @@ describe("composer state core", () => {
       "scan_attachment",
       "parse_text_attachment",
     ])
+    expect(planned.plan.receipt.contentRef).toBeUndefined()
+    expect(JSON.stringify(planned.plan.receipt)).not.toContain(
+      "local-file:/private/tmp/notes.md",
+    )
+    expect(planned.plan.tasks[0]).toMatchObject({
+      kind: "register_local_attachment",
+      contentRef: "local-file:/private/tmp/notes.md",
+    })
 
     const localRef = composerAttachmentContentAddressedRef({
       surface: "desktop-local",

--- a/packages/composer-state/src/index.ts
+++ b/packages/composer-state/src/index.ts
@@ -777,6 +777,22 @@ export const composerAttachmentThumbnailRef = (input: {
   return `attachment_thumbnail.${input.surface}.sha256.${digest}.${input.attachmentId}`
 }
 
+const publicSafeAttachmentContentRef = (
+  surface: ComposerAttachmentSurface,
+  contentRef: string | undefined,
+): string | undefined =>
+  contentRef?.startsWith(`attachment.${surface}.sha256.`) === true
+    ? contentRef
+    : undefined
+
+const publicSafeAttachmentThumbnailRef = (
+  surface: ComposerAttachmentSurface,
+  thumbnailRef: string | undefined,
+): string | undefined =>
+  thumbnailRef?.startsWith(`attachment_thumbnail.${surface}.sha256.`) === true
+    ? thumbnailRef
+    : undefined
+
 const receiptRefForAttachment = (input: {
   attachmentId: ComposerAttachmentId
   surface: ComposerAttachmentSurface
@@ -795,42 +811,49 @@ export const projectComposerAttachmentUploadReceipt = (input: {
   surface: ComposerAttachmentSurface
   observedAt?: number
   errorCode?: string
-}): ComposerAttachmentUploadReceipt => ({
-  kind: "composer_attachment_privacy_receipt",
-  schemaVersion: COMPOSER_SCHEMA_VERSION,
-  receiptRef: receiptRefForAttachment({
+}): ComposerAttachmentUploadReceipt => {
+  const contentRef = publicSafeAttachmentContentRef(
+    input.surface,
+    input.attachment.contentRef,
+  )
+  const thumbnailRef = publicSafeAttachmentThumbnailRef(
+    input.surface,
+    input.attachment.thumbnailRef,
+  )
+
+  return {
+    kind: "composer_attachment_privacy_receipt",
+    schemaVersion: COMPOSER_SCHEMA_VERSION,
+    receiptRef: receiptRefForAttachment({
+      attachmentId: input.attachment.id,
+      surface: input.surface,
+      status: input.attachment.status,
+      ...(input.attachment.digest === undefined
+        ? {}
+        : { digest: input.attachment.digest }),
+      ...(input.errorCode === undefined ? {} : { errorCode: input.errorCode }),
+    }),
     attachmentId: input.attachment.id,
     surface: input.surface,
     status: input.attachment.status,
+    name: input.attachment.name,
+    mime: input.attachment.mime,
+    sizeBytes: input.attachment.sizeBytes,
     ...(input.attachment.digest === undefined
       ? {}
       : { digest: input.attachment.digest }),
+    ...(contentRef === undefined ? {} : { contentRef }),
+    ...(thumbnailRef === undefined ? {} : { thumbnailRef }),
+    ...(input.attachment.dimensions === undefined
+      ? {}
+      : { dimensions: input.attachment.dimensions }),
+    ...(input.attachment.source === undefined
+      ? {}
+      : { source: input.attachment.source }),
     ...(input.errorCode === undefined ? {} : { errorCode: input.errorCode }),
-  }),
-  attachmentId: input.attachment.id,
-  surface: input.surface,
-  status: input.attachment.status,
-  name: input.attachment.name,
-  mime: input.attachment.mime,
-  sizeBytes: input.attachment.sizeBytes,
-  ...(input.attachment.digest === undefined
-    ? {}
-    : { digest: input.attachment.digest }),
-  ...(input.attachment.contentRef === undefined
-    ? {}
-    : { contentRef: input.attachment.contentRef }),
-  ...(input.attachment.thumbnailRef === undefined
-    ? {}
-    : { thumbnailRef: input.attachment.thumbnailRef }),
-  ...(input.attachment.dimensions === undefined
-    ? {}
-    : { dimensions: input.attachment.dimensions }),
-  ...(input.attachment.source === undefined
-    ? {}
-    : { source: input.attachment.source }),
-  ...(input.errorCode === undefined ? {} : { errorCode: input.errorCode }),
-  observedAt: input.observedAt ?? Date.now(),
-})
+    observedAt: input.observedAt ?? Date.now(),
+  }
+}
 
 const mimeAllowedByPolicy = (
   mime: string,


### PR DESCRIPTION
Addresses (no linked issue).

### Changes
- Filter composer attachment upload receipts so only content-addressed attachment and thumbnail refs are projected.
- Keep local/browser executor refs on upload tasks while omitting them from receipts.
- Document the receipt boundary and add regression coverage for hosted and desktop-local attachment flows.

### Verification
- `bun test clients/khala-code-desktop/tests/khala-codex-fleet-tools.test.ts apps/pylon/src/khala-spawn.test.ts apps/pylon/tests/khala-spawn.test.ts apps/pylon/src/presence-codex-account-capacity.test.ts apps/pylon/tests/presence.test.ts`: passed (exit 0)