### PR TITLE
feat(khala): route account OpenRouter BYOK

### DIFF
--- a/apps/openagents.com/workers/api/src/index.ts
+++ b/apps/openagents.com/workers/api/src/index.ts
@@ -6612,12 +6612,16 @@ const storeConnectedProviderApiKey =
   async (
     input: Readonly<{
       providerAccountRef: string
-      provider: 'anthropic_claude' | 'google_gemini'
+      provider: 'anthropic_claude' | 'google_gemini' | 'openrouter'
       apiKey: string
     }>,
   ): Promise<void> => {
     const providerField =
-      input.provider === 'anthropic_claude' ? 'anthropic' : 'google'
+      input.provider === 'anthropic_claude'
+        ? 'anthropic'
+        : input.provider === 'google_gemini'
+          ? 'google'
+          : 'openrouter'
 
     await kv.put(
       providerAuthSecretKey(input.providerAccountRef),
@@ -6686,6 +6690,31 @@ const readConnectedCodexAuthMaterial = async (
     authContentEnv: 'OPENCODE_AUTH_CONTENT',
     authContentJson: JSON.stringify(parsed),
   }
+}
+
+const readConnectedOpenRouterApiKey = async (
+  kv: KVNamespace,
+  providerAccountRef: string,
+): Promise<Redacted.Redacted<string> | undefined> => {
+  const raw = await kv.get(providerAuthSecretKey(providerAccountRef), 'text')
+
+  if (raw === null) {
+    return undefined
+  }
+
+  const parsed = safeJsonRecord(raw)
+  const openrouter = isRecord(parsed) ? parsed.openrouter : undefined
+
+  if (!isRecord(openrouter) || optionalString(openrouter.type) !== 'api_key') {
+    return undefined
+  }
+
+  const key = optionalString(openrouter.key)?.trim()
+  if (key === undefined || key === '') {
+    return undefined
+  }
+
+  return Redacted.make(key)
 }
 
 export const handleProgrammaticAgentRegistration = async (
@@ -12495,6 +12524,68 @@ const exactRouteRegistry = makeExactRouteRegistry<Env>([
         // `demand_kind=internal` (header-independent), keeping our own dogfood
         // out of the external trace corpus + demand ledger. Empty => no-op.
         internalAccountRefs,
+        resolveAccountByok: async accountRef => {
+          const agentUserId = accountRef.startsWith('agent:')
+            ? accountRef.slice('agent:'.length)
+            : undefined
+          if (agentUserId === undefined || agentUserId === '') {
+            return undefined
+          }
+          const db = openAgentsDatabase(env)
+          const openauthCredential = await db
+            .prepare(
+              `SELECT openauth_user_id
+                 FROM agent_credentials
+                WHERE user_id = ?
+                  AND openauth_user_id IS NOT NULL
+                  AND status = 'active'
+                  AND revoked_at IS NULL
+                ORDER BY last_used_at DESC
+                LIMIT 1`,
+            )
+            .bind(agentUserId)
+            .first<{ openauth_user_id: string | null }>()
+          const openauthUserId =
+            openauthCredential?.openauth_user_id ??
+            (
+              await db
+                .prepare(
+                  `SELECT openauth_user_id
+                     FROM openauth_agent_links
+                    WHERE agent_user_id = ?
+                      AND status = 'active'
+                      AND revoked_at IS NULL
+                    ORDER BY updated_at DESC
+                    LIMIT 1`,
+                )
+                .bind(agentUserId)
+                .first<{ openauth_user_id: string | null }>()
+            )?.openauth_user_id
+          if (openauthUserId === undefined || openauthUserId === null) {
+            return undefined
+          }
+          const accounts = await makeD1ProviderAccountRepository(
+            db,
+          ).listAccountsForUser(openauthUserId)
+          const account = accounts.find(
+            candidate =>
+              candidate.provider === 'openrouter' &&
+              candidate.authMode === 'api_key' &&
+              candidate.status === 'connected' &&
+              candidate.health !== 'requires_reauth' &&
+              candidate.secretRef !== null,
+          )
+          if (account === undefined) {
+            return undefined
+          }
+          const apiKey = await readConnectedOpenRouterApiKey(
+            env.AUTH_STORAGE,
+            account.providerAccountRef,
+          )
+          return apiKey === undefined
+            ? undefined
+            : { apiKey, provider: 'openrouter' as const }
+        },
         codingDelegation: {
           agentStore: makeD1AgentRegistrationStore(openAgentsDatabase(env)),
           pylonStore: makeD1PylonApiStore(openAgentsDatabase(env)),

--- a/apps/openagents.com/workers/api/src/inference/chat-completions-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/chat-completions-routes.test.ts
@@ -1570,6 +1570,112 @@ describe('POST /v1/chat/completions', () => {
     })
   })
 
+  test('routes account-attached OpenRouter BYOK when no request key is provided', async () => {
+    let capturedRequest: InferenceRequest | undefined
+    const registry = new InferenceProviderRegistry()
+    registry.register({
+      complete: request =>
+        Effect.sync(() => {
+          capturedRequest = request
+          return {
+            content: 'account BYOK response',
+            finishReason: 'stop',
+            servedModel: 'openrouter/account-model',
+            usage: { completionTokens: 2, promptTokens: 4, totalTokens: 6 },
+          }
+        }),
+      id: OPENROUTER_KHALA_FALLBACK_ADAPTER_ID,
+      stream: () => Effect.sync(() => []),
+    })
+    const metered: Array<MeteringContext> = []
+
+    const response = await run(
+      handleChatCompletions(
+        chatRequest(helloBody),
+        baseDeps({
+          lanePlan: selectAdapterPlan,
+          meteringHook: context =>
+            Effect.sync(() => {
+              metered.push(context)
+              return { metered: true, receiptRef: 'must-not-run' }
+            }),
+          readAvailableMsat: async () => {
+            throw new Error('account BYOK must not require credit balance')
+          },
+          registry,
+          resolveAccountByok: async () => ({
+            apiKey: Redacted.make('sk-or-account-owned-key'),
+            provider: 'openrouter',
+          }),
+        }),
+      ),
+    )
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get(KHALA_BYOK_ACK_HEADER)).toBe('routed')
+    expect(capturedRequest?.model).toBe(KHALA_MODEL_ID)
+    expect(capturedRequest?.callerProviderKey?.provider).toBe('openrouter')
+    expect(
+      capturedRequest?.callerProviderKey === undefined
+        ? undefined
+        : Redacted.value(capturedRequest.callerProviderKey.apiKey),
+    ).toBe('sk-or-account-owned-key')
+    expect(metered).toEqual([])
+    const text = await response.text()
+    expect(text).toContain('openagents/khala')
+    expect(text).not.toContain('sk-or-account-owned-key')
+  })
+
+  test('prefers request-specific BYOK over account-attached OpenRouter BYOK', async () => {
+    let capturedRequest: InferenceRequest | undefined
+    const registry = new InferenceProviderRegistry()
+    registry.register({
+      complete: request =>
+        Effect.sync(() => {
+          capturedRequest = request
+          return {
+            content: 'request BYOK response',
+            finishReason: 'stop',
+            servedModel: 'openrouter/request-model',
+            usage: { completionTokens: 2, promptTokens: 4, totalTokens: 6 },
+          }
+        }),
+      id: OPENROUTER_KHALA_FALLBACK_ADAPTER_ID,
+      stream: () => Effect.sync(() => []),
+    })
+    let accountResolverCalled = false
+
+    const response = await run(
+      handleChatCompletions(
+        chatRequest(helloBody, {
+          headers: {
+            [KHALA_BYOK_PROVIDER_HEADER]: 'openrouter',
+            [KHALA_BYOK_PROVIDER_KEY_HEADER]: 'sk-or-request-owned-key',
+          },
+        }),
+        baseDeps({
+          lanePlan: selectAdapterPlan,
+          registry,
+          resolveAccountByok: async () => {
+            accountResolverCalled = true
+            return {
+              apiKey: Redacted.make('sk-or-account-owned-key'),
+              provider: 'openrouter',
+            }
+          },
+        }),
+      ),
+    )
+
+    expect(response.status).toBe(200)
+    expect(accountResolverCalled).toBe(false)
+    expect(
+      capturedRequest?.callerProviderKey === undefined
+        ? undefined
+        : Redacted.value(capturedRequest.callerProviderKey.apiKey),
+    ).toBe('sk-or-request-owned-key')
+  })
+
   test('rejects malformed BYOK provider keys before dispatch', async () => {
     let dispatched = false
     const registry = new InferenceProviderRegistry()

--- a/apps/openagents.com/workers/api/src/inference/chat-completions-routes.ts
+++ b/apps/openagents.com/workers/api/src/inference/chat-completions-routes.ts
@@ -221,6 +221,7 @@ type KhalaByokState =
       _tag: 'accepted'
       apiKey: Redacted.Redacted<string>
       provider: 'openrouter'
+      source: 'account' | 'request'
     }>
   | Readonly<{ _tag: 'invalid'; reason: string }>
 
@@ -242,6 +243,7 @@ const resolveKhalaByokState = (headers: Headers): KhalaByokState => {
       _tag: 'accepted',
       apiKey: Redacted.make(requireProviderApiKeyShape(rawKey)),
       provider: 'openrouter',
+      source: 'request',
     }
   } catch {
     return {
@@ -414,6 +416,16 @@ export type InferenceFundingResolver = (
 
 export const defaultCardFundingResolver: InferenceFundingResolver = async () =>
   'card'
+
+export type KhalaAccountByokResolver = (
+  accountRef: string,
+) => Promise<
+  | Readonly<{
+      apiKey: Redacted.Redacted<string>
+      provider: 'openrouter'
+    }>
+  | undefined
+>
 
 // ROUTING SEAM ------------------------------------------------------------
 // Resolves a requested model alias to an adapter id. #5476 shipped a resolver
@@ -632,6 +644,14 @@ export type ChatCompletionsDeps = Readonly<{
   // Resolves the account's funding kind (card | bitcoin) for the metering hook.
   // Defaults to card (no Bitcoin discount).
   resolveFundingKind?: InferenceFundingResolver
+  // ACCOUNT-ATTACHED BYOK (#7646). Resolves a connected OpenRouter API-key
+  // provider account for this authenticated OpenAgents account. Request-specific
+  // BYOK headers take precedence and remain ephemeral; this resolver is only
+  // consulted when those headers are absent. The resolver returns redacted key
+  // material only, and the route still pins the public model surface to
+  // `openagents/khala`, routes through Khala identity/tool/tracing/metering
+  // boundaries, and records served tokens with no OpenAgents credit debit.
+  resolveAccountByok?: KhalaAccountByokResolver | undefined
   // Minimum available balance (msat) required to accept a request. Until #5477
   // prices per-model, any positive balance clears the gate; an account with
   // zero/negative available balance is rejected.
@@ -2629,16 +2649,34 @@ export const handleChatCompletions = (
         { status: 400 },
       )
     }
-    const byok = resolveKhalaByokState(request.headers)
-    if (byok._tag === 'invalid') {
+    const requestByok = resolveKhalaByokState(request.headers)
+    if (requestByok._tag === 'invalid') {
       return noStoreJsonResponse(
         {
           error: 'invalid_byok_provider_key',
-          reason: byok.reason,
+          reason: requestByok.reason,
         },
-        { headers: byokResponseHeaders(byok, false), status: 400 },
+        { headers: byokResponseHeaders(requestByok, false), status: 400 },
       )
     }
+    const accountByok =
+      requestByok._tag === 'absent' && deps.resolveAccountByok !== undefined
+        ? yield* Effect.tryPromise({
+            try: () => deps.resolveAccountByok!(session.accountRef),
+            catch: () => undefined,
+          }).pipe(Effect.catch(() => Effect.void))
+        : undefined
+    const byok: KhalaByokState =
+      requestByok._tag === 'accepted'
+        ? requestByok
+        : accountByok === undefined
+          ? requestByok
+          : {
+              _tag: 'accepted',
+              apiKey: accountByok.apiKey,
+              provider: accountByok.provider,
+              source: 'account',
+            }
 
     const nowEpochSeconds = deps.nowEpochSeconds ?? currentEpochSeconds
     const newId = deps.newId ?? defaultId

--- a/apps/openagents.com/workers/api/src/provider-account-api-key.test.ts
+++ b/apps/openagents.com/workers/api/src/provider-account-api-key.test.ts
@@ -2,6 +2,7 @@ import { Effect } from 'effect'
 import { describe, expect, test } from 'vitest'
 
 import {
+  type ApiKeyConnectProvider,
   PROVIDER_API_KEY_CONNECT_POLICIES,
   connectProviderApiKeyAccount,
   probeProviderApiKey,
@@ -139,7 +140,7 @@ const dependencies = (probeStatus: number) => ({
   storeConnectedApiKey: (
     input: Readonly<{
       providerAccountRef: string
-      provider: 'anthropic_claude' | 'google_gemini'
+      provider: ApiKeyConnectProvider
       apiKey: string
     }>,
   ) => {
@@ -158,7 +159,10 @@ describe('provider api key connect policy', () => {
   test('exposes exactly the ToS-cleared API-key BYOK providers', () => {
     expect(
       PROVIDER_API_KEY_CONNECT_POLICIES.map(policy => policy.provider),
-    ).toEqual(['anthropic_claude', 'google_gemini'])
+    ).toEqual(['openrouter', 'anthropic_claude', 'google_gemini'])
+    expect(
+      providerApiKeyConnectPolicyForRouteSegment('openrouter')?.provider,
+    ).toBe('openrouter')
     expect(
       providerApiKeyConnectPolicyForRouteSegment('anthropic')?.provider,
     ).toBe('anthropic_claude')

--- a/apps/openagents.com/workers/api/src/provider-account-api-key.ts
+++ b/apps/openagents.com/workers/api/src/provider-account-api-key.ts
@@ -6,6 +6,7 @@ import {
 import {
   ANTHROPIC_CLAUDE_PROVIDER,
   GOOGLE_GEMINI_PROVIDER,
+  OPENROUTER_PROVIDER,
   type IdFactory,
   type ProviderAccountHealth,
   type ProviderAccountRecord,
@@ -40,10 +41,11 @@ import {
 export type ApiKeyConnectProvider =
   | typeof ANTHROPIC_CLAUDE_PROVIDER
   | typeof GOOGLE_GEMINI_PROVIDER
+  | typeof OPENROUTER_PROVIDER
 
 export type ProviderApiKeyConnectPolicy = Readonly<{
   provider: ApiKeyConnectProvider
-  routeSegment: 'anthropic' | 'google-gemini'
+  routeSegment: 'anthropic' | 'google-gemini' | 'openrouter'
   secretRefSegment: string
   probeUrl: string
   probeHeaders: (apiKey: string) => Readonly<Record<string, string>>
@@ -51,6 +53,15 @@ export type ProviderApiKeyConnectPolicy = Readonly<{
 
 export const PROVIDER_API_KEY_CONNECT_POLICIES: ReadonlyArray<ProviderApiKeyConnectPolicy> =
   [
+    {
+      provider: OPENROUTER_PROVIDER,
+      routeSegment: 'openrouter',
+      secretRefSegment: 'openrouter',
+      probeUrl: 'https://openrouter.ai/api/v1/models',
+      probeHeaders: apiKey => ({
+        authorization: `Bearer ${apiKey}`,
+      }),
+    },
     {
       provider: ANTHROPIC_CLAUDE_PROVIDER,
       routeSegment: 'anthropic',

--- a/apps/openagents.com/workers/api/src/provider-account-domain.ts
+++ b/apps/openagents.com/workers/api/src/provider-account-domain.ts
@@ -21,6 +21,7 @@ import {
 export const CHATGPT_CODEX_PROVIDER = 'chatgpt_codex' as const
 export const GOOGLE_GEMINI_PROVIDER = 'google_gemini' as const
 export const ANTHROPIC_CLAUDE_PROVIDER = 'anthropic_claude' as const
+export const OPENROUTER_PROVIDER = 'openrouter' as const
 export const CHATGPT_CODEX_VERIFICATION_URL =
   'https://auth.openai.com/codex/device'
 export const PROVIDER_ACCOUNT_PUBLIC_COLLECTIONS = {
@@ -74,6 +75,7 @@ export type ProviderAccountProvider =
   | typeof CHATGPT_CODEX_PROVIDER
   | typeof GOOGLE_GEMINI_PROVIDER
   | typeof ANTHROPIC_CLAUDE_PROVIDER
+  | typeof OPENROUTER_PROVIDER
 
 export const providerDisplayName = (
   provider: ProviderAccountProvider,
@@ -82,7 +84,9 @@ export const providerDisplayName = (
     ? 'ChatGPT/Codex'
     : provider === GOOGLE_GEMINI_PROVIDER
       ? 'Google Gemini'
-      : 'Anthropic Claude'
+      : provider === ANTHROPIC_CLAUDE_PROVIDER
+        ? 'Anthropic Claude'
+        : 'OpenRouter'
 
 export type ProviderConnectionAttemptStatus =
   | 'pending'

--- a/apps/openagents.com/workers/api/src/provider-account-repository.ts
+++ b/apps/openagents.com/workers/api/src/provider-account-repository.ts
@@ -75,7 +75,6 @@ export const makeD1ProviderAccountRepository = (
         `SELECT *
          FROM provider_accounts
          WHERE user_id = ?
-           AND provider = 'chatgpt_codex'
            AND deleted_at IS NULL
          ORDER BY updated_at DESC
          LIMIT 50`,

--- a/clients/khala-cli/src/cli.ts
+++ b/clients/khala-cli/src/cli.ts
@@ -1650,8 +1650,8 @@ function formatKeyAdded(record: StoredProviderKey, env: Record<string, string | 
   return [
     `Saved your ${record.provider} key (${redactProviderKey(record.key)}).`,
     terminalStyle.meta(`Stored locally at ${providerKeyPath(env)} (only you can read it).`),
-    terminalStyle.meta("Khala now sends this key with your chats so usage can run on your own provider account."),
-    terminalStyle.meta("Full upstream BYOK routing is rolling out; until then the server acknowledges the key and chats use the shared collective. Run `khala key remove` to stop sending it."),
+    terminalStyle.meta("Khala sends this key to the hosted OpenAgents gateway for each chat; usage runs through Khala on your provider account."),
+    terminalStyle.meta("Run `khala key remove` to stop sending the request-specific key."),
   ].join("\n")
 }
 

--- a/clients/khala-code-desktop/README.md
+++ b/clients/khala-code-desktop/README.md
@@ -12,9 +12,9 @@ The desktop host routes model traffic through the hosted OpenAgents cloud:
 OPENAGENTS_AGENT_TOKEN=... bun run dev
 ```
 
-Request-specific OpenRouter BYOK is passed to hosted Khala instead of being used
-as a local model backend. Set both credentials when you want the hosted gateway
-to spend a request against your OpenRouter key:
+OpenRouter BYOK is passed to hosted Khala instead of being used as a local model
+backend. An account-attached OpenRouter key is used automatically by the hosted
+gateway. A request-specific key, when set, takes precedence for that request:
 
 ```sh
 OPENAGENTS_AGENT_TOKEN=... OPENROUTER_API_KEY=... bun run dev


### PR DESCRIPTION
Addresses (no linked issue).

### Changes
- Adds support for storing and reading connected OpenRouter API keys alongside existing provider credentials.
- Routes chat completions through account-attached OpenRouter BYOK when no request-specific key is provided, while preserving request BYOK precedence.
- Updates BYOK/account capacity tests and Khala CLI/desktop docs copy for Codex fleet behavior.

### Verification
- `bun test clients/khala-code-desktop/tests/khala-codex-fleet-tools.test.ts apps/pylon/src/khala-spawn.test.ts apps/pylon/tests/khala-spawn.test.ts apps/pylon/src/presence-codex-account-capacity.test.ts apps/pylon/tests/presence.test.ts`
- Result: passed (exit 0)