### PR TITLE
feat(khala-code-desktop): worker 2/5. Five default-account public OpenA…

### DIFF
--- a/clients/khala-code-desktop/src/bun/rpc-handlers.ts
+++ b/clients/khala-code-desktop/src/bun/rpc-handlers.ts
@@ -28,6 +28,7 @@ import {
   collectCodexAccountEmails,
   ensureLocalPylon,
   inspectCodexFleet,
+  type KhalaCodexFleetToolOptions,
   openExternalUrl,
   removeCodexAccount,
 } from "./khala-codex-fleet-tools.js"
@@ -41,6 +42,7 @@ export type KhalaCodeDesktopRpcHandlersInput = {
   readonly consumeCodexRateLimitResetCredit?: (input: {
     readonly idempotencyKey: string
   }) => MaybePromise<KhalaCodexRateLimitResetOutcome>
+  readonly codexFleetToolOptions?: KhalaCodexFleetToolOptions
   readonly env: ChatEnv
   readonly emitChatTurnEvent?: (event: KhalaCodeDesktopChatTurnEvent) => void
   readonly onDeviceDeciderStatus: () => MaybePromise<OnDeviceDeciderSelection>
@@ -143,7 +145,7 @@ export function createKhalaCodeDesktopRpcRequestHandlers(
     async codexFleetStatus(): Promise<KhalaCodeDesktopFleetStatus> {
       const fleet = await inspectCodexFleet(
         { includeProcesses: true, startPylon: false },
-        { env: input.env as NodeJS.ProcessEnv },
+        { ...input.codexFleetToolOptions, env: input.env as NodeJS.ProcessEnv },
       )
       const emails = await collectCodexAccountEmails(
         fleet.accounts.map(account => account.accountRef),
@@ -165,13 +167,17 @@ export function createKhalaCodeDesktopRpcRequestHandlers(
           readiness: account.readiness,
           quotaState: account.quotaState,
           accountKey: account.accountKey,
+          capacity: account.capacity,
           email: emails[account.accountRef] ?? null,
         })),
         activeAssignments: fleet.activeAssignments.map(marker => ({
           assignmentRef: marker.assignmentRef,
+          elapsedMs: marker.elapsedMs,
           issueRef: marker.issueRef,
+          tokenRate: marker.tokenRate,
           updatedAt: marker.updatedAt,
         })),
+        tokenRate: fleet.tokenRate,
         processes: fleet.processes.map(process => ({
           pid: process.pid,
           parentPid: process.parentPid,

--- a/clients/khala-code-desktop/src/shared/rpc.ts
+++ b/clients/khala-code-desktop/src/shared/rpc.ts
@@ -135,12 +135,47 @@ export type KhalaCodeDesktopFleetAccount = {
   readonly readiness: string
   readonly quotaState: string | null
   readonly accountKey: string | null
+  readonly capacity: KhalaCodeDesktopFleetCapacity | null
   readonly email: string | null
+}
+
+export type KhalaCodeDesktopFleetCapacity = {
+  readonly available: number | null
+  readonly busy: number | null
+  readonly queued: number | null
+  readonly ready: number | null
+}
+
+export type KhalaCodeDesktopFleetTokenMeasurementStatus =
+  | "exact"
+  | "estimated"
+  | "not_measured"
+  | "pending"
+
+export type KhalaCodeDesktopFleetAssignmentTokenRate = {
+  readonly source: string
+  readonly status: KhalaCodeDesktopFleetTokenMeasurementStatus
+  readonly tokenCountKind: string | null
+  readonly tokens: number | null
+  readonly tokensPerMinute: number | null
+}
+
+export type KhalaCodeDesktopFleetTokenRate = {
+  readonly activeAdjustedTokensPerMinute: number | null
+  readonly completedStatus: KhalaCodeDesktopFleetTokenMeasurementStatus
+  readonly completedTokenRows: number | null
+  readonly completedTokensPerMinute: number | null
+  readonly inFlightTokens: number | null
+  readonly inFlightTokensPerMinute: number | null
+  readonly source: "pylon_khala_apm" | "unavailable"
+  readonly unavailableReason: string | null
 }
 
 export type KhalaCodeDesktopFleetAssignment = {
   readonly assignmentRef: string | null
+  readonly elapsedMs: number | null
   readonly issueRef: string | null
+  readonly tokenRate: KhalaCodeDesktopFleetAssignmentTokenRate
   readonly updatedAt: string | null
 }
 
@@ -160,6 +195,7 @@ export type KhalaCodeDesktopFleetStatus = {
   }
   readonly availableCodexAssignments: number | null
   readonly maxCodexAssignments: number | null
+  readonly tokenRate: KhalaCodeDesktopFleetTokenRate
   readonly accounts: readonly KhalaCodeDesktopFleetAccount[]
   readonly activeAssignments: readonly KhalaCodeDesktopFleetAssignment[]
   readonly processes: readonly KhalaCodeDesktopFleetProcess[]

--- a/clients/khala-code-desktop/src/ui/fleet-status.ts
+++ b/clients/khala-code-desktop/src/ui/fleet-status.ts
@@ -83,6 +83,62 @@ const detailChip = (label: string, value: string): HTMLElement => {
   return chip
 }
 
+const unknownNumber = (value: number | null): string =>
+  value === null ? "?" : String(value)
+
+const formatElapsedMs = (elapsedMs: number | null): string | null => {
+  if (elapsedMs === null) return null
+  const seconds = Math.max(0, Math.round(elapsedMs / 1000))
+  const minutes = Math.floor(seconds / 60)
+  const remainder = seconds % 60
+  return minutes === 0 ? `${remainder}s` : `${minutes}m ${remainder}s`
+}
+
+const accountCapacityLabel = (
+  capacity: KhalaCodeDesktopFleetAccount["capacity"],
+): string | null => {
+  if (capacity === null) return null
+  return `${unknownNumber(capacity.available)}/${unknownNumber(capacity.ready)} free`
+}
+
+const fleetTokenRateLabel = (
+  tokenRate: KhalaCodeDesktopFleetStatus["tokenRate"],
+): string => {
+  if (tokenRate.source === "unavailable") return "not measured"
+  if (tokenRate.completedStatus === "pending") return "pending exact rows"
+  if (tokenRate.completedStatus === "not_measured") return "not measured"
+  if (tokenRate.completedTokensPerMinute === null) return titleize(tokenRate.completedStatus)
+  return `${tokenRate.completedTokensPerMinute}/min ${tokenRate.completedStatus}`
+}
+
+const fleetInFlightLabel = (
+  tokenRate: KhalaCodeDesktopFleetStatus["tokenRate"],
+): string | null => {
+  if (tokenRate.inFlightTokens === null) return null
+  const rate = tokenRate.inFlightTokensPerMinute === null
+    ? ""
+    : `, ${tokenRate.inFlightTokensPerMinute}/min`
+  return `${tokenRate.inFlightTokens} token(s)${rate}`
+}
+
+const assignmentTokenRateLabel = (
+  tokenRate: KhalaCodeDesktopFleetStatus["activeAssignments"][number]["tokenRate"],
+): string => {
+  if (tokenRate.status === "pending") return "pending exact rows"
+  if (tokenRate.status === "not_measured") return "not measured"
+  const tokens = tokenRate.tokens === null ? "unknown" : `${tokenRate.tokens}`
+  const rate = tokenRate.tokensPerMinute === null ? "" : `, ${tokenRate.tokensPerMinute}/min`
+  return `${tokens} ${tokenRate.status}${rate}`
+}
+
+const appendChip = (
+  container: HTMLElement,
+  label: string,
+  value: string | null,
+): void => {
+  if (value !== null) container.append(detailChip(label, value))
+}
+
 const sectionHeader = (title: string, meta?: string): HTMLElement => {
   const header = el("div", "khala-fleet-section-header")
   header.append(el("h3", "khala-fleet-section-title", title))
@@ -141,6 +197,24 @@ const accountCard = (
   })
   card.append(remove)
 
+  const details = el("div", "khala-fleet-card-details")
+  appendChip(details, "readiness", titleize(account.readiness))
+  appendChip(details, "slots", accountCapacityLabel(account.capacity))
+  if (account.capacity !== null) {
+    appendChip(
+      details,
+      "busy",
+      account.capacity.busy === null ? null : String(account.capacity.busy),
+    )
+    appendChip(
+      details,
+      "queued",
+      account.capacity.queued === null ? null : String(account.capacity.queued),
+    )
+  }
+  appendChip(details, "quota", account.quotaState)
+  card.append(details)
+
   return card
 }
 
@@ -171,9 +245,11 @@ const renderReady = (
   )
   pylonCard.append(pylonId)
   pylonCard.append(badge(pylonState, titleize(data.pylon.status)))
-  if (capacity !== null) {
-    pylonCard.append(el("span", "khala-fleet-capacity", capacity))
-  }
+  const pylonDetails = el("div", "khala-fleet-card-details")
+  appendChip(pylonDetails, "slots", capacity)
+  appendChip(pylonDetails, "token rate", fleetTokenRateLabel(data.tokenRate))
+  appendChip(pylonDetails, "in flight", fleetInFlightLabel(data.tokenRate))
+  pylonCard.append(pylonDetails)
   pylonSection.append(pylonCard)
   container.append(pylonSection)
 
@@ -217,6 +293,8 @@ const renderReady = (
       if (marker.assignmentRef !== null) {
         chips.append(detailChip("assignment", marker.assignmentRef))
       }
+      appendChip(chips, "elapsed", formatElapsedMs(marker.elapsedMs))
+      appendChip(chips, "tokens", assignmentTokenRateLabel(marker.tokenRate))
       row.append(chips)
       list.append(row)
     }

--- a/clients/khala-code-desktop/src/ui/styles.css
+++ b/clients/khala-code-desktop/src/ui/styles.css
@@ -943,6 +943,13 @@ button {
   font-size: 0.72rem;
   color: color-mix(in srgb, var(--oa-color-component-text) 55%, transparent);
 }
+.khala-fleet-card-details {
+  grid-column: 1 / -1;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  min-width: 0;
+}
 .khala-fleet-capacity {
   grid-column: 1 / -1;
   font-size: 0.74rem;

--- a/clients/khala-code-desktop/tests/app-shell.test.ts
+++ b/clients/khala-code-desktop/tests/app-shell.test.ts
@@ -45,6 +45,18 @@ describe("khala code desktop app shell", () => {
     expect(html).not.toContain("Pylons")
   })
 
+  test("renders Fleet Status capacity and token evidence chips", async () => {
+    const fleetPanel = await Bun.file(new URL("../src/ui/fleet-status.ts", import.meta.url)).text()
+    const css = await Bun.file(new URL("../src/ui/styles.css", import.meta.url)).text()
+
+    expect(fleetPanel).toContain("accountCapacityLabel")
+    expect(fleetPanel).toContain("fleetTokenRateLabel")
+    expect(fleetPanel).toContain("assignmentTokenRateLabel")
+    expect(fleetPanel).toContain('appendChip(pylonDetails, "token rate"')
+    expect(fleetPanel).toContain('appendChip(chips, "tokens"')
+    expect(css).toContain(".khala-fleet-card-details")
+  })
+
   test("renders a visible Gym pane entry without seeded private proof data", async () => {
     const html = await Bun.file(new URL("../src/ui/index.html", import.meta.url)).text()
     const sidebar = await Bun.file(new URL("../src/ui/sidebar.ts", import.meta.url)).text()

--- a/clients/khala-code-desktop/tests/rpc-handlers.test.ts
+++ b/clients/khala-code-desktop/tests/rpc-handlers.test.ts
@@ -1,6 +1,67 @@
-import { describe, expect, test } from "bun:test"
+import { afterEach, describe, expect, test } from "bun:test"
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
 
 import { createKhalaCodeDesktopRpcRequestHandlers } from "../src/bun/rpc-handlers"
+import type {
+  KhalaCodexFleetCommandInput,
+  KhalaCodexFleetCommandResult,
+} from "../src/bun/khala-codex-fleet-tools"
+
+const tempDirs: string[] = []
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map(dir => rm(dir, { force: true, recursive: true })))
+})
+
+async function tempPylonFixture(): Promise<{
+  readonly appPath: string
+  readonly env: Record<string, string>
+  readonly home: string
+}> {
+  const root = await mkdtemp(join(tmpdir(), "khala-code-rpc-fleet-"))
+  tempDirs.push(root)
+  const appPath = join(root, "apps", "pylon")
+  const home = join(root, "pylon-home")
+  await mkdir(appPath, { recursive: true })
+  await mkdir(home, { recursive: true })
+  await writeFile(join(appPath, "package.json"), JSON.stringify({ name: "@openagentsinc/pylon" }))
+  return {
+    appPath,
+    env: {
+      OPENAGENTS_BUN_PATH: process.execPath,
+      OPENAGENTS_PYLON_APP_PATH: appPath,
+      PYLON_HOME: home,
+    },
+    home,
+  }
+}
+
+function ok(stdout: unknown): KhalaCodexFleetCommandResult {
+  return {
+    exitCode: 0,
+    signal: null,
+    stderr: "",
+    stdout: typeof stdout === "string" ? stdout : JSON.stringify(stdout),
+    timedOut: false,
+  }
+}
+
+function failed(stderr: string): KhalaCodexFleetCommandResult {
+  return {
+    exitCode: 1,
+    signal: null,
+    stderr,
+    stdout: "",
+    timedOut: false,
+  }
+}
+
+function pylonArgs(input: KhalaCodexFleetCommandInput): readonly string[] {
+  const index = input.cmd.indexOf("src/index.ts")
+  return index === -1 ? input.cmd : input.cmd.slice(index + 1)
+}
 
 describe("Khala Code desktop RPC handlers", () => {
   test("answers native desktop status probes instead of falling through", async () => {
@@ -127,6 +188,141 @@ describe("Khala Code desktop RPC handlers", () => {
             homeRef: "env:CODEX_HOME",
           },
         ],
+      },
+    })
+  })
+
+  test("projects Fleet Status capacity and token evidence through RPC", async () => {
+    const fixture = await tempPylonFixture()
+    const accountKey = "4db4cc18ebc55f39fb4da894"
+    const accountRefHash = `account.pylon.codex.${accountKey}`
+    const markerRoot = join(fixture.home, "active-assignment-runs")
+    await mkdir(markerRoot, { recursive: true })
+    await writeFile(join(markerRoot, "assignment.public.rpc.json"), JSON.stringify({
+      accountRefHash,
+      assignmentRef: "assignment.public.rpc",
+      refreshedAt: "2026-06-30T18:00:00.000Z",
+      schema: "openagents.pylon.active_assignment_run.v0.1",
+      service: "codex",
+      startedAt: "2026-06-30T17:58:00.000Z",
+    }))
+
+    const runner = async (input: KhalaCodexFleetCommandInput): Promise<KhalaCodexFleetCommandResult> => {
+      const args = pylonArgs(input)
+      const joined = args.join(" ")
+      if (joined === "provider go-online --json") {
+        return ok({
+          ok: true,
+          ownCapacityDispatch: {
+            availableCodexAssignments: 2,
+            codexAccounts: [{
+              accountKey,
+              available: 2,
+              busy: 1,
+              queued: 0,
+              ready: 3,
+            }],
+            maxCodexAssignments: 3,
+          },
+          pylonRef: "pylon.local.rpc",
+        })
+      }
+      if (joined === "codex accounts list --json") {
+        return ok({
+          accounts: [{
+            accountRef: "codex-2",
+            accountRefHash,
+            homeState: "present",
+            provider: "codex",
+          }],
+          schema: "openagents.pylon.accounts_list.v0.3",
+        })
+      }
+      if (joined === "accounts status --provider codex --json") {
+        return ok({
+          accounts: [{
+            accountRef: "codex-2",
+            accountRefHash,
+            provider: "codex",
+            quota: { state: "available" },
+            readiness: { state: "ready" },
+          }],
+          schema: "openagents.pylon.accounts_status.v0.1",
+        })
+      }
+      if (joined === "khala apm --base-url https://openagents.com --json") {
+        return ok({
+          active: {
+            adjustedTokensPerMinute: 315,
+            inFlightTokens: 630,
+            inFlightTokensPerMinute: 315,
+            serverAssignmentCount: 1,
+            serverAssignments: [{
+              assignmentRef: "assignment.public.rpc",
+              elapsedMs: 120_000,
+              source: "fleet.activeAssignments.tokensSoFar",
+              tokenCountKind: "exact",
+              tokens: 630,
+              tokensPerMinute: 315,
+            }],
+          },
+          counted: {
+            completedTokenRows: 2,
+            completedTokensPerMinute: 48,
+            sourceRefs: ["d1:token_usage_events"],
+          },
+          schema: "openagents.pylon.khala_apm.v0.1",
+        })
+      }
+      if (input.cmd[0] === "ps") return ok("  PID  PPID     ELAPSED COMMAND\n")
+      return failed(`unexpected command: ${joined}`)
+    }
+
+    const handlers = createKhalaCodeDesktopRpcRequestHandlers({
+      appleFmReadiness: () => {
+        throw new Error("not used")
+      },
+      codexFleetToolOptions: { runner },
+      env: fixture.env,
+      onDeviceDeciderStatus: () => {
+        throw new Error("not used")
+      },
+      workingDirectory: process.cwd(),
+    })
+
+    await expect(handlers.codexFleetStatus()).resolves.toMatchObject({
+      accounts: [{
+        accountRef: "codex-2",
+        capacity: {
+          available: 2,
+          busy: 1,
+          queued: 0,
+          ready: 3,
+        },
+        quotaState: "available",
+        readiness: "ready",
+      }],
+      activeAssignments: [{
+        assignmentRef: "assignment.public.rpc",
+        tokenRate: {
+          status: "exact",
+          tokenCountKind: "exact",
+          tokens: 630,
+          tokensPerMinute: 315,
+        },
+      }],
+      availableCodexAssignments: 2,
+      maxCodexAssignments: 3,
+      pylon: {
+        pylonRef: "pylon.local.rpc",
+        status: "online",
+      },
+      tokenRate: {
+        completedStatus: "exact",
+        completedTokenRows: 2,
+        completedTokensPerMinute: 48,
+        inFlightTokens: 630,
+        inFlightTokensPerMinute: 315,
       },
     })
   })


### PR DESCRIPTION
Automated OpenAgents Pylon Codex assignment change.

### Changes
- `clients/khala-code-desktop/src/bun/rpc-handlers.ts`
- `clients/khala-code-desktop/src/shared/rpc.ts`
- `clients/khala-code-desktop/src/ui/fleet-status.ts`
- `clients/khala-code-desktop/src/ui/styles.css`
- `clients/khala-code-desktop/tests/app-shell.test.ts`
- `clients/khala-code-desktop/tests/rpc-handlers.test.ts`

### Verification
```
bun test clients/khala-code-desktop/tests/khala-codex-fleet-tools.test.ts apps/pylon/src/khala-spawn.test.ts apps/pylon/tests/khala-spawn.test.ts apps/pylon/src/presence-codex-account-capacity.test.ts apps/pylon/tests/presence.test.ts
```
Passed locally (exit 0).