### PR TITLE
feat(khala-code-desktop): worker 1/1. Default-account fill packet. Insp…

### DIFF
--- a/clients/khala-code-desktop/src/bun/rpc-handlers.ts
+++ b/clients/khala-code-desktop/src/bun/rpc-handlers.ts
@@ -166,6 +166,7 @@ export function createKhalaCodeDesktopRpcRequestHandlers(
           quotaState: account.quotaState,
           accountKey: account.accountKey,
           email: emails[account.accountRef] ?? null,
+          capacity: account.capacity,
         })),
         activeAssignments: fleet.activeAssignments.map(marker => ({
           assignmentRef: marker.assignmentRef,

--- a/clients/khala-code-desktop/src/shared/rpc.ts
+++ b/clients/khala-code-desktop/src/shared/rpc.ts
@@ -136,6 +136,12 @@ export type KhalaCodeDesktopFleetAccount = {
   readonly quotaState: string | null
   readonly accountKey: string | null
   readonly email: string | null
+  readonly capacity: {
+    readonly available: number | null
+    readonly busy: number | null
+    readonly queued: number | null
+    readonly ready: number | null
+  } | null
 }
 
 export type KhalaCodeDesktopFleetAssignment = {

--- a/clients/khala-code-desktop/src/ui/fleet-status.ts
+++ b/clients/khala-code-desktop/src/ui/fleet-status.ts
@@ -67,6 +67,24 @@ const titleize = (value: string): string =>
 const summaryLine = (parts: ReadonlyArray<string | null>): string =>
   parts.filter((part): part is string => Boolean(part)).join("  ·  ")
 
+const isDisplayOnlyDefaultAccountRef = (accountRef: string): boolean =>
+  /^(?:\(default\)|default)$/iu.test(accountRef.trim())
+
+const slotValue = (value: number | null): string =>
+  value === null ? "?" : String(value)
+
+const accountCapacityLabel = (
+  capacity: KhalaCodeDesktopFleetAccount["capacity"],
+): string | null => {
+  if (capacity === null) return null
+  if (capacity.available !== null && capacity.ready !== null) {
+    return `${capacity.available}/${capacity.ready} free`
+  }
+  if (capacity.available !== null) return `${capacity.available} free`
+  if (capacity.ready !== null) return `${capacity.ready} ready`
+  return "unknown"
+}
+
 const badge = (state: string, label: string): HTMLElement => {
   const node = el("span", "khala-fleet-badge")
   node.dataset.state = state
@@ -101,7 +119,13 @@ const accountCard = (
 
   const identity = el("div", "khala-fleet-account-identity")
   const top = el("div", "khala-fleet-account-top")
-  top.append(el("strong", undefined, account.accountRef))
+  top.append(
+    el(
+      "strong",
+      undefined,
+      isDisplayOnlyDefaultAccountRef(account.accountRef) ? "default" : account.accountRef,
+    ),
+  )
   top.append(el("span", "khala-fleet-provider", account.provider))
   identity.append(top)
   identity.append(el("span", "khala-fleet-email", account.email ?? "not signed in"))
@@ -140,6 +164,23 @@ const accountCard = (
     handlers.onRemove(account.accountRef)
   })
   card.append(remove)
+
+  const accountDetails = el("div", "khala-fleet-chips khala-fleet-account-details")
+  if (isDisplayOnlyDefaultAccountRef(account.accountRef)) {
+    accountDetails.append(detailChip("routing", "default slot"))
+  }
+  const capacity = accountCapacityLabel(account.capacity)
+  if (capacity !== null) accountDetails.append(detailChip("slots", capacity))
+  if (account.capacity?.busy !== null && account.capacity?.busy !== undefined) {
+    accountDetails.append(detailChip("busy", slotValue(account.capacity.busy)))
+  }
+  if (account.capacity?.queued !== null && account.capacity?.queued !== undefined) {
+    accountDetails.append(detailChip("queued", slotValue(account.capacity.queued)))
+  }
+  if (account.quotaState !== null) {
+    accountDetails.append(detailChip("quota", account.quotaState))
+  }
+  if (accountDetails.childElementCount > 0) card.append(accountDetails)
 
   return card
 }

--- a/clients/khala-code-desktop/src/ui/styles.css
+++ b/clients/khala-code-desktop/src/ui/styles.css
@@ -943,6 +943,9 @@ button {
   font-size: 0.72rem;
   color: color-mix(in srgb, var(--oa-color-component-text) 55%, transparent);
 }
+.khala-fleet-account-details {
+  grid-column: 1 / -1;
+}
 .khala-fleet-capacity {
   grid-column: 1 / -1;
   font-size: 0.74rem;

--- a/clients/khala-code-desktop/tests/app-shell.test.ts
+++ b/clients/khala-code-desktop/tests/app-shell.test.ts
@@ -45,6 +45,23 @@ describe("khala code desktop app shell", () => {
     expect(html).not.toContain("Pylons")
   })
 
+  test("renders per-account fleet capacity and the display-only default slot", async () => {
+    const rpc = await Bun.file(new URL("../src/shared/rpc.ts", import.meta.url)).text()
+    const fleet = await Bun.file(new URL("../src/ui/fleet-status.ts", import.meta.url)).text()
+    const handlers = await Bun.file(new URL("../src/bun/rpc-handlers.ts", import.meta.url)).text()
+    const css = await Bun.file(new URL("../src/ui/styles.css", import.meta.url)).text()
+
+    expect(rpc).toContain("readonly capacity: {")
+    expect(handlers).toContain("capacity: account.capacity")
+    expect(fleet).toContain("accountCapacityLabel")
+    expect(fleet).toContain("routing\", \"default slot")
+    expect(fleet).toContain("detailChip(\"slots\", capacity)")
+    expect(fleet).toContain("detailChip(\"busy\", slotValue(account.capacity.busy))")
+    expect(fleet).toContain("detailChip(\"queued\", slotValue(account.capacity.queued))")
+    expect(css).toContain(".khala-fleet-account-details")
+    expect(css).toContain("grid-column: 1 / -1")
+  })
+
   test("renders a visible Gym pane entry without seeded private proof data", async () => {
     const html = await Bun.file(new URL("../src/ui/index.html", import.meta.url)).text()
     const sidebar = await Bun.file(new URL("../src/ui/sidebar.ts", import.meta.url)).text()


### PR DESCRIPTION
Automated OpenAgents Pylon Codex assignment change.

### Changes
- `clients/khala-code-desktop/src/bun/rpc-handlers.ts`
- `clients/khala-code-desktop/src/shared/rpc.ts`
- `clients/khala-code-desktop/src/ui/fleet-status.ts`
- `clients/khala-code-desktop/src/ui/styles.css`
- `clients/khala-code-desktop/tests/app-shell.test.ts`

### Verification
```
bun test clients/khala-code-desktop/tests/khala-codex-fleet-tools.test.ts apps/pylon/src/khala-spawn.test.ts apps/pylon/tests/khala-spawn.test.ts apps/pylon/src/presence-codex-account-capacity.test.ts apps/pylon/tests/presence.test.ts
```
Passed locally (exit 0).