### PR TITLE
feat(pylon): worker 3/5. Five default-account public OpenAgents fill pa…

### DIFF
--- a/apps/openagents.com/workers/api/src/pylon-codex-turn-ingest-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/pylon-codex-turn-ingest-routes.test.ts
@@ -190,6 +190,10 @@ class MemoryProofStore
       },
       tokenUsage: {
         rowCount: 2,
+        refs: [
+          'event.inference.served-tokens.pylon-codex.001',
+          'event.inference.served-tokens.pylon-codex.002',
+        ],
         provider: 'pylon-codex-own-capacity',
         model: 'openagents/pylon-codex',
         usageTruth: 'exact',
@@ -253,6 +257,7 @@ class MemoryProofStore
       },
       tokenUsage: {
         rowCount: 0,
+        refs: [],
         provider: 'pylon-codex-own-capacity',
         model: 'openagents/pylon-codex',
         usageTruth: 'exact',
@@ -591,8 +596,10 @@ type ProofTokenUsageRow = Readonly<{
   cache_read_tokens: number
   demand_kind: string
   demand_source: string
+  id: string
   input_tokens: number
   model: string
+  observed_at: string
   output_tokens: number
   provider: string
   reasoning_tokens: number
@@ -923,10 +930,53 @@ const makeFakeProofD1 = (): D1Database & {
     )
   }
 
+  const matchToken = (
+    row: ProofTokenUsageRow,
+    values: ReadonlyArray<unknown>,
+  ): boolean => {
+    const [
+      provider,
+      model,
+      demandKind,
+      demandSource,
+      taskRef,
+      accountRef,
+      actorUserId,
+    ] = values.map(String)
+    return (
+      row.provider === provider &&
+      row.model === model &&
+      row.usage_truth === 'exact' &&
+      row.demand_kind === demandKind &&
+      row.demand_source === demandSource &&
+      row.task_ref === taskRef &&
+      row.account_ref === accountRef &&
+      row.actor_user_id === actorUserId
+    )
+  }
+
   const statement = (query: string): D1PreparedStatement => {
     let bound: ReadonlyArray<unknown> = []
     const stmt: D1PreparedStatement = {
       all: async <T,>() => {
+        if (
+          query.includes('SELECT id') &&
+          query.includes('FROM token_usage_events')
+        ) {
+          return {
+            meta: {} as D1Meta & Record<string, unknown>,
+            results: tokenRows
+              .filter(row => matchToken(row, bound))
+              .sort(
+                (left, right) =>
+                  left.observed_at.localeCompare(right.observed_at) ||
+                  left.id.localeCompare(right.id),
+              )
+              .slice(0, 100)
+              .map(row => ({ id: row.id })) as unknown as T[],
+            success: true as const,
+          }
+        }
         if (query.includes('SELECT trace_uuid')) {
           return {
             meta: {} as D1Meta & Record<string, unknown>,
@@ -981,26 +1031,7 @@ const makeFakeProofD1 = (): D1Database & {
       },
       first: async <T,>() => {
         if (query.includes('FROM token_usage_events')) {
-          const [
-            provider,
-            model,
-            demandKind,
-            demandSource,
-            taskRef,
-            accountRef,
-            actorUserId,
-          ] = bound.map(String)
-          const matches = tokenRows.filter(
-            row =>
-              row.provider === provider &&
-              row.model === model &&
-              row.usage_truth === 'exact' &&
-              row.demand_kind === demandKind &&
-              row.demand_source === demandSource &&
-              row.task_ref === taskRef &&
-              row.account_ref === accountRef &&
-              row.actor_user_id === actorUserId,
-          )
+          const matches = tokenRows.filter(row => matchToken(row, bound))
           return {
             cache_read_tokens: matches.reduce(
               (total, row) => total + row.cache_read_tokens,
@@ -1397,6 +1428,10 @@ describe('GET /api/pylon/codex/proof', () => {
       },
       tokenUsage: {
         rowCount: 2,
+        refs: [
+          'event.inference.served-tokens.pylon-codex.001',
+          'event.inference.served-tokens.pylon-codex.002',
+        ],
         provider: 'pylon-codex-own-capacity',
         model: 'openagents/pylon-codex',
         usageTruth: 'exact',
@@ -1470,8 +1505,10 @@ describe('GET /api/pylon/codex/proof', () => {
         cache_read_tokens: 3,
         demand_kind: 'own_capacity',
         demand_source: 'khala_coding_delegation',
+        id: 'event.inference.served-tokens.pylon-codex.001',
         input_tokens: 100,
         model: 'openagents/pylon-codex',
+        observed_at: '2026-06-26T12:00:01.000Z',
         output_tokens: 50,
         provider: 'pylon-codex-own-capacity',
         reasoning_tokens: 10,
@@ -1485,8 +1522,10 @@ describe('GET /api/pylon/codex/proof', () => {
         cache_read_tokens: 7,
         demand_kind: 'own_capacity',
         demand_source: 'khala_coding_delegation',
+        id: 'event.inference.served-tokens.pylon-codex.002',
         input_tokens: 20,
         model: 'openagents/pylon-codex',
+        observed_at: '2026-06-26T12:00:02.000Z',
         output_tokens: 15,
         provider: 'pylon-codex-own-capacity',
         reasoning_tokens: 4,
@@ -1500,8 +1539,10 @@ describe('GET /api/pylon/codex/proof', () => {
         cache_read_tokens: 1000,
         demand_kind: 'own_capacity',
         demand_source: 'khala_coding_delegation',
+        id: 'event.inference.served-tokens.pylon-codex.other',
         input_tokens: 1000,
         model: 'openagents/pylon-codex',
+        observed_at: '2026-06-26T12:00:03.000Z',
         output_tokens: 1000,
         provider: 'pylon-codex-own-capacity',
         reasoning_tokens: 1000,
@@ -1564,6 +1605,10 @@ describe('GET /api/pylon/codex/proof', () => {
       inputTokens: 120,
       outputTokens: 65,
       reasoningTokens: 14,
+      refs: [
+        'event.inference.served-tokens.pylon-codex.001',
+        'event.inference.served-tokens.pylon-codex.002',
+      ],
       rowCount: 2,
       totalTokens: 185,
       usageTruth: 'exact',
@@ -1767,8 +1812,10 @@ describe('GET /api/pylon/codex/trace-status', () => {
       cache_read_tokens: 3,
       demand_kind: 'own_capacity',
       demand_source: 'khala_coding_delegation',
+      id: 'event.inference.served-tokens.pylon-codex.final',
       input_tokens: 100,
       model: 'openagents/pylon-codex',
+      observed_at: '2026-06-26T12:00:05.000Z',
       output_tokens: 50,
       provider: 'pylon-codex-own-capacity',
       reasoning_tokens: 10,
@@ -1822,6 +1869,7 @@ describe('GET /api/pylon/codex/trace-status', () => {
     })
     expect(complete.tokenUsage).toMatchObject({
       rowCount: 1,
+      refs: ['event.inference.served-tokens.pylon-codex.final'],
       status: 'recorded',
       totalTokens: 150,
     })

--- a/apps/openagents.com/workers/api/src/pylon-codex-turn-ingest-routes.ts
+++ b/apps/openagents.com/workers/api/src/pylon-codex-turn-ingest-routes.ts
@@ -209,6 +209,7 @@ export type PylonCodexAssignmentProof = Readonly<{
   }>
   tokenUsage: Readonly<{
     rowCount: number
+    refs: ReadonlyArray<string>
     provider: typeof PYLON_CODEX_PROVIDER
     model: typeof PYLON_CODEX_MODEL_NAME
     usageTruth: 'exact'
@@ -456,6 +457,10 @@ type PylonCodexTokenProofRow = Readonly<{
   total_tokens: number | null
 }>
 
+type PylonCodexTokenUsageRefRow = Readonly<{
+  id: string
+}>
+
 type PylonCodexTraceProofRow = Readonly<{
   trace_uuid: string
   trajectory_id?: string
@@ -581,6 +586,34 @@ export const makeD1PylonCodexAssignmentProofStore = (
       )
       .first<PylonCodexTokenProofRow>()
 
+    const tokenRows = await db
+      .prepare(
+        `
+          SELECT id
+          FROM token_usage_events
+          WHERE provider = ?
+            AND model = ?
+            AND usage_truth = 'exact'
+            AND demand_kind = ?
+            AND demand_source = ?
+            AND task_ref = ?
+            AND account_ref = ?
+            AND actor_user_id = ?
+          ORDER BY observed_at ASC, id ASC
+          LIMIT 100
+        `,
+      )
+      .bind(
+        PYLON_CODEX_PROVIDER,
+        PYLON_CODEX_MODEL_NAME,
+        PYLON_CODEX_DEMAND_KIND,
+        PYLON_CODEX_DEMAND_SOURCE,
+        input.assignmentRef,
+        `agent:${input.ownerAgentUserId}`,
+        input.ownerUserId,
+      )
+      .all<PylonCodexTokenUsageRefRow>()
+
     const traceTrajectoryPrefix = `pylon_codex:${input.assignmentRef}:`
     const traceFilter = `
       owner_user_id = ?
@@ -663,6 +696,7 @@ export const makeD1PylonCodexAssignmentProofStore = (
 
     const traces = traceRows.results ?? []
     const rawEvents = rawRows.results ?? []
+    const tokenRefs = tokenRows.results ?? []
 
     return {
       schemaVersion: 'openagents.pylon.codex_assignment_proof.v1',
@@ -674,6 +708,7 @@ export const makeD1PylonCodexAssignmentProofStore = (
       },
       tokenUsage: {
         rowCount: Number(tokenRow?.row_count ?? 0),
+        refs: boundedProofRefs(tokenRefs, 'id'),
         provider: PYLON_CODEX_PROVIDER,
         model: PYLON_CODEX_MODEL_NAME,
         usageTruth: 'exact',
@@ -734,6 +769,34 @@ export const makeD1PylonCodexAssignmentProofStore = (
         input.ownerUserId,
       )
       .first<PylonCodexTokenProofRow>()
+
+    const tokenRows = await db
+      .prepare(
+        `
+          SELECT id
+          FROM token_usage_events
+          WHERE provider = ?
+            AND model = ?
+            AND usage_truth = 'exact'
+            AND demand_kind = ?
+            AND demand_source = ?
+            AND task_ref = ?
+            AND account_ref = ?
+            AND actor_user_id = ?
+          ORDER BY observed_at ASC, id ASC
+          LIMIT 100
+        `,
+      )
+      .bind(
+        PYLON_CODEX_PROVIDER,
+        PYLON_CODEX_MODEL_NAME,
+        PYLON_CODEX_DEMAND_KIND,
+        PYLON_CODEX_DEMAND_SOURCE,
+        input.assignment.assignmentRef,
+        `agent:${input.ownerAgentUserId}`,
+        input.ownerUserId,
+      )
+      .all<PylonCodexTokenUsageRefRow>()
 
     const eventRow = await db
       .prepare(
@@ -912,6 +975,7 @@ export const makeD1PylonCodexAssignmentProofStore = (
 
     const traces = traceRows.results ?? []
     const rawEvents = rawRows.results ?? []
+    const tokenRefs = tokenRows.results ?? []
     const finalTraceUuid =
       traces.find(row => !String(row.trajectory_id ?? '').includes(':chunk:'))
         ?.trace_uuid ?? null
@@ -975,6 +1039,7 @@ export const makeD1PylonCodexAssignmentProofStore = (
       },
       tokenUsage: {
         rowCount: tokenRowCount,
+        refs: boundedProofRefs(tokenRefs, 'id'),
         provider: PYLON_CODEX_PROVIDER,
         model: PYLON_CODEX_MODEL_NAME,
         usageTruth: 'exact',

--- a/apps/pylon/src/khala-requester.ts
+++ b/apps/pylon/src/khala-requester.ts
@@ -151,6 +151,7 @@ export type PylonKhalaAssignmentTraceStatusResult = {
     outputTokens: number
     provider: "pylon-codex-own-capacity"
     reasoningTokens: number
+    refs: string[]
     rowCount: number
     status: "pending" | "recorded"
     totalTokens: number
@@ -194,6 +195,7 @@ export type PylonKhalaProofResult = {
     outputTokens: number
     provider: "pylon-codex-own-capacity"
     reasoningTokens: number
+    refs: string[]
     rowCount: number
     totalTokens: number
     usageTruth: "exact"
@@ -449,6 +451,7 @@ const checklistItem = (ref: string, ok: boolean): PylonKhalaProofChecklistItem =
 export function evaluatePylonKhalaProofChecklist(
   proof: Omit<PylonKhalaProofResult, "ok" | "proofChecklist">,
 ): PylonKhalaProofChecklist {
+  const tokenUsageRefs = proof.tokenUsage.refs ?? []
   const items = [
     checklistItem(
       "check.khala_proof.schema.codex_assignment_proof_v1",
@@ -466,7 +469,8 @@ export function evaluatePylonKhalaProofChecklist(
       "check.khala_proof.token_usage.rows_and_tokens_present",
       proof.tokenUsage.rowCount > 0 &&
         proof.tokenUsage.totalTokens > 0 &&
-        proof.tokenUsage.totalTokens >= proof.tokenUsage.inputTokens + proof.tokenUsage.outputTokens,
+        proof.tokenUsage.totalTokens >= proof.tokenUsage.inputTokens + proof.tokenUsage.outputTokens &&
+        tokenUsageRefs.length >= Math.min(proof.tokenUsage.rowCount, 100),
     ),
     checklistItem(
       "check.khala_proof.traces.owner_only_present",
@@ -514,6 +518,8 @@ export function evaluatePylonKhalaCloseoutChecklist(
   const statusCloseoutPolicy =
     status.closeoutPolicy ?? unavailableCloseoutPolicy
   const proofCloseoutPolicy = proof.closeoutPolicy ?? unavailableCloseoutPolicy
+  const statusTokenUsageRefs = status.tokenUsage.refs ?? []
+  const proofTokenUsageRefs = proof.tokenUsage.refs ?? []
   const items = [
     checklistItem(
       "check.khala_closeout.status_schema.codex_assignment_trace_status_v1",
@@ -579,6 +585,13 @@ export function evaluatePylonKhalaCloseoutChecklist(
         status.tokenUsage.reasoningTokens === proof.tokenUsage.reasoningTokens &&
         status.tokenUsage.cacheReadTokens === proof.tokenUsage.cacheReadTokens &&
         status.tokenUsage.totalTokens === proof.tokenUsage.totalTokens,
+    ),
+    checklistItem(
+      "check.khala_closeout.token_usage_refs_consistent",
+      statusTokenUsageRefs.length >= Math.min(status.tokenUsage.rowCount, 100) &&
+        proofTokenUsageRefs.length >= Math.min(proof.tokenUsage.rowCount, 100) &&
+        statusTokenUsageRefs.length === proofTokenUsageRefs.length &&
+        statusTokenUsageRefs.every((ref, index) => ref === proofTokenUsageRefs[index]),
     ),
     checklistItem(
       "check.khala_closeout.proof_checklist.ok",

--- a/apps/pylon/src/khala-spawn.test.ts
+++ b/apps/pylon/src/khala-spawn.test.ts
@@ -338,6 +338,7 @@ const exactProof: PylonKhalaProofResult = {
     outputTokens: 5,
     provider: "pylon-codex-own-capacity",
     reasoningTokens: 1,
+    refs: ["event.inference.served-tokens.pylon-codex.owner"],
     rowCount: 1,
     totalTokens: 16,
     usageTruth: "exact",

--- a/apps/pylon/tests/khala-burndown.test.ts
+++ b/apps/pylon/tests/khala-burndown.test.ts
@@ -101,6 +101,7 @@ const proofResult = (assignmentRef: string, totalTokens: number): PylonKhalaProo
     outputTokens: 20,
     provider: "pylon-codex-own-capacity",
     reasoningTokens: 0,
+    refs: [`event.inference.served-tokens.pylon-codex.${assignmentRef}`],
     rowCount: 1,
     totalTokens,
     usageTruth: "exact",

--- a/apps/pylon/tests/khala-requester.test.ts
+++ b/apps/pylon/tests/khala-requester.test.ts
@@ -54,6 +54,10 @@ async function runPylonCli(args: string[], env: Record<string, string>) {
       PYLON_DISABLE_DAEMON_ROUTING: "1",
       PYLON_DISABLE_OPENCODE_STARTUP: "1",
       PYLON_SPARK_BACKUP_DISABLED: "1",
+      OPENAGENTS_PYLON_CODEX_BUSY: "",
+      OPENAGENTS_PYLON_CODEX_ACCOUNT_CONCURRENCY: "",
+      OPENAGENTS_PYLON_CODEX_CONCURRENCY: "",
+      OPENAGENTS_PYLON_CODEX_QUEUED: "",
       ...env,
     },
     stderr: "pipe",
@@ -149,6 +153,7 @@ function completeTraceStatus(overrides: Record<string, unknown> = {}) {
     },
     tokenUsage: {
       rowCount: 1,
+      refs: ["event.inference.served-tokens.pylon-codex.001"],
       provider: "pylon-codex-own-capacity",
       model: "openagents/pylon-codex",
       usageTruth: "exact",
@@ -215,6 +220,7 @@ function completeProof(overrides: Record<string, unknown> = {}) {
     },
     tokenUsage: {
       rowCount: 1,
+      refs: ["event.inference.served-tokens.pylon-codex.001"],
       provider: "pylon-codex-own-capacity",
       model: "openagents/pylon-codex",
       usageTruth: "exact",
@@ -806,6 +812,7 @@ describe("pylon khala requester API", () => {
               },
               tokenUsage: {
                 rowCount: 0,
+                refs: [],
                 provider: "pylon-codex-own-capacity",
                 model: "openagents/pylon-codex",
                 usageTruth: "exact",
@@ -906,6 +913,10 @@ describe("pylon khala requester API", () => {
               },
               tokenUsage: {
                 rowCount: 2,
+                refs: [
+                  "event.inference.served-tokens.pylon-codex.001",
+                  "event.inference.served-tokens.pylon-codex.002",
+                ],
                 provider: "pylon-codex-own-capacity",
                 model: "openagents/pylon-codex",
                 usageTruth: "exact",
@@ -996,6 +1007,7 @@ describe("pylon khala requester API", () => {
         outputTokens: 0,
         provider: "pylon-codex-own-capacity",
         reasoningTokens: 0,
+        refs: [],
         rowCount: 0,
         totalTokens: 0,
         usageTruth: "exact",
@@ -1051,6 +1063,7 @@ describe("pylon khala requester API", () => {
       },
       tokenUsage: {
         ...completeProof().tokenUsage,
+        refs: [],
         rowCount: 0,
         totalTokens: 0,
       },
@@ -1084,6 +1097,7 @@ describe("pylon khala requester API", () => {
         },
         tokenUsage: {
           ...completeTraceStatus().tokenUsage,
+          refs: [],
           rowCount: 0,
           status: "pending",
           totalTokens: 0,
@@ -1124,6 +1138,10 @@ describe("pylon khala requester API", () => {
     const proofPayload = completeProof({
       tokenUsage: {
         ...completeProof().tokenUsage,
+        refs: [
+          "event.inference.served-tokens.pylon-codex.001",
+          "event.inference.served-tokens.pylon-codex.002",
+        ],
         rowCount: 2,
         totalTokens: 280,
       },
@@ -1137,6 +1155,23 @@ describe("pylon khala requester API", () => {
     expect(checklist.ok).toBe(false)
     expect(checklist.blockerRefs).toContain(
       "blocker.khala_closeout.token_usage_totals_consistent",
+    )
+    expect(checklist.blockerRefs).toContain(
+      "blocker.khala_closeout.token_usage_refs_consistent",
+    )
+  })
+
+  test("proof checklist fails closed when exact token row refs are missing", () => {
+    const proofPayload = completeProof()
+    const { refs: _refs, ...tokenUsageWithoutRefs } = proofPayload.tokenUsage
+    const checklist = evaluatePylonKhalaProofChecklist({
+      ...proofPayload,
+      tokenUsage: tokenUsageWithoutRefs,
+    } as unknown as ProofPayload)
+
+    expect(checklist.ok).toBe(false)
+    expect(checklist.blockerRefs).toContain(
+      "blocker.khala_proof.token_usage.rows_and_tokens_present",
     )
   })
 
@@ -1321,6 +1356,7 @@ describe("pylon khala requester API", () => {
             },
             tokenUsage: {
               rowCount: 1,
+              refs: ["event.inference.served-tokens.pylon-codex.001"],
               provider: "pylon-codex-own-capacity",
               model: "openagents/pylon-codex",
               usageTruth: "exact",
@@ -1482,6 +1518,7 @@ describe("pylon khala requester API", () => {
             },
             tokenUsage: {
               rowCount: 0,
+              refs: [],
               provider: "pylon-codex-own-capacity",
               model: "openagents/pylon-codex",
               usageTruth: "exact",

--- a/apps/pylon/tests/khala-spawn.test.ts
+++ b/apps/pylon/tests/khala-spawn.test.ts
@@ -92,6 +92,7 @@ const proofResult = (assignmentRef: string, totalTokens: number): PylonKhalaProo
     outputTokens: 20,
     provider: "pylon-codex-own-capacity",
     reasoningTokens: 5,
+    refs: [`event.inference.served-tokens.pylon-codex.${assignmentRef}`],
     rowCount: 1,
     totalTokens,
     usageTruth: "exact",


### PR DESCRIPTION
Automated OpenAgents Pylon Codex assignment change.

### Changes
- `apps/openagents.com/workers/api/src/pylon-codex-turn-ingest-routes.test.ts`
- `apps/openagents.com/workers/api/src/pylon-codex-turn-ingest-routes.ts`
- `apps/pylon/src/khala-requester.ts`
- `apps/pylon/src/khala-spawn.test.ts`
- `apps/pylon/tests/khala-burndown.test.ts`
- `apps/pylon/tests/khala-requester.test.ts`
- `apps/pylon/tests/khala-spawn.test.ts`

### Verification
```
bun test clients/khala-code-desktop/tests/khala-codex-fleet-tools.test.ts apps/pylon/src/khala-spawn.test.ts apps/pylon/tests/khala-spawn.test.ts apps/pylon/src/presence-codex-account-capacity.test.ts apps/pylon/tests/presence.test.ts
```
Passed locally (exit 0).