### PR TITLE
fix(pylon): accept neutral agent assignment payloads

### DIFF
--- a/apps/pylon/src/agent-runner-registry.ts
+++ b/apps/pylon/src/agent-runner-registry.ts
@@ -9,6 +9,7 @@ import {
 } from "./claude-agent.js"
 import {
   CLAUDE_AGENT_TASK_AGENT_KIND,
+  CLAUDE_AGENT_TASK_SCHEMA,
   claudeAgentTaskFrom,
   executeClaudeAgentAssignment,
   type ClaudeAgentCheckoutRunner,
@@ -24,6 +25,7 @@ import {
   CODEX_AGENT_OWNER_LOCAL_APPROVAL_POLICY,
   CODEX_AGENT_OWNER_LOCAL_SANDBOX_MODE,
   CODEX_AGENT_TASK_AGENT_KIND,
+  CODEX_AGENT_TASK_SCHEMA,
   codexAgentTaskFrom,
   executeCodexAgentAssignment,
   type CodexAgentExecutionOptions,
@@ -37,8 +39,21 @@ export type AgentRunnerKind = "claude_agent" | "codex"
 export type AgentRunnerTaskAgentKind =
   | typeof CLAUDE_AGENT_TASK_AGENT_KIND
   | typeof CODEX_AGENT_TASK_AGENT_KIND
+export type AgentRunnerTaskSchema =
+  | typeof CLAUDE_AGENT_TASK_SCHEMA
+  | typeof CODEX_AGENT_TASK_SCHEMA
+export type AgentRunnerTaskPayloadKey = "claudeAgent" | "codex"
 export type AgentRunnerServiceRef = "claude" | "codex"
 export type AgentRunnerAccountProvider = "claude_agent" | "codex"
+
+export const AGENT_RUNNER_NEUTRAL_TASK_KEY = "agent" as const
+
+export type AgentRunnerTaskContract = {
+  agentKind: AgentRunnerTaskAgentKind
+  neutralPayloadKey: typeof AGENT_RUNNER_NEUTRAL_TASK_KEY
+  payloadKey: AgentRunnerTaskPayloadKey
+  schema: AgentRunnerTaskSchema
+}
 
 export type AgentRunnerReadinessProbeKind =
   | "claude_agent_sdk_import"
@@ -107,6 +122,21 @@ export type AgentRunnerExecutionOptions = {
   fetch?: typeof fetch
 }
 
+export type AgentRunnerRunInput = {
+  state: PylonLocalState
+  lease: PylonAssignmentLease
+  now: Date
+  options: AgentRunnerExecutionOptions
+}
+
+export type AgentRunnerRunResult = AgentRunnerCloseoutRecord | null
+
+export interface AgentRunner {
+  readonly kind: AgentRunnerKind
+  canRunAssignment: (codingAssignment: unknown) => boolean
+  run: (input: AgentRunnerRunInput) => Promise<AgentRunnerRunResult>
+}
+
 export type AgentRunnerDescriptor = {
   kind: AgentRunnerKind
   agentKind: AgentRunnerTaskAgentKind
@@ -115,14 +145,10 @@ export type AgentRunnerDescriptor = {
   serviceRef: AgentRunnerServiceRef
   capabilityRef: string
   runtime: AgentRunnerRuntimeContract
+  task: AgentRunnerTaskContract
   canRunAssignment: (codingAssignment: unknown) => boolean
-  execute: (
-    state: PylonLocalState,
-    lease: PylonAssignmentLease,
-    now: Date,
-    options: AgentRunnerExecutionOptions,
-  ) => Promise<AgentRunnerCloseoutRecord | null>
-}
+  run: (input: AgentRunnerRunInput) => Promise<AgentRunnerRunResult>
+} & AgentRunner
 
 export type AgentRunnerResolution =
   | { status: "matched"; runner: AgentRunnerDescriptor }
@@ -133,9 +159,94 @@ export type AgentRunnerResolution =
       blockerRef: "blocker.assignment.agent_runner_ambiguous"
     }
 
+const CLAUDE_AGENT_RUNNER_TASK: AgentRunnerTaskContract = {
+  agentKind: CLAUDE_AGENT_TASK_AGENT_KIND,
+  neutralPayloadKey: AGENT_RUNNER_NEUTRAL_TASK_KEY,
+  payloadKey: "claudeAgent",
+  schema: CLAUDE_AGENT_TASK_SCHEMA,
+}
+
+const CODEX_AGENT_RUNNER_TASK: AgentRunnerTaskContract = {
+  agentKind: CODEX_AGENT_TASK_AGENT_KIND,
+  neutralPayloadKey: AGENT_RUNNER_NEUTRAL_TASK_KEY,
+  payloadKey: "codex",
+  schema: CODEX_AGENT_TASK_SCHEMA,
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object"
+}
+
+function taskPayloadMatches(task: AgentRunnerTaskContract, payload: unknown): payload is Record<string, unknown> {
+  if (!isRecord(payload)) return false
+  return payload.schema === task.schema && payload.agentKind === task.agentKind
+}
+
 function hasObjectField(value: unknown, key: string): boolean {
-  const field = (value as Record<string, unknown> | undefined)?.[key]
+  const field = isRecord(value) ? value[key] : undefined
   return field !== null && typeof field === "object"
+}
+
+function agentRunnerTaskPayloadFromAssignment(
+  task: AgentRunnerTaskContract,
+  codingAssignment: unknown,
+): { payload: Record<string, unknown>; source: "legacy" | "neutral" } | null {
+  if (!isRecord(codingAssignment)) return null
+  const legacyPayload = codingAssignment[task.payloadKey]
+  if (taskPayloadMatches(task, legacyPayload)) {
+    return { payload: legacyPayload, source: "legacy" }
+  }
+  const neutralPayload = codingAssignment[task.neutralPayloadKey]
+  if (taskPayloadMatches(task, neutralPayload)) {
+    return { payload: neutralPayload, source: "neutral" }
+  }
+  return null
+}
+
+function normalizeCodingAssignmentForTask(
+  task: AgentRunnerTaskContract,
+  codingAssignment: unknown,
+): unknown {
+  const matched = agentRunnerTaskPayloadFromAssignment(task, codingAssignment)
+  if (matched === null || matched.source === "legacy" || !isRecord(codingAssignment)) {
+    return codingAssignment
+  }
+  return {
+    ...codingAssignment,
+    [task.payloadKey]: matched.payload,
+  }
+}
+
+function normalizeLeaseForTask(
+  task: AgentRunnerTaskContract,
+  lease: PylonAssignmentLease,
+): PylonAssignmentLease {
+  if (lease.codingAssignment === undefined) return lease
+  const normalized = normalizeCodingAssignmentForTask(task, lease.codingAssignment)
+  return normalized === lease.codingAssignment
+    ? lease
+    : { ...lease, codingAssignment: normalized as PylonAssignmentLease["codingAssignment"] }
+}
+
+function accountRefHashFromPayload(payload: Record<string, unknown>): string | null {
+  const accountRefHash = payload.accountRefHash
+  return typeof accountRefHash === "string" && accountRefHash.trim() !== ""
+    ? accountRefHash.trim()
+    : null
+}
+
+export function agentRunnerTaskPayloadForLease(
+  lease: PylonAssignmentLease,
+): { runner: AgentRunnerDescriptor; payload: Record<string, unknown>; source: "legacy" | "neutral" } | null {
+  const resolution = agentRunnerResolutionForLease(lease)
+  if (resolution.status !== "matched") return null
+  const matched = agentRunnerTaskPayloadFromAssignment(resolution.runner.task, lease.codingAssignment)
+  return matched === null ? null : { runner: resolution.runner, ...matched }
+}
+
+export function agentRunnerAccountRefHashForLease(lease: PylonAssignmentLease): string | null {
+  const matched = agentRunnerTaskPayloadForLease(lease)
+  return matched === null ? null : accountRefHashFromPayload(matched.payload)
 }
 
 function commonExecutionOptions(options: AgentRunnerExecutionOptions) {
@@ -155,6 +266,7 @@ export const AGENT_RUNNER_REGISTRY: ReadonlyArray<AgentRunnerDescriptor> = [
     accountProvider: "claude_agent",
     serviceRef: "claude",
     capabilityRef: CLAUDE_AGENT_CAPABILITY_REF,
+    task: CLAUDE_AGENT_RUNNER_TASK,
     runtime: {
       sdkPackage: CLAUDE_AGENT_SDK_PACKAGE,
       readinessProbe: "claude_agent_sdk_import",
@@ -174,9 +286,10 @@ export const AGENT_RUNNER_REGISTRY: ReadonlyArray<AgentRunnerDescriptor> = [
         enforcement: "deny_before_tool_use",
       },
     },
-    canRunAssignment: (codingAssignment) => claudeAgentTaskFrom(codingAssignment) !== null,
-    execute: (state, lease, now, options) =>
-      executeClaudeAgentAssignment(state, lease, now, {
+    canRunAssignment: (codingAssignment) =>
+      claudeAgentTaskFrom(normalizeCodingAssignmentForTask(CLAUDE_AGENT_RUNNER_TASK, codingAssignment)) !== null,
+    run: ({ state, lease, now, options }) =>
+      executeClaudeAgentAssignment(state, normalizeLeaseForTask(CLAUDE_AGENT_RUNNER_TASK, lease), now, {
         ...commonExecutionOptions(options),
         ...(options.claudeAgentCheckoutRunner === undefined
           ? {}
@@ -192,6 +305,7 @@ export const AGENT_RUNNER_REGISTRY: ReadonlyArray<AgentRunnerDescriptor> = [
     accountProvider: "codex",
     serviceRef: "codex",
     capabilityRef: CODEX_AGENT_CAPABILITY_REF,
+    task: CODEX_AGENT_RUNNER_TASK,
     runtime: {
       sdkPackage: CODEX_AGENT_SDK_PACKAGE,
       readinessProbe: "codex_sdk_import_or_cli_login",
@@ -211,9 +325,10 @@ export const AGENT_RUNNER_REGISTRY: ReadonlyArray<AgentRunnerDescriptor> = [
         enforcement: "reject_closeout_on_escape",
       },
     },
-    canRunAssignment: (codingAssignment) => codexAgentTaskFrom(codingAssignment) !== null,
-    execute: (state, lease, now, options) =>
-      executeCodexAgentAssignment(state, lease, now, {
+    canRunAssignment: (codingAssignment) =>
+      codexAgentTaskFrom(normalizeCodingAssignmentForTask(CODEX_AGENT_RUNNER_TASK, codingAssignment)) !== null,
+    run: ({ state, lease, now, options }) =>
+      executeCodexAgentAssignment(state, normalizeLeaseForTask(CODEX_AGENT_RUNNER_TASK, lease), now, {
         ...commonExecutionOptions(options),
         ...(options.codexAgentProbe === undefined ? {} : { codexAgentProbe: options.codexAgentProbe }),
         ...(options.codexAgentRunner === undefined ? {} : { codexAgentRunner: options.codexAgentRunner }),
@@ -270,5 +385,5 @@ export async function executeRegisteredAgentRunner(
 ): Promise<AgentRunnerCloseoutRecord | null> {
   const resolution = agentRunnerResolutionForLease(lease)
   if (resolution.status !== "matched") return null
-  return resolution.runner.execute(state, lease, now, options)
+  return resolution.runner.run({ state, lease, now, options })
 }

--- a/apps/pylon/src/agent-runtime-adapter.ts
+++ b/apps/pylon/src/agent-runtime-adapter.ts
@@ -245,7 +245,12 @@ function createRegisteredAgentRuntimeAdapter(
       closeoutToEvents(
         runner.adapterKind,
         request,
-        await runner.execute(request.state, request.lease, request.now, options),
+        await runner.run({
+          state: request.state,
+          lease: request.lease,
+          now: request.now,
+          options,
+        }),
       ),
   })
 }

--- a/apps/pylon/src/assignment.ts
+++ b/apps/pylon/src/assignment.ts
@@ -28,6 +28,7 @@ import type { PylonCodexAuthValidityProbe } from "./account-connect.js"
 import { probeAndRecordCodexAccountAuthHealth } from "./codex-account-auth-health.js"
 import type { CodexAgentRuntimePhase, CodexAgentRunner } from "./codex-agent-executor.js"
 import {
+  agentRunnerAccountRefHashForLease,
   agentRunnerForLease,
   agentRunnerResolutionForLease,
   agentRunnerServiceForLease,
@@ -972,21 +973,7 @@ function codingRunServiceForLease(lease: PylonAssignmentLease): PylonCodingServi
 }
 
 function codingRunAccountRefHashForLease(lease: PylonAssignmentLease): string | null {
-  const codingAssignment = lease.codingAssignment as { claudeAgent?: unknown; codex?: unknown } | undefined
-  const service = codingRunServiceForLease(lease)
-  const payload =
-    service === "claude"
-      ? codingAssignment?.claudeAgent
-      : service === "codex"
-        ? codingAssignment?.codex
-        : null
-  if (payload === null || typeof payload !== "object") {
-    return null
-  }
-  const accountRefHash = (payload as { accountRefHash?: unknown }).accountRefHash
-  return typeof accountRefHash === "string" && accountRefHash.trim() !== ""
-    ? accountRefHash.trim()
-    : null
+  return agentRunnerAccountRefHashForLease(lease)
 }
 
 function isLegacyLease(value: unknown): value is PylonAssignmentLease {

--- a/apps/pylon/src/index.ts
+++ b/apps/pylon/src/index.ts
@@ -2343,15 +2343,23 @@ async function localCodexDispatchAccounts(
 
 function khalaCodexCapacityAdvertisementEnv(
   env: NodeJS.ProcessEnv,
-  _requestedSlots: number,
+  requestedSlots: number,
 ): NodeJS.ProcessEnv {
-  const perAccountTarget =
-    positiveIntegerEnv(env.OPENAGENTS_PYLON_CODEX_ACCOUNT_CONCURRENCY) ??
+  const requestedFloor = Math.max(
+    5,
+    Number.isSafeInteger(requestedSlots) && requestedSlots > 0
+      ? Math.floor(requestedSlots)
+      : 1,
+  )
+  const inheritedPooledConcurrency =
     positiveIntegerEnv(env.OPENAGENTS_PYLON_CODEX_CONCURRENCY) ??
     1
-  const pooledTarget =
-    positiveIntegerEnv(env.OPENAGENTS_PYLON_CODEX_CONCURRENCY) ??
-    perAccountTarget
+  const explicitPerAccountConcurrency =
+    positiveIntegerEnv(env.OPENAGENTS_PYLON_CODEX_ACCOUNT_CONCURRENCY)
+  const perAccountTarget =
+    explicitPerAccountConcurrency ??
+    Math.max(inheritedPooledConcurrency, requestedFloor)
+  const pooledTarget = Math.max(inheritedPooledConcurrency, requestedFloor)
   return {
     ...env,
     OPENAGENTS_PYLON_CODEX_ACCOUNT_CONCURRENCY: String(perAccountTarget),

--- a/apps/pylon/tests/agent-runtime-adapter.test.ts
+++ b/apps/pylon/tests/agent-runtime-adapter.test.ts
@@ -20,10 +20,13 @@ import {
   type AgentRuntimeRunRequest,
 } from "../src/agent-runtime-adapter"
 import {
+  AGENT_RUNNER_NEUTRAL_TASK_KEY,
   AGENT_RUNNER_REGISTRY,
+  agentRunnerAccountRefHashForLease,
   agentRunnerForLease,
   agentRunnerResolutionForLease,
   agentRunnerServiceForLease,
+  agentRunnerTaskPayloadForLease,
 } from "../src/agent-runner-registry"
 import { createBootstrapSummary, parseBootstrapArgs } from "../src/bootstrap"
 import { CLAUDE_AGENT_SDK_PACKAGE } from "../src/claude-agent"
@@ -120,6 +123,7 @@ describe("AgentRuntimeAdapter", () => {
         kind: runner.kind,
         runtime: runner.runtime,
         serviceRef: runner.serviceRef,
+        task: runner.task,
       })),
     ).toEqual([
       {
@@ -147,6 +151,12 @@ describe("AgentRuntimeAdapter", () => {
           },
         },
         serviceRef: "claude",
+        task: {
+          agentKind: "claude_agent_sdk",
+          neutralPayloadKey: AGENT_RUNNER_NEUTRAL_TASK_KEY,
+          payloadKey: "claudeAgent",
+          schema: CLAUDE_AGENT_TASK_SCHEMA,
+        },
       },
       {
         accountProvider: "codex",
@@ -173,6 +183,12 @@ describe("AgentRuntimeAdapter", () => {
           },
         },
         serviceRef: "codex",
+        task: {
+          agentKind: "codex_sdk",
+          neutralPayloadKey: AGENT_RUNNER_NEUTRAL_TASK_KEY,
+          payloadKey: "codex",
+          schema: CODEX_AGENT_TASK_SCHEMA,
+        },
       },
     ])
 
@@ -209,6 +225,57 @@ describe("AgentRuntimeAdapter", () => {
     expect(agentRunnerServiceForLease(claudeLease)).toBe("claude")
     expect(agentRunnerForLease(codexLease)?.adapterKind).toBe("codex")
     expect(agentRunnerServiceForLease(codexLease)).toBe("codex")
+  })
+
+  test("neutral agent payload envelopes resolve through the registry without runner-specific assignment branches", () => {
+    const claudeLease = {
+      schema: "openagents.pylon.assignment_lease.v0.3",
+      assignmentRef: "assignment.public.registry.neutral_claude",
+      leaseRef: "lease.public.registry.neutral_claude",
+      goal: "goal.public.registry.neutral_claude",
+      paymentMode: "no-spend",
+      capabilityRefs: [],
+      codingAssignment: {
+        [AGENT_RUNNER_NEUTRAL_TASK_KEY]: {
+          schema: CLAUDE_AGENT_TASK_SCHEMA,
+          agentKind: "claude_agent_sdk",
+          fixtureRef: CLAUDE_AGENT_SUM_REPAIR_FIXTURE_REF,
+          accountRefHash: "account.pylon.claude_agent.aaaaaaaaaaaa",
+        },
+      },
+      expiresAt: now.toISOString(),
+    } as const
+    const codexLease = {
+      ...claudeLease,
+      assignmentRef: "assignment.public.registry.neutral_codex",
+      leaseRef: "lease.public.registry.neutral_codex",
+      codingAssignment: {
+        [AGENT_RUNNER_NEUTRAL_TASK_KEY]: {
+          schema: CODEX_AGENT_TASK_SCHEMA,
+          agentKind: "codex_sdk",
+          fixtureRef: CODEX_AGENT_SUM_REPAIR_FIXTURE_REF,
+          accountRefHash: "account.pylon.codex.bbbbbbbbbbbb",
+        },
+      },
+    } as const
+
+    expect(agentRunnerForLease(claudeLease)?.kind).toBe("claude_agent")
+    expect(agentRunnerServiceForLease(claudeLease)).toBe("claude")
+    expect(agentRunnerAccountRefHashForLease(claudeLease)).toBe("account.pylon.claude_agent.aaaaaaaaaaaa")
+    expect(agentRunnerTaskPayloadForLease(claudeLease)).toMatchObject({
+      source: "neutral",
+      runner: { kind: "claude_agent" },
+      payload: { agentKind: "claude_agent_sdk" },
+    })
+
+    expect(agentRunnerForLease(codexLease)?.kind).toBe("codex")
+    expect(agentRunnerServiceForLease(codexLease)).toBe("codex")
+    expect(agentRunnerAccountRefHashForLease(codexLease)).toBe("account.pylon.codex.bbbbbbbbbbbb")
+    expect(agentRunnerTaskPayloadForLease(codexLease)).toMatchObject({
+      source: "neutral",
+      runner: { kind: "codex" },
+      payload: { agentKind: "codex_sdk" },
+    })
   })
 
   test("registry resolution rejects ambiguous mixed-runner assignment payloads", () => {
@@ -311,6 +378,48 @@ describe("AgentRuntimeAdapter", () => {
       expect(replayAgentRuntimeEventLog(events).artifactRefs[0]).toStartWith(
         "artifact.pylon.claude_agent_task.patch.",
       )
+    })
+  })
+
+  test("registered adapters execute neutral agent payload envelopes", async () => {
+    const codexAdapter = createCodexAgentRuntimeAdapter({
+      codexAgentProbe: readyCodexProbe,
+      codexAgentRunner: fixingCodexRunner,
+    })
+    await withRequest({
+      [AGENT_RUNNER_NEUTRAL_TASK_KEY]: {
+        schema: CODEX_AGENT_TASK_SCHEMA,
+        agentKind: "codex_sdk",
+        fixtureRef: CODEX_AGENT_SUM_REPAIR_FIXTURE_REF,
+      },
+    }, async (request) => {
+      expect(await Effect.runPromise(codexAdapter.canRun(request))).toBe(true)
+      const projection = replayAgentRuntimeEventLog(await collect(codexAdapter.start(request)))
+      expect(projection).toMatchObject({
+        state: "completed",
+        externalStatus: "completed",
+      })
+      expect(projection.artifactRefs[0]).toStartWith("artifact.pylon.codex_agent_task.patch.")
+    })
+
+    const claudeAdapter = createClaudeCodeAgentRuntimeAdapter({
+      claudeAgentProbe: readyClaudeProbe,
+      claudeAgentRunner: fixingClaudeRunner,
+    })
+    await withRequest({
+      [AGENT_RUNNER_NEUTRAL_TASK_KEY]: {
+        schema: CLAUDE_AGENT_TASK_SCHEMA,
+        agentKind: "claude_agent_sdk",
+        fixtureRef: CLAUDE_AGENT_SUM_REPAIR_FIXTURE_REF,
+      },
+    }, async (request) => {
+      expect(await Effect.runPromise(claudeAdapter.canRun(request))).toBe(true)
+      const projection = replayAgentRuntimeEventLog(await collect(claudeAdapter.start(request)))
+      expect(projection).toMatchObject({
+        state: "completed",
+        externalStatus: "completed",
+      })
+      expect(projection.artifactRefs[0]).toStartWith("artifact.pylon.claude_agent_task.patch.")
     })
   })
 


### PR DESCRIPTION
Addresses (no linked issue).

### Changes
- Added runner task contracts for Claude and Codex assignments so Pylon can recognize both legacy provider-specific payload keys and the neutral `agent` payload key.
- Normalized neutral assignment payloads back to the runner-specific shape before execution and exposed payload/account-ref-hash helpers for lease handling.
- Updated assignment/runtime adapter wiring to use the shared runner `run` interface and covered the neutral payload path with tests.

### Verification
- `bun run test:pylon` passed (exit 0).