### PR TITLE
Surface Codex turn auth blockers

### DIFF
--- a/clients/khala-code-desktop/src/bun/rpc-handlers.ts
+++ b/clients/khala-code-desktop/src/bun/rpc-handlers.ts
@@ -377,16 +377,33 @@ export function createKhalaCodeDesktopRpcRequestHandlers(
     ],
   })
 
-  const labelCodexHarnessResponse = (
+  const failedCodexHarnessBlockerRefs = async (
     response: KhalaCodeDesktopChatTurnResponse,
-  ): KhalaCodeDesktopChatTurnResponse => ({
-    ...response,
-    backend: {
-      ...response.backend,
-      runtimeMode: "codex_harness",
-      toolCatalogKind: response.backend.toolCatalogKind ?? "codex_app_server",
-    },
-  })
+  ): Promise<readonly string[]> => {
+    if (response.ok || response.backend.kind !== "codex_app_server") return []
+    if (response.backend.turnStatus !== "failed") return []
+    try {
+      const status = await codexHarnessStatus()
+      return [...new Set(status.auth.blockerRefs)]
+    } catch {
+      return []
+    }
+  }
+
+  const labelCodexHarnessResponse = async (
+    response: KhalaCodeDesktopChatTurnResponse,
+  ): Promise<KhalaCodeDesktopChatTurnResponse> => {
+    const blockerRefs = response.backend.blockerRefs ?? await failedCodexHarnessBlockerRefs(response)
+    return {
+      ...response,
+      backend: {
+        ...response.backend,
+        ...(blockerRefs.length === 0 ? {} : { blockerRefs }),
+        runtimeMode: "codex_harness",
+        toolCatalogKind: response.backend.toolCatalogKind ?? "codex_app_server",
+      },
+    }
+  }
 
   const ecosystemNotifications: CodexAppServerNotification[] = []
   const ecosystemNotificationMethods = new Set([
@@ -1304,7 +1321,7 @@ export function createKhalaCodeDesktopRpcRequestHandlers(
     },
     async submitChatMessage(request) {
       if (!useLegacyKhalaNativeRuntime()) {
-        return labelCodexHarnessResponse(await requireCodexChatRuntime().startTurn({
+        return await labelCodexHarnessResponse(await requireCodexChatRuntime().startTurn({
           ...request,
           cwd: input.workingDirectory,
         }))

--- a/clients/khala-code-desktop/src/shared/rpc.ts
+++ b/clients/khala-code-desktop/src/shared/rpc.ts
@@ -105,6 +105,7 @@ export type KhalaCodeDesktopChatTurnRequest = {
 
 export type KhalaCodeDesktopBackendProjection = {
   readonly baseUrl?: string
+  readonly blockerRefs?: readonly string[]
   readonly credentialSource?: "env:OPENROUTER_API_KEY" | "khala-provider-key"
   readonly kind: "codex_app_server" | "hosted_openagents" | "mock"
   readonly model: string

--- a/clients/khala-code-desktop/tests/rpc-handlers.test.ts
+++ b/clients/khala-code-desktop/tests/rpc-handlers.test.ts
@@ -476,6 +476,71 @@ describe("Khala Code desktop RPC handlers", () => {
     expect(legacyTurnStarted).toBe(false)
   })
 
+  test("adds typed Codex auth blocker refs to failed Codex app-server chat turns", async () => {
+    const handlers = createKhalaCodeDesktopRpcRequestHandlers({
+      appleFmReadiness: () => {
+        throw new Error("not used")
+      },
+      codexChatRuntime: throwingCodexChatRuntime({
+        startTurn: async () => ({
+          backend: {
+            kind: "codex_app_server",
+            model: "gpt-5.1-codex",
+            threadId: "thread-codex-auth-missing",
+            turnId: "turn-codex-auth-missing",
+            turnStatus: "failed",
+          },
+          messages: [{
+            id: "turn-codex-auth-missing-status",
+            role: "system",
+            body: "Codex completed the turn with status: failed.",
+          }],
+          ok: false,
+          toolNames: [],
+          usedTools: [],
+        }),
+      }),
+      codexHarnessStatus: () => readyHarness({
+        available: false,
+        reason: "Codex auth.json is missing.",
+        status: "unavailable",
+        auth: {
+          state: "credentials_missing",
+          blockerRefs: ["blocker.codex.credentials_missing"],
+          accessTokenPresent: false,
+          accountIdPresent: false,
+          refreshTokenPresent: false,
+          error: "Codex auth.json is missing.",
+        },
+        signIn: {
+          required: true,
+          command: "codex login",
+          warning: "Run codex login yourself for the primary user Codex session; Khala Code uses separate device-auth only for isolated Pylon worker homes.",
+        },
+      }),
+      env: {},
+      onDeviceDeciderStatus: () => {
+        throw new Error("not used")
+      },
+      workingDirectory: process.cwd(),
+    })
+
+    await expect(handlers.submitChatMessage({
+      messages: [{ id: "user-1", role: "user", body: "Say hello" }],
+      sessionId: "desktop-session-1",
+      turnId: "desktop-turn-1",
+    })).resolves.toMatchObject({
+      backend: {
+        kind: "codex_app_server",
+        blockerRefs: ["blocker.codex.credentials_missing"],
+        runtimeMode: "codex_harness",
+        toolCatalogKind: "codex_app_server",
+        turnStatus: "failed",
+      },
+      ok: false,
+    })
+  })
+
   test("keeps the Khala-native chat runtime behind the explicit legacy flag", async () => {
     let legacyTurnStarted = false
     const handlers = createKhalaCodeDesktopRpcRequestHandlers({


### PR DESCRIPTION
## Problem

Batch A Khala Desktop acceptance testing found that failed Codex app-server chat turns return only a generic failed turn status, while `codexHarnessStatus` already exposes typed auth blockers such as `blocker.codex.credentials_missing`. Callers had to infer the blocker from a separate status path.

## Change

- Adds optional `backend.blockerRefs` to the Khala Code Desktop chat-turn response projection.
- When the default Codex harness RPC path returns a failed Codex app-server turn, copies the existing harness auth blocker refs into the response backend.
- Adds a focused RPC regression test for the missing-auth failed-turn shape.

## Files Touched

- `clients/khala-code-desktop/src/shared/rpc.ts`
- `clients/khala-code-desktop/src/bun/rpc-handlers.ts`
- `clients/khala-code-desktop/tests/rpc-handlers.test.ts`

## Validation

- `bun test clients/khala-code-desktop/tests/rpc-handlers.test.ts -t "adds typed Codex auth blocker refs"`
- `bun test clients/khala-code-desktop/tests/rpc-handlers.test.ts`
- `bun run --cwd clients/khala-code-desktop typecheck`
- `git diff --check`

## Value

This clears the Batch A reporting gap from the Product Promises acceptance thread: a failed signed-out Codex turn now carries the same public-safe blocker ref as the readiness/status lane, so tests and UI callers can report `blocker.codex.credentials_missing` directly.

## Not Changed

- No Batch B signed-app, Apple FM, provider-capacity, settlement, or marketplace claim.
- No fabricated progress or capacity evidence.
- No change to Codex auth storage or default Codex home behavior.
