### PR TITLE
Add Pylon orchestration worker lifecycle state

### DIFF
--- a/apps/pylon/src/orchestration/store.ts
+++ b/apps/pylon/src/orchestration/store.ts
@@ -112,6 +112,16 @@ export type OrchestrationMessageKind =
   | "escalation"
   | "decision_gate"
 
+export type OrchestrationMessage = {
+  id: string
+  threadId: string
+  taskId: string | null
+  dispatchContextId: string | null
+  kind: OrchestrationMessageKind
+  body: string
+  createdAt: string
+}
+
 export type CreateTaskInput = {
   id: string
   parentId?: string | null
@@ -131,6 +141,25 @@ export type CreateDispatchContextInput = {
   maxConcurrentSlots?: number
   lastHeartbeatAt?: Date | null
   baseBehindBy?: number
+  now?: Date
+}
+
+export type RecordWorkerHeartbeatInput = {
+  contextId: string
+  taskId?: string | null
+  at?: Date
+  baseBehindBy?: number
+  status?: DispatchContextStatus
+  body?: string
+}
+
+export type RecordWorkerDoneInput = {
+  contextId: string
+  taskId: string
+  status: Extract<OrchestrationTaskStatus, "completed" | "failed" | "blocked">
+  result?: string | null
+  body?: string
+  maxFailures?: number
   now?: Date
 }
 
@@ -209,6 +238,16 @@ type VirtualHeadRow = {
   updated_at: string
 }
 
+type MessageRow = {
+  id: string
+  thread_id: string
+  task_id: string | null
+  dispatch_context_id: string | null
+  kind: OrchestrationMessageKind
+  body: string
+  created_at: string
+}
+
 const taskFromRow = (row: TaskRow): OrchestrationTask => ({
   id: row.id,
   parentId: row.parent_id,
@@ -265,6 +304,16 @@ const virtualHeadFromRow = (row: VirtualHeadRow): VirtualHead => ({
   pendingTaskIds: parsePendingTaskIds(row.pending_task_ids_json),
   createdAt: row.created_at,
   updatedAt: row.updated_at,
+})
+
+const messageFromRow = (row: MessageRow): OrchestrationMessage => ({
+  id: row.id,
+  threadId: row.thread_id,
+  taskId: row.task_id,
+  dispatchContextId: row.dispatch_context_id,
+  kind: row.kind,
+  body: row.body,
+  createdAt: row.created_at,
 })
 
 const virtualHeadProjectionRef = (input: { repo: string; branch: string; taskId: string; branchFrom: string }): string => {
@@ -477,6 +526,43 @@ export class PylonOrchestrationStore {
     return this.getDispatchContext(id) ?? current
   }
 
+  recordWorkerHeartbeat(input: RecordWorkerHeartbeatInput): OrchestrationMessage {
+    const at = input.at ?? new Date()
+    const context = this.getDispatchContext(input.contextId)
+    if (context === null) throw new Error(`unknown dispatch context: ${input.contextId}`)
+    const taskId = input.taskId ?? context.currentTaskId
+    const task = taskId === null ? null : this.getTask(taskId)
+    const threadId = task?.threadId ?? taskId ?? context.id
+    const body = input.body ?? `heartbeat ${context.assigneeHandle}${taskId === null ? "" : ` on ${taskId}`}`
+    const id = `message.${threadId}.${context.id}.heartbeat.${at.getTime()}`
+
+    this.db.run("BEGIN IMMEDIATE")
+    try {
+      this.recordHeartbeat(input.contextId, {
+        at,
+        ...(input.baseBehindBy === undefined ? {} : { baseBehindBy: input.baseBehindBy }),
+        ...(input.status === undefined ? {} : { status: input.status }),
+      })
+      this.appendMessage({
+        id,
+        threadId,
+        taskId,
+        dispatchContextId: context.id,
+        kind: "heartbeat",
+        body,
+        now: at,
+      })
+      this.db.run("COMMIT")
+    } catch (error) {
+      this.db.run("ROLLBACK")
+      throw error
+    }
+
+    const message = this.getMessage(id)
+    if (message === null) throw new Error(`failed to record orchestration heartbeat message ${id}`)
+    return message
+  }
+
   markDispatched(taskId: string, contextId: string, now: Date = new Date()): void {
     const at = iso(now)
     this.db.run("BEGIN IMMEDIATE")
@@ -642,6 +728,76 @@ export class PylonOrchestrationStore {
     return this.getDispatchContext(id) ?? current
   }
 
+  recordWorkerDone(input: RecordWorkerDoneInput): DispatchContext {
+    const now = input.now ?? new Date()
+    const at = iso(now)
+    const task = this.getTask(input.taskId)
+    if (task === null) throw new Error(`unknown orchestration task: ${input.taskId}`)
+    const context = this.getDispatchContext(input.contextId)
+    if (context === null) throw new Error(`unknown dispatch context: ${input.contextId}`)
+    if (context.currentTaskId !== input.taskId) {
+      throw new Error(`dispatch context ${input.contextId} is not assigned to task ${input.taskId}`)
+    }
+
+    const maxFailures = input.maxFailures ?? 3
+    const failureCount = input.status === "failed" ? context.failureCount + 1 : 0
+    const contextStatus: DispatchContextStatus =
+      input.status === "failed" && failureCount >= maxFailures ? "circuit_broken" : "idle"
+    const body = input.body ?? `worker_done ${input.taskId} ${input.status}`
+
+    this.db.run("BEGIN IMMEDIATE")
+    try {
+      this.db
+        .query(`
+          UPDATE pylon_orchestration_tasks
+             SET status = $status,
+                 result_json = $result,
+                 updated_at = $now
+           WHERE id = $taskId
+        `)
+        .run({
+          $taskId: input.taskId,
+          $status: input.status,
+          $result: input.result ?? null,
+          $now: at,
+        })
+      this.db
+        .query(`
+          UPDATE pylon_orchestration_dispatch_contexts
+             SET status = $contextStatus,
+                 current_task_id = NULL,
+                 failure_count = $failureCount,
+                 updated_at = $now
+           WHERE id = $contextId
+        `)
+        .run({
+          $contextId: input.contextId,
+          $contextStatus: contextStatus,
+          $failureCount: failureCount,
+          $now: at,
+        })
+      this.releaseVirtualHeadTask(input.taskId, now)
+      this.appendMessage({
+        id: `message.${input.taskId}.${input.contextId}.worker_done.${now.getTime()}`,
+        threadId: task.threadId,
+        taskId: input.taskId,
+        dispatchContextId: input.contextId,
+        kind: "worker_done",
+        body,
+        now,
+      })
+      this.db.run("COMMIT")
+    } catch (error) {
+      this.db.run("ROLLBACK")
+      throw error
+    }
+
+    if (input.status === "completed") {
+      this.promoteReadyTasks(now)
+    }
+    return this.getDispatchContext(input.contextId) ?? context
+  }
+
   appendMessage(input: {
     id: string
     threadId: string
@@ -667,6 +823,22 @@ export class PylonOrchestrationStore {
         $body: input.body,
         $createdAt: iso(input.now),
       })
+  }
+
+  getMessage(id: string): OrchestrationMessage | null {
+    const row = this.db
+      .query("SELECT * FROM pylon_orchestration_messages WHERE id = $id")
+      .get({ $id: id }) as MessageRow | null
+    return row === null ? null : messageFromRow(row)
+  }
+
+  listMessages(threadId?: string): OrchestrationMessage[] {
+    const rows = threadId === undefined
+      ? this.db.query("SELECT * FROM pylon_orchestration_messages ORDER BY created_at ASC, id ASC").all()
+      : this.db
+        .query("SELECT * FROM pylon_orchestration_messages WHERE thread_id = $threadId ORDER BY created_at ASC, id ASC")
+        .all({ $threadId: threadId })
+    return (rows as MessageRow[]).map(messageFromRow)
   }
 
   publicSnapshot(): { tasks: PublicOrchestrationTask[]; dispatchContexts: PublicDispatchContext[] } {

--- a/apps/pylon/src/orchestration/supervisor-orchestration.test.ts
+++ b/apps/pylon/src/orchestration/supervisor-orchestration.test.ts
@@ -338,6 +338,100 @@ describe("Pylon supervisor orchestration store", () => {
     expect(store.getVirtualHead("OpenAgentsInc/openagents", "main")?.pendingTaskIds).toEqual(["task.b"])
   })
 
+  test("records worker heartbeat and done messages while releasing completed dispatches", () => {
+    const now = new Date("2026-06-27T12:00:00.000Z")
+    const heartbeatAt = new Date("2026-06-27T12:01:00.000Z")
+    const doneAt = new Date("2026-06-27T12:02:00.000Z")
+    const store = createPylonOrchestrationStore(new Database(":memory:"))
+    store.createTask({ id: "task.root", spec: baseTaskSpec, now })
+    store.createTask({
+      id: "task.child",
+      spec: { ...baseTaskSpec, title: "child" },
+      deps: ["task.root"],
+      now,
+    })
+    store.createDispatchContext({
+      id: "ctx.codex",
+      assigneeHandle: "codex-1",
+      runnerKind: "codex",
+      lastHeartbeatAt: now,
+      now,
+    })
+
+    dispatchReadySupervisorTasks(store, { now })
+    const heartbeat = store.recordWorkerHeartbeat({
+      contextId: "ctx.codex",
+      at: heartbeatAt,
+      baseBehindBy: 2,
+      body: "codex-1 still running task.root",
+    })
+    const contextAfterHeartbeat = store.getDispatchContext("ctx.codex")
+
+    expect(heartbeat.kind).toBe("heartbeat")
+    expect(heartbeat.threadId).toBe("task.root")
+    expect(heartbeat.taskId).toBe("task.root")
+    expect(contextAfterHeartbeat?.lastHeartbeatAt).toBe(heartbeatAt.toISOString())
+    expect(contextAfterHeartbeat?.baseBehindBy).toBe(2)
+
+    const released = store.recordWorkerDone({
+      contextId: "ctx.codex",
+      taskId: "task.root",
+      status: "completed",
+      result: JSON.stringify({ ok: true }),
+      now: doneAt,
+    })
+
+    expect(store.getTask("task.root")?.status).toBe("completed")
+    expect(store.getTask("task.child")?.status).toBe("ready")
+    expect(released.status).toBe("idle")
+    expect(released.currentTaskId).toBeNull()
+    expect(released.failureCount).toBe(0)
+    expect(store.getVirtualHead("OpenAgentsInc/openagents", "main")?.pendingTaskIds).toEqual([])
+    expect(store.listMessages("task.root").map((message) => message.kind)).toEqual([
+      "dispatch",
+      "heartbeat",
+      "worker_done",
+    ])
+  })
+
+  test("worker failures increment the dispatch circuit breaker and preserve dependent blockers", () => {
+    const now = new Date("2026-06-27T12:00:00.000Z")
+    const store = createPylonOrchestrationStore(new Database(":memory:"))
+    store.createTask({ id: "task.fail", spec: baseTaskSpec, now })
+    store.createTask({
+      id: "task.dependent",
+      spec: { ...baseTaskSpec, title: "dependent" },
+      deps: ["task.fail"],
+      now,
+    })
+    store.createDispatchContext({
+      id: "ctx.codex",
+      assigneeHandle: "codex-1",
+      runnerKind: "codex",
+      lastHeartbeatAt: now,
+      now,
+    })
+
+    dispatchReadySupervisorTasks(store, { now })
+    const context = store.recordWorkerDone({
+      contextId: "ctx.codex",
+      taskId: "task.fail",
+      status: "failed",
+      maxFailures: 1,
+      now,
+    })
+
+    expect(store.getTask("task.fail")?.status).toBe("failed")
+    expect(store.getTask("task.dependent")?.status).toBe("pending")
+    expect(context.status).toBe("circuit_broken")
+    expect(context.failureCount).toBe(1)
+    expect(context.currentTaskId).toBeNull()
+    expect(store.listMessages("task.fail").map((message) => message.kind)).toEqual([
+      "dispatch",
+      "worker_done",
+    ])
+  })
+
   test("classifies heartbeat liveness with fresh, stale, hung, and missing states", () => {
     const now = new Date("2026-06-27T12:00:00.000Z")
     const store = createPylonOrchestrationStore(new Database(":memory:"))

--- a/docs/ade/2026-06-27-orca-orchestrator-adaptation-report.md
+++ b/docs/ade/2026-06-27-orca-orchestrator-adaptation-report.md
@@ -173,6 +173,12 @@ Each entry declares: how to **detect** the binary, how to **launch** it, how pro
 - **"Khala mobile operator companion + Durable-Object relay"** — E2EE pairing, agent-status subscription, finish notifications (socket + APNs), follow-up/steer send, method allowlist; DO-mediated for remote fleets. AaaS console.
 - **"Uniform agent-status ingest pipeline across all runners"** — generalize the Codex turn reporter into a runner-neutral status event consumed by dashboard + mobile + Artanis.
 
+### 2026-07-01 implementation note
+
+Pylon now has a first production slice of the Orca-style state spine in `apps/pylon/src/orchestration/`: a SQLite task DAG, dispatch contexts with runner-kind matching and heartbeat/base-drift eligibility, group addressing, virtual HEAD reservations for concurrent git tasks, and typed worker lifecycle APIs. The latest slice adds `recordWorkerHeartbeat`, `recordWorkerDone`, and message readback so worker progress and terminal closeout are represented as correlated `heartbeat` / `worker_done` messages while the dispatch context is released for constant-motion follow-on work. Failed worker closeouts increment the same circuit-breaker counter used by dispatch planning; completed closeouts release virtual HEAD reservations and promote dependents.
+
+Next: wire these store APIs into the existing local assignment runner/supervisor loop so accepted Khala Code leases emit orchestration heartbeats and worker-done records in addition to the current assignment progress and closeout projections.
+
 ---
 
 ## 7. License / attribution note


### PR DESCRIPTION
## Summary

- Adds typed worker lifecycle APIs to the Pylon orchestration store: `recordWorkerHeartbeat`, `recordWorkerDone`, and message readback.
- Persists correlated `heartbeat` / `worker_done` messages, releases completed dispatch contexts back to idle, removes completed/failed tasks from virtual HEAD reservations, promotes dependents on completion, and increments the dispatch circuit breaker on worker failure.
- Updates the Orca adaptation report with the landed slice and next integration step.

Refs: `docs/ade/2026-06-27-orca-orchestrator-adaptation-report.md`; Orca adaptation sequence for unified runner registry / typed coordinator state.

## Verification

- `bun test apps/pylon/src/orchestration/supervisor-orchestration.test.ts`
- `bun run check:deploy` (`command.public.pylon_khala.verify.6cf8448a5fc19f3e391ba274`)

## Token/account evidence

- Local bounded Pylon/Codex task branch only; no provider credentials or raw tokens printed.
- Verification ran locally with repo dependencies installed by `bun install`; no assignment token rows were generated by this code-only slice.