### PR TITLE
Wrap Codex workspace import parity

### DIFF
--- a/clients/khala-code-desktop/src/bun/codex-app-server-gap-matrix.ts
+++ b/clients/khala-code-desktop/src/bun/codex-app-server-gap-matrix.ts
@@ -256,9 +256,9 @@ export const KHALA_CODE_CODEX_APP_SERVER_GAP_MATRIX: readonly KhalaCodeCodexAppS
     ],
     upstreamGapId: "codex.app_server.gap.memory_and_import_management",
     khalaAdapter:
-      "Khala can render skills/hooks/import state from app-server, but memory mutation and AGENTS.md authoring need Codex-owned semantics or a tiny tested adapter.",
+      "Implemented wrapper coverage reads skills, hooks, importable external config, import histories, and fs metadata through Codex app-server, and passes skill/import/fs mutations through unchanged. Memory mutation and rich slash-command flows still need Codex-owned semantics.",
     rationale:
-      "Some primitives exist, but TUI memory and init flows still contain product decisions that should not be recreated freely in Khala.",
+      "The stable app-server primitives are now wrapped for desktop settings and diagnostics. The row remains an upstream gap because /memories, /init, and debug memory slash-command semantics are still TUI-owned and should not become a second Khala implementation.",
     linkedIssues: [
       "https://github.com/OpenAgentsInc/openagents/issues/7785",
       "https://github.com/OpenAgentsInc/openagents/issues/7795",
@@ -266,6 +266,7 @@ export const KHALA_CODE_CODEX_APP_SERVER_GAP_MATRIX: readonly KhalaCodeCodexAppS
     testRefs: [
       "clients/khala-code-desktop/tests/codex-slash-commands.test.ts",
       "clients/khala-code-desktop/tests/codex-ecosystem.test.ts",
+      "clients/khala-code-desktop/tests/rpc-handlers.test.ts",
       "clients/khala-code-desktop/tests/codex-app-server-gap-matrix.test.ts",
     ],
     updateTrigger:

--- a/clients/khala-code-desktop/src/bun/rpc-handlers.ts
+++ b/clients/khala-code-desktop/src/bun/rpc-handlers.ts
@@ -509,6 +509,8 @@ export function createKhalaCodeDesktopRpcRequestHandlers(
   const ecosystemNotifications: CodexAppServerNotification[] = []
   const ecosystemNotificationMethods = new Set([
     "app/list/updated",
+    "externalAgentConfig/import/completed",
+    "externalAgentConfig/import/progress",
     "mcpServer/oauthLogin/completed",
     "mcpServer/startupStatus/updated",
     "skills/changed",
@@ -627,6 +629,8 @@ export function createKhalaCodeDesktopRpcRequestHandlers(
     const [
       skillsList,
       hooksList,
+      externalAgentConfigDetect,
+      externalAgentConfigImportHistories,
       pluginList,
       pluginInstalled,
       appsList,
@@ -637,6 +641,11 @@ export function createKhalaCodeDesktopRpcRequestHandlers(
         ...(request.forceReloadSkills === undefined ? {} : { forceReload: request.forceReloadSkills }),
       }),
       capture("hooks/list", "hooks/list", { cwds: [cwd] }),
+      capture("externalAgentConfig/detect", "externalAgentConfig/detect", {
+        cwds: [cwd],
+        includeHome: true,
+      }),
+      capture("externalAgentConfig/import/readHistories", "externalAgentConfig/import/readHistories"),
       capture("plugin/list", "plugin/list", { cwds: [cwd] }),
       capture("plugin/installed", "plugin/installed", { cwds: [cwd] }),
       capture("app/list", "app/list", {
@@ -654,6 +663,8 @@ export function createKhalaCodeDesktopRpcRequestHandlers(
       errors,
       skillsList,
       hooksList,
+      externalAgentConfigDetect,
+      externalAgentConfigImportHistories,
       pluginList,
       pluginInstalled,
       appsList,
@@ -1287,6 +1298,30 @@ export function createKhalaCodeDesktopRpcRequestHandlers(
     },
     async codexEcosystemRead(request = {}) {
       return readCodexEcosystem(request)
+    },
+    async codexExternalAgentConfigDetect(request = {}) {
+      return codexAppServerAction("externalAgentConfig/detect", {
+        ...(request.cwds === undefined ? {} : { cwds: request.cwds }),
+        ...(request.includeHome === undefined ? {} : { includeHome: request.includeHome }),
+      })
+    },
+    async codexExternalAgentConfigImport(request) {
+      return codexAppServerAction("externalAgentConfig/import", {
+        migrationItems: request.migrationItems,
+        ...(request.source === undefined ? {} : { source: request.source }),
+      })
+    },
+    async codexExternalAgentConfigImportHistoriesRead() {
+      return codexAppServerAction("externalAgentConfig/import/readHistories")
+    },
+    async codexFsGetMetadata(request) {
+      return codexAppServerAction("fs/getMetadata", request)
+    },
+    async codexFsReadFile(request) {
+      return codexAppServerAction("fs/readFile", request)
+    },
+    async codexFsWriteFile(request) {
+      return codexAppServerAction("fs/writeFile", request)
     },
     async codexMarketplaceAdd(request) {
       return codexAppServerAction("marketplace/add", {

--- a/clients/khala-code-desktop/src/shared/codex-ecosystem.ts
+++ b/clients/khala-code-desktop/src/shared/codex-ecosystem.ts
@@ -1,6 +1,7 @@
 export type KhalaCodeDesktopCodexEcosystemSource =
   | "apps"
   | "hooks"
+  | "imports"
   | "khala"
   | "marketplace"
   | "mcp"
@@ -78,6 +79,7 @@ export type KhalaCodeDesktopCodexEcosystemProjection = Readonly<{
   sections: Readonly<{
     apps: KhalaCodeDesktopCodexEcosystemSection
     hooks: KhalaCodeDesktopCodexEcosystemSection
+    imports: KhalaCodeDesktopCodexEcosystemSection
     khala: KhalaCodeDesktopCodexEcosystemSection
     marketplace: KhalaCodeDesktopCodexEcosystemSection
     mcp: KhalaCodeDesktopCodexEcosystemSection
@@ -97,6 +99,8 @@ export type ProjectKhalaCodeDesktopCodexEcosystemInput = Readonly<{
   appsList?: unknown
   cwd?: string
   errors?: readonly string[]
+  externalAgentConfigDetect?: unknown
+  externalAgentConfigImportHistories?: unknown
   hooksList?: unknown
   mcpServerStatusList?: unknown
   notifications?: readonly KhalaCodeDesktopCodexEcosystemRawNotification[]
@@ -163,6 +167,15 @@ const limitedDetail = (value: string): string =>
 
 const countObjectKeys = (value: unknown): number =>
   isRecord(value) ? Object.keys(value).length : 0
+
+const numberField = (
+  value: unknown,
+  key: string,
+): number | null => {
+  if (!isRecord(value)) return null
+  const field = value[key]
+  return typeof field === "number" && Number.isFinite(field) ? field : null
+}
 
 const uniqueById = (
   items: readonly KhalaCodeDesktopCodexEcosystemItem[],
@@ -643,6 +656,102 @@ const parseMcp = (
   return { diagnostics, items: uniqueById(items) }
 }
 
+const countImportResultItems = (value: unknown, key: string): number =>
+  arrayField(value, key).length
+
+const parseExternalImports = (
+  detectResponse: unknown,
+  historiesResponse: unknown,
+  notifications: readonly KhalaCodeDesktopCodexEcosystemRawNotification[],
+  observedAt: string,
+): {
+  readonly diagnostics: readonly KhalaCodeDesktopCodexEcosystemDiagnostic[]
+  readonly items: readonly KhalaCodeDesktopCodexEcosystemItem[]
+} => {
+  const diagnostics: KhalaCodeDesktopCodexEcosystemDiagnostic[] = []
+  const items: KhalaCodeDesktopCodexEcosystemItem[] = []
+  for (const item of arrayField(detectResponse, "items")) {
+    const itemType = safeLabel(stringField(item, "itemType"), "UNKNOWN")
+    const description = safeLabel(stringField(item, "description"), itemType)
+    const cwd = stringField(item, "cwd")
+    const scope = cwd === null ? "home" : "workspace"
+    const projected: KhalaCodeDesktopCodexEcosystemItem = {
+      id: `import:detect:${itemType}:${scope}:${safeIdPart(description)}`,
+      name: itemType,
+      source: "imports",
+      state: "install_required",
+      detail: limitedDetail(`${description} (${scope})`),
+      authRequired: false,
+      enabled: true,
+      installed: false,
+      managed: false,
+    }
+    items.push(projected)
+    diagnostics.push(itemDiagnostic({
+      action: "review",
+      detail: `${description} is importable through Codex externalAgentConfig/import.`,
+      item: projected,
+      observedAt,
+      severity: "info",
+      title: `${itemType} config can be imported`,
+    }))
+  }
+
+  for (const history of arrayField(historiesResponse, "data")) {
+    const importId = safeLabel(stringField(history, "importId"), "unknown-import")
+    const successes = countImportResultItems(history, "successes")
+    const failures = countImportResultItems(history, "failures")
+    const completedAtMs = numberField(history, "completedAtMs")
+    const projected: KhalaCodeDesktopCodexEcosystemItem = {
+      id: `import:history:${importId}`,
+      name: importId,
+      source: "imports",
+      state: failures > 0 ? "error" : "ready",
+      detail: `${successes} imported, ${failures} failed${completedAtMs === null ? "" : ` at ${completedAtMs}`}`,
+      authRequired: false,
+      enabled: true,
+      installed: true,
+      managed: false,
+    }
+    items.push(projected)
+    if (failures > 0) {
+      diagnostics.push(itemDiagnostic({
+        action: "review",
+        detail: `Codex import ${importId} completed with ${failures} failed item(s).`,
+        item: projected,
+        observedAt,
+        severity: "warning",
+        title: "Codex import needs review",
+      }))
+    }
+  }
+
+  for (const notification of notifications) {
+    if (
+      notification.method !== "externalAgentConfig/import/progress" &&
+      notification.method !== "externalAgentConfig/import/completed"
+    ) {
+      continue
+    }
+    const importId = safeLabel(stringField(notification.params, "importId"), "unknown-import")
+    const resultCount = arrayField(notification.params, "itemTypeResults").length
+    const projected: KhalaCodeDesktopCodexEcosystemItem = {
+      id: `import:notification:${importId}`,
+      name: importId,
+      source: "imports",
+      state: notification.method.endsWith("/completed") ? "ready" : "managed",
+      detail: `${resultCount} import result group(s) reported by Codex.`,
+      authRequired: false,
+      enabled: true,
+      installed: true,
+      managed: notification.method.endsWith("/progress"),
+    }
+    items.push(projected)
+  }
+
+  return { diagnostics, items: uniqueById(items) }
+}
+
 const khalaExtensionItems = (): readonly KhalaCodeDesktopCodexEcosystemItem[] => [
   {
     id: "khala:swarm",
@@ -708,6 +817,19 @@ const notificationSummary = (
       summary: `${name} MCP OAuth login ${success === false ? "failed" : "completed"}.`,
     }
   }
+  if (
+    notification.method === "externalAgentConfig/import/progress" ||
+    notification.method === "externalAgentConfig/import/completed"
+  ) {
+    const importId = safeLabel(stringField(notification.params, "importId"), "unknown import")
+    const resultCount = arrayField(notification.params, "itemTypeResults").length
+    return {
+      method: notification.method,
+      receivedAt: notification.receivedAt,
+      severity: "info",
+      summary: `Codex external config import ${importId} ${notification.method.endsWith("/completed") ? "completed" : "progressed"} with ${resultCount} result group(s).`,
+    }
+  }
   return null
 }
 
@@ -738,6 +860,12 @@ export const projectKhalaCodeDesktopCodexEcosystem = (
     )
   const skills = parseSkills(input.skillsList, observedAt)
   const hooks = parseHooks(input.hooksList, observedAt)
+  const imports = parseExternalImports(
+    input.externalAgentConfigDetect,
+    input.externalAgentConfigImportHistories,
+    sourceNotifications,
+    observedAt,
+  )
   const plugins = parsePluginMarketplaces(input.pluginList, input.pluginInstalled, observedAt)
   const apps = parseApps(input.appsList, observedAt)
   const mcp = parseMcp(input.mcpServerStatusList, sourceNotifications, observedAt)
@@ -745,6 +873,7 @@ export const projectKhalaCodeDesktopCodexEcosystem = (
   const sections = {
     apps: section("apps", "Apps and connectors", apps.items),
     hooks: section("hooks", "Hooks", hooks.items),
+    imports: section("imports", "External config imports", imports.items),
     khala: section("khala", "Khala desktop extensions", khalaItems),
     marketplace: section("marketplace", "Plugin marketplaces", plugins.marketplaceItems),
     mcp: section("mcp", "MCP servers", mcp.items),
@@ -766,6 +895,7 @@ export const projectKhalaCodeDesktopCodexEcosystem = (
     ...notificationDiagnostics(notifications),
     ...skills.diagnostics,
     ...hooks.diagnostics,
+    ...imports.diagnostics,
     ...plugins.diagnostics,
     ...apps.diagnostics,
     ...mcp.diagnostics,

--- a/clients/khala-code-desktop/src/shared/rpc.ts
+++ b/clients/khala-code-desktop/src/shared/rpc.ts
@@ -389,6 +389,42 @@ export type KhalaCodeDesktopCodexSkillsConfigWriteRequest = {
   readonly path?: string | null
 }
 
+export type KhalaCodeDesktopCodexExternalAgentConfigDetectRequest = {
+  readonly cwds?: readonly string[] | null
+  readonly includeHome?: boolean
+}
+
+export type KhalaCodeDesktopCodexExternalAgentConfigMigrationItem = {
+  readonly itemType:
+    | "AGENTS_MD"
+    | "COMMANDS"
+    | "CONFIG"
+    | "HOOKS"
+    | "MCP_SERVER_CONFIG"
+    | "PLUGINS"
+    | "SESSIONS"
+    | "SKILLS"
+    | "SUBAGENTS"
+    | string
+  readonly description: string
+  readonly cwd: string | null
+  readonly details?: KhalaCodeDesktopCodexJsonValue | null
+}
+
+export type KhalaCodeDesktopCodexExternalAgentConfigImportRequest = {
+  readonly migrationItems: readonly KhalaCodeDesktopCodexExternalAgentConfigMigrationItem[]
+  readonly source?: string | null
+}
+
+export type KhalaCodeDesktopCodexFsPathRequest = {
+  readonly path: string
+}
+
+export type KhalaCodeDesktopCodexFsWriteFileRequest = {
+  readonly dataBase64: string
+  readonly path: string
+}
+
 export type KhalaCodeDesktopCodexMcpResourceReadRequest = {
   readonly server: string
   readonly threadId?: string | null
@@ -766,6 +802,12 @@ export type KhalaCodeDesktopRPCSchema = {
     codexApprovalRespond(request: KhalaCodeDesktopCodexApprovalRespondRequest): Promise<KhalaCodeDesktopCodexApprovalRespondResult>
     codexConfigValueWrite(request: KhalaCodeDesktopCodexConfigValueWriteRequest): Promise<KhalaCodeDesktopCodexConfigValueWriteResult>
     codexEcosystemRead(request?: KhalaCodeDesktopCodexEcosystemReadRequest): Promise<KhalaCodeDesktopCodexEcosystemReadResult>
+    codexExternalAgentConfigDetect(request?: KhalaCodeDesktopCodexExternalAgentConfigDetectRequest): Promise<KhalaCodeDesktopCodexAppServerActionResult>
+    codexExternalAgentConfigImport(request: KhalaCodeDesktopCodexExternalAgentConfigImportRequest): Promise<KhalaCodeDesktopCodexAppServerActionResult>
+    codexExternalAgentConfigImportHistoriesRead(): Promise<KhalaCodeDesktopCodexAppServerActionResult>
+    codexFsGetMetadata(request: KhalaCodeDesktopCodexFsPathRequest): Promise<KhalaCodeDesktopCodexAppServerActionResult>
+    codexFsReadFile(request: KhalaCodeDesktopCodexFsPathRequest): Promise<KhalaCodeDesktopCodexAppServerActionResult>
+    codexFsWriteFile(request: KhalaCodeDesktopCodexFsWriteFileRequest): Promise<KhalaCodeDesktopCodexAppServerActionResult>
     codexMarketplaceAdd(request: KhalaCodeDesktopCodexMarketplaceAddRequest): Promise<KhalaCodeDesktopCodexAppServerActionResult>
     codexMarketplaceRemove(request: KhalaCodeDesktopCodexMarketplaceRemoveRequest): Promise<KhalaCodeDesktopCodexAppServerActionResult>
     codexMarketplaceUpgrade(request?: KhalaCodeDesktopCodexMarketplaceUpgradeRequest): Promise<KhalaCodeDesktopCodexAppServerActionResult>

--- a/clients/khala-code-desktop/src/ui/codex-settings-panel.ts
+++ b/clients/khala-code-desktop/src/ui/codex-settings-panel.ts
@@ -297,6 +297,7 @@ export const mountCodexSettingsPanel = (
     for (const summary of [
       current.sections.skills,
       current.sections.hooks,
+      current.sections.imports,
       current.sections.plugins,
       current.sections.marketplace,
       current.sections.apps,

--- a/clients/khala-code-desktop/src/ui/main.ts
+++ b/clients/khala-code-desktop/src/ui/main.ts
@@ -141,6 +141,30 @@ const previewRpc = (): DesktopRpc => ({
       postPreviewRpc<
         Awaited<ReturnType<DesktopRpcRequests["codexEcosystemRead"]>>
       >("codexEcosystemRead", request),
+    codexExternalAgentConfigDetect: request =>
+      postPreviewRpc<
+        Awaited<ReturnType<DesktopRpcRequests["codexExternalAgentConfigDetect"]>>
+      >("codexExternalAgentConfigDetect", request),
+    codexExternalAgentConfigImport: request =>
+      postPreviewRpc<
+        Awaited<ReturnType<DesktopRpcRequests["codexExternalAgentConfigImport"]>>
+      >("codexExternalAgentConfigImport", request),
+    codexExternalAgentConfigImportHistoriesRead: () =>
+      postPreviewRpc<
+        Awaited<ReturnType<DesktopRpcRequests["codexExternalAgentConfigImportHistoriesRead"]>>
+      >("codexExternalAgentConfigImportHistoriesRead"),
+    codexFsGetMetadata: request =>
+      postPreviewRpc<
+        Awaited<ReturnType<DesktopRpcRequests["codexFsGetMetadata"]>>
+      >("codexFsGetMetadata", request),
+    codexFsReadFile: request =>
+      postPreviewRpc<
+        Awaited<ReturnType<DesktopRpcRequests["codexFsReadFile"]>>
+      >("codexFsReadFile", request),
+    codexFsWriteFile: request =>
+      postPreviewRpc<
+        Awaited<ReturnType<DesktopRpcRequests["codexFsWriteFile"]>>
+      >("codexFsWriteFile", request),
     codexMarketplaceAdd: request =>
       postPreviewRpc<
         Awaited<ReturnType<DesktopRpcRequests["codexMarketplaceAdd"]>>
@@ -1723,6 +1747,18 @@ const controls = {
     rpc.request.codexConfigValueWrite(request),
   codexEcosystemRead: (request?: Parameters<DesktopRpcRequests["codexEcosystemRead"]>[0]) =>
     rpc.request.codexEcosystemRead(request),
+  codexExternalAgentConfigDetect: (request?: Parameters<DesktopRpcRequests["codexExternalAgentConfigDetect"]>[0]) =>
+    rpc.request.codexExternalAgentConfigDetect(request),
+  codexExternalAgentConfigImport: (request: Parameters<DesktopRpcRequests["codexExternalAgentConfigImport"]>[0]) =>
+    rpc.request.codexExternalAgentConfigImport(request),
+  codexExternalAgentConfigImportHistoriesRead: () =>
+    rpc.request.codexExternalAgentConfigImportHistoriesRead(),
+  codexFsGetMetadata: (request: Parameters<DesktopRpcRequests["codexFsGetMetadata"]>[0]) =>
+    rpc.request.codexFsGetMetadata(request),
+  codexFsReadFile: (request: Parameters<DesktopRpcRequests["codexFsReadFile"]>[0]) =>
+    rpc.request.codexFsReadFile(request),
+  codexFsWriteFile: (request: Parameters<DesktopRpcRequests["codexFsWriteFile"]>[0]) =>
+    rpc.request.codexFsWriteFile(request),
   codexMarketplaceAdd: (request: Parameters<DesktopRpcRequests["codexMarketplaceAdd"]>[0]) =>
     rpc.request.codexMarketplaceAdd(request),
   codexMarketplaceRemove: (request: Parameters<DesktopRpcRequests["codexMarketplaceRemove"]>[0]) =>

--- a/clients/khala-code-desktop/tests/codex-ecosystem.test.ts
+++ b/clients/khala-code-desktop/tests/codex-ecosystem.test.ts
@@ -57,6 +57,27 @@ describe("Khala Code Codex ecosystem projection", () => {
           errors: [],
         }],
       },
+      externalAgentConfigDetect: {
+        items: [{
+          itemType: "AGENTS_MD",
+          description: "Import workspace instructions from another agent",
+          cwd: "/workspace/openagents",
+          details: null,
+        }],
+      },
+      externalAgentConfigImportHistories: {
+        data: [{
+          importId: "import-ok",
+          completedAtMs: 1782926400000,
+          successes: [{
+            itemType: "AGENTS_MD",
+            cwd: "/workspace/openagents",
+            source: "CLAUDE.md",
+            target: "AGENTS.md",
+          }],
+          failures: [],
+        }],
+      },
       pluginList: {
         marketplaces: [{
           name: "curated",
@@ -184,6 +205,18 @@ describe("Khala Code Codex ecosystem projection", () => {
           },
           receivedAt: "2026-07-01T12:02:00.000Z",
         },
+        {
+          method: "externalAgentConfig/import/completed",
+          params: {
+            importId: "import-ok",
+            itemTypeResults: [{
+              itemType: "AGENTS_MD",
+              successes: [],
+              failures: [],
+            }],
+          },
+          receivedAt: "2026-07-01T12:03:00.000Z",
+        },
       ],
     })
 
@@ -194,10 +227,13 @@ describe("Khala Code Codex ecosystem projection", () => {
     expect(projection.sections.plugins.disabledCount).toBe(1)
     expect(projection.sections.apps.authRequiredCount).toBe(1)
     expect(projection.sections.apps.disabledCount).toBe(1)
+    expect(projection.sections.imports.installRequiredCount).toBe(1)
     expect(projection.sections.mcp.authRequiredCount).toBe(1)
     expect(projection.sections.khala.count).toBe(2)
     expect(projection.notifications.map(notification => notification.method)).toContain("skills/changed")
+    expect(projection.notifications.map(notification => notification.method)).toContain("externalAgentConfig/import/completed")
     expect(projection.diagnostics.map(diagnostic => diagnostic.title)).toContain("Codex skills changed")
+    expect(projection.diagnostics.map(diagnostic => diagnostic.title)).toContain("AGENTS_MD config can be imported")
     expect(projection.diagnostics.some(diagnostic =>
       diagnostic.title === "github MCP server needs login"
     )).toBe(true)
@@ -249,6 +285,29 @@ describe("Khala Code Codex ecosystem projection", () => {
         }],
         nextCursor: null,
       },
+      externalAgentConfigDetect: {
+        items: [{
+          itemType: "CONFIG",
+          description: "Import config",
+          cwd: "/workspace",
+          details: { token: "SECRET_VALUE" },
+        }],
+      },
+      externalAgentConfigImportHistories: {
+        data: [{
+          importId: "import-secret",
+          completedAtMs: 1782926400000,
+          successes: [],
+          failures: [{
+            itemType: "CONFIG",
+            errorType: "secret",
+            failureStage: "read",
+            message: "SECRET_VALUE",
+            cwd: "/workspace",
+            source: "/private/config.json",
+          }],
+        }],
+      },
       mcpServerStatusList: {
         data: [{
           name: "mystery-mcp",
@@ -265,6 +324,7 @@ describe("Khala Code Codex ecosystem projection", () => {
     expect(projection.sections.skills.unknownCount).toBe(1)
     expect(projection.sections.apps.unknownCount).toBe(1)
     expect(projection.sections.mcp.unknownCount).toBe(1)
+    expect(projection.sections.imports.errorCount).toBe(1)
     expect(projection.diagnostics.some(diagnostic =>
       diagnostic.title.includes("Unknown")
     )).toBe(true)

--- a/clients/khala-code-desktop/tests/rpc-handlers.test.ts
+++ b/clients/khala-code-desktop/tests/rpc-handlers.test.ts
@@ -1488,6 +1488,31 @@ describe("Khala Code desktop RPC handlers", () => {
           if (method === "hooks/list") {
             return { data: [{ cwd: "/repo", hooks: [], warnings: [], errors: [] }] } as Result
           }
+          if (method === "externalAgentConfig/detect") {
+            return {
+              items: [{
+                itemType: "AGENTS_MD",
+                description: "Import AGENTS.md from another agent",
+                cwd: "/repo",
+                details: null,
+              }],
+            } as Result
+          }
+          if (method === "externalAgentConfig/import/readHistories") {
+            return {
+              data: [{
+                importId: "import-1",
+                completedAtMs: 1782926400000,
+                successes: [{
+                  itemType: "AGENTS_MD",
+                  cwd: "/repo",
+                  source: "CLAUDE.md",
+                  target: "AGENTS.md",
+                }],
+                failures: [],
+              }],
+            } as Result
+          }
           if (method === "plugin/list" || method === "plugin/installed") {
             return {
               marketplaces: [{
@@ -1587,6 +1612,8 @@ describe("Khala Code desktop RPC handlers", () => {
     expect(requests.map(request => request.method)).toEqual([
       "skills/list",
       "hooks/list",
+      "externalAgentConfig/detect",
+      "externalAgentConfig/import/readHistories",
       "plugin/list",
       "plugin/installed",
       "app/list",
@@ -1596,15 +1623,20 @@ describe("Khala Code desktop RPC handlers", () => {
       cwds: ["/repo"],
       forceReload: true,
     })
-    expect(requests[4].params).toEqual({
+    expect(requests[2].params).toEqual({
+      cwds: ["/repo"],
+      includeHome: true,
+    })
+    expect(requests[6].params).toEqual({
       threadId: "thread-1",
       forceRefetch: true,
     })
-    expect(requests[5].params).toEqual({
+    expect(requests[7].params).toEqual({
       detail: "full",
       threadId: "thread-1",
     })
     expect(result.sections.skills.count).toBe(1)
+    expect(result.sections.imports.installRequiredCount).toBe(1)
     expect(result.sections.mcp.authRequiredCount).toBe(1)
     expect(result.notifications.map(notification => notification.method)).toContain("skills/changed")
   })
@@ -1656,6 +1688,20 @@ describe("Khala Code desktop RPC handlers", () => {
 
     await handlers.codexSkillsExtraRootsSet({ extraRoots: ["/repo/skills"] })
     await handlers.codexSkillsConfigWrite({ name: "github", enabled: false })
+    await handlers.codexExternalAgentConfigDetect({ cwds: ["/repo"], includeHome: true })
+    await handlers.codexExternalAgentConfigImport({
+      source: "claude",
+      migrationItems: [{
+        itemType: "AGENTS_MD",
+        description: "Import AGENTS.md",
+        cwd: "/repo",
+        details: null,
+      }],
+    })
+    await handlers.codexExternalAgentConfigImportHistoriesRead()
+    await handlers.codexFsReadFile({ path: "/repo/AGENTS.md" })
+    await handlers.codexFsWriteFile({ path: "/repo/AGENTS.md", dataBase64: "IyBBR0VOVFMK" })
+    await handlers.codexFsGetMetadata({ path: "/repo/AGENTS.md" })
     await handlers.codexMarketplaceAdd({ source: "https://github.com/acme/plugins", refName: "main" })
     await handlers.codexMarketplaceRemove({ marketplaceName: "acme" })
     await handlers.codexMarketplaceUpgrade({ marketplaceName: "acme" })
@@ -1675,6 +1721,12 @@ describe("Khala Code desktop RPC handlers", () => {
     expect(requests.map(request => request.method)).toEqual([
       "skills/extraRoots/set",
       "skills/config/write",
+      "externalAgentConfig/detect",
+      "externalAgentConfig/import",
+      "externalAgentConfig/import/readHistories",
+      "fs/readFile",
+      "fs/writeFile",
+      "fs/getMetadata",
       "marketplace/add",
       "marketplace/remove",
       "marketplace/upgrade",
@@ -1685,7 +1737,7 @@ describe("Khala Code desktop RPC handlers", () => {
       "mcpServer/tool/call",
       "config/mcpServer/reload",
     ])
-    expect(requests[9].params).toEqual({
+    expect(requests[15].params).toEqual({
       threadId: "thread-1",
       server: "github",
       tool: "list_issues",

--- a/docs/khala-code/2026-07-01-codex-app-server-gap-matrix.md
+++ b/docs/khala-code/2026-07-01-codex-app-server-gap-matrix.md
@@ -32,7 +32,7 @@ the behavior small.
 | `settings-ecosystem-account-surfaces` | `covered_by_app_server` | `/model`, `/permissions`, `/experimental`, `/usage`, `/mcp`, `/app`, `/apps`, `/plugins`, `/logout` | `model/list`, `modelProvider/capabilities/read`, `permissionProfile/list`, `experimentalFeature/list`, `experimentalFeature/enablement/set`, `account/usage/read`, `account/rateLimits/read`, `account/rateLimitResetCredit/consume`, `account/read`, `mcpServerStatus/list`, `mcpServer/resource/read`, `mcpServer/tool/call`, `mcpServer/oauth/login`, `config/mcpServer/reload`, `app/list`, `plugin/list`, `plugin/read`, `plugin/installed`, `account/logout`, `config/read`, `config/value/write`, `config/batchWrite`, `configRequirements/read` | None | Khala owns the web settings panels, but values and mutations remain Codex app-server state. |
 | `desktop-local-ui-adapters` | `khala_adapter_with_test` | `/copy`, `/raw`, `/status`, `/debug-config`, `/title`, `/quit`, `/exit`, `/feedback`, `/rollout`, `/clear`, `/test-approval` | `config/read`, `account/usage/read`, `feedback/upload`, `getAuthStatus`, `getConversationSummary` | None | Tiny desktop adapters for browser selection, window title, visible transcript, local status, and debug diagnostics. |
 | `tui-preferences-and-appearance` | `upstream_app_server_gap` | `/keymap`, `/vim`, `/statusline`, `/theme`, `/pets`, `/personality` | `config/read`, `config/value/write`, `config/batchWrite` | None | `codex.app_server.gap.tui_preferences` |
-| `workspace-knowledge-memory-and-import` | `upstream_app_server_gap` | `/memories`, `/skills`, `/import`, `/hooks`, `/init`, `/debug-m-drop`, `/debug-m-update` | `skills/list`, `skills/config/write`, `skills/extraRoots/set`, `hooks/list`, `externalAgentConfig/detect`, `externalAgentConfig/import`, `externalAgentConfig/import/readHistories`, `fs/readFile`, `fs/writeFile`, `fs/getMetadata` | None | `codex.app_server.gap.memory_and_import_management` |
+| `workspace-knowledge-memory-and-import` | `upstream_app_server_gap` | `/memories`, `/skills`, `/import`, `/hooks`, `/init`, `/debug-m-drop`, `/debug-m-update` | `skills/list`, `skills/config/write`, `skills/extraRoots/set`, `hooks/list`, `externalAgentConfig/detect`, `externalAgentConfig/import`, `externalAgentConfig/import/readHistories`, `fs/readFile`, `fs/writeFile`, `fs/getMetadata` | None | Khala now wraps the stable app-server methods for settings/actions and import diagnostics. Remaining gap: `codex.app_server.gap.memory_and_import_management` for TUI-owned `/memories`, `/init`, and debug memory semantics. |
 | `multi-agent-side-conversation-and-plan` | `upstream_app_server_gap` | `/approve`, `/plan`, `/agent`, `/subagents`, `/side`, `/btw` | `turn/steer`, `thread/fork`, `thread/inject_items`, `thread/approveGuardianDeniedAction`, `thread/metadata/update`, `thread/read` | None | `codex.app_server.gap.side_agent_plan_controls` |
 | `ide-file-mention-and-diff` | `upstream_app_server_gap` | `/ide`, `/diff`, `/mention` | `fuzzyFileSearch`, `gitDiffToRemote`, `fs/readDirectory`, `fs/readFile`, `config/read` | None | `codex.app_server.gap.ide_mentions_diff` |
 | `windows-sandbox-setup-and-readable-roots` | `upstream_app_server_gap` | `/setup-default-sandbox`, `/sandbox-add-read-dir` | `windowsSandbox/setupStart`, `windowsSandbox/readiness`, `config/read`, `config/value/write` | None | `codex.app_server.gap.windows_sandbox_read_roots` |
@@ -45,9 +45,11 @@ GitHub issues, or protocol notes:
 
 - `codex.app_server.gap.tui_preferences`: expose preference metadata and
   mutation semantics for keymap, Vim, statusline, theme, pets, and personality.
-- `codex.app_server.gap.memory_and_import_management`: expose memory list,
-  memory mutation, import, and `AGENTS.md` init semantics instead of relying on
-  TUI-only flows.
+- `codex.app_server.gap.memory_and_import_management`: Khala Code now wraps
+  Codex app-server skills, hooks, external config detect/import/history, and
+  fs read/write/metadata methods. Remaining upstream work is memory list,
+  memory mutation, and full `AGENTS.md` init slash-command semantics instead of
+  relying on TUI-only flows.
 - `codex.app_server.gap.side_agent_plan_controls`: expose side-conversation,
   subagent, plan-edit, and auto-review controls as app-server methods or
   metadata.

--- a/docs/khala-code/2026-07-01-codex-parity-contract.md
+++ b/docs/khala-code/2026-07-01-codex-parity-contract.md
@@ -31,7 +31,8 @@ source under `projects/repos/codex`.
   permissions paths.
 - `clients/khala-code-desktop/tests/rpc-handlers.test.ts` covers Codex model,
   permission profile, config read/write, feature flags, usage/status, MCP,
-  plugin, skill, app, and hook RPC pass-through.
+  plugin, skill, app, hook, external config import, and workspace fs RPC
+  pass-through.
 - `clients/khala-code-desktop/tests/headless.test.ts` covers Codex-backed
   headless JSONL mode and missing-Codex errors.
 - `clients/khala-code-desktop/tests/khala-chat-runtime.test.ts` is explicitly


### PR DESCRIPTION
## Summary
- Add Khala Code desktop RPC pass-throughs for Codex `externalAgentConfig/detect`, `externalAgentConfig/import`, `externalAgentConfig/import/readHistories`, `fs/readFile`, `fs/writeFile`, and `fs/getMetadata`.
- Extend the Codex ecosystem projection/settings surface with public-safe external config import diagnostics, import history status, and import progress/completion notifications.
- Update focused RPC/projection tests and Khala Code parity docs/gap matrix to document implemented wrapper coverage and remaining upstream memory/init slash-command gaps.

## Validation
- `KHALA_CODE_CODEX_REFERENCE_ROOT=/Users/christopherdavid/work/projects/repos/codex bun test clients/khala-code-desktop/tests/codex-ecosystem.test.ts clients/khala-code-desktop/tests/rpc-handlers.test.ts clients/khala-code-desktop/tests/codex-app-server-gap-matrix.test.ts clients/khala-code-desktop/tests/codex-parity-contract.test.ts clients/khala-code-desktop/tests/codex-slash-commands.test.ts` (38 pass)
- `KHALA_CODE_CODEX_REFERENCE_ROOT=/Users/christopherdavid/work/projects/repos/codex bun run --cwd clients/khala-code-desktop typecheck`
- `KHALA_CODE_CODEX_REFERENCE_ROOT=/Users/christopherdavid/work/projects/repos/codex bun run --cwd clients/khala-code-desktop verify` (244 tests pass, UI build pass, Bun entry build pass)

Note: the assignment asked for `command.public.pylon_khala.verify.362e39b9b3e14a945586138e`; that exact ref was not present in local task metadata, so I ran the repo-owned Khala Code verify command above and recorded the mismatch here.