### PR TITLE
Implement Khala Code background terminal adapter

### DIFF
--- a/clients/khala-code-desktop/src/bun/codex-app-server-gap-matrix.ts
+++ b/clients/khala-code-desktop/src/bun/codex-app-server-gap-matrix.ts
@@ -388,7 +388,7 @@ export const KHALA_CODE_CODEX_APP_SERVER_GAP_MATRIX: readonly KhalaCodeCodexAppS
   {
     id: "background-terminal-management",
     area: "background terminal listing and cleanup",
-    decision: "upstream_app_server_gap",
+    decision: "khala_adapter_with_test",
     codexSourceRefs: [
       "codex-rs/tui/src/slash_command.rs",
       "codex-rs/app-server-protocol/src/protocol/common.rs",
@@ -406,9 +406,9 @@ export const KHALA_CODE_CODEX_APP_SERVER_GAP_MATRIX: readonly KhalaCodeCodexAppS
     ],
     upstreamGapId: "codex.app_server.gap.background_terminals",
     khalaAdapter:
-      "Khala may call the experimental methods only behind parity checks; stable product copy should keep this row as an upstream gap until Codex stabilizes the methods.",
+      "Khala slash dispatch and RPC actions call Codex's experimental background terminal list, clean, and terminate methods directly with bounded list pagination.",
     rationale:
-      "Codex protocol marks these methods experimental, so Khala must avoid treating them as stable feature parity.",
+      "Codex owns background terminal state. Khala only wraps the experimental app-server methods and keeps stable product copy gated until Codex stabilizes them.",
     linkedIssues: [
       "https://github.com/OpenAgentsInc/openagents/issues/7785",
       "https://github.com/OpenAgentsInc/openagents/issues/7795",
@@ -416,6 +416,7 @@ export const KHALA_CODE_CODEX_APP_SERVER_GAP_MATRIX: readonly KhalaCodeCodexAppS
     testRefs: [
       "clients/khala-code-desktop/tests/codex-slash-commands.test.ts",
       "clients/khala-code-desktop/tests/codex-app-server-gap-matrix.test.ts",
+      "clients/khala-code-desktop/tests/rpc-handlers.test.ts",
     ],
     updateTrigger:
       "Update when Codex stabilizes, renames, or removes background terminal app-server methods.",

--- a/clients/khala-code-desktop/src/bun/rpc-handlers.ts
+++ b/clients/khala-code-desktop/src/bun/rpc-handlers.ts
@@ -19,6 +19,9 @@ import {
   type KhalaCodeDesktopChatTurnEvent,
   type KhalaCodeDesktopChatTurnResponse,
   type KhalaCodeDesktopCodexConfigValueWriteRequest,
+  type KhalaCodeDesktopCodexBackgroundTerminalsCleanRequest,
+  type KhalaCodeDesktopCodexBackgroundTerminalsListRequest,
+  type KhalaCodeDesktopCodexBackgroundTerminalsTerminateRequest,
   type KhalaCodeDesktopCodexEcosystemReadRequest,
   type KhalaCodeDesktopCodexEcosystemReadResult,
   type KhalaCodeDesktopCodexSettingsReadRequest,
@@ -599,6 +602,39 @@ export function createKhalaCodeDesktopRpcRequestHandlers(
     }
   }
 
+  const nonEmptyCodexField = (
+    value: string,
+    label: string,
+  ): string => {
+    const trimmed = value.trim()
+    if (trimmed.length === 0) throw new Error(`${label} is required`)
+    return trimmed
+  }
+
+  const codexBackgroundTerminalsList = async (
+    request: KhalaCodeDesktopCodexBackgroundTerminalsListRequest,
+  ): Promise<KhalaCodeDesktopCodexAppServerActionResult> =>
+    codexAppServerAction("thread/backgroundTerminals/list", {
+      threadId: nonEmptyCodexField(request.threadId, "threadId"),
+      cursor: request.cursor ?? null,
+      limit: request.limit ?? 50,
+    })
+
+  const codexBackgroundTerminalsClean = async (
+    request: KhalaCodeDesktopCodexBackgroundTerminalsCleanRequest,
+  ): Promise<KhalaCodeDesktopCodexAppServerActionResult> =>
+    codexAppServerAction("thread/backgroundTerminals/clean", {
+      threadId: nonEmptyCodexField(request.threadId, "threadId"),
+    })
+
+  const codexBackgroundTerminalsTerminate = async (
+    request: KhalaCodeDesktopCodexBackgroundTerminalsTerminateRequest,
+  ): Promise<KhalaCodeDesktopCodexAppServerActionResult> =>
+    codexAppServerAction("thread/backgroundTerminals/terminate", {
+      threadId: nonEmptyCodexField(request.threadId, "threadId"),
+      processId: nonEmptyCodexField(request.processId, "processId"),
+    })
+
   const readCodexEcosystem = async (
     request: KhalaCodeDesktopCodexEcosystemReadRequest = {},
   ): Promise<KhalaCodeDesktopCodexEcosystemReadResult> => {
@@ -934,14 +970,24 @@ export function createKhalaCodeDesktopRpcRequestHandlers(
         }
         case "ps":
         case "stop": {
-          const response = await requestCodexAppServer(dispatch.method, { threadId })
+          const response = command.command === "ps"
+            ? await codexBackgroundTerminalsList({ threadId: threadId ?? "" })
+            : await codexBackgroundTerminalsClean({ threadId: threadId ?? "" })
+          if (!response.ok) {
+            return blockedSlashCommand({
+              command: command.command,
+              message: response.error ?? "Codex background terminal request failed.",
+              method: response.method,
+              ...(threadId === null ? {} : { threadId }),
+            })
+          }
           return dispatchedSlashCommand({
             command: command.command,
-            method: dispatch.method,
+            method: response.method,
             message: command.command === "ps"
-              ? "Loaded Codex background terminal commands."
-              : "Requested cleanup of Codex background terminal commands.",
-            response,
+              ? "Loaded Codex background terminals."
+              : "Requested Codex background terminal cleanup.",
+            response: response.response,
             ...(threadId === null ? {} : { threadId }),
           })
         }
@@ -1281,6 +1327,15 @@ export function createKhalaCodeDesktopRpcRequestHandlers(
           error: error instanceof Error ? error.message : String(error),
         }
       }
+    },
+    async codexBackgroundTerminalsClean(request) {
+      return codexBackgroundTerminalsClean(request)
+    },
+    async codexBackgroundTerminalsList(request) {
+      return codexBackgroundTerminalsList(request)
+    },
+    async codexBackgroundTerminalsTerminate(request) {
+      return codexBackgroundTerminalsTerminate(request)
     },
     async codexConfigValueWrite(request) {
       return writeCodexConfigValue(request)

--- a/clients/khala-code-desktop/src/shared/codex-slash-commands.ts
+++ b/clients/khala-code-desktop/src/shared/codex-slash-commands.ts
@@ -618,7 +618,7 @@ export const KHALA_CODE_DESKTOP_SLASH_COMMANDS = [
     enumName: "Stop",
     command: "stop",
     aliases: ["clean"],
-    description: "Stops an active background terminal command",
+    description: "Stop all background terminal commands",
     supportsInlineArgs: false,
     availableInSideConversation: false,
     availableDuringTask: true,

--- a/clients/khala-code-desktop/src/shared/rpc.ts
+++ b/clients/khala-code-desktop/src/shared/rpc.ts
@@ -379,6 +379,21 @@ export type KhalaCodeDesktopCodexAppServerActionResult = {
   readonly error?: string
 }
 
+export type KhalaCodeDesktopCodexBackgroundTerminalsListRequest = {
+  readonly cursor?: string | null
+  readonly limit?: number | null
+  readonly threadId: string
+}
+
+export type KhalaCodeDesktopCodexBackgroundTerminalsCleanRequest = {
+  readonly threadId: string
+}
+
+export type KhalaCodeDesktopCodexBackgroundTerminalsTerminateRequest = {
+  readonly processId: string
+  readonly threadId: string
+}
+
 export type KhalaCodeDesktopCodexSkillsExtraRootsSetRequest = {
   readonly extraRoots: readonly string[]
 }
@@ -764,6 +779,9 @@ export type KhalaCodeDesktopRPCSchema = {
     codexFleetPromoteThread(request: KhalaCodeDesktopFleetPromotionRequest): Promise<KhalaCodeDesktopFleetPromotionResult>
     codexHarnessStatus(): Promise<KhalaCodeDesktopCodexHarnessStatus>
     codexApprovalRespond(request: KhalaCodeDesktopCodexApprovalRespondRequest): Promise<KhalaCodeDesktopCodexApprovalRespondResult>
+    codexBackgroundTerminalsClean(request: KhalaCodeDesktopCodexBackgroundTerminalsCleanRequest): Promise<KhalaCodeDesktopCodexAppServerActionResult>
+    codexBackgroundTerminalsList(request: KhalaCodeDesktopCodexBackgroundTerminalsListRequest): Promise<KhalaCodeDesktopCodexAppServerActionResult>
+    codexBackgroundTerminalsTerminate(request: KhalaCodeDesktopCodexBackgroundTerminalsTerminateRequest): Promise<KhalaCodeDesktopCodexAppServerActionResult>
     codexConfigValueWrite(request: KhalaCodeDesktopCodexConfigValueWriteRequest): Promise<KhalaCodeDesktopCodexConfigValueWriteResult>
     codexEcosystemRead(request?: KhalaCodeDesktopCodexEcosystemReadRequest): Promise<KhalaCodeDesktopCodexEcosystemReadResult>
     codexMarketplaceAdd(request: KhalaCodeDesktopCodexMarketplaceAddRequest): Promise<KhalaCodeDesktopCodexAppServerActionResult>

--- a/clients/khala-code-desktop/src/ui/main.ts
+++ b/clients/khala-code-desktop/src/ui/main.ts
@@ -133,6 +133,18 @@ const previewRpc = (): DesktopRpc => ({
       postPreviewRpc<
         Awaited<ReturnType<DesktopRpcRequests["codexApprovalRespond"]>>
       >("codexApprovalRespond", request),
+    codexBackgroundTerminalsClean: request =>
+      postPreviewRpc<
+        Awaited<ReturnType<DesktopRpcRequests["codexBackgroundTerminalsClean"]>>
+      >("codexBackgroundTerminalsClean", request),
+    codexBackgroundTerminalsList: request =>
+      postPreviewRpc<
+        Awaited<ReturnType<DesktopRpcRequests["codexBackgroundTerminalsList"]>>
+      >("codexBackgroundTerminalsList", request),
+    codexBackgroundTerminalsTerminate: request =>
+      postPreviewRpc<
+        Awaited<ReturnType<DesktopRpcRequests["codexBackgroundTerminalsTerminate"]>>
+      >("codexBackgroundTerminalsTerminate", request),
     codexConfigValueWrite: request =>
       postPreviewRpc<
         Awaited<ReturnType<DesktopRpcRequests["codexConfigValueWrite"]>>

--- a/clients/khala-code-desktop/tests/codex-app-server-gap-matrix.test.ts
+++ b/clients/khala-code-desktop/tests/codex-app-server-gap-matrix.test.ts
@@ -127,6 +127,21 @@ describe("Khala Code Codex app-server gap matrix", () => {
     expect(clientCommandsWithoutAdapterDecision).toEqual([])
   })
 
+  test("tracks background terminal parity as an experimental Khala adapter", () => {
+    const row = KHALA_CODE_CODEX_APP_SERVER_GAP_MATRIX.find(row =>
+      row.id === "background-terminal-management"
+    )
+    expect(row).toMatchObject({
+      decision: "khala_adapter_with_test",
+      experimentalAppServerMethods: [
+        "thread/backgroundTerminals/list",
+        "thread/backgroundTerminals/clean",
+        "thread/backgroundTerminals/terminate",
+      ],
+    })
+    expect(row?.testRefs).toContain("clients/khala-code-desktop/tests/rpc-handlers.test.ts")
+  })
+
   test("keeps the human-readable matrix document in sync with checked rows", async () => {
     const docPath = join(repoRoot, KHALA_CODE_CODEX_APP_SERVER_GAP_DOC_PATH)
     expect(existsSync(docPath)).toBe(true)

--- a/clients/khala-code-desktop/tests/codex-slash-commands.test.ts
+++ b/clients/khala-code-desktop/tests/codex-slash-commands.test.ts
@@ -25,6 +25,11 @@ const kebabCase = (value: string): string =>
 const codexSlashCommandSourcePath = (): string => {
   const explicit = process.env.KHALA_CODE_CODEX_SLASH_COMMAND_SOURCE?.trim()
   if (explicit !== undefined && explicit.length > 0 && existsSync(explicit)) return explicit
+  const explicitRoot = process.env.KHALA_CODE_CODEX_REFERENCE_ROOT?.trim()
+  if (explicitRoot !== undefined && explicitRoot.length > 0) {
+    const candidate = join(explicitRoot, "codex-rs/tui/src/slash_command.rs")
+    if (existsSync(candidate)) return candidate
+  }
 
   let current = dirname(fileURLToPath(import.meta.url))
   for (let depth = 0; depth < 10; depth += 1) {
@@ -112,6 +117,27 @@ describe("Khala Code Codex slash command registry", () => {
       "pets",
       "mcp",
     ])
+  })
+
+  test("maps background terminal slash commands to experimental app-server methods", () => {
+    expect(findKhalaCodeDesktopSlashCommand("/ps")?.dispatch).toMatchObject({
+      kind: "app_server",
+      method: "thread/backgroundTerminals/list",
+      experimental: true,
+      requiresThread: true,
+    })
+    expect(findKhalaCodeDesktopSlashCommand("/stop")?.dispatch).toMatchObject({
+      kind: "app_server",
+      method: "thread/backgroundTerminals/clean",
+      experimental: true,
+      requiresThread: true,
+    })
+    expect(findKhalaCodeDesktopSlashCommand("/clean")?.dispatch).toMatchObject({
+      kind: "app_server",
+      method: "thread/backgroundTerminals/clean",
+      experimental: true,
+      requiresThread: true,
+    })
   })
 
   test("matches Codex platform/debug visibility gates", () => {

--- a/clients/khala-code-desktop/tests/rpc-handlers.test.ts
+++ b/clients/khala-code-desktop/tests/rpc-handlers.test.ts
@@ -1058,6 +1058,121 @@ describe("Khala Code desktop RPC handlers", () => {
     }])
   })
 
+  test("dispatches background terminal slash commands and RPC actions through Codex app-server", async () => {
+    const requests: { method: string, params: unknown }[] = []
+    const handlers = createKhalaCodeDesktopRpcRequestHandlers({
+      appleFmReadiness: () => {
+        throw new Error("not used")
+      },
+      codexAppServerHost: {
+        dispose: () => undefined,
+        request: async <Result>(method: string, params?: unknown) => {
+          requests.push({ method, params })
+          return method === "thread/backgroundTerminals/list"
+            ? {
+              data: [{
+                command: "python3 -m http.server",
+                cwd: "/workspace",
+                itemId: "item-1",
+                osPid: null,
+                processId: "42",
+              }],
+              nextCursor: null,
+            } as Result
+            : { ok: true } as Result
+        },
+        respondToServerRequest: () => undefined,
+        restart: async () => ({
+          ok: true,
+          action: "restart",
+          changed: false,
+          status: stoppedAppServerStatus(),
+        }),
+        start: async () => ({
+          ok: true,
+          action: "start",
+          changed: false,
+          status: stoppedAppServerStatus(),
+        }),
+        status: stoppedAppServerStatus,
+        stop: async () => ({
+          ok: true,
+          action: "stop",
+          changed: false,
+          status: stoppedAppServerStatus(),
+        }),
+        subscribe: () => () => undefined,
+      },
+      codexChatRuntime: throwingCodexChatRuntime({
+        threadIdForSession: async sessionId => {
+          expect(sessionId).toBe("desktop-session-bg")
+          return "thread-bg"
+        },
+      }),
+      env: {},
+      onDeviceDeciderStatus: () => {
+        throw new Error("not used")
+      },
+      workingDirectory: process.cwd(),
+    })
+
+    await expect(handlers.slashCommandDispatch({
+      raw: "/ps",
+      sessionId: "desktop-session-bg",
+    })).resolves.toMatchObject({
+      ok: true,
+      command: "ps",
+      method: "thread/backgroundTerminals/list",
+      status: "dispatched",
+      message: "Loaded Codex background terminals.",
+      threadId: "thread-bg",
+    })
+
+    await expect(handlers.slashCommandDispatch({
+      raw: "/clean",
+      sessionId: "desktop-session-bg",
+    })).resolves.toMatchObject({
+      ok: true,
+      command: "stop",
+      method: "thread/backgroundTerminals/clean",
+      status: "dispatched",
+      message: "Requested Codex background terminal cleanup.",
+      threadId: "thread-bg",
+    })
+
+    await expect(handlers.codexBackgroundTerminalsTerminate({
+      processId: "42",
+      threadId: "thread-bg",
+    })).resolves.toMatchObject({
+      ok: true,
+      method: "thread/backgroundTerminals/terminate",
+    })
+
+    expect(requests).toEqual([
+      {
+        method: "thread/backgroundTerminals/list",
+        params: {
+          threadId: "thread-bg",
+          cursor: null,
+          limit: 50,
+        },
+      },
+      {
+        method: "thread/backgroundTerminals/clean",
+        params: {
+          threadId: "thread-bg",
+        },
+      },
+      {
+        method: "thread/backgroundTerminals/terminate",
+        params: {
+          threadId: "thread-bg",
+          processId: "42",
+        },
+      },
+    ])
+  })
+
   test("returns blocked and gap results for unavailable slash commands", async () => {
     const handlers = createKhalaCodeDesktopRpcRequestHandlers({
       appleFmReadiness: () => {

--- a/docs/khala-code/2026-07-01-codex-app-server-gap-matrix.md
+++ b/docs/khala-code/2026-07-01-codex-app-server-gap-matrix.md
@@ -17,9 +17,10 @@ the behavior small.
 - `covered_by_app_server`: Codex exposes stable app-server methods. Khala can
   build richer desktop navigation or layout, but the state and mutations must
   round-trip through app-server.
-- `khala_adapter_with_test`: The command is a desktop shell affordance such as
-  copy, clear, title, or diagnostics. Khala can own a tiny adapter if a test
-  covers it and the adapter does not become a second Codex Core.
+- `khala_adapter_with_test`: The command is a desktop shell affordance or a
+  bounded wrapper over experimental app-server methods. Khala can own a tiny
+  adapter if a test covers it and the adapter does not become a second Codex
+  Core.
 - `upstream_app_server_gap`: Codex TUI owns behavior that Khala needs for full
   parity. Khala should request a narrow app-server method or metadata contract
   before implementing the behavior.
@@ -36,7 +37,7 @@ the behavior small.
 | `multi-agent-side-conversation-and-plan` | `upstream_app_server_gap` | `/approve`, `/plan`, `/agent`, `/subagents`, `/side`, `/btw` | `turn/steer`, `thread/fork`, `thread/inject_items`, `thread/approveGuardianDeniedAction`, `thread/metadata/update`, `thread/read` | None | `codex.app_server.gap.side_agent_plan_controls` |
 | `ide-file-mention-and-diff` | `upstream_app_server_gap` | `/ide`, `/diff`, `/mention` | `fuzzyFileSearch`, `gitDiffToRemote`, `fs/readDirectory`, `fs/readFile`, `config/read` | None | `codex.app_server.gap.ide_mentions_diff` |
 | `windows-sandbox-setup-and-readable-roots` | `upstream_app_server_gap` | `/setup-default-sandbox`, `/sandbox-add-read-dir` | `windowsSandbox/setupStart`, `windowsSandbox/readiness`, `config/read`, `config/value/write` | None | `codex.app_server.gap.windows_sandbox_read_roots` |
-| `background-terminal-management` | `upstream_app_server_gap` | `/ps`, `/stop` | None | `thread/backgroundTerminals/list`, `thread/backgroundTerminals/clean`, `thread/backgroundTerminals/terminate` | `codex.app_server.gap.background_terminals` |
+| `background-terminal-management` | `khala_adapter_with_test` | `/ps`, `/stop` | None | `thread/backgroundTerminals/list`, `thread/backgroundTerminals/clean`, `thread/backgroundTerminals/terminate` | Khala wraps Codex's experimental background terminal methods directly: `/ps` lists with bounded pagination, `/stop` and `/clean` request cleanup, and the RPC action path can terminate an explicit app-server `processId`. Stable product copy still tracks `codex.app_server.gap.background_terminals` until Codex stabilizes the methods. |
 
 ## Upstream-ready Gap Names
 
@@ -56,7 +57,9 @@ GitHub issues, or protocol notes:
 - `codex.app_server.gap.windows_sandbox_read_roots`: expose readable-root
   mutation in the Windows sandbox contract.
 - `codex.app_server.gap.background_terminals`: stabilize the existing
-  experimental background terminal list, clean, and terminate methods.
+  experimental background terminal list, clean, and terminate methods. Khala
+  Code now has an adapter over those experimental methods, but the upstream
+  stabilization gap remains visible.
 
 ## Update Rule
 
@@ -73,7 +76,8 @@ The matrix test enforces that:
 
 - every Codex slash command is present exactly once;
 - every stable app-server method exists in the generated Codex schema;
-- experimental background terminal methods stay labeled experimental;
+- experimental background terminal methods stay labeled experimental and route
+  through a tested Khala adapter;
 - every TUI-local behavior has either a named upstream gap or a tested Khala
   adapter rationale;
 - this human-readable document contains every row id and upstream gap id.


### PR DESCRIPTION
## Summary
- Wire Khala Code `/ps`, `/stop`, and `/clean` through Codex app-server background terminal methods instead of a Khala-local process manager.
- Add typed RPC actions for background terminal list, clean, and per-process terminate using Codex `thread/backgroundTerminals/*` methods with bounded list pagination.
- Update the Codex app-server gap matrix/docs to mark background terminal parity as a tested experimental Khala adapter while preserving the upstream stabilization gap.

## Validation
- `KHALA_CODE_CODEX_REFERENCE_ROOT=/Users/christopherdavid/work/projects/repos/codex bun test clients/khala-code-desktop/tests/codex-slash-commands.test.ts clients/khala-code-desktop/tests/codex-app-server-gap-matrix.test.ts clients/khala-code-desktop/tests/rpc-handlers.test.ts`
- `KHALA_CODE_CODEX_REFERENCE_ROOT=/Users/christopherdavid/work/projects/repos/codex bun run --cwd clients/khala-code-desktop verify`

## Notes
- `origin/main` advanced after this task checkout was created, so this is a PR branch instead of a direct main push.
- Running `bun run --cwd clients/khala-code-desktop verify` without `KHALA_CODE_CODEX_REFERENCE_ROOT` still depends on a sibling `projects/repos/codex` fixture checkout; this bounded workspace only had the referenced Codex checkout at the absolute path from issue #7803.