### PR TITLE
Add Pylon runner-neutral status control surface

### DIFF
--- a/apps/pylon/README.md
+++ b/apps/pylon/README.md
@@ -293,6 +293,17 @@ payout target`) run from the palette and always end in an explicit
   Codex/Claude composer execution only, reject local danger modes, accept
   per-session account/workspace selectors, and retain path-safe artifacts
   under the Pylon home.
+- Registered assignment runners also expose a runner-neutral status/control
+  contract for Khala Code fleet and inbox projections. Status events use
+  `openagents.pylon.agent_runner_status_event.v1` with a neutral state
+  (`idle`, `queued`, `working`, `waiting`, `blocked`, `done`, `failed`, or
+  `offline`), runner/task/dispatch refs, public-safe worktree refs, and the
+  supported control verbs. Control commands use
+  `openagents.pylon.agent_runner_control_command.v1`; the initial allowlist is
+  `status.list`, `task.list`, `task.update`, `task.dispatch`, and
+  `dispatch.cancel`. This is a contract/projection surface only: current Codex
+  and Claude assignment execution still flows through the existing lease runner
+  paths, and destructive or spendful controls remain outside this local slice.
 
 ### TUI test harness
 

--- a/apps/pylon/src/agent-status-reporter.ts
+++ b/apps/pylon/src/agent-status-reporter.ts
@@ -1,7 +1,36 @@
 export const PYLON_AGENT_STATUS_SCHEMA_VERSION =
   "openagents.pylon.agent_status.v1"
+export const PYLON_AGENT_RUNNER_STATUS_EVENT_SCHEMA_VERSION =
+  "openagents.pylon.agent_runner_status_event.v1"
+export const PYLON_AGENT_RUNNER_CONTROL_COMMAND_SCHEMA_VERSION =
+  "openagents.pylon.agent_runner_control_command.v1"
 
 export type AgentStatusRunnerKind = "codex_sdk" | "claude_agent" | "local_command"
+
+export type AgentRunnerNeutralState =
+  | "idle"
+  | "queued"
+  | "working"
+  | "waiting"
+  | "blocked"
+  | "done"
+  | "failed"
+  | "offline"
+
+export type AgentRunnerControlVerb =
+  | "status.list"
+  | "task.list"
+  | "task.update"
+  | "task.dispatch"
+  | "dispatch.cancel"
+
+export const PYLON_AGENT_RUNNER_CONTROL_VERBS: ReadonlyArray<AgentRunnerControlVerb> = [
+  "status.list",
+  "task.list",
+  "task.update",
+  "task.dispatch",
+  "dispatch.cancel",
+]
 
 export type AgentStatusUsage = {
   inputTokens?: number
@@ -48,6 +77,53 @@ export type AgentStatusReport = {
 
 export type AgentStatusReporter = (report: AgentStatusReport) => Promise<void>
 
+export type AgentRunnerStatusHistoryEntry = {
+  state: AgentRunnerNeutralState
+  stateStartedAt: string
+}
+
+export type AgentRunnerStatusEvent = {
+  eventRef: string
+  runnerRef: string
+  runnerKind: string
+  state: AgentRunnerNeutralState
+  stateStartedAt: string
+  updatedAt: string
+  assignmentRef?: string
+  taskId?: string
+  dispatchContextId?: string
+  assigneeHandle?: string
+  pylonRef?: string
+  worktreeId?: string
+  worktreeRef?: string
+  capabilityRefs?: ReadonlyArray<string>
+  supportedControlVerbs?: ReadonlyArray<AgentRunnerControlVerb>
+  refs?: ReadonlyArray<string>
+  blockerRefs?: ReadonlyArray<string>
+  stateHistory?: ReadonlyArray<AgentRunnerStatusHistoryEntry>
+}
+
+export type AgentRunnerControlCommand = {
+  commandRef: string
+  verb: AgentRunnerControlVerb
+  issuedAt: string
+  target: {
+    runnerRef?: string
+    runnerKind?: string
+    taskId?: string
+    dispatchContextId?: string
+    groupAddress?: string
+  }
+  payload?: {
+    status?: AgentRunnerNeutralState
+    title?: string
+    prompt?: string
+    result?: string
+    reason?: string
+    refs?: ReadonlyArray<string>
+  }
+}
+
 export const normalizeAgentStatusBaseUrl = (
   value: string | undefined,
 ): string | undefined => {
@@ -72,6 +148,20 @@ export const boundedString = (
   if (trimmed === undefined || trimmed === "") return undefined
   return trimmed.length > max ? trimmed.slice(0, max) : trimmed
 }
+
+export const boundedStringArray = (
+  values: ReadonlyArray<string> | undefined,
+  maxItems: number,
+  maxLength: number,
+): string[] =>
+  [...(values ?? [])]
+    .map(value => boundedString(value, maxLength))
+    .filter((value): value is string =>
+      value !== undefined &&
+      !value.startsWith("/") &&
+      !/^[A-Za-z]:[\\/]/.test(value),
+    )
+    .slice(0, maxItems)
 
 export const encodeAgentStatusItems = (
   items: ReadonlyArray<AgentStatusItem>,
@@ -142,3 +232,73 @@ export const encodeAgentStatusReport = (
   items: encodeAgentStatusItems(report.items),
   ...(report.rawEvents === undefined ? {} : { rawEvents: report.rawEvents }),
 })
+
+export const encodeAgentRunnerStatusEvent = (
+  event: AgentRunnerStatusEvent,
+): Record<string, unknown> => ({
+  schemaVersion: PYLON_AGENT_RUNNER_STATUS_EVENT_SCHEMA_VERSION,
+  eventRef: event.eventRef,
+  runnerRef: event.runnerRef,
+  runnerKind: event.runnerKind,
+  state: event.state,
+  stateStartedAt: event.stateStartedAt,
+  updatedAt: event.updatedAt,
+  ...(event.assignmentRef === undefined ? {} : { assignmentRef: event.assignmentRef }),
+  ...(event.taskId === undefined ? {} : { taskId: event.taskId }),
+  ...(event.dispatchContextId === undefined ? {} : { dispatchContextId: event.dispatchContextId }),
+  ...(event.assigneeHandle === undefined ? {} : { assigneeHandle: boundedString(event.assigneeHandle, 120) }),
+  ...(event.pylonRef === undefined ? {} : { pylonRef: event.pylonRef }),
+  ...(event.worktreeId === undefined ? {} : { worktreeId: boundedString(event.worktreeId, 160) }),
+  ...(event.worktreeRef === undefined ? {} : { worktreeRef: event.worktreeRef }),
+  ...(event.capabilityRefs === undefined ? {} : { capabilityRefs: boundedStringArray(event.capabilityRefs, 32, 160) }),
+  ...(event.supportedControlVerbs === undefined
+    ? {}
+    : {
+        supportedControlVerbs: event.supportedControlVerbs.filter((verb): verb is AgentRunnerControlVerb =>
+          PYLON_AGENT_RUNNER_CONTROL_VERBS.includes(verb as AgentRunnerControlVerb),
+        ),
+      }),
+  refs: boundedStringArray(event.refs, 64, 240),
+  blockerRefs: boundedStringArray(event.blockerRefs, 64, 240),
+  ...(event.stateHistory === undefined
+    ? {}
+    : {
+        stateHistory: event.stateHistory.slice(-20).map(entry => ({
+          state: entry.state,
+          stateStartedAt: entry.stateStartedAt,
+        })),
+      }),
+})
+
+export const encodeAgentRunnerControlCommand = (
+  command: AgentRunnerControlCommand,
+): Record<string, unknown> => {
+  if (!PYLON_AGENT_RUNNER_CONTROL_VERBS.includes(command.verb)) {
+    throw new Error(`unsupported agent runner control verb: ${command.verb}`)
+  }
+  return {
+    schemaVersion: PYLON_AGENT_RUNNER_CONTROL_COMMAND_SCHEMA_VERSION,
+    commandRef: command.commandRef,
+    verb: command.verb,
+    issuedAt: command.issuedAt,
+    target: {
+      ...(command.target.runnerRef === undefined ? {} : { runnerRef: command.target.runnerRef }),
+      ...(command.target.runnerKind === undefined ? {} : { runnerKind: command.target.runnerKind }),
+      ...(command.target.taskId === undefined ? {} : { taskId: command.target.taskId }),
+      ...(command.target.dispatchContextId === undefined ? {} : { dispatchContextId: command.target.dispatchContextId }),
+      ...(command.target.groupAddress === undefined ? {} : { groupAddress: boundedString(command.target.groupAddress, 160) }),
+    },
+    ...(command.payload === undefined
+      ? {}
+      : {
+          payload: {
+            ...(command.payload.status === undefined ? {} : { status: command.payload.status }),
+            ...(command.payload.title === undefined ? {} : { title: boundedString(command.payload.title, 240) }),
+            ...(command.payload.prompt === undefined ? {} : { prompt: boundedString(command.payload.prompt, 4 * 1024) }),
+            ...(command.payload.result === undefined ? {} : { result: boundedString(command.payload.result, 4 * 1024) }),
+            ...(command.payload.reason === undefined ? {} : { reason: boundedString(command.payload.reason, 240) }),
+            ...(command.payload.refs === undefined ? {} : { refs: boundedStringArray(command.payload.refs, 32, 240) }),
+          },
+        }),
+  }
+}

--- a/apps/pylon/src/orchestration/status-control.ts
+++ b/apps/pylon/src/orchestration/status-control.ts
@@ -1,0 +1,87 @@
+import { createHash } from "node:crypto"
+
+import {
+  PYLON_AGENT_RUNNER_CONTROL_VERBS,
+  encodeAgentRunnerStatusEvent,
+  type AgentRunnerNeutralState,
+  type AgentRunnerStatusEvent,
+} from "../agent-status-reporter.js"
+import type { DispatchContext, OrchestrationTask } from "./store.js"
+
+const stableRef = (prefix: string, value: string): string =>
+  `${prefix}.${createHash("sha256").update(value).digest("hex").slice(0, 24)}`
+
+export function neutralStateForDispatchContext(
+  context: DispatchContext,
+  task?: OrchestrationTask | null,
+): AgentRunnerNeutralState {
+  if (context.status === "circuit_broken") return "offline"
+  if (context.status === "blocked") return "blocked"
+  if (context.status === "failed") return "failed"
+  if (context.status === "completed") return "done"
+  if (context.status === "dispatched") return "working"
+  if (task?.status === "pending") return "queued"
+  return "idle"
+}
+
+export function agentRunnerStatusEventForDispatchContext(input: {
+  context: DispatchContext
+  task?: OrchestrationTask | null
+  pylonRef?: string
+  assignmentRef?: string
+  now?: Date
+}): AgentRunnerStatusEvent {
+  const updatedAt = (input.now ?? new Date(input.context.updatedAt)).toISOString()
+  const state = neutralStateForDispatchContext(input.context, input.task)
+  const taskId = input.task?.id ?? input.context.currentTaskId ?? undefined
+  const runnerRef = stableRef(
+    "runner.public.pylon",
+    `${input.pylonRef ?? "pylon.local"}:${input.context.id}:${input.context.runnerKind}`,
+  )
+  const eventRef = stableRef(
+    "event.public.pylon.runner_status",
+    `${runnerRef}:${state}:${taskId ?? "idle"}:${input.context.updatedAt}`,
+  )
+  return {
+    eventRef,
+    runnerRef,
+    runnerKind: input.context.runnerKind,
+    state,
+    stateStartedAt: input.context.updatedAt,
+    updatedAt,
+    ...(input.assignmentRef === undefined ? {} : { assignmentRef: input.assignmentRef }),
+    ...(taskId === undefined ? {} : { taskId }),
+    dispatchContextId: input.context.id,
+    assigneeHandle: input.context.assigneeHandle,
+    ...(input.pylonRef === undefined ? {} : { pylonRef: input.pylonRef }),
+    ...(input.context.worktreeId === null ? {} : { worktreeId: input.context.worktreeId }),
+    ...(input.context.worktreePath === null
+      ? {}
+      : { worktreeRef: stableRef("worktree.public.pylon", `${input.context.id}:${input.context.worktreePath}`) }),
+    supportedControlVerbs: PYLON_AGENT_RUNNER_CONTROL_VERBS,
+    refs: [
+      `runner-kind.pylon.${input.context.runnerKind}`,
+      `dispatch-context-status.pylon.${input.context.status}`,
+      ...(input.task === undefined || input.task === null ? [] : [`task-status.pylon.${input.task.status}`]),
+    ],
+    blockerRefs: input.context.status === "circuit_broken"
+      ? ["blocker.pylon.runner.circuit_broken"]
+      : [],
+    stateHistory: [
+      {
+        state,
+        stateStartedAt: input.context.updatedAt,
+      },
+    ],
+  }
+}
+
+export function encodeAgentRunnerStatusEventForDispatchContext(input: {
+  context: DispatchContext
+  task?: OrchestrationTask | null
+  pylonRef?: string
+  assignmentRef?: string
+  now?: Date
+}): Record<string, unknown> {
+  return encodeAgentRunnerStatusEvent(agentRunnerStatusEventForDispatchContext(input))
+}

--- a/apps/pylon/src/orchestration/supervisor-orchestration.test.ts
+++ b/apps/pylon/src/orchestration/supervisor-orchestration.test.ts
@@ -3,6 +3,7 @@ import { Database } from "bun:sqlite"
 
 import { dispatchEligibility, dispatchLiveness, dispatchReadySupervisorTasks } from "./coordinator.js"
 import { parseOrchestrationGroupAddress, resolveOrchestrationGroup } from "./groups.js"
+import { encodeAgentRunnerStatusEventForDispatchContext } from "./status-control.js"
 import {
   createPylonOrchestrationStore,
   isStoredOrchestrationRunnerKind,
@@ -135,6 +136,46 @@ describe("Pylon supervisor orchestration store", () => {
     ])
     expect(store.getTask("task.codex")?.status).toBe("dispatched")
     expect(store.getTask("task.claude")?.status).toBe("dispatched")
+  })
+
+  test("projects dispatch contexts as runner-neutral fleet status events", () => {
+    const now = new Date("2026-07-01T12:00:00.000Z")
+    const store = createPylonOrchestrationStore(new Database(":memory:"))
+    const task = store.createTask({
+      id: "task.7809",
+      spec: { ...baseTaskSpec, title: "Issue #7809", runnerKind: "codex" },
+      now,
+    })
+    store.createDispatchContext({
+      id: "ctx.codex.7809",
+      assigneeHandle: "codex-1",
+      runnerKind: "codex",
+      worktreeId: "wt-7809",
+      worktreePath: "/Users/private/worktree",
+      lastHeartbeatAt: now,
+      now,
+    })
+    store.markDispatched(task.id, "ctx.codex.7809", now)
+    const context = store.getDispatchContext("ctx.codex.7809")
+
+    expect(context).not.toBeNull()
+    const event = encodeAgentRunnerStatusEventForDispatchContext({
+      context: context!,
+      task: store.getTask(task.id),
+      pylonRef: "pylon.public.runner-status",
+      now: new Date("2026-07-01T12:01:00.000Z"),
+    })
+
+    expect(event).toMatchObject({
+      runnerKind: "codex",
+      state: "working",
+      taskId: "task.7809",
+      dispatchContextId: "ctx.codex.7809",
+      pylonRef: "pylon.public.runner-status",
+      supportedControlVerbs: ["status.list", "task.list", "task.update", "task.dispatch", "dispatch.cancel"],
+    })
+    expect(String(event.worktreeRef)).toStartWith("worktree.public.pylon.")
+    expect(JSON.stringify(event)).not.toContain("/Users/private/worktree")
   })
 
   test("normalizes legacy runner aliases through the AgentRunner registry vocabulary", () => {

--- a/apps/pylon/tests/codex-turn-reporter.test.ts
+++ b/apps/pylon/tests/codex-turn-reporter.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, test } from "bun:test"
 
 import {
+  PYLON_AGENT_RUNNER_CONTROL_COMMAND_SCHEMA_VERSION,
+  PYLON_AGENT_RUNNER_STATUS_EVENT_SCHEMA_VERSION,
   PYLON_AGENT_STATUS_SCHEMA_VERSION,
+  encodeAgentRunnerControlCommand,
+  encodeAgentRunnerStatusEvent,
   encodeAgentStatusReport,
 } from "../src/agent-status-reporter"
 import {
@@ -49,6 +53,61 @@ describe("Pylon Codex turn reporter", () => {
       { itemType: "command_execution", ordinal: 1, outputBytes: 12 },
     ])
     expect(JSON.stringify(body)).not.toContain("/Users/")
+  })
+
+  test("encodes runner-neutral status events and allowlisted control commands", () => {
+    const status = encodeAgentRunnerStatusEvent({
+      eventRef: "event.public.pylon.runner_status.test",
+      runnerRef: "runner.public.pylon.test",
+      runnerKind: "codex",
+      state: "working",
+      stateStartedAt: "2026-07-01T12:00:00.000Z",
+      updatedAt: "2026-07-01T12:01:00.000Z",
+      pylonRef: "pylon.public.test",
+      taskId: "task.public.test",
+      dispatchContextId: "ctx.codex.1",
+      worktreeId: "wt-public",
+      worktreeRef: "worktree.public.pylon.test",
+      supportedControlVerbs: ["status.list", "task.list", "task.update", "task.dispatch", "dispatch.cancel"],
+      refs: ["ref.public.ok", "/Users/private/path"],
+      stateHistory: Array.from({ length: 22 }, (_, index) => ({
+        state: index === 21 ? "working" : "idle",
+        stateStartedAt: `2026-07-01T12:${String(index).padStart(2, "0")}:00.000Z`,
+      })),
+    })
+
+    expect(status).toMatchObject({
+      schemaVersion: PYLON_AGENT_RUNNER_STATUS_EVENT_SCHEMA_VERSION,
+      runnerKind: "codex",
+      state: "working",
+      taskId: "task.public.test",
+    })
+    expect((status.stateHistory as unknown[]).length).toBe(20)
+    expect(JSON.stringify(status)).not.toContain("/Users/private/path")
+
+    const command = encodeAgentRunnerControlCommand({
+      commandRef: "command.public.pylon.runner_control.test",
+      verb: "task.dispatch",
+      issuedAt: "2026-07-01T12:02:00.000Z",
+      target: {
+        groupAddress: "@runner:codex",
+        taskId: "task.public.test",
+      },
+      payload: {
+        prompt: "Dispatch the public issue.",
+        refs: ["issue.public.7809"],
+      },
+    })
+
+    expect(command).toMatchObject({
+      schemaVersion: PYLON_AGENT_RUNNER_CONTROL_COMMAND_SCHEMA_VERSION,
+      commandRef: "command.public.pylon.runner_control.test",
+      verb: "task.dispatch",
+      target: {
+        groupAddress: "@runner:codex",
+        taskId: "task.public.test",
+      },
+    })
   })
 
   test("posts the exact turn envelope with bearer auth and stable idempotency", async () => {


### PR DESCRIPTION
## Summary
- Add schema-versioned Pylon runner-neutral status events and control commands for fleet/inbox consumers.
- Project orchestration dispatch contexts into public-safe runner status events without leaking local worktree paths.
- Document supported status states, control verbs, and current limitations.

## Validation
- bun test apps/pylon/tests/codex-turn-reporter.test.ts apps/pylon/src/orchestration/supervisor-orchestration.test.ts
- bun run --cwd apps/pylon typecheck
- bun run --cwd apps/pylon test (1969 pass, 3 skip, 0 fail)

Refs #7809