### PR TITLE
Retry Khala spawn assignment conflicts

### DIFF
--- a/apps/pylon/src/khala-spawn.test.ts
+++ b/apps/pylon/src/khala-spawn.test.ts
@@ -561,4 +561,86 @@ describe("Khala spawn proof gate", () => {
       "failure.khala_spawn.request_public_safety_blocked",
     )
   })
+
+  test("retries transient HTTP 409 assignment creation and reports recovery", async () => {
+    const tokenCounts = [5000, 5016]
+    const sleeps: number[] = []
+    let requestAttempts = 0
+    const result = await runPylonKhalaSpawnPlan({
+      deps: {
+        readProof: async () => exactProof,
+        readTokensServed: async () => tokenCounts.shift() ?? 5016,
+        requestAssignment: async () => {
+          requestAttempts += 1
+          if (requestAttempts < 3) {
+            throw new Error("pylon khala request failed (409): assignment slot conflict")
+          }
+          return requestResult
+        },
+        runAssignment: async () => ({
+          closeout: { status: "accepted" },
+          ok: true,
+        }),
+        sleep: async (ms) => {
+          sleeps.push(ms)
+        },
+      },
+      network: {
+        agentToken: "agent.public.test",
+        baseUrl: "https://openagents.example",
+      },
+      plan,
+      summary: {} as never,
+    })
+
+    const statuses = result.results[0]?.lifecycleEvents.flatMap((event) =>
+      event.status === undefined ? [] : [event.status]
+    )
+    expect(result.ok).toBe(true)
+    expect(requestAttempts).toBe(3)
+    expect(sleeps).toEqual([750, 2000])
+    expect(statuses).toContain("retry.khala_spawn.assignment_http_409")
+    expect(statuses).toContain("retry.khala_spawn.assignment_http_409_recovered")
+    expect(statuses).toContain("retry.khala_spawn.assignment_http_409_succeeded")
+    expect(result.results[0]?.failure).toBeNull()
+    expect(result.results[0]?.state).toBe("accepted")
+  })
+
+  test("exhausts bounded HTTP 409 assignment creation retries with public-safe blocker", async () => {
+    const sleeps: number[] = []
+    let requestAttempts = 0
+    const result = await runPylonKhalaSpawnPlan({
+      deps: {
+        readTokensServed: async () => null,
+        requestAssignment: async () => {
+          requestAttempts += 1
+          throw new Error("pylon khala request failed (409): assignment slot conflict")
+        },
+        sleep: async (ms) => {
+          sleeps.push(ms)
+        },
+      },
+      network: {
+        agentToken: "agent.public.test",
+        baseUrl: "https://openagents.example",
+      },
+      plan,
+      summary: {} as never,
+    })
+
+    const statuses = result.results[0]?.lifecycleEvents.flatMap((event) =>
+      event.status === undefined ? [] : [event.status]
+    )
+    expect(result.ok).toBe(false)
+    expect(requestAttempts).toBe(4)
+    expect(sleeps).toEqual([750, 2000, 4000])
+    expect(statuses).toContain("retry.khala_spawn.assignment_http_409")
+    expect(statuses).toContain("failure.khala_spawn.assignment_http_409_retry_exhausted")
+    expect(result.blockerRefs).toContain("blocker.khala_spawn.slot_http_409")
+    expect(result.results[0]?.failure).toEqual({
+      message: "worker failed because the OpenAgents API returned HTTP 409",
+      phase: "requesting",
+      ref: "failure.khala_spawn.http_409",
+    })
+  })
 })

--- a/apps/pylon/src/khala-spawn.ts
+++ b/apps/pylon/src/khala-spawn.ts
@@ -214,6 +214,7 @@ const failureRef = (suffix: string) => `failure.khala_spawn.${suffix}`
 
 const defaultProofRetryDelaysMs = [500, 1_500, 3_000] as const
 const defaultProofBackfillRetryDelaysMs = [5_000, 10_000, 20_000, 30_000] as const
+const defaultAssignment409RetryDelaysMs = [750, 2_000, 4_000] as const
 
 const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms))
 
@@ -521,6 +522,50 @@ function spawnFailureProjection(input: {
   }
 }
 
+function isHttp409AssignmentConflict(error: unknown): boolean {
+  const raw = error instanceof Error ? error.message : String(error)
+  const status = /\((\d{3})\)/u.exec(raw)?.[1]
+  return status === "409" || /\bHTTP\s+409\b/iu.test(raw)
+}
+
+async function requestAssignmentWith409Retry<Slot extends PylonKhalaSpawnSlotLike>(input: {
+  emit: (
+    state: PylonKhalaSpawnWorkerState,
+    message: string,
+    patch?: Partial<PylonKhalaSpawnWorkerEvent>,
+  ) => Promise<void>
+  network: TipsNetworkOptions
+  requestAssignment: NonNullable<PylonKhalaSpawnRunDeps<Slot>["requestAssignment"]>
+  sleep: (ms: number) => Promise<void>
+  slot: Slot
+}): Promise<{ request: PylonKhalaRequestResult; retried409: boolean }> {
+  let last409: unknown
+  for (let attempt = 0; attempt <= defaultAssignment409RetryDelaysMs.length; attempt += 1) {
+    try {
+      const request = await input.requestAssignment(input.network, input.slot.requestInput, input.slot)
+      if (attempt > 0) {
+        await input.emit("requesting", "Khala assignment creation recovered after transient HTTP 409", {
+          status: "retry.khala_spawn.assignment_http_409_recovered",
+        })
+      }
+      return { request, retried409: attempt > 0 }
+    } catch (error) {
+      if (!isHttp409AssignmentConflict(error)) throw error
+      last409 = error
+      const delay = defaultAssignment409RetryDelaysMs[attempt]
+      if (delay === undefined) break
+      await input.emit("requesting", "Khala assignment creation hit transient HTTP 409; retrying", {
+        status: "retry.khala_spawn.assignment_http_409",
+      })
+      await input.sleep(delay)
+    }
+  }
+  await input.emit("requesting", "Khala assignment creation exhausted HTTP 409 retries", {
+    status: "failure.khala_spawn.assignment_http_409_retry_exhausted",
+  })
+  throw last409 ?? new Error("pylon khala request failed (409): assignment creation retry exhausted")
+}
+
 async function readProofWithRetry<Slot extends PylonKhalaSpawnSlotLike>(input: {
   delaysMs?: readonly number[]
   network: TipsNetworkOptions
@@ -746,7 +791,13 @@ async function runPylonKhalaSpawnSlot<Slot extends PylonKhalaSpawnSlotLike>(inpu
     await emit("queued", "worker queued")
     state = "requesting"
     await emit("requesting", "requesting Khala durable assignment")
-    const request = await input.requestAssignment(input.network, input.slot.requestInput, input.slot)
+    const { request, retried409 } = await requestAssignmentWith409Retry({
+      emit,
+      network: input.network,
+      requestAssignment: input.requestAssignment,
+      sleep: pause,
+      slot: input.slot,
+    })
     assignmentRef = request.assignmentRef
     durableRequestId = request.durableRequestId
     if (assignmentRef === null) {
@@ -755,7 +806,10 @@ async function runPylonKhalaSpawnSlot<Slot extends PylonKhalaSpawnSlotLike>(inpu
       await emit("failed", "Khala request did not return an assignment ref")
     } else {
       state = "assignment_created"
-      await emit("assignment_created", "Khala assignment ref created", { assignmentRef })
+      await emit("assignment_created", "Khala assignment ref created", {
+        assignmentRef,
+        ...(retried409 ? { status: "retry.khala_spawn.assignment_http_409_succeeded" } : {}),
+      })
       const run = await input.runAssignment(
         input.summary,
         {


### PR DESCRIPTION
## Summary
- Add bounded retry/backoff for transient HTTP 409 responses during `khala spawn` assignment creation.
- Emit public-safe lifecycle diagnostics for 409 retry, recovery, succeeded-after-retry, and retry exhaustion.
- Add focused tests for retry success and exhausted retry behavior without live network calls.

## Validation
- `bun test apps/pylon/src/khala-spawn.test.ts apps/pylon/src/khala-burndown.test.ts`

Fixes #7810