### PR TITLE
Implement Khala Code IDE mention diff parity

### DIFF
--- a/clients/khala-code-desktop/src/bun/codex-app-server-gap-matrix.ts
+++ b/clients/khala-code-desktop/src/bun/codex-app-server-gap-matrix.ts
@@ -317,7 +317,7 @@ export const KHALA_CODE_CODEX_APP_SERVER_GAP_MATRIX: readonly KhalaCodeCodexAppS
   {
     id: "ide-file-mention-and-diff",
     area: "IDE context, file mention insertion, and diff viewers",
-    decision: "upstream_app_server_gap",
+    decision: "covered_by_app_server",
     codexSourceRefs: [
       "codex-rs/tui/src/slash_command.rs",
       "codex-rs/tui/src/bottom_pane/mentions_v2",
@@ -337,19 +337,21 @@ export const KHALA_CODE_CODEX_APP_SERVER_GAP_MATRIX: readonly KhalaCodeCodexAppS
     ],
     upstreamGapId: "codex.app_server.gap.ide_mentions_diff",
     khalaAdapter:
-      "Khala can build richer browser pickers, but must source candidates and diff content from app-server methods or request missing APIs.",
+      "Khala projects bounded mention candidates, remote diff content, and IDE status from app-server methods; richer IDE mutation remains upstream-owned.",
     rationale:
-      "Mention and diff UI are attractive desktop advantages, but Codex owns workspace interpretation, ignored files, and diff semantics.",
+      "Codex exposes the search, filesystem, diff, and config reads needed for the current wrapper slice. Khala can render richer desktop UI, but Codex remains the source of truth for workspace interpretation, ignored files, and diff semantics.",
     linkedIssues: [
       "https://github.com/OpenAgentsInc/openagents/issues/7785",
       "https://github.com/OpenAgentsInc/openagents/issues/7795",
+      "https://github.com/OpenAgentsInc/openagents/issues/7805",
     ],
     testRefs: [
       "clients/khala-code-desktop/tests/codex-slash-commands.test.ts",
+      "clients/khala-code-desktop/tests/rpc-handlers.test.ts",
       "clients/khala-code-desktop/tests/codex-app-server-gap-matrix.test.ts",
     ],
     updateTrigger:
-      "Update when Codex exposes full local diff, IDE context, or mention metadata through app-server.",
+      "Update when Codex changes fuzzy search, fs read, remote diff, config, IDE metadata, or mention semantics.",
   },
   {
     id: "windows-sandbox-setup-and-readable-roots",

--- a/clients/khala-code-desktop/src/bun/rpc-handlers.ts
+++ b/clients/khala-code-desktop/src/bun/rpc-handlers.ts
@@ -24,6 +24,9 @@ import {
   type KhalaCodeDesktopCodexBackgroundTerminalsTerminateRequest,
   type KhalaCodeDesktopCodexEcosystemReadRequest,
   type KhalaCodeDesktopCodexEcosystemReadResult,
+  type KhalaCodeDesktopCodexMentionCandidate,
+  type KhalaCodeDesktopCodexMentionCandidatesRequest,
+  type KhalaCodeDesktopCodexMentionCandidatesResult,
   type KhalaCodeDesktopCodexSettingsReadRequest,
   type KhalaCodeDesktopCodexSettingsReadResult,
   type KhalaCodeDesktopSlashCommandDispatchRequest,
@@ -102,6 +105,109 @@ const appInfo = (): KhalaCodeDesktopAppInfo => ({
   app: "Khala Code Desktop",
   observedAt: new Date().toISOString(),
 })
+
+const MAX_MENTION_CANDIDATES = 20
+const MAX_DIRECTORY_CANDIDATES = 20
+const MAX_DIFF_DISPLAY_CHARS = 80_000
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null
+
+const stringValue = (value: unknown): string | null =>
+  typeof value === "string" ? value : null
+
+const numberValue = (value: unknown): number | undefined =>
+  typeof value === "number" && Number.isFinite(value) ? value : undefined
+
+const normalizeMentionCandidate = (value: unknown): KhalaCodeDesktopCodexMentionCandidate | null => {
+  if (!isRecord(value)) return null
+  const path = stringValue(value.path)
+  const fileName = stringValue(value.file_name) ?? stringValue(value.fileName) ?? path
+  if (path === null || fileName === null || path.length === 0 || fileName.length === 0) return null
+  const matchType = stringValue(value.match_type) ?? stringValue(value.matchType)
+  const candidate: KhalaCodeDesktopCodexMentionCandidate = {
+    fileName,
+    kind: matchType === "directory" ? "directory" : "file",
+    path,
+  }
+  const root = stringValue(value.root)
+  const score = numberValue(value.score)
+  return {
+    ...candidate,
+    ...(root === null ? {} : { root }),
+    ...(score === undefined ? {} : { score }),
+  }
+}
+
+const normalizeDirectoryCandidate = (value: unknown): KhalaCodeDesktopCodexMentionCandidate | null => {
+  if (!isRecord(value)) return null
+  const fileName = stringValue(value.fileName)
+  if (fileName === null || fileName.length === 0) return null
+  return {
+    fileName,
+    kind: value.isDirectory === true ? "directory" : "file",
+    path: fileName,
+  }
+}
+
+const mentionMessage = (input: {
+  readonly candidates: readonly KhalaCodeDesktopCodexMentionCandidate[]
+  readonly source: "fs/readDirectory" | "fuzzyFileSearch"
+  readonly truncated: boolean
+}): string => {
+  if (input.candidates.length === 0) {
+    return `Codex ${input.source} returned no mention candidates.`
+  }
+  const lines = input.candidates.map(candidate =>
+    `- ${candidate.kind === "directory" ? "dir" : "file"} ${candidate.path}`,
+  )
+  return [
+    `Codex ${input.source} mention candidates${input.truncated ? " (truncated)" : ""}:`,
+    ...lines,
+  ].join("\n")
+}
+
+const diffMessage = (response: unknown): { readonly message: string, readonly response: unknown } => {
+  const record = isRecord(response) ? response : {}
+  const diff = stringValue(record.diff) ?? ""
+  const sha = stringValue(record.sha)
+  if (diff.length === 0) {
+    return {
+      message: "Codex gitDiffToRemote returned no diff.",
+      response,
+    }
+  }
+  const truncated = diff.length > MAX_DIFF_DISPLAY_CHARS
+  const displayDiff = truncated ? diff.slice(0, MAX_DIFF_DISPLAY_CHARS) : diff
+  return {
+    message: [
+      `Codex gitDiffToRemote${sha === null ? "" : ` at ${sha}`}${truncated ? " (truncated)" : ""}:`,
+      "```diff",
+      displayDiff,
+      "```",
+    ].join("\n"),
+    response: {
+      sha,
+      diff: displayDiff,
+      truncated,
+      originalLength: diff.length,
+    },
+  }
+}
+
+const ideMessage = (response: unknown): string => {
+  const config = isRecord(response) && isRecord(response.config) ? response.config : {}
+  const ide = config.ide ?? config.ide_integration ?? config.ideIntegration
+  if (ide === undefined || ide === null) {
+    return "Codex app-server config has no IDE integration status; IDE controls are unsupported by this Codex build."
+  }
+  return [
+    "Codex app-server IDE integration status:",
+    "```json",
+    JSON.stringify(ide, null, 2),
+    "```",
+  ].join("\n")
+}
 
 const runtimeStatus = (input: {
   readonly available: boolean
@@ -585,6 +691,48 @@ export function createKhalaCodeDesktopRpcRequestHandlers(
     return input.codexAppServerHost.request(method, params)
   }
 
+  const readCodexMentionCandidates = async (
+    request: KhalaCodeDesktopCodexMentionCandidatesRequest = {},
+  ): Promise<KhalaCodeDesktopCodexMentionCandidatesResult> => {
+    const cwd = request.cwd ?? input.workingDirectory
+    const query = request.query?.trim() ?? ""
+    if (query.length === 0) {
+      const response = await requestCodexAppServer("fs/readDirectory", { path: cwd })
+      const entries = isRecord(response) && Array.isArray(response.entries)
+        ? response.entries
+        : []
+      const candidates = entries
+        .map(normalizeDirectoryCandidate)
+        .filter((candidate): candidate is KhalaCodeDesktopCodexMentionCandidate => candidate !== null)
+        .slice(0, MAX_DIRECTORY_CANDIDATES)
+      return {
+        ok: true,
+        candidates,
+        source: "fs/readDirectory",
+        truncated: entries.length > MAX_DIRECTORY_CANDIDATES,
+      }
+    }
+
+    const response = await requestCodexAppServer("fuzzyFileSearch", {
+      query,
+      roots: [cwd],
+      cancellationToken: null,
+    })
+    const files = isRecord(response) && Array.isArray(response.files)
+      ? response.files
+      : []
+    const candidates = files
+      .map(normalizeMentionCandidate)
+      .filter((candidate): candidate is KhalaCodeDesktopCodexMentionCandidate => candidate !== null)
+      .slice(0, MAX_MENTION_CANDIDATES)
+    return {
+      ok: true,
+      candidates,
+      source: "fuzzyFileSearch",
+      truncated: files.length > MAX_MENTION_CANDIDATES,
+    }
+  }
+
   const codexAppServerAction = async (
     method: string,
     params?: unknown,
@@ -977,6 +1125,46 @@ export function createKhalaCodeDesktopRpcRequestHandlers(
             message: "Started a Codex review turn.",
             response,
             ...(threadId === null ? {} : { threadId }),
+          })
+        }
+        case "mention": {
+          const response = await readCodexMentionCandidates({
+            ...(request.cwd === undefined ? {} : { cwd: request.cwd }),
+            query: args,
+          })
+          return dispatchedSlashCommand({
+            command: command.command,
+            method: response.source,
+            message: mentionMessage({
+              candidates: response.candidates,
+              source: response.source,
+              truncated: response.truncated,
+            }),
+            response,
+          })
+        }
+        case "diff": {
+          const response = await requestCodexAppServer(dispatch.method, {
+            cwd: request.cwd ?? input.workingDirectory,
+          })
+          const projected = diffMessage(response)
+          return dispatchedSlashCommand({
+            command: command.command,
+            method: dispatch.method,
+            message: projected.message,
+            response: projected.response,
+          })
+        }
+        case "ide": {
+          const response = await requestCodexAppServer(dispatch.method, {
+            cwd: request.cwd ?? input.workingDirectory,
+            includeLayers: true,
+          })
+          return dispatchedSlashCommand({
+            command: command.command,
+            method: dispatch.method,
+            message: ideMessage(response),
+            response,
           })
         }
         case "ps":
@@ -1390,6 +1578,19 @@ export function createKhalaCodeDesktopRpcRequestHandlers(
     },
     async codexMarketplaceUpgrade(request = {}) {
       return codexAppServerAction("marketplace/upgrade", request)
+    },
+    async codexMentionCandidates(request = {}) {
+      try {
+        return await readCodexMentionCandidates(request)
+      } catch (error) {
+        return {
+          ok: false,
+          candidates: [],
+          source: request.query?.trim() ? "fuzzyFileSearch" : "fs/readDirectory",
+          truncated: false,
+          error: error instanceof Error ? error.message : String(error),
+        }
+      }
     },
     async codexMcpOauthLogin(request) {
       return codexAppServerAction("mcpServer/oauth/login", {

--- a/clients/khala-code-desktop/src/shared/codex-slash-commands.ts
+++ b/clients/khala-code-desktop/src/shared/codex-slash-commands.ts
@@ -135,7 +135,10 @@ export const KHALA_CODE_DESKTOP_SLASH_COMMANDS = [
     availableInSideConversation: true,
     availableDuringTask: true,
     group: "settings",
-    dispatch: gap("Codex IDE integration settings are still TUI-local and need an app-server settings surface."),
+    dispatch: appServer("config/read", {
+      appServerDependency:
+        "Khala projects IDE integration status from Codex app-server config; richer IDE mutation remains upstream-owned.",
+    }),
   }),
   command({
     enumName: "Permissions",
@@ -436,7 +439,7 @@ export const KHALA_CODE_DESKTOP_SLASH_COMMANDS = [
     availableInSideConversation: true,
     availableDuringTask: true,
     group: "turn_task",
-    dispatch: gap("Codex git diff viewing needs a desktop diff adapter or upstream app-server diff read method."),
+    dispatch: appServer("gitDiffToRemote"),
   }),
   command({
     enumName: "Mention",
@@ -446,7 +449,7 @@ export const KHALA_CODE_DESKTOP_SLASH_COMMANDS = [
     availableInSideConversation: true,
     availableDuringTask: true,
     group: "turn_task",
-    dispatch: gap("Codex mention insertion needs a desktop mention picker wired to app-server file/symbol APIs."),
+    dispatch: appServer("fuzzyFileSearch"),
   }),
   command({
     enumName: "Status",

--- a/clients/khala-code-desktop/src/shared/rpc.ts
+++ b/clients/khala-code-desktop/src/shared/rpc.ts
@@ -394,6 +394,27 @@ export type KhalaCodeDesktopCodexBackgroundTerminalsTerminateRequest = {
   readonly threadId: string
 }
 
+export type KhalaCodeDesktopCodexMentionCandidate = {
+  readonly fileName: string
+  readonly kind: "directory" | "file"
+  readonly path: string
+  readonly root?: string
+  readonly score?: number
+}
+
+export type KhalaCodeDesktopCodexMentionCandidatesRequest = {
+  readonly cwd?: string
+  readonly query?: string
+}
+
+export type KhalaCodeDesktopCodexMentionCandidatesResult = {
+  readonly ok: boolean
+  readonly candidates: readonly KhalaCodeDesktopCodexMentionCandidate[]
+  readonly source: "fs/readDirectory" | "fuzzyFileSearch"
+  readonly truncated: boolean
+  readonly error?: string
+}
+
 export type KhalaCodeDesktopCodexSkillsExtraRootsSetRequest = {
   readonly extraRoots: readonly string[]
 }
@@ -829,6 +850,7 @@ export type KhalaCodeDesktopRPCSchema = {
     codexMarketplaceAdd(request: KhalaCodeDesktopCodexMarketplaceAddRequest): Promise<KhalaCodeDesktopCodexAppServerActionResult>
     codexMarketplaceRemove(request: KhalaCodeDesktopCodexMarketplaceRemoveRequest): Promise<KhalaCodeDesktopCodexAppServerActionResult>
     codexMarketplaceUpgrade(request?: KhalaCodeDesktopCodexMarketplaceUpgradeRequest): Promise<KhalaCodeDesktopCodexAppServerActionResult>
+    codexMentionCandidates(request?: KhalaCodeDesktopCodexMentionCandidatesRequest): Promise<KhalaCodeDesktopCodexMentionCandidatesResult>
     codexMcpOauthLogin(request: KhalaCodeDesktopCodexMcpOauthLoginRequest): Promise<KhalaCodeDesktopCodexAppServerActionResult>
     codexMcpResourceRead(request: KhalaCodeDesktopCodexMcpResourceReadRequest): Promise<KhalaCodeDesktopCodexAppServerActionResult>
     codexMcpServerReload(): Promise<KhalaCodeDesktopCodexAppServerActionResult>

--- a/clients/khala-code-desktop/src/ui/main.ts
+++ b/clients/khala-code-desktop/src/ui/main.ts
@@ -189,6 +189,10 @@ const previewRpc = (): DesktopRpc => ({
       postPreviewRpc<
         Awaited<ReturnType<DesktopRpcRequests["codexMarketplaceUpgrade"]>>
       >("codexMarketplaceUpgrade", request),
+    codexMentionCandidates: request =>
+      postPreviewRpc<
+        Awaited<ReturnType<DesktopRpcRequests["codexMentionCandidates"]>>
+      >("codexMentionCandidates", request),
     codexMcpOauthLogin: request =>
       postPreviewRpc<
         Awaited<ReturnType<DesktopRpcRequests["codexMcpOauthLogin"]>>
@@ -1777,6 +1781,8 @@ const controls = {
     rpc.request.codexMarketplaceRemove(request),
   codexMarketplaceUpgrade: (request?: Parameters<DesktopRpcRequests["codexMarketplaceUpgrade"]>[0]) =>
     rpc.request.codexMarketplaceUpgrade(request),
+  codexMentionCandidates: (request?: Parameters<DesktopRpcRequests["codexMentionCandidates"]>[0]) =>
+    rpc.request.codexMentionCandidates(request),
   codexMcpOauthLogin: (request: Parameters<DesktopRpcRequests["codexMcpOauthLogin"]>[0]) =>
     rpc.request.codexMcpOauthLogin(request),
   codexMcpResourceRead: (request: Parameters<DesktopRpcRequests["codexMcpResourceRead"]>[0]) =>

--- a/clients/khala-code-desktop/tests/codex-slash-commands.test.ts
+++ b/clients/khala-code-desktop/tests/codex-slash-commands.test.ts
@@ -210,4 +210,19 @@ describe("Khala Code Codex slash command registry", () => {
       }
     }
   })
+
+  test("maps IDE, diff, and mention parity commands to Codex app-server methods", () => {
+    expect(findKhalaCodeDesktopSlashCommand("/ide")?.dispatch).toMatchObject({
+      kind: "app_server",
+      method: "config/read",
+    })
+    expect(findKhalaCodeDesktopSlashCommand("/diff")?.dispatch).toMatchObject({
+      kind: "app_server",
+      method: "gitDiffToRemote",
+    })
+    expect(findKhalaCodeDesktopSlashCommand("/mention")?.dispatch).toMatchObject({
+      kind: "app_server",
+      method: "fuzzyFileSearch",
+    })
+  })
 })

--- a/clients/khala-code-desktop/tests/rpc-handlers.test.ts
+++ b/clients/khala-code-desktop/tests/rpc-handlers.test.ts
@@ -5,7 +5,10 @@ import { join } from "node:path"
 
 import { createKhalaCodeDesktopRpcRequestHandlers } from "../src/bun/rpc-handlers"
 import type { CodexAppServerChatRuntime } from "../src/bun/codex-app-server-chat-runtime"
-import type { CodexAppServerNotificationHandler } from "../src/bun/codex-app-server-client"
+import type {
+  CodexAppServerHost,
+  CodexAppServerNotificationHandler,
+} from "../src/bun/codex-app-server-client"
 import type {
   KhalaCodexFleetCommandInput,
   KhalaCodexFleetCommandResult,
@@ -127,6 +130,36 @@ const stoppedAppServerStatus = (): KhalaCodeDesktopCodexAppServerStatus => ({
   state: "stopped",
   transport: "stdio",
 })
+
+function codexAppServerHost(
+  request: CodexAppServerHost["request"],
+): CodexAppServerHost {
+  return {
+    dispose: () => undefined,
+    request,
+    respondToServerRequest: () => undefined,
+    restart: async () => ({
+      ok: true,
+      action: "restart",
+      changed: false,
+      status: stoppedAppServerStatus(),
+    }),
+    start: async () => ({
+      ok: true,
+      action: "start",
+      changed: false,
+      status: stoppedAppServerStatus(),
+    }),
+    status: stoppedAppServerStatus,
+    stop: async () => ({
+      ok: true,
+      action: "stop",
+      changed: false,
+      status: stoppedAppServerStatus(),
+    }),
+    subscribe: () => () => undefined,
+  }
+}
 
 function throwingCodexChatRuntime(
   overrides: Partial<CodexAppServerChatRuntime> = {},
@@ -1204,6 +1237,240 @@ describe("Khala Code desktop RPC handlers", () => {
       ok: false,
       command: "init",
       status: "gap",
+    })
+  })
+
+  test("dispatches mention candidates through bounded Codex app-server file search", async () => {
+    const requests: { method: string, params: unknown }[] = []
+    const files = Array.from({ length: 25 }, (_, index) => ({
+      root: "/repo",
+      path: `src/file-${index}.ts`,
+      match_type: index % 2 === 0 ? "file" : "directory",
+      file_name: `file-${index}.ts`,
+      score: 100 - index,
+      indices: [0],
+    }))
+    const handlers = createKhalaCodeDesktopRpcRequestHandlers({
+      appleFmReadiness: () => {
+        throw new Error("not used")
+      },
+      codexAppServerHost: codexAppServerHost(async <Result>(method: string, params?: unknown) => {
+        requests.push({ method, params })
+        return { files } as Result
+      }),
+      codexChatRuntime: throwingCodexChatRuntime(),
+      env: {},
+      onDeviceDeciderStatus: () => {
+        throw new Error("not used")
+      },
+      workingDirectory: "/repo",
+    })
+
+    const result = await handlers.slashCommandDispatch({
+      cwd: "/repo/workspace",
+      raw: "/mention worker",
+      sessionId: "desktop-session-slash",
+    })
+    const composerResult = await handlers.codexMentionCandidates({
+      cwd: "/repo/workspace",
+      query: "worker",
+    })
+
+    expect(result).toMatchObject({
+      ok: true,
+      command: "mention",
+      method: "fuzzyFileSearch",
+      status: "dispatched",
+    })
+    expect(composerResult).toMatchObject({
+      ok: true,
+      source: "fuzzyFileSearch",
+      truncated: true,
+    })
+    expect(requests).toEqual([
+      {
+        method: "fuzzyFileSearch",
+        params: {
+          query: "worker",
+          roots: ["/repo/workspace"],
+          cancellationToken: null,
+        },
+      },
+      {
+        method: "fuzzyFileSearch",
+        params: {
+          query: "worker",
+          roots: ["/repo/workspace"],
+          cancellationToken: null,
+        },
+      },
+    ])
+    expect(result.message).toContain("Codex fuzzyFileSearch mention candidates (truncated)")
+    expect(JSON.stringify(result.response)).toContain('"truncated":true')
+    expect((result.response as { candidates: unknown[] }).candidates).toHaveLength(20)
+    expect(composerResult.candidates).toHaveLength(20)
+  })
+
+  test("dispatches empty mention browsing through Codex fs/readDirectory", async () => {
+    const requests: { method: string, params: unknown }[] = []
+    const handlers = createKhalaCodeDesktopRpcRequestHandlers({
+      appleFmReadiness: () => {
+        throw new Error("not used")
+      },
+      codexAppServerHost: codexAppServerHost(async <Result>(method: string, params?: unknown) => {
+        requests.push({ method, params })
+        return { entries: [] } as Result
+      }),
+      codexChatRuntime: throwingCodexChatRuntime(),
+      env: {},
+      onDeviceDeciderStatus: () => {
+        throw new Error("not used")
+      },
+      workingDirectory: "/repo",
+    })
+
+    await expect(handlers.slashCommandDispatch({
+      raw: "/mention",
+      sessionId: "desktop-session-slash",
+    })).resolves.toMatchObject({
+      ok: true,
+      command: "mention",
+      method: "fs/readDirectory",
+      message: "Codex fs/readDirectory returned no mention candidates.",
+      status: "dispatched",
+    })
+    await expect(handlers.codexMentionCandidates()).resolves.toMatchObject({
+      ok: true,
+      candidates: [],
+      source: "fs/readDirectory",
+      truncated: false,
+    })
+    expect(requests).toEqual([
+      {
+        method: "fs/readDirectory",
+        params: { path: "/repo" },
+      },
+      {
+        method: "fs/readDirectory",
+        params: { path: "/repo" },
+      },
+    ])
+  })
+
+  test("dispatches diff and IDE status through Codex app-server", async () => {
+    const requests: { method: string, params: unknown }[] = []
+    const handlers = createKhalaCodeDesktopRpcRequestHandlers({
+      appleFmReadiness: () => {
+        throw new Error("not used")
+      },
+      codexAppServerHost: codexAppServerHost(async <Result>(method: string, params?: unknown) => {
+        requests.push({ method, params })
+        if (method === "gitDiffToRemote") {
+          return {
+            sha: "abc123",
+            diff: "diff --git a/a.ts b/a.ts\n+added\n",
+          } as Result
+        }
+        return {
+          config: {
+            ide_integration: {
+              status: "connected",
+              editor: "vscode",
+            },
+          },
+        } as Result
+      }),
+      codexChatRuntime: throwingCodexChatRuntime(),
+      env: {},
+      onDeviceDeciderStatus: () => {
+        throw new Error("not used")
+      },
+      workingDirectory: "/repo",
+    })
+
+    await expect(handlers.slashCommandDispatch({
+      cwd: "/repo/project",
+      raw: "/diff",
+      sessionId: "desktop-session-slash",
+    })).resolves.toMatchObject({
+      ok: true,
+      command: "diff",
+      method: "gitDiffToRemote",
+      message: expect.stringContaining("```diff"),
+      status: "dispatched",
+    })
+    await expect(handlers.slashCommandDispatch({
+      cwd: "/repo/project",
+      raw: "/ide",
+      sessionId: "desktop-session-slash",
+    })).resolves.toMatchObject({
+      ok: true,
+      command: "ide",
+      method: "config/read",
+      message: expect.stringContaining("connected"),
+      status: "dispatched",
+    })
+    expect(requests).toEqual([
+      {
+        method: "gitDiffToRemote",
+        params: { cwd: "/repo/project" },
+      },
+      {
+        method: "config/read",
+        params: { cwd: "/repo/project", includeLayers: true },
+      },
+    ])
+  })
+
+  test("returns typed diff empty and error states", async () => {
+    const emptyHandlers = createKhalaCodeDesktopRpcRequestHandlers({
+      appleFmReadiness: () => {
+        throw new Error("not used")
+      },
+      codexAppServerHost: codexAppServerHost(async <Result>() => ({
+        sha: "abc123",
+        diff: "",
+      } as Result)),
+      codexChatRuntime: throwingCodexChatRuntime(),
+      env: {},
+      onDeviceDeciderStatus: () => {
+        throw new Error("not used")
+      },
+      workingDirectory: "/repo",
+    })
+    await expect(emptyHandlers.slashCommandDispatch({
+      raw: "/diff",
+      sessionId: "desktop-session-slash",
+    })).resolves.toMatchObject({
+      ok: true,
+      command: "diff",
+      message: "Codex gitDiffToRemote returned no diff.",
+      status: "dispatched",
+    })
+
+    const errorHandlers = createKhalaCodeDesktopRpcRequestHandlers({
+      appleFmReadiness: () => {
+        throw new Error("not used")
+      },
+      codexAppServerHost: codexAppServerHost(async () => {
+        throw new Error("gitDiffToRemote unavailable")
+      }),
+      codexChatRuntime: throwingCodexChatRuntime(),
+      env: {},
+      onDeviceDeciderStatus: () => {
+        throw new Error("not used")
+      },
+      workingDirectory: "/repo",
+    })
+    await expect(errorHandlers.slashCommandDispatch({
+      raw: "/diff",
+      sessionId: "desktop-session-slash",
+    })).resolves.toMatchObject({
+      ok: false,
+      command: "diff",
+      message: "gitDiffToRemote unavailable",
+      method: "gitDiffToRemote",
+      status: "blocked",
     })
   })
 

--- a/docs/khala-code/2026-07-01-codex-app-server-gap-matrix.md
+++ b/docs/khala-code/2026-07-01-codex-app-server-gap-matrix.md
@@ -35,7 +35,7 @@ the behavior small.
 | `tui-preferences-and-appearance` | `upstream_app_server_gap` | `/keymap`, `/vim`, `/statusline`, `/theme`, `/pets`, `/personality` | `config/read`, `config/value/write`, `config/batchWrite` | None | `codex.app_server.gap.tui_preferences` |
 | `workspace-knowledge-memory-and-import` | `upstream_app_server_gap` | `/memories`, `/skills`, `/import`, `/hooks`, `/init`, `/debug-m-drop`, `/debug-m-update` | `skills/list`, `skills/config/write`, `skills/extraRoots/set`, `hooks/list`, `externalAgentConfig/detect`, `externalAgentConfig/import`, `externalAgentConfig/import/readHistories`, `fs/readFile`, `fs/writeFile`, `fs/getMetadata` | None | Khala now wraps the stable app-server methods for settings/actions and import diagnostics. Remaining gap: `codex.app_server.gap.memory_and_import_management` for TUI-owned `/memories`, `/init`, and debug memory semantics. |
 | `multi-agent-side-conversation-and-plan` | `upstream_app_server_gap` | `/approve`, `/plan`, `/agent`, `/subagents`, `/side`, `/btw` | `turn/steer`, `thread/fork`, `thread/inject_items`, `thread/approveGuardianDeniedAction`, `thread/metadata/update`, `thread/read` | None | `codex.app_server.gap.side_agent_plan_controls` |
-| `ide-file-mention-and-diff` | `upstream_app_server_gap` | `/ide`, `/diff`, `/mention` | `fuzzyFileSearch`, `gitDiffToRemote`, `fs/readDirectory`, `fs/readFile`, `config/read` | None | `codex.app_server.gap.ide_mentions_diff` |
+| `ide-file-mention-and-diff` | `covered_by_app_server` | `/ide`, `/diff`, `/mention` | `fuzzyFileSearch`, `gitDiffToRemote`, `fs/readDirectory`, `fs/readFile`, `config/read` | None | Khala now projects bounded mention candidates, remote diff content, and IDE status from app-server methods; `codex.app_server.gap.ide_mentions_diff` remains only for richer IDE mutation/metadata beyond the current wrapper slice. |
 | `windows-sandbox-setup-and-readable-roots` | `upstream_app_server_gap` | `/setup-default-sandbox`, `/sandbox-add-read-dir` | `windowsSandbox/setupStart`, `windowsSandbox/readiness`, `config/read`, `config/value/write` | None | `codex.app_server.gap.windows_sandbox_read_roots` |
 | `background-terminal-management` | `khala_adapter_with_test` | `/ps`, `/stop` | None | `thread/backgroundTerminals/list`, `thread/backgroundTerminals/clean`, `thread/backgroundTerminals/terminate` | Khala wraps Codex's experimental background terminal methods directly: `/ps` lists with bounded pagination, `/stop` and `/clean` request cleanup, and the RPC action path can terminate an explicit app-server `processId`. Stable product copy still tracks `codex.app_server.gap.background_terminals` until Codex stabilizes the methods. |
 
@@ -54,8 +54,9 @@ GitHub issues, or protocol notes:
 - `codex.app_server.gap.side_agent_plan_controls`: expose side-conversation,
   subagent, plan-edit, and auto-review controls as app-server methods or
   metadata.
-- `codex.app_server.gap.ide_mentions_diff`: expose IDE integration state,
-  mention candidates, and diff-read semantics through app-server.
+- `codex.app_server.gap.ide_mentions_diff`: expose richer IDE mutation and
+  metadata beyond the current bounded app-server-backed mention/diff/status
+  wrapper.
 - `codex.app_server.gap.windows_sandbox_read_roots`: expose readable-root
   mutation in the Windows sandbox contract.
 - `codex.app_server.gap.background_terminals`: stabilize the existing

--- a/docs/khala-code/2026-07-01-codex-wrapper-implementation-log.md
+++ b/docs/khala-code/2026-07-01-codex-wrapper-implementation-log.md
@@ -526,3 +526,25 @@ Validation:
 - `bun run --cwd clients/khala-code-desktop typecheck`
 - `bun test clients/khala-code-desktop/tests/codex-app-server-gap-matrix.test.ts clients/khala-code-desktop/tests/codex-parity-contract.test.ts clients/khala-code-desktop/tests/codex-slash-commands.test.ts`
 - `bun run --cwd clients/khala-code-desktop verify`
+
+## Issue #7805: IDE Mention And Diff Wrapper Parity
+
+Status: implemented
+
+Khala Code now maps `/mention`, `/diff`, and `/ide` to Codex app-server instead
+of treating them as open parity gaps. `/mention <query>` and the
+`codexMentionCandidates` composer RPC call `fuzzyFileSearch` with the current
+workspace root and return bounded candidate lists; bare `/mention` and empty
+composer mention queries use `fs/readDirectory` for bounded directory browsing.
+`/diff` calls `gitDiffToRemote` and renders the returned patch through the
+existing diff transcript renderer, with an explicit empty-diff state. `/ide`
+reads `config/read` and reports app-server/config-derived IDE status, or a
+typed unsupported state when the pinned Codex build has no IDE metadata.
+
+The gap matrix now marks `ide-file-mention-and-diff` as app-server-covered for
+this wrapper slice. The remaining upstream gap is narrower: richer IDE mutation
+and metadata beyond the bounded read/status behavior implemented here.
+
+Validation:
+
+- `bun test clients/khala-code-desktop/tests/codex-slash-commands.test.ts clients/khala-code-desktop/tests/rpc-handlers.test.ts clients/khala-code-desktop/tests/codex-app-server-gap-matrix.test.ts`


### PR DESCRIPTION
## Summary
- Maps `/ide`, `/diff`, and `/mention` to Codex app-server methods instead of gap results.
- Adds a bounded `codexMentionCandidates` RPC for composer mention candidate lookups backed by `fuzzyFileSearch`/`fs/readDirectory`.
- Projects `gitDiffToRemote` patches, empty diff state, and app-server/config-derived IDE status through the desktop slash dispatcher.
- Updates the checked gap matrix and wrapper implementation log for issue #7805.

## Validation
- `KHALA_CODE_CODEX_REFERENCE_ROOT=/Users/christopherdavid/work/projects/repos/codex KHALA_CODE_CODEX_SLASH_COMMAND_SOURCE=/Users/christopherdavid/work/projects/repos/codex/codex-rs/tui/src/slash_command.rs bun test clients/khala-code-desktop/tests/codex-app-server-gap-matrix.test.ts clients/khala-code-desktop/tests/codex-slash-commands.test.ts clients/khala-code-desktop/tests/rpc-handlers.test.ts` (requested verification `command.public.pylon_khala.verify.362e39b9b3e14a945586138e`; 39 pass)
- `bun run --cwd clients/khala-code-desktop typecheck`
- `KHALA_CODE_CODEX_REFERENCE_ROOT=/Users/christopherdavid/work/projects/repos/codex KHALA_CODE_CODEX_SLASH_COMMAND_SOURCE=/Users/christopherdavid/work/projects/repos/codex/codex-rs/tui/src/slash_command.rs bun run --cwd clients/khala-code-desktop verify` (252 pass + UI/Bun builds)

Closes #7805