### PR TITLE
Harden Pylon orchestration dispatch state

### DIFF
--- a/apps/pylon/README.md
+++ b/apps/pylon/README.md
@@ -158,6 +158,27 @@ pylon apple-fm status
 pylon apple-fm tool-stream-demo
 ```
 
+## Local Orchestration Store
+
+`apps/pylon/src/orchestration/` contains the local supervisor state spine for
+registered agent runners. The store persists a typed task DAG, dispatch
+contexts keyed by runner vocabulary (`codex`, `claude_agent`, or `generic`),
+heartbeat timestamps, base-drift counters, and a three-failure circuit breaker
+for flapping runner contexts. The legacy `claude` runner alias is accepted at
+read/write boundaries and normalized to `claude_agent`.
+
+When a dispatched context records a failure, the assigned task is moved to
+`failed`, the context is released, and the context is quarantined as
+`circuit_broken` after the configured failure threshold. Later heartbeats update
+liveness data but do not clear a circuit breaker; an operator must explicitly
+reset or replace that context.
+
+Use `publicSnapshot()` for surfaces that may leave the local process. That
+projection contains task/context refs, statuses, runner kinds, heartbeat/drift
+metadata, and repo refs only. It intentionally omits task prompts and replaces
+local worktree paths with `null`; raw prompts, verification details, and local
+paths remain local-only execution state.
+
 ## Dashboard (TUI)
 
 Running `pylon` with no subcommand opens the observational dashboard: an

--- a/apps/pylon/src/orchestration/store.ts
+++ b/apps/pylon/src/orchestration/store.ts
@@ -40,6 +40,21 @@ export type OrchestrationTask = {
   updatedAt: string
 }
 
+export type PublicOrchestrationTask = {
+  id: string
+  parentId: string | null
+  threadId: string
+  status: OrchestrationTaskStatus
+  deps: string[]
+  runnerKind: OrchestrationRunnerKind | null
+  repo: string | null
+  branch: string | null
+  baseCommit: string | null
+  issueRef: string | null
+  createdAt: string
+  updatedAt: string
+}
+
 export type VirtualHead = {
   repo: string
   branch: string
@@ -84,6 +99,10 @@ export type DispatchContext = {
   maxConcurrentSlots: number
   createdAt: string
   updatedAt: string
+}
+
+export type PublicDispatchContext = Omit<DispatchContext, "worktreePath"> & {
+  worktreePath: null
 }
 
 export type OrchestrationMessageKind =
@@ -136,6 +155,11 @@ const parseSpec = (value: string): OrchestrationTaskSpec => {
     ...(runnerKind === undefined ? {} : { runnerKind: normalizeOrchestrationRunnerKind(runnerKind) }),
   }
 }
+
+const normalizeTaskSpec = (spec: OrchestrationTaskSpec): OrchestrationTaskSpec => ({
+  ...spec,
+  ...(spec.runnerKind === undefined ? {} : { runnerKind: normalizeOrchestrationRunnerKind(spec.runnerKind) }),
+})
 
 export function normalizeOrchestrationRunnerKind(
   kind: OrchestrationRunnerKind | LegacyAgentRunnerKind,
@@ -197,6 +221,21 @@ const taskFromRow = (row: TaskRow): OrchestrationTask => ({
   updatedAt: row.updated_at,
 })
 
+export const publicOrchestrationTaskFrom = (task: OrchestrationTask): PublicOrchestrationTask => ({
+  id: task.id,
+  parentId: task.parentId,
+  threadId: task.threadId,
+  status: task.status,
+  deps: task.deps,
+  runnerKind: task.spec.runnerKind ?? null,
+  repo: task.spec.repo ?? null,
+  branch: task.spec.branch ?? null,
+  baseCommit: task.spec.baseCommit ?? null,
+  issueRef: task.spec.issueRef ?? null,
+  createdAt: task.createdAt,
+  updatedAt: task.updatedAt,
+})
+
 const contextFromRow = (row: DispatchContextRow): DispatchContext => ({
   id: row.id,
   assigneeHandle: row.assignee_handle,
@@ -211,6 +250,11 @@ const contextFromRow = (row: DispatchContextRow): DispatchContext => ({
   maxConcurrentSlots: row.max_concurrent_slots,
   createdAt: row.created_at,
   updatedAt: row.updated_at,
+})
+
+export const publicDispatchContextFrom = (context: DispatchContext): PublicDispatchContext => ({
+  ...context,
+  worktreePath: null,
 })
 
 const virtualHeadFromRow = (row: VirtualHeadRow): VirtualHead => ({
@@ -317,7 +361,7 @@ export class PylonOrchestrationStore {
         $id: input.id,
         $parentId: input.parentId ?? null,
         $threadId: threadId,
-        $spec: JSON.stringify(input.spec),
+        $spec: JSON.stringify(normalizeTaskSpec(input.spec)),
         $status: status,
         $deps: JSON.stringify(deps),
         $createdAt: now,
@@ -345,7 +389,7 @@ export class PylonOrchestrationStore {
   updateTaskSpec(id: string, spec: OrchestrationTaskSpec, now: Date = new Date()): OrchestrationTask {
     this.db
       .query("UPDATE pylon_orchestration_tasks SET spec_json = $spec, updated_at = $now WHERE id = $id")
-      .run({ $id: id, $spec: JSON.stringify(spec), $now: iso(now) })
+      .run({ $id: id, $spec: JSON.stringify(normalizeTaskSpec(spec)), $now: iso(now) })
     const task = this.getTask(id)
     if (task === null) throw new Error(`unknown orchestration task: ${id}`)
     return task
@@ -416,7 +460,10 @@ export class PylonOrchestrationStore {
     return (rows as DispatchContextRow[]).map(contextFromRow)
   }
 
-  recordHeartbeat(id: string, input: { at?: Date; baseBehindBy?: number; status?: DispatchContextStatus } = {}): void {
+  recordHeartbeat(id: string, input: { at?: Date; baseBehindBy?: number; status?: DispatchContextStatus } = {}): DispatchContext {
+    const current = this.getDispatchContext(id)
+    if (current === null) throw new Error(`unknown dispatch context: ${id}`)
+    const status = current.status === "circuit_broken" ? "circuit_broken" : input.status ?? null
     this.db
       .query(`
         UPDATE pylon_orchestration_dispatch_contexts
@@ -426,7 +473,8 @@ export class PylonOrchestrationStore {
                updated_at = $at
          WHERE id = $id
       `)
-      .run({ $id: id, $at: iso(input.at), $baseBehindBy: input.baseBehindBy ?? null, $status: input.status ?? null })
+      .run({ $id: id, $at: iso(input.at), $baseBehindBy: input.baseBehindBy ?? null, $status: status })
+    return this.getDispatchContext(id) ?? current
   }
 
   markDispatched(taskId: string, contextId: string, now: Date = new Date()): void {
@@ -565,16 +613,32 @@ export class PylonOrchestrationStore {
     if (current === null) throw new Error(`unknown dispatch context: ${id}`)
     const failureCount = current.failureCount + 1
     const status: DispatchContextStatus = failureCount >= maxFailures ? "circuit_broken" : "idle"
-    this.db
-      .query(`
-        UPDATE pylon_orchestration_dispatch_contexts
-           SET failure_count = $failureCount,
-               status = $status,
-               current_task_id = NULL,
-               updated_at = $now
-         WHERE id = $id
-      `)
-      .run({ $id: id, $failureCount: failureCount, $status: status, $now: iso(now) })
+    const at = iso(now)
+    this.db.run("BEGIN IMMEDIATE")
+    try {
+      if (current.currentTaskId !== null) {
+        this.db
+          .query("UPDATE pylon_orchestration_tasks SET status = 'failed', updated_at = $now WHERE id = $taskId")
+          .run({ $taskId: current.currentTaskId, $now: at })
+      }
+      this.db
+        .query(`
+          UPDATE pylon_orchestration_dispatch_contexts
+             SET failure_count = $failureCount,
+                 status = $status,
+                 current_task_id = NULL,
+                 updated_at = $now
+           WHERE id = $id
+        `)
+        .run({ $id: id, $failureCount: failureCount, $status: status, $now: at })
+      if (current.currentTaskId !== null) {
+        this.releaseVirtualHeadTask(current.currentTaskId, now)
+      }
+      this.db.run("COMMIT")
+    } catch (error) {
+      this.db.run("ROLLBACK")
+      throw error
+    }
     return this.getDispatchContext(id) ?? current
   }
 
@@ -603,6 +667,13 @@ export class PylonOrchestrationStore {
         $body: input.body,
         $createdAt: iso(input.now),
       })
+  }
+
+  publicSnapshot(): { tasks: PublicOrchestrationTask[]; dispatchContexts: PublicDispatchContext[] } {
+    return {
+      tasks: this.listTasks().map(publicOrchestrationTaskFrom),
+      dispatchContexts: this.listDispatchContexts().map(publicDispatchContextFrom),
+    }
   }
 }
 

--- a/apps/pylon/src/orchestration/supervisor-orchestration.test.ts
+++ b/apps/pylon/src/orchestration/supervisor-orchestration.test.ts
@@ -40,21 +40,51 @@ describe("Pylon supervisor orchestration store", () => {
   })
 
   test("records dispatch failures as a three-strike circuit breaker", () => {
+    const now = new Date("2026-06-27T12:00:00.000Z")
     const store = createPylonOrchestrationStore(new Database(":memory:"))
+    store.createTask({ id: "task.flaky", spec: baseTaskSpec, now })
     store.createDispatchContext({
       id: "ctx.codex.1",
       assigneeHandle: "codex-1",
       runnerKind: "codex",
-      lastHeartbeatAt: new Date("2026-06-27T12:00:00.000Z"),
+      lastHeartbeatAt: now,
+      now,
     })
+    store.markDispatched("task.flaky", "ctx.codex.1", now)
 
-    expect(store.recordDispatchFailure("ctx.codex.1").status).toBe("idle")
+    expect(store.recordDispatchFailure("ctx.codex.1", 3, now).status).toBe("idle")
+    expect(store.getTask("task.flaky")?.status).toBe("failed")
     expect(store.recordDispatchFailure("ctx.codex.1").status).toBe("idle")
     const broken = store.recordDispatchFailure("ctx.codex.1")
 
     expect(broken.failureCount).toBe(3)
     expect(broken.status).toBe("circuit_broken")
     expect(dispatchEligibility(broken, { now: new Date("2026-06-27T12:01:00.000Z") })).toEqual({
+      ok: false,
+      reason: "circuit_broken",
+    })
+  })
+
+  test("keeps circuit-broken dispatch contexts quarantined across heartbeats", () => {
+    const now = new Date("2026-06-27T12:00:00.000Z")
+    const store = createPylonOrchestrationStore(new Database(":memory:"))
+    store.createDispatchContext({
+      id: "ctx.flapping",
+      assigneeHandle: "codex-flap",
+      runnerKind: "codex",
+      lastHeartbeatAt: now,
+      now,
+    })
+
+    store.recordDispatchFailure("ctx.flapping", 1, now)
+    const heartbeat = store.recordHeartbeat("ctx.flapping", {
+      at: new Date("2026-06-27T12:01:00.000Z"),
+      status: "idle",
+    })
+
+    expect(heartbeat.status).toBe("circuit_broken")
+    expect(heartbeat.lastHeartbeatAt).toBe("2026-06-27T12:01:00.000Z")
+    expect(dispatchEligibility(heartbeat, { now: new Date("2026-06-27T12:01:30.000Z") })).toEqual({
       ok: false,
       reason: "circuit_broken",
     })
@@ -180,6 +210,10 @@ describe("Pylon supervisor orchestration store", () => {
 
   test("normalizes legacy runner aliases through the AgentRunner registry vocabulary", () => {
     const store = createPylonOrchestrationStore(new Database(":memory:"))
+    const task = store.createTask({
+      id: "task.legacy-claude",
+      spec: { ...baseTaskSpec, runnerKind: "claude_agent" },
+    })
     const context = store.createDispatchContext({
       id: "ctx.legacy-claude",
       assigneeHandle: "claude-legacy",
@@ -187,11 +221,58 @@ describe("Pylon supervisor orchestration store", () => {
       lastHeartbeatAt: new Date("2026-06-27T12:00:00.000Z"),
     })
 
+    expect(task.spec.runnerKind).toBe("claude_agent")
     expect(context.runnerKind).toBe("claude_agent")
     expect(normalizeOrchestrationRunnerKind("claude")).toBe("claude_agent")
     expect(isStoredOrchestrationRunnerKind("claude_agent")).toBe(true)
     expect(isStoredOrchestrationRunnerKind("claude")).toBe(true)
     expect(isStoredOrchestrationRunnerKind("opencode")).toBe(false)
+  })
+
+  test("projects public-safe task and dispatch-context state without prompts or worktree paths", () => {
+    const now = new Date("2026-06-27T12:00:00.000Z")
+    const store = createPylonOrchestrationStore(new Database(":memory:"))
+    store.createTask({
+      id: "task.public-safe",
+      spec: {
+        ...baseTaskSpec,
+        prompt: "Public issue prompt with operational detail.",
+        issueRef: "issue.7808",
+        runnerKind: "codex",
+      },
+      now,
+    })
+    store.createDispatchContext({
+      id: "ctx.public-safe",
+      assigneeHandle: "codex-1",
+      runnerKind: "codex",
+      worktreeId: "wt-public-safe",
+      worktreePath: "/private/local/worktree/path",
+      lastHeartbeatAt: now,
+      now,
+    })
+
+    const snapshot = store.publicSnapshot()
+
+    expect(snapshot.tasks).toEqual([
+      {
+        id: "task.public-safe",
+        parentId: null,
+        threadId: "task.public-safe",
+        status: "ready",
+        deps: [],
+        runnerKind: "codex",
+        repo: "OpenAgentsInc/openagents",
+        branch: "main",
+        baseCommit: "abc123",
+        issueRef: "issue.7808",
+        createdAt: "2026-06-27T12:00:00.000Z",
+        updatedAt: "2026-06-27T12:00:00.000Z",
+      },
+    ])
+    expect(JSON.stringify(snapshot)).not.toContain("Public issue prompt")
+    expect(JSON.stringify(snapshot)).not.toContain("/private/local/worktree/path")
+    expect(snapshot.dispatchContexts[0]?.worktreePath).toBeNull()
   })
 
   test("refuses an otherwise healthy idle context when the ready task requires another runner", () => {


### PR DESCRIPTION
## Summary
- Fail the assigned orchestration task when a dispatch context records a runner failure, and keep virtual-head reservations in sync.
- Keep circuit-broken dispatch contexts quarantined across later heartbeats until an explicit operator reset/replacement.
- Normalize task runner kinds through the registered runner vocabulary and add a public-safe orchestration snapshot that omits prompts and local worktree paths.
- Document the local orchestration store guarantees in the Pylon README.

Closes #7808.

## Validation
- `bun test apps/pylon/src/orchestration/supervisor-orchestration.test.ts apps/pylon/src/assignment-runtime-progress.test.ts`
- `bun run --cwd apps/pylon typecheck`