### PR TITLE
Surface Codex parity reference blocker

### DIFF
--- a/clients/khala-code-desktop/src/bun/codex-parity-contract.ts
+++ b/clients/khala-code-desktop/src/bun/codex-parity-contract.ts
@@ -9,6 +9,27 @@ export const KHALA_CODE_CODEX_PARITY_REFERENCE_COMMIT =
 export const KHALA_CODE_CODEX_PARITY_REFERENCE_LABEL =
   "openai/codex app-server v2 schema at db887d03e1"
 
+export const KHALA_CODE_CODEX_REFERENCE_CHECKOUT_MISSING_BLOCKER_REF =
+  "blocker.codex_reference_checkout_missing"
+
+const KHALA_CODE_CODEX_REFERENCE_SCHEMA_DIR =
+  "codex-rs/app-server-protocol/schema/typescript"
+
+type KhalaCodeCodexReferenceRootInspectionEnv = Readonly<Record<string, string | undefined>>
+
+export type KhalaCodeCodexReferenceRootStatus =
+  | {
+      readonly ok: true
+      readonly root: string
+      readonly status: "ready"
+    }
+  | {
+      readonly blockerRef: typeof KHALA_CODE_CODEX_REFERENCE_CHECKOUT_MISSING_BLOCKER_REF
+      readonly ok: false
+      readonly reason: string
+      readonly status: "blocked"
+    }
+
 export type KhalaCodeCodexParityHarness =
   | "codex_wrapper_fixture"
   | "codex_wrapper_live"
@@ -290,19 +311,55 @@ export const KHALA_CODE_CODEX_PARITY_REQUIRED_THREAD_ITEM_TYPES = [
   "contextCompaction",
 ] as const
 
-export function findCodexReferenceRoot(startDir = dirname(fileURLToPath(import.meta.url))): string {
-  const explicit = process.env.KHALA_CODE_CODEX_REFERENCE_ROOT?.trim()
-  if (explicit !== undefined && explicit.length > 0 && existsSync(explicit)) return explicit
+const referenceSchemaRoot = (root: string): string =>
+  join(root, KHALA_CODE_CODEX_REFERENCE_SCHEMA_DIR)
+
+const codexReferenceCheckoutMissing = (reason: string): KhalaCodeCodexReferenceRootStatus => ({
+  blockerRef: KHALA_CODE_CODEX_REFERENCE_CHECKOUT_MISSING_BLOCKER_REF,
+  ok: false,
+  reason,
+  status: "blocked",
+})
+
+export function inspectCodexReferenceRoot(
+  startDir = dirname(fileURLToPath(import.meta.url)),
+  env: KhalaCodeCodexReferenceRootInspectionEnv = process.env,
+): KhalaCodeCodexReferenceRootStatus {
+  const explicit = env.KHALA_CODE_CODEX_REFERENCE_ROOT?.trim()
+  if (explicit !== undefined && explicit.length > 0) {
+    if (existsSync(referenceSchemaRoot(explicit))) {
+      return {
+        ok: true,
+        root: explicit,
+        status: "ready",
+      }
+    }
+    return codexReferenceCheckoutMissing(
+      `KHALA_CODE_CODEX_REFERENCE_ROOT does not contain ${KHALA_CODE_CODEX_REFERENCE_SCHEMA_DIR}: ${explicit}`,
+    )
+  }
 
   let current = startDir
   for (let depth = 0; depth < 10; depth += 1) {
     const candidate = join(current, "projects/repos/codex")
-    if (existsSync(join(candidate, "codex-rs/app-server-protocol/schema/typescript"))) {
-      return candidate
+    if (existsSync(referenceSchemaRoot(candidate))) {
+      return {
+        ok: true,
+        root: candidate,
+        status: "ready",
+      }
     }
     current = dirname(current)
   }
-  throw new Error("Could not locate projects/repos/codex reference checkout")
+  return codexReferenceCheckoutMissing(
+    `Could not locate projects/repos/codex reference checkout with ${KHALA_CODE_CODEX_REFERENCE_SCHEMA_DIR} from ${startDir}`,
+  )
+}
+
+export function findCodexReferenceRoot(startDir = dirname(fileURLToPath(import.meta.url))): string {
+  const status = inspectCodexReferenceRoot(startDir)
+  if (status.ok) return status.root
+  throw new Error(status.reason)
 }
 
 export async function readCodexReferenceCommit(root = findCodexReferenceRoot()): Promise<string> {

--- a/clients/khala-code-desktop/tests/codex-app-server-gap-matrix.test.ts
+++ b/clients/khala-code-desktop/tests/codex-app-server-gap-matrix.test.ts
@@ -11,7 +11,8 @@ import {
 } from "../src/bun/codex-app-server-gap-matrix"
 import {
   extractAppServerMethodsFromGeneratedType,
-  findCodexReferenceRoot,
+  inspectCodexReferenceRoot,
+  KHALA_CODE_CODEX_REFERENCE_CHECKOUT_MISSING_BLOCKER_REF,
   KHALA_CODE_CODEX_PARITY_REFERENCE_COMMIT,
   readCodexSchemaFile,
 } from "../src/bun/codex-parity-contract"
@@ -24,6 +25,19 @@ const repoRoot = new URL("../../..", import.meta.url).pathname
 
 const sorted = (values: readonly string[]): readonly string[] => [...values].sort()
 
+const expectCodexReferenceRootOrBlocker = (): string | null => {
+  const status = inspectCodexReferenceRoot()
+  if (status.ok) return status.root
+
+  expect(status).toMatchObject({
+    blockerRef: KHALA_CODE_CODEX_REFERENCE_CHECKOUT_MISSING_BLOCKER_REF,
+    ok: false,
+    status: "blocked",
+  })
+  expect(status.reason.length).toBeGreaterThan(0)
+  return null
+}
+
 describe("Khala Code Codex app-server gap matrix", () => {
   test("pins the same Codex reference as the parity contract", () => {
     expect(KHALA_CODE_CODEX_APP_SERVER_GAP_MATRIX_REFERENCE_COMMIT).toBe(
@@ -35,7 +49,6 @@ describe("Khala Code Codex app-server gap matrix", () => {
     const rowIds = KHALA_CODE_CODEX_APP_SERVER_GAP_MATRIX.map(row => row.id)
     expect(new Set(rowIds).size).toBe(rowIds.length)
 
-    const codexRoot = findCodexReferenceRoot()
     const incompleteRows = KHALA_CODE_CODEX_APP_SERVER_GAP_MATRIX.filter(row =>
       row.area.length === 0 ||
       row.rationale.length === 0 ||
@@ -46,17 +59,20 @@ describe("Khala Code Codex app-server gap matrix", () => {
     ).map(row => row.id)
     expect(incompleteRows).toEqual([])
 
-    const missingCodexRefs = KHALA_CODE_CODEX_APP_SERVER_GAP_MATRIX
-      .flatMap(row => row.codexSourceRefs.map(ref => ({ row: row.id, ref })))
-      .filter(({ ref }) => !existsSync(join(codexRoot, ref)))
-    expect(missingCodexRefs).toEqual([])
-
     const invalidDecisions = KHALA_CODE_CODEX_APP_SERVER_GAP_MATRIX.filter(row => {
       if (row.decision === "covered_by_app_server") return row.appServerMethods.length === 0
       if (row.decision === "khala_adapter_with_test") return row.khalaAdapter === undefined
       return row.upstreamGapId?.startsWith("codex.app_server.gap.") !== true
     }).map(row => row.id)
     expect(invalidDecisions).toEqual([])
+
+    const codexRoot = expectCodexReferenceRootOrBlocker()
+    if (codexRoot === null) return
+
+    const missingCodexRefs = KHALA_CODE_CODEX_APP_SERVER_GAP_MATRIX
+      .flatMap(row => row.codexSourceRefs.map(ref => ({ row: row.id, ref })))
+      .filter(({ ref }) => !existsSync(join(codexRoot, ref)))
+    expect(missingCodexRefs).toEqual([])
   })
 
   test("maps every slash command exactly once", () => {
@@ -73,7 +89,9 @@ describe("Khala Code Codex app-server gap matrix", () => {
   })
 
   test("uses real generated methods for stable app-server rows", async () => {
-    const root = findCodexReferenceRoot()
+    const root = expectCodexReferenceRootOrBlocker()
+    if (root === null) return
+
     const generatedClientMethods = new Set(extractAppServerMethodsFromGeneratedType(
       await readCodexSchemaFile(root, "ClientRequest.ts"),
     ))

--- a/clients/khala-code-desktop/tests/codex-parity-contract.test.ts
+++ b/clients/khala-code-desktop/tests/codex-parity-contract.test.ts
@@ -6,7 +6,8 @@ import {
   codexSchemaPath,
   extractAppServerMethodsFromGeneratedType,
   extractThreadItemTypesFromGeneratedType,
-  findCodexReferenceRoot,
+  inspectCodexReferenceRoot,
+  KHALA_CODE_CODEX_REFERENCE_CHECKOUT_MISSING_BLOCKER_REF,
   KHALA_CODE_CODEX_PARITY_COVERAGE,
   KHALA_CODE_CODEX_PARITY_REFERENCE_COMMIT,
   KHALA_CODE_CODEX_PARITY_REQUIRED_CLIENT_METHODS,
@@ -22,9 +23,36 @@ import {
   khalaCodeDesktopSlashCommandDispatchCoverage,
 } from "../src/shared/codex-slash-commands"
 
+const expectCodexReferenceRootOrBlocker = (): string | null => {
+  const status = inspectCodexReferenceRoot()
+  if (status.ok) return status.root
+
+  expect(status).toMatchObject({
+    blockerRef: KHALA_CODE_CODEX_REFERENCE_CHECKOUT_MISSING_BLOCKER_REF,
+    ok: false,
+    status: "blocked",
+  })
+  expect(status.reason.length).toBeGreaterThan(0)
+  return null
+}
+
 describe("Khala Code Codex parity contract", () => {
+  test("reports blocker.codex_reference_checkout_missing when the reference checkout is absent", () => {
+    const status = inspectCodexReferenceRoot("/private/tmp/khala-code-missing-codex-reference", {})
+
+    expect(status).toMatchObject({
+      blockerRef: KHALA_CODE_CODEX_REFERENCE_CHECKOUT_MISSING_BLOCKER_REF,
+      ok: false,
+      status: "blocked",
+    })
+    if (status.ok) return
+
+    expect(status.reason).toContain("projects/repos/codex")
+  })
+
   test("pins the Codex reference checkout used for fixture parity", async () => {
-    const root = findCodexReferenceRoot()
+    const root = expectCodexReferenceRootOrBlocker()
+    if (root === null) return
 
     expect(await readCodexReferenceCommit(root)).toBe(KHALA_CODE_CODEX_PARITY_REFERENCE_COMMIT)
     expect(existsSync(`${root}/codex-rs/tui/src/slash_command.rs`)).toBe(true)
@@ -33,7 +61,9 @@ describe("Khala Code Codex parity contract", () => {
   })
 
   test("requires generated app-server schema files and parity-critical methods", async () => {
-    const root = findCodexReferenceRoot()
+    const root = expectCodexReferenceRootOrBlocker()
+    if (root === null) return
+
     const missingFiles = KHALA_CODE_CODEX_PARITY_REQUIRED_SCHEMA_FILES
       .filter(relative => !existsSync(codexSchemaPath(root, relative)))
 
@@ -61,7 +91,9 @@ describe("Khala Code Codex parity contract", () => {
   })
 
   test("tracks upstream ThreadItem variants with fixture coverage", async () => {
-    const root = findCodexReferenceRoot()
+    const root = expectCodexReferenceRootOrBlocker()
+    if (root === null) return
+
     const upstreamTypes = extractThreadItemTypesFromGeneratedType(
       await readCodexSchemaFile(root, "v2/ThreadItem.ts"),
     )

--- a/clients/khala-code-desktop/tests/codex-slash-commands.test.ts
+++ b/clients/khala-code-desktop/tests/codex-slash-commands.test.ts
@@ -5,6 +5,10 @@ import { dirname, join } from "node:path"
 import { fileURLToPath } from "node:url"
 
 import {
+  inspectCodexReferenceRoot,
+  KHALA_CODE_CODEX_REFERENCE_CHECKOUT_MISSING_BLOCKER_REF,
+} from "../src/bun/codex-parity-contract"
+import {
   KHALA_CODE_DESKTOP_SLASH_COMMANDS,
   evaluateKhalaCodeDesktopSlashCommandAvailability,
   findKhalaCodeDesktopSlashCommand,
@@ -19,28 +23,71 @@ type ParsedCodexSlashCommand = {
   readonly enumName: string
 }
 
+type CodexSlashCommandSourceStatus =
+  | {
+      readonly ok: true
+      readonly path: string
+      readonly status: "ready"
+    }
+  | {
+      readonly blockerRef: typeof KHALA_CODE_CODEX_REFERENCE_CHECKOUT_MISSING_BLOCKER_REF
+      readonly ok: false
+      readonly reason: string
+      readonly status: "blocked"
+    }
+
 const kebabCase = (value: string): string =>
   value.replace(/([a-z0-9])([A-Z])/g, "$1-$2").toLowerCase()
 
-const codexSlashCommandSourcePath = (): string => {
+const codexSlashCommandSourceBlocked = (reason: string): CodexSlashCommandSourceStatus => ({
+  blockerRef: KHALA_CODE_CODEX_REFERENCE_CHECKOUT_MISSING_BLOCKER_REF,
+  ok: false,
+  reason,
+  status: "blocked",
+})
+
+const inspectCodexSlashCommandSourcePath = (): CodexSlashCommandSourceStatus => {
   const explicit = process.env.KHALA_CODE_CODEX_SLASH_COMMAND_SOURCE?.trim()
-  if (explicit !== undefined && explicit.length > 0 && existsSync(explicit)) return explicit
-  const explicitRoot = process.env.KHALA_CODE_CODEX_REFERENCE_ROOT?.trim()
-  if (explicitRoot !== undefined && explicitRoot.length > 0) {
-    const candidate = join(explicitRoot, "codex-rs/tui/src/slash_command.rs")
-    if (existsSync(candidate)) return candidate
+  if (explicit !== undefined && explicit.length > 0) {
+    if (existsSync(explicit)) {
+      return {
+        ok: true,
+        path: explicit,
+        status: "ready",
+      }
+    }
+    return codexSlashCommandSourceBlocked(
+      `KHALA_CODE_CODEX_SLASH_COMMAND_SOURCE does not exist: ${explicit}`,
+    )
   }
 
-  let current = dirname(fileURLToPath(import.meta.url))
-  for (let depth = 0; depth < 10; depth += 1) {
-    const candidate = join(
-      current,
-      "projects/repos/codex/codex-rs/tui/src/slash_command.rs",
-    )
-    if (existsSync(candidate)) return candidate
-    current = dirname(current)
+  const reference = inspectCodexReferenceRoot(dirname(fileURLToPath(import.meta.url)))
+  if (!reference.ok) return reference
+
+  const candidate = join(reference.root, "codex-rs/tui/src/slash_command.rs")
+  if (existsSync(candidate)) {
+    return {
+      ok: true,
+      path: candidate,
+      status: "ready",
+    }
   }
-  throw new Error("Could not locate projects/repos/codex/codex-rs/tui/src/slash_command.rs")
+  return codexSlashCommandSourceBlocked(
+    `Codex reference checkout is missing codex-rs/tui/src/slash_command.rs: ${candidate}`,
+  )
+}
+
+const expectCodexSlashCommandSourcePathOrBlocker = (): string | null => {
+  const status = inspectCodexSlashCommandSourcePath()
+  if (status.ok) return status.path
+
+  expect(status).toMatchObject({
+    blockerRef: KHALA_CODE_CODEX_REFERENCE_CHECKOUT_MISSING_BLOCKER_REF,
+    ok: false,
+    status: "blocked",
+  })
+  expect(status.reason.length).toBeGreaterThan(0)
+  return null
 }
 
 const parseCodexSlashCommands = (source: string): readonly ParsedCodexSlashCommand[] => {
@@ -76,7 +123,10 @@ const parseCodexSlashCommands = (source: string): readonly ParsedCodexSlashComma
 
 describe("Khala Code Codex slash command registry", () => {
   test("tracks the upstream Codex SlashCommand enum and aliases", async () => {
-    const source = await readFile(codexSlashCommandSourcePath(), "utf8")
+    const sourcePath = expectCodexSlashCommandSourcePathOrBlocker()
+    if (sourcePath === null) return
+
+    const source = await readFile(sourcePath, "utf8")
     const upstream = parseCodexSlashCommands(source)
     const khala = KHALA_CODE_DESKTOP_SLASH_COMMANDS.map(command => ({
       aliases: command.aliases,


### PR DESCRIPTION
## Problem

Lathe's Batch A addendum found that the live parity smoke degrades cleanly when it is not requested, but the default Khala Code parity contract tests threw `Could not locate projects/repos/codex reference checkout` in a bare checkout.

## Change

- Adds `inspectCodexReferenceRoot()` with a typed `blocker.codex_reference_checkout_missing` status for missing or misconfigured Codex reference checkouts.
- Keeps `findCodexReferenceRoot()` fail-hard for callers that explicitly require the reference checkout.
- Updates the app-server parity, gap-matrix, and slash-command contract tests to accept the typed blocker when the pinned Codex tree is absent.
- Leaves local Khala metadata checks unconditional so registry and matrix drift still fails normally.

## Files Touched

- `clients/khala-code-desktop/src/bun/codex-parity-contract.ts`
- `clients/khala-code-desktop/tests/codex-parity-contract.test.ts`
- `clients/khala-code-desktop/tests/codex-app-server-gap-matrix.test.ts`
- `clients/khala-code-desktop/tests/codex-slash-commands.test.ts`

## Validation

- `bun install --frozen-lockfile`
- `bun run typecheck` from `clients/khala-code-desktop`
- `bun test clients/khala-code-desktop/tests/codex-parity-contract.test.ts clients/khala-code-desktop/tests/codex-app-server-gap-matrix.test.ts clients/khala-code-desktop/tests/codex-slash-commands.test.ts` -> 22 pass
- `git diff --check HEAD~1..HEAD`
- `bun test tests/*.test.ts` from `clients/khala-code-desktop` -> 264 pass, 1 fail. Residual failure is unrelated and outside touched files: `Khala Code desktop chat runtime > uses the default Rampart model redaction before hosted provider requests` expects `Hello Alice Johnson.` but receives `Hello [GIVEN_NAME_1] [SURNAME_1].`

## Maintenance / Product Value

This makes the default bare-clone parity lane reviewable: missing local Codex fixtures now produce a public, stable blocker reference instead of an unstructured thrown setup error.

## Intentionally Not Changed

- No authenticated live Codex turn.
- No Batch B signed app, Apple FM, or Mac provider capacity work.
- No marketplace, settlement, green-claim, or hosted redaction behavior changes.
