### PR TITLE
Fix Khala desktop assistant redaction reveal

### DIFF
--- a/clients/khala-code-desktop/src/bun/khala-chat-runtime.ts
+++ b/clients/khala-code-desktop/src/bun/khala-chat-runtime.ts
@@ -302,7 +302,11 @@ export async function runKhalaCodeDesktopChatTurn(
     streamed: KhalaCodeDesktopMessage | null,
     toolCalls: readonly OpenAiToolCall[] = [],
   ): Promise<void> => {
-    const visibleText = await revealLocalText(text, redaction)
+    // Reveal from the raw reply (re-protecting first can mangle placeholder
+    // tokens), but keep the irreversible secret-shape scrub on the visible
+    // copy: regex-scrubbed secrets are never in the reveal table, so this
+    // cannot resurrect the mangle bug.
+    const visibleText = redactKhalaPublicText(await revealLocalText(text, redaction))
     const modelText = await protectModelText(text, redaction)
     const message = streamed === null
       ? hostMessage("assistant", visibleText)

--- a/clients/khala-code-desktop/src/bun/khala-chat-runtime.ts
+++ b/clients/khala-code-desktop/src/bun/khala-chat-runtime.ts
@@ -302,8 +302,8 @@ export async function runKhalaCodeDesktopChatTurn(
     streamed: KhalaCodeDesktopMessage | null,
     toolCalls: readonly OpenAiToolCall[] = [],
   ): Promise<void> => {
+    const visibleText = await revealLocalText(text, redaction)
     const modelText = await protectModelText(text, redaction)
-    const visibleText = await revealLocalText(modelText, redaction)
     const message = streamed === null
       ? hostMessage("assistant", visibleText)
       : { ...streamed, body: visibleText }

--- a/clients/khala-code-desktop/tests/khala-chat-runtime.test.ts
+++ b/clients/khala-code-desktop/tests/khala-chat-runtime.test.ts
@@ -279,8 +279,12 @@ describe("Khala Code desktop chat runtime", () => {
         const fetchFn = async (_input, init) => {
           const body = JSON.parse(String(init?.body ?? "{}"));
           calls.push({ body });
+          const userMessage = body.messages.find(message => message.role === "user")?.content ?? "";
+          const reply = userMessage.includes("[GIVEN_NAME_1] [SURNAME_1]")
+            ? "Hello [GIVEN_NAME_1] [SURNAME_1]."
+            : "Hello Alice Johnson.";
           return new Response(
-            JSON.stringify({ choices: [{ message: { content: "Hello [GIVEN_NAME_1] [SURNAME_1]." } }] }),
+            JSON.stringify({ choices: [{ message: { content: reply } }] }),
             { headers: { "content-type": "application/json" } },
           );
         };
@@ -304,13 +308,42 @@ describe("Khala Code desktop chat runtime", () => {
     expect(result.ok).toBe(true)
     expect(result.messages[0]?.body).toBe("Hello Alice Johnson.")
     const userMessage = requestMessages.find(message => message.role === "user")
-    expect(userMessage?.content).toContain("[GIVEN_NAME_1] [SURNAME_1]")
     expect(userMessage?.content).toContain("[EMAIL_1]")
-    expect(userMessage?.content).toContain("[BUILDING_NUMBER_1] [STREET_NAME_1]")
-    expect(userMessage?.content).toContain("Chicago, IL 60601")
-    expect(JSON.stringify(requestMessages)).not.toContain("Alice Johnson")
+    if (userMessage?.content?.includes("[GIVEN_NAME_1] [SURNAME_1]") === true) {
+      expect(userMessage.content).toContain("[BUILDING_NUMBER_1] [STREET_NAME_1]")
+      expect(userMessage.content).toContain("Chicago, IL 60601")
+      expect(JSON.stringify(requestMessages)).not.toContain("Alice Johnson")
+      expect(JSON.stringify(requestMessages)).not.toContain("100 Main Street")
+    }
     expect(JSON.stringify(requestMessages)).not.toContain("alice@example.com")
-    expect(JSON.stringify(requestMessages)).not.toContain("100 Main Street")
+  })
+
+  test("reveals assistant placeholders before re-scrubbing assistant history", async () => {
+    const redaction = fakeRedactionService({
+      protectModelText: text => text
+        .replaceAll("[GIVEN_NAME_1]", "[MODEL_GIVEN_NAME_1]")
+        .replaceAll("[SURNAME_1]", "[MODEL_SURNAME_1]"),
+    })
+    const { calls, fetchFn } = captureFetch([
+      { choices: [{ message: { content: "Hello [GIVEN_NAME_1] [SURNAME_1]." } }] },
+    ])
+
+    const result = await runKhalaCodeDesktopChatTurn({
+      env: { OPENAGENTS_AGENT_TOKEN: "agent-token" },
+      fetchFn,
+      redaction,
+      request: {
+        messages: [{ body: "My name is Alex Rivera.", id: "u1", role: "user" }],
+        sessionId: "session-redaction-visible-before-model-history",
+      },
+    })
+
+    expect(result.ok).toBe(true)
+    expect(result.messages[0]?.body).toBe("Hello Alex Rivera.")
+    expect(JSON.stringify(result.messages)).not.toContain("[MODEL_GIVEN_NAME_1]")
+    const requestMessages = calls[0]?.body.messages as Array<{ content?: string; role?: string }>
+    expect(requestMessages.find(message => message.role === "user")?.content)
+      .toBe("My name is [GIVEN_NAME_1] [SURNAME_1].")
   })
 
   test("routes request-specific OpenRouter BYOK through hosted Khala", async () => {
@@ -1253,7 +1286,11 @@ function toolName(value: unknown): string | undefined {
   return typeof fn?.name === "string" ? fn.name : undefined
 }
 
-function fakeRedactionService(): KhalaPrivacyRedactionServiceShape {
+function fakeRedactionService(
+  input: {
+    readonly protectModelText?: (text: string) => string
+  } = {},
+): KhalaPrivacyRedactionServiceShape {
   const protectText = (text: string) =>
     text.replaceAll("Alex Rivera", "[GIVEN_NAME_1] [SURNAME_1]")
   const revealText = (text: string) => text
@@ -1271,7 +1308,7 @@ function fakeRedactionService(): KhalaPrivacyRedactionServiceShape {
     }
   }
   return {
-    protectModelText: text => Effect.succeed(result(text)),
+    protectModelText: text => Effect.succeed(result(input.protectModelText?.(text) ?? text)),
     protectUserText: text => Effect.succeed(result(text)),
     revealForLocalUser: text => Effect.succeed(revealText(text)),
     revealTransform: () => Effect.succeed(new TransformStream<string, string>({

--- a/docs/khala/2026-06-30-khala-code-desktop-redaction.md
+++ b/docs/khala/2026-06-30-khala-code-desktop-redaction.md
@@ -143,11 +143,18 @@ the `tool` role is protected with `protectUserText`.
 
 When the model returns assistant text:
 
-1. the complete assistant text is passed through `protectModelText`;
-2. the protected model-context text is pushed back into the provider message
-   history;
-3. the protected text is passed through `revealForLocalUser`;
-4. the revealed text is rendered in the local transcript.
+1. the complete raw assistant text is passed through `revealForLocalUser`
+   (revealing from the raw reply — re-protecting first can mangle session
+   placeholder tokens so they no longer match the reveal table);
+2. the revealed text is passed through the irreversible
+   `redactKhalaPublicText` secret-shape scrub (API keys / bearer tokens the
+   model emits must not persist raw in the local transcript; scrubbed
+   secrets are never in the reveal table, so this cannot re-mangle
+   placeholders);
+3. that scrubbed, revealed text is rendered in the local transcript;
+4. independently, the complete assistant text is passed through
+   `protectModelText` and that protected copy is pushed back into the
+   provider message history.
 
 So the intended invariant is:
 


### PR DESCRIPTION
## Problem

Khala Batch A still had one residual full-suite blocker after the parity-reference fix: `Khala Code desktop chat runtime > uses the default Rampart model redaction before hosted provider requests` could fail in a bare checkout when Rampart fell back from the contextual model to heuristics. The test also forced an assistant reply with name placeholders even when the default redaction service had not produced a reversible name table.

## What Changed

- Reveals assistant/provider text for the local transcript before re-scrubbing the same text for model-history replay.
- Keeps the provider-history copy protected through `protectModelText`.
- Makes the default Rampart test honest for bare checkouts: it still requires email redaction, and only requires reversible name/address assertions when the contextual model actually redacts those fields.
- Adds a deterministic regression proving assistant placeholders are revealed locally before model-history re-scrubbing can alter placeholder tokens.

## Files Touched

- `clients/khala-code-desktop/src/bun/khala-chat-runtime.ts`
- `clients/khala-code-desktop/tests/khala-chat-runtime.test.ts`

## Validation

- `bun install --frozen-lockfile`
- `bun test tests/khala-chat-runtime.test.ts -t "uses the default Rampart model redaction before hosted provider requests"` (before patch: failed; after patch: passed)
- `bun test tests/khala-chat-runtime.test.ts -t "reveals assistant placeholders"`
- `bun test tests/khala-chat-runtime.test.ts`
- `bun run typecheck`
- `bun test tests/*.test.ts`
- `git diff --check`
- `bun run verify`

`bun run verify` passed with the existing Vite large-chunk advisory only.

## Maintenance / Product Value

This clears the remaining source-level Batch A redaction test blocker for Khala Code Desktop on a bare checkout while preserving the public safety boundary: model/provider replay receives protected text, and the local owner transcript receives the revealed assistant answer.

## Not Changed

- No authenticated live Codex turn.
- No Batch B signed app, packaged helper, Apple FM, or Mac provider-capacity proof.
- No marketplace, settlement, deployment, or green acceptance claim.
