### PR TITLE
T2.1: FleetRun record on the orchestration store

### DIFF
--- a/apps/pylon/src/orchestration/store.ts
+++ b/apps/pylon/src/orchestration/store.ts
@@ -1,5 +1,10 @@
 import type { Database } from "bun:sqlite"
 import { createHash } from "node:crypto"
+import { existsSync } from "node:fs"
+import { mkdir, readFile, writeFile } from "node:fs/promises"
+import { join } from "node:path"
+import { Schema as S } from "effect"
+import type { PylonPaths } from "../state.js"
 import {
   isAgentRunnerKind,
   normalizeAgentRunnerKind,
@@ -7,7 +12,7 @@ import {
   type LegacyAgentRunnerKind,
 } from "../agent-runner-registry.js"
 
-export const ORCHESTRATION_SCHEMA_VERSION = 1
+export const ORCHESTRATION_SCHEMA_VERSION = 2
 
 export type OrchestrationTaskStatus =
   | "pending"
@@ -26,6 +31,7 @@ export type OrchestrationTaskSpec = {
   branch?: string
   baseCommit?: string
   issueRef?: string
+  fleetRunRef?: string
 }
 
 export type OrchestrationTask = {
@@ -51,8 +57,88 @@ export type PublicOrchestrationTask = {
   branch: string | null
   baseCommit: string | null
   issueRef: string | null
+  fleetRunRef: string | null
   createdAt: string
   updatedAt: string
+}
+
+export const FLEET_RUN_SCHEMA = "openagents.khala_code.fleet_run.v1" as const
+export const FLEET_RUN_OWNER_LOCAL_STATE_SCHEMA = "openagents.khala_code.fleet_runs.owner_local.v1" as const
+
+export const FleetRunWorkSourceSchema = S.Literals(["github_backlog", "issue_list", "fixture"])
+export type FleetRunWorkSource = typeof FleetRunWorkSourceSchema.Type
+
+export const FleetRunWorkerKindSchema = S.Literals(["codex", "claude", "auto"])
+export type FleetRunWorkerKind = typeof FleetRunWorkerKindSchema.Type
+
+export const FleetRunDispatchKindSchema = S.Literals(["handoff", "supervised_dispatch"])
+export type FleetRunDispatchKind = typeof FleetRunDispatchKindSchema.Type
+
+export const FleetRunStateSchema = S.Literals([
+  "draft",
+  "running",
+  "paused",
+  "draining",
+  "stopped",
+  "completed",
+])
+export type FleetRunState = typeof FleetRunStateSchema.Type
+
+export const FleetRunStopConditionSchema = S.Literals(["backlog_empty", "target_reached", "manual_stop"])
+export type FleetRunStopCondition = typeof FleetRunStopConditionSchema.Type
+
+export const FleetRunRefillPolicySchema = S.Struct({
+  maxPerAccount: S.Number,
+  cooldownAware: S.Boolean,
+  stopCondition: FleetRunStopConditionSchema,
+})
+export type FleetRunRefillPolicy = typeof FleetRunRefillPolicySchema.Type
+
+export const FleetRunCountersSchema = S.Struct({
+  workUnitsTotal: S.Number,
+  activeAssignments: S.Number,
+  completedAssignments: S.Number,
+  failedAssignments: S.Number,
+  blockedAssignments: S.Number,
+})
+export type FleetRunCounters = typeof FleetRunCountersSchema.Type
+
+export const FleetRunSchema = S.Struct({
+  schema: S.Literal(FLEET_RUN_SCHEMA),
+  runRef: S.String,
+  objective: S.String,
+  workSource: FleetRunWorkSourceSchema,
+  targetConcurrency: S.Number,
+  workerKind: FleetRunWorkerKindSchema,
+  refillPolicy: FleetRunRefillPolicySchema,
+  state: FleetRunStateSchema,
+  dispatchKind: FleetRunDispatchKindSchema,
+  dagTracked: S.Boolean,
+  startedAt: S.NullOr(S.String),
+  counters: FleetRunCountersSchema,
+  createdAt: S.String,
+  updatedAt: S.String,
+})
+export type FleetRun = typeof FleetRunSchema.Type
+
+export const FleetRunOwnerLocalStateSchema = S.Struct({
+  schema: S.Literal(FLEET_RUN_OWNER_LOCAL_STATE_SCHEMA),
+  runs: S.Array(FleetRunSchema),
+})
+export type FleetRunOwnerLocalState = typeof FleetRunOwnerLocalStateSchema.Type
+
+export type CreateFleetRunInput = {
+  runRef: string
+  objective: string
+  workSource: FleetRunWorkSource
+  targetConcurrency: number
+  workerKind: FleetRunWorkerKind
+  refillPolicy?: Partial<FleetRunRefillPolicy>
+  state?: FleetRunState
+  dispatchKind?: FleetRunDispatchKind
+  startedAt?: Date | string | null
+  counters?: Partial<FleetRunCounters>
+  now?: Date
 }
 
 export type VirtualHead = {
@@ -167,6 +253,20 @@ type SqliteDatabase = Pick<Database, "exec" | "query" | "run">
 
 const iso = (date: Date = new Date()): string => date.toISOString()
 
+const DEFAULT_FLEET_RUN_COUNTERS: FleetRunCounters = {
+  workUnitsTotal: 0,
+  activeAssignments: 0,
+  completedAssignments: 0,
+  failedAssignments: 0,
+  blockedAssignments: 0,
+}
+
+const DEFAULT_FLEET_RUN_REFILL_POLICY: FleetRunRefillPolicy = {
+  maxPerAccount: 1,
+  cooldownAware: true,
+  stopCondition: "backlog_empty",
+}
+
 const parseJsonArray = (value: string): string[] => {
   const parsed: unknown = JSON.parse(value)
   return Array.isArray(parsed) ? parsed.filter((entry): entry is string => typeof entry === "string") : []
@@ -189,6 +289,71 @@ const normalizeTaskSpec = (spec: OrchestrationTaskSpec): OrchestrationTaskSpec =
   ...spec,
   ...(spec.runnerKind === undefined ? {} : { runnerKind: normalizeOrchestrationRunnerKind(spec.runnerKind) }),
 })
+
+const assertWholePositive = (field: string, value: number): void => {
+  if (!Number.isInteger(value) || value < 1) throw new Error(`fleet run ${field} must be a positive integer`)
+}
+
+const assertWholeNonNegative = (field: string, value: number): void => {
+  if (!Number.isInteger(value) || value < 0) throw new Error(`fleet run ${field} must be a non-negative integer`)
+}
+
+export function decodeFleetRun(input: unknown): FleetRun {
+  const run = S.decodeUnknownSync(FleetRunSchema)(input)
+  if (!run.runRef.trim()) throw new Error("fleet run runRef is required")
+  if (!run.objective.trim()) throw new Error("fleet run objective is required")
+  assertWholePositive("targetConcurrency", run.targetConcurrency)
+  assertWholePositive("refillPolicy.maxPerAccount", run.refillPolicy.maxPerAccount)
+  for (const [key, value] of Object.entries(run.counters) as Array<[keyof FleetRunCounters, number]>) {
+    assertWholeNonNegative(`counters.${key}`, value)
+  }
+  if (run.dispatchKind === "handoff" && run.dagTracked) {
+    throw new Error("fleet run handoff records must not be DAG-tracked")
+  }
+  if (run.dispatchKind === "supervised_dispatch" && !run.dagTracked) {
+    throw new Error("fleet run supervised dispatch records must be DAG-tracked")
+  }
+  if (run.startedAt !== null && Number.isNaN(Date.parse(run.startedAt))) {
+    throw new Error("fleet run startedAt must be ISO-compatible or null")
+  }
+  if (Number.isNaN(Date.parse(run.createdAt)) || Number.isNaN(Date.parse(run.updatedAt))) {
+    throw new Error("fleet run timestamps must be ISO-compatible")
+  }
+  return run
+}
+
+export function buildFleetRun(input: CreateFleetRunInput): FleetRun {
+  const now = input.now ?? new Date()
+  const state = input.state ?? "draft"
+  const dispatchKind = input.dispatchKind ?? "supervised_dispatch"
+  const run: FleetRun = {
+    schema: FLEET_RUN_SCHEMA,
+    runRef: input.runRef,
+    objective: input.objective,
+    workSource: input.workSource,
+    targetConcurrency: input.targetConcurrency,
+    workerKind: input.workerKind,
+    refillPolicy: {
+      ...DEFAULT_FLEET_RUN_REFILL_POLICY,
+      ...input.refillPolicy,
+    },
+    state,
+    dispatchKind,
+    dagTracked: dispatchKind === "supervised_dispatch",
+    startedAt: input.startedAt === undefined
+      ? state === "running" ? iso(now) : null
+      : input.startedAt instanceof Date ? iso(input.startedAt) : input.startedAt,
+    counters: {
+      ...DEFAULT_FLEET_RUN_COUNTERS,
+      ...input.counters,
+    },
+    createdAt: iso(now),
+    updatedAt: iso(now),
+  }
+  return decodeFleetRun(run)
+}
+
+const fleetRunFromJson = (value: string): FleetRun => decodeFleetRun(JSON.parse(value))
 
 export function normalizeOrchestrationRunnerKind(
   kind: OrchestrationRunnerKind | LegacyAgentRunnerKind,
@@ -238,6 +403,17 @@ type VirtualHeadRow = {
   updated_at: string
 }
 
+type FleetRunRow = {
+  run_ref: string
+  record_json: string
+  state: FleetRunState
+  dispatch_kind: FleetRunDispatchKind
+  worker_kind: FleetRunWorkerKind
+  created_at: string
+  updated_at: string
+  started_at: string | null
+}
+
 type MessageRow = {
   id: string
   thread_id: string
@@ -271,6 +447,7 @@ export const publicOrchestrationTaskFrom = (task: OrchestrationTask): PublicOrch
   branch: task.spec.branch ?? null,
   baseCommit: task.spec.baseCommit ?? null,
   issueRef: task.spec.issueRef ?? null,
+  fleetRunRef: task.spec.fleetRunRef ?? null,
   createdAt: task.createdAt,
   updatedAt: task.updatedAt,
 })
@@ -388,10 +565,116 @@ export class PylonOrchestrationStore {
         updated_at TEXT NOT NULL,
         PRIMARY KEY (repo, branch)
       );
+      CREATE TABLE IF NOT EXISTS pylon_orchestration_fleet_runs (
+        run_ref TEXT PRIMARY KEY,
+        record_json TEXT NOT NULL,
+        state TEXT NOT NULL CHECK (state IN ('draft', 'running', 'paused', 'draining', 'stopped', 'completed')),
+        dispatch_kind TEXT NOT NULL CHECK (dispatch_kind IN ('handoff', 'supervised_dispatch')),
+        worker_kind TEXT NOT NULL CHECK (worker_kind IN ('codex', 'claude', 'auto')),
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL,
+        started_at TEXT
+      );
+      CREATE INDEX IF NOT EXISTS idx_pylon_orchestration_fleet_runs_state
+        ON pylon_orchestration_fleet_runs(state, updated_at);
+      CREATE INDEX IF NOT EXISTS idx_pylon_orchestration_fleet_runs_dispatch
+        ON pylon_orchestration_fleet_runs(dispatch_kind, updated_at);
     `)
     this.db
       .query("INSERT OR REPLACE INTO pylon_orchestration_meta (key, value) VALUES ('schema_version', $version)")
       .run({ $version: String(ORCHESTRATION_SCHEMA_VERSION) })
+  }
+
+  createFleetRun(input: CreateFleetRunInput): FleetRun {
+    const run = buildFleetRun(input)
+    return this.upsertFleetRun(run)
+  }
+
+  upsertFleetRun(input: FleetRun, now?: Date): FleetRun {
+    const current = decodeFleetRun(input)
+    const updatedAt = now === undefined ? current.updatedAt : iso(now)
+    const run = decodeFleetRun({ ...current, updatedAt })
+    this.db
+      .query(`
+        INSERT INTO pylon_orchestration_fleet_runs
+          (run_ref, record_json, state, dispatch_kind, worker_kind, created_at, updated_at, started_at)
+        VALUES
+          ($runRef, $recordJson, $state, $dispatchKind, $workerKind, $createdAt, $updatedAt, $startedAt)
+        ON CONFLICT(run_ref) DO UPDATE SET
+          record_json = excluded.record_json,
+          state = excluded.state,
+          dispatch_kind = excluded.dispatch_kind,
+          worker_kind = excluded.worker_kind,
+          updated_at = excluded.updated_at,
+          started_at = excluded.started_at
+      `)
+      .run({
+        $runRef: run.runRef,
+        $recordJson: JSON.stringify(run),
+        $state: run.state,
+        $dispatchKind: run.dispatchKind,
+        $workerKind: run.workerKind,
+        $createdAt: run.createdAt,
+        $updatedAt: run.updatedAt,
+        $startedAt: run.startedAt,
+      })
+    const stored = this.getFleetRun(run.runRef)
+    if (stored === null) throw new Error(`failed to persist fleet run ${run.runRef}`)
+    return stored
+  }
+
+  getFleetRun(runRef: string): FleetRun | null {
+    const row = this.db
+      .query("SELECT * FROM pylon_orchestration_fleet_runs WHERE run_ref = $runRef")
+      .get({ $runRef: runRef }) as FleetRunRow | null
+    return row === null ? null : fleetRunFromJson(row.record_json)
+  }
+
+  listFleetRuns(state?: FleetRunState): FleetRun[] {
+    const rows = state === undefined
+      ? this.db.query("SELECT * FROM pylon_orchestration_fleet_runs ORDER BY created_at ASC").all()
+      : this.db
+        .query("SELECT * FROM pylon_orchestration_fleet_runs WHERE state = $state ORDER BY created_at ASC")
+        .all({ $state: state })
+    return (rows as FleetRunRow[]).map((row) => fleetRunFromJson(row.record_json))
+  }
+
+  updateFleetRunState(runRef: string, state: FleetRunState, now: Date = new Date()): FleetRun {
+    const current = this.getFleetRun(runRef)
+    if (current === null) throw new Error(`unknown fleet run: ${runRef}`)
+    return this.upsertFleetRun({
+      ...current,
+      state,
+      startedAt: state === "running" && current.startedAt === null ? iso(now) : current.startedAt,
+      updatedAt: iso(now),
+    })
+  }
+
+  reconcileFleetRun(runRef: string, now: Date = new Date()): FleetRun {
+    const run = this.getFleetRun(runRef)
+    if (run === null) throw new Error(`unknown fleet run: ${runRef}`)
+    const tasks = this.listTasks().filter((task) => task.spec.fleetRunRef === runRef)
+    const counters: FleetRunCounters = {
+      workUnitsTotal: tasks.length,
+      activeAssignments: tasks.filter((task) => task.status === "dispatched").length,
+      completedAssignments: tasks.filter((task) => task.status === "completed").length,
+      failedAssignments: tasks.filter((task) => task.status === "failed").length,
+      blockedAssignments: tasks.filter((task) => task.status === "blocked").length,
+    }
+    const terminalCount = counters.completedAssignments + counters.failedAssignments + counters.blockedAssignments
+    const shouldClose =
+      tasks.length > 0 &&
+      terminalCount === tasks.length &&
+      counters.activeAssignments === 0 &&
+      (run.state === "running" || run.state === "draining")
+    const state: FleetRunState = shouldClose && counters.failedAssignments === 0 && counters.blockedAssignments === 0
+      ? "completed"
+      : shouldClose ? "stopped" : run.state
+    return this.upsertFleetRun({ ...run, state, counters, updatedAt: iso(now) })
+  }
+
+  reconcileFleetRuns(now: Date = new Date()): FleetRun[] {
+    return this.listFleetRuns().map((run) => this.reconcileFleetRun(run.runRef, now))
   }
 
   createTask(input: CreateTaskInput): OrchestrationTask {
@@ -847,6 +1130,55 @@ export class PylonOrchestrationStore {
       dispatchContexts: this.listDispatchContexts().map(publicDispatchContextFrom),
     }
   }
+}
+
+export const fleetRunOwnerLocalStatePath = (paths: Pick<PylonPaths, "home">): string =>
+  join(paths.home, "fleet-runs.json")
+
+export async function loadFleetRunOwnerLocalState(
+  paths: Pick<PylonPaths, "home">,
+): Promise<FleetRunOwnerLocalState> {
+  const path = fleetRunOwnerLocalStatePath(paths)
+  if (!existsSync(path)) return { schema: FLEET_RUN_OWNER_LOCAL_STATE_SCHEMA, runs: [] }
+  const parsed: unknown = JSON.parse(await readFile(path, "utf8"))
+  const state = S.decodeUnknownSync(FleetRunOwnerLocalStateSchema)(parsed)
+  return { ...state, runs: state.runs.map(decodeFleetRun) }
+}
+
+export async function saveFleetRunOwnerLocalState(
+  paths: Pick<PylonPaths, "home">,
+  state: FleetRunOwnerLocalState,
+): Promise<void> {
+  const decoded = S.decodeUnknownSync(FleetRunOwnerLocalStateSchema)(state)
+  const validated = { ...decoded, runs: decoded.runs.map(decodeFleetRun) }
+  await mkdir(paths.home, { recursive: true })
+  await writeFile(fleetRunOwnerLocalStatePath(paths), `${JSON.stringify(validated, null, 2)}\n`, { mode: 0o600 })
+}
+
+export async function syncFleetRunsToOwnerLocalState(
+  store: PylonOrchestrationStore,
+  paths: Pick<PylonPaths, "home">,
+): Promise<FleetRunOwnerLocalState> {
+  const state: FleetRunOwnerLocalState = {
+    schema: FLEET_RUN_OWNER_LOCAL_STATE_SCHEMA,
+    runs: store.listFleetRuns(),
+  }
+  await saveFleetRunOwnerLocalState(paths, state)
+  return state
+}
+
+export async function reconcileFleetRunsFromOwnerLocalState(
+  store: PylonOrchestrationStore,
+  paths: Pick<PylonPaths, "home">,
+  input: { now?: Date } = {},
+): Promise<FleetRun[]> {
+  const localState = await loadFleetRunOwnerLocalState(paths)
+  for (const run of localState.runs) {
+    store.upsertFleetRun(run, input.now)
+  }
+  const reconciled = store.reconcileFleetRuns(input.now)
+  await syncFleetRunsToOwnerLocalState(store, paths)
+  return reconciled
 }
 
 export const createPylonOrchestrationStore = (db: SqliteDatabase): PylonOrchestrationStore => {

--- a/apps/pylon/src/orchestration/supervisor-orchestration.test.ts
+++ b/apps/pylon/src/orchestration/supervisor-orchestration.test.ts
@@ -1,13 +1,22 @@
 import { describe, expect, test } from "bun:test"
 import { Database } from "bun:sqlite"
+import { mkdtemp, readFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
 
 import { dispatchEligibility, dispatchLiveness, dispatchReadySupervisorTasks } from "./coordinator.js"
 import { parseOrchestrationGroupAddress, resolveOrchestrationGroup } from "./groups.js"
 import { encodeAgentRunnerStatusEventForDispatchContext } from "./status-control.js"
 import {
+  FLEET_RUN_SCHEMA,
   createPylonOrchestrationStore,
+  fleetRunOwnerLocalStatePath,
   isStoredOrchestrationRunnerKind,
+  loadFleetRunOwnerLocalState,
   normalizeOrchestrationRunnerKind,
+  reconcileFleetRunsFromOwnerLocalState,
+  saveFleetRunOwnerLocalState,
+  syncFleetRunsToOwnerLocalState,
 } from "./store.js"
 
 const baseTaskSpec = {
@@ -266,6 +275,7 @@ describe("Pylon supervisor orchestration store", () => {
         branch: "main",
         baseCommit: "abc123",
         issueRef: "issue.7808",
+        fleetRunRef: null,
         createdAt: "2026-06-27T12:00:00.000Z",
         updatedAt: "2026-06-27T12:00:00.000Z",
       },
@@ -273,6 +283,209 @@ describe("Pylon supervisor orchestration store", () => {
     expect(JSON.stringify(snapshot)).not.toContain("Public issue prompt")
     expect(JSON.stringify(snapshot)).not.toContain("/private/local/worktree/path")
     expect(snapshot.dispatchContexts[0]?.worktreePath).toBeNull()
+  })
+
+  test("persists FleetRun records on the orchestration store with supervised-dispatch taxonomy", () => {
+    const now = new Date("2026-07-01T12:00:00.000Z")
+    const store = createPylonOrchestrationStore(new Database(":memory:"))
+    const run = store.createFleetRun({
+      runRef: "fleet_run.t2_1",
+      objective: "Burn down the public Fable fixture backlog.",
+      workSource: "fixture",
+      targetConcurrency: 25,
+      workerKind: "codex",
+      state: "running",
+      refillPolicy: {
+        maxPerAccount: 3,
+        cooldownAware: true,
+        stopCondition: "backlog_empty",
+      },
+      now,
+    })
+
+    expect(run).toMatchObject({
+      schema: FLEET_RUN_SCHEMA,
+      runRef: "fleet_run.t2_1",
+      workSource: "fixture",
+      targetConcurrency: 25,
+      workerKind: "codex",
+      state: "running",
+      dispatchKind: "supervised_dispatch",
+      dagTracked: true,
+      startedAt: "2026-07-01T12:00:00.000Z",
+      counters: {
+        workUnitsTotal: 0,
+        activeAssignments: 0,
+        completedAssignments: 0,
+        failedAssignments: 0,
+        blockedAssignments: 0,
+      },
+    })
+    expect(store.getFleetRun("fleet_run.t2_1")).toEqual(run)
+    expect(store.listFleetRuns("running").map((entry) => entry.runRef)).toEqual(["fleet_run.t2_1"])
+  })
+
+  test("rejects FleetRun handoffs that claim DAG tracking", () => {
+    const store = createPylonOrchestrationStore(new Database(":memory:"))
+    const handoff = store.createFleetRun({
+      runRef: "fleet_run.handoff",
+      objective: "One-shot handoff.",
+      workSource: "fixture",
+      targetConcurrency: 1,
+      workerKind: "codex",
+      dispatchKind: "handoff",
+    })
+
+    expect(handoff.dispatchKind).toBe("handoff")
+    expect(handoff.dagTracked).toBe(false)
+    expect(() => store.upsertFleetRun({ ...handoff, dagTracked: true })).toThrow(
+      "fleet run handoff records must not be DAG-tracked",
+    )
+  })
+
+  test("reconciles FleetRun counters from existing orchestration tasks", () => {
+    const now = new Date("2026-07-01T12:00:00.000Z")
+    const doneAt = new Date("2026-07-01T12:05:00.000Z")
+    const store = createPylonOrchestrationStore(new Database(":memory:"))
+    store.createFleetRun({
+      runRef: "fleet_run.reconcile",
+      objective: "Run three fixture work units.",
+      workSource: "fixture",
+      targetConcurrency: 2,
+      workerKind: "codex",
+      state: "running",
+      now,
+    })
+    store.createTask({
+      id: "task.completed",
+      spec: { ...baseTaskSpec, title: "completed", fleetRunRef: "fleet_run.reconcile" },
+      now,
+    })
+    store.createTask({
+      id: "task.dispatched",
+      spec: { ...baseTaskSpec, title: "dispatched", fleetRunRef: "fleet_run.reconcile" },
+      now,
+    })
+    store.createTask({
+      id: "task.blocked",
+      spec: { ...baseTaskSpec, title: "blocked", fleetRunRef: "fleet_run.reconcile" },
+      now,
+    })
+    store.createDispatchContext({
+      id: "ctx.codex.reconcile",
+      assigneeHandle: "codex-1",
+      runnerKind: "codex",
+      lastHeartbeatAt: now,
+      now,
+    })
+    store.markDispatched("task.dispatched", "ctx.codex.reconcile", now)
+    store.completeTask("task.completed", JSON.stringify({ ok: true }), doneAt)
+    store.updateTaskSpec("task.blocked", { ...baseTaskSpec, title: "blocked", fleetRunRef: "fleet_run.reconcile" }, doneAt)
+    store.recordWorkerDone({
+      contextId: "ctx.codex.reconcile",
+      taskId: "task.dispatched",
+      status: "completed",
+      now: doneAt,
+    })
+    store.updateFleetRunState("fleet_run.reconcile", "running", doneAt)
+
+    const reconciled = store.reconcileFleetRun("fleet_run.reconcile", doneAt)
+
+    expect(reconciled.counters).toEqual({
+      workUnitsTotal: 3,
+      activeAssignments: 0,
+      completedAssignments: 2,
+      failedAssignments: 0,
+      blockedAssignments: 0,
+    })
+    expect(reconciled.state).toBe("running")
+  })
+
+  test("reconciles completed FleetRuns when every DAG-tracked work unit is terminal", () => {
+    const now = new Date("2026-07-01T12:00:00.000Z")
+    const store = createPylonOrchestrationStore(new Database(":memory:"))
+    store.createFleetRun({
+      runRef: "fleet_run.completed",
+      objective: "Finish a fixture work unit.",
+      workSource: "fixture",
+      targetConcurrency: 1,
+      workerKind: "codex",
+      state: "running",
+      now,
+    })
+    store.createTask({
+      id: "task.done",
+      spec: { ...baseTaskSpec, title: "done", fleetRunRef: "fleet_run.completed" },
+      now,
+    })
+    store.completeTask("task.done", JSON.stringify({ ok: true }), now)
+
+    const reconciled = store.reconcileFleetRun("fleet_run.completed", now)
+
+    expect(reconciled.state).toBe("completed")
+    expect(reconciled.counters.completedAssignments).toBe(1)
+  })
+
+  test("mirrors FleetRun records to owner-local state and rehydrates a fresh store", async () => {
+    const now = new Date("2026-07-01T12:00:00.000Z")
+    const home = await mkdtemp(join(tmpdir(), "pylon-fleet-runs-"))
+    const store = createPylonOrchestrationStore(new Database(":memory:"))
+    const run = store.createFleetRun({
+      runRef: "fleet_run.owner_local",
+      objective: "Resume fixture work after restart.",
+      workSource: "fixture",
+      targetConcurrency: 4,
+      workerKind: "auto",
+      state: "paused",
+      now,
+    })
+
+    await syncFleetRunsToOwnerLocalState(store, { home })
+    const statePath = fleetRunOwnerLocalStatePath({ home })
+    const file = JSON.parse(await readFile(statePath, "utf8")) as { runs: unknown[] }
+    expect(file.runs).toHaveLength(1)
+    expect(file.runs[0]).toMatchObject({ runRef: run.runRef, schema: FLEET_RUN_SCHEMA })
+
+    const freshStore = createPylonOrchestrationStore(new Database(":memory:"))
+    const rehydrated = await reconcileFleetRunsFromOwnerLocalState(freshStore, { home }, { now })
+
+    expect(rehydrated.map((entry) => entry.runRef)).toEqual(["fleet_run.owner_local"])
+    expect(freshStore.getFleetRun("fleet_run.owner_local")?.state).toBe("paused")
+    expect(await loadFleetRunOwnerLocalState({ home })).toMatchObject({
+      runs: [{ runRef: "fleet_run.owner_local" }],
+    })
+  })
+
+  test("owner-local FleetRun state rejects malformed persisted records", async () => {
+    const home = await mkdtemp(join(tmpdir(), "pylon-fleet-runs-bad-"))
+
+    await expect(saveFleetRunOwnerLocalState({ home }, {
+      schema: "openagents.khala_code.fleet_runs.owner_local.v1",
+      runs: [
+        {
+          schema: FLEET_RUN_SCHEMA,
+          runRef: "fleet_run.bad",
+          objective: "bad",
+          workSource: "fixture",
+          targetConcurrency: 0,
+          workerKind: "codex",
+          refillPolicy: { maxPerAccount: 1, cooldownAware: true, stopCondition: "backlog_empty" },
+          state: "draft",
+          dispatchKind: "supervised_dispatch",
+          dagTracked: true,
+          startedAt: null,
+          counters: {
+            workUnitsTotal: 0,
+            activeAssignments: 0,
+            completedAssignments: 0,
+            failedAssignments: 0,
+            blockedAssignments: 0,
+          },
+          createdAt: "2026-07-01T12:00:00.000Z",
+          updatedAt: "2026-07-01T12:00:00.000Z",
+        },
+      ],
+    })).rejects.toThrow("fleet run targetConcurrency must be a positive integer")
   })
 
   test("refuses an otherwise healthy idle context when the ready task requires another runner", () => {


### PR DESCRIPTION
Closes #7826

## Summary

- Added the `openagents.khala_code.fleet_run.v1` Effect Schema, record types, and validation on the existing Pylon orchestration store.
- Persisted FleetRun records in `pylon_orchestration_fleet_runs` and linked DAG work units through `OrchestrationTaskSpec.fleetRunRef` for counter reconciliation.
- Added owner-local `fleet-runs.json` load/save/sync/reconcile helpers under the Pylon home.
- Covered supervised-dispatch vs handoff taxonomy, persistence, counter reconciliation, completion reconciliation, owner-local restart rehydration, and malformed local state rejection in the existing orchestration test suite.

## Verification

Required command ref `command.public.pylon_khala.verify.28484fe0b746db06b92c2eb2` resolved to:

```sh
bun run --cwd apps/pylon test
```

Output:

```text
$ bun test --max-concurrency=1
1981 pass
3 skip
0 fail
8624 expect() calls
Ran 1984 tests across 274 files. [32.45s]
```

Additional focused checks:

```sh
bun test apps/pylon/src/orchestration/supervisor-orchestration.test.ts
```

```text
20 pass
0 fail
91 expect() calls
Ran 20 tests across 1 file. [130.00ms]
```

```sh
bun run --cwd apps/pylon typecheck
```

```text
$ tsc -p tsconfig.json --noEmit
```

`bun run check:deploy` was run and currently fails before reaching this Pylon change in the existing `apps/openagents.com` architecture gate:

```text
Zero-debt architecture check failed:
- raw time/id/random primitives: count 1, budget 0.
  workers/api/src/inference/gym/mutalisk-khala-delegation-routes.ts: 1
- Worker Response return surfaces: count 132, budget 123.
- workers/api/src/inference/gym/mutalisk-khala-delegation-routes.ts: 1 Effect.runPromise call(s) are outside the named temporary bridge allowlist.
- public projection route /api/public/gym/mutalisk-khala-delegation/runs is not in the projection-surface ledger.
error: script "check:architecture" exited with code 1
```

No user-facing copy changed.