### PR TITLE
T6.4: Fixture Codex app-server process

### DIFF
--- a/clients/khala-code-desktop/fixtures/codex-app-server/default-notification-script.json
+++ b/clients/khala-code-desktop/fixtures/codex-app-server/default-notification-script.json
@@ -1,0 +1,147 @@
+{
+  "schema": "khala-code-desktop.fixture-codex-app-server-script.v1",
+  "name": "default-live-shaped-turn",
+  "model": "gpt-5.1-codex-fixture",
+  "modelProvider": "openai",
+  "steps": [
+    {
+      "kind": "notification",
+      "method": "turn/started",
+      "params": {
+        "threadId": "{{threadId}}",
+        "turn": {
+          "id": "{{turnId}}",
+          "status": "inProgress"
+        }
+      }
+    },
+    {
+      "kind": "serverRequest",
+      "requestId": "approval.command.{{turnId}}",
+      "method": "item/commandExecution/requestApproval",
+      "params": {
+        "threadId": "{{threadId}}",
+        "turnId": "{{turnId}}",
+        "itemId": "item-command-{{turnId}}",
+        "command": "printf fixture-app-server",
+        "cwd": "{{cwd}}",
+        "reason": "Fixture command approval before deterministic terminal output.",
+        "availableDecisions": ["accept", "decline"],
+        "proposedExecpolicyAmendment": ["printf fixture-app-server"]
+      }
+    },
+    {
+      "kind": "notification",
+      "method": "item/started",
+      "params": {
+        "threadId": "{{threadId}}",
+        "turnId": "{{turnId}}",
+        "item": {
+          "type": "commandExecution",
+          "id": "item-command-{{turnId}}",
+          "command": "printf fixture-app-server",
+          "cwd": "{{cwd}}",
+          "status": "inProgress"
+        }
+      }
+    },
+    {
+      "kind": "notification",
+      "method": "item/commandExecution/outputDelta",
+      "params": {
+        "threadId": "{{threadId}}",
+        "turnId": "{{turnId}}",
+        "itemId": "item-command-{{turnId}}",
+        "delta": "fixture terminal: booted\n"
+      }
+    },
+    {
+      "kind": "notification",
+      "method": "item/completed",
+      "params": {
+        "threadId": "{{threadId}}",
+        "turnId": "{{turnId}}",
+        "item": {
+          "type": "commandExecution",
+          "id": "item-command-{{turnId}}",
+          "command": "printf fixture-app-server",
+          "cwd": "{{cwd}}",
+          "status": "completed",
+          "exitCode": 0,
+          "aggregatedOutput": "fixture terminal: booted\n"
+        }
+      }
+    },
+    {
+      "kind": "notification",
+      "method": "item/started",
+      "params": {
+        "threadId": "{{threadId}}",
+        "turnId": "{{turnId}}",
+        "item": {
+          "type": "agentMessage",
+          "id": "item-agent-{{turnId}}",
+          "text": ""
+        }
+      }
+    },
+    {
+      "kind": "notification",
+      "method": "item/agentMessage/delta",
+      "params": {
+        "threadId": "{{threadId}}",
+        "turnId": "{{turnId}}",
+        "itemId": "item-agent-{{turnId}}",
+        "delta": "Fixture app-server completed deterministically."
+      }
+    },
+    {
+      "kind": "notification",
+      "method": "item/completed",
+      "params": {
+        "threadId": "{{threadId}}",
+        "turnId": "{{turnId}}",
+        "item": {
+          "type": "agentMessage",
+          "id": "item-agent-{{turnId}}",
+          "text": "Fixture app-server completed deterministically."
+        }
+      }
+    },
+    {
+      "kind": "notification",
+      "method": "thread/tokenUsage/updated",
+      "params": {
+        "threadId": "{{threadId}}",
+        "turnId": "{{turnId}}",
+        "info": {
+          "last_token_usage": {
+            "input_tokens": 11,
+            "cached_input_tokens": 2,
+            "output_tokens": 7,
+            "reasoning_output_tokens": 3,
+            "total_tokens": 21
+          },
+          "total_token_usage": {
+            "input_tokens": 11,
+            "cached_input_tokens": 2,
+            "output_tokens": 7,
+            "reasoning_output_tokens": 3,
+            "total_tokens": 21
+          }
+        }
+      }
+    },
+    {
+      "kind": "notification",
+      "method": "turn/completed",
+      "params": {
+        "threadId": "{{threadId}}",
+        "turn": {
+          "id": "{{turnId}}",
+          "status": "completed"
+        }
+      }
+    }
+  ]
+}

--- a/clients/khala-code-desktop/src/bun/codex-app-server-client.ts
+++ b/clients/khala-code-desktop/src/bun/codex-app-server-client.ts
@@ -1,4 +1,5 @@
 import { spawn } from "node:child_process"
+import { fileURLToPath } from "node:url"
 
 import type {
   KhalaCodeDesktopCodexAppServerControlResult,
@@ -97,6 +98,7 @@ export type CodexAppServerHost = Readonly<{
 }>
 
 export type CreateCodexAppServerHostOptions = {
+  readonly codexArgs?: readonly string[]
   readonly clientInfo?: {
     readonly name: string
     readonly title: string
@@ -116,6 +118,12 @@ const defaultClientInfo = {
   version: "0.1.0",
 }
 
+const DEFAULT_CODEX_APP_SERVER_ARGS = ["app-server", "--stdio"] as const
+
+const DEFAULT_FIXTURE_APP_SERVER_PATH = fileURLToPath(
+  new URL("./fixture-codex-app-server.ts", import.meta.url),
+)
+
 const isoNow = (): string => new Date().toISOString()
 
 const configuredCodexCommand = (
@@ -129,6 +137,40 @@ const configuredCodexCommand = (
   const command = env.KHALA_CODE_CODEX_COMMAND?.trim()
   if (command !== undefined && command.length > 0) return command
   return "codex"
+}
+
+const fixtureEnabled = (env: NodeJS.ProcessEnv): boolean => {
+  const value = env.KHALA_CODE_CODEX_APP_SERVER_FIXTURE?.trim().toLowerCase()
+  return value === "1" || value === "true" || value === "yes"
+}
+
+const configuredLaunch = (
+  env: NodeJS.ProcessEnv,
+  explicitCommand?: string,
+  explicitArgs?: readonly string[],
+): { readonly args: readonly string[]; readonly command: string } => {
+  if (explicitArgs !== undefined) {
+    return {
+      args: explicitArgs,
+      command: configuredCodexCommand(env, explicitCommand),
+    }
+  }
+  if (fixtureEnabled(env)) {
+    return {
+      args: [
+        env.KHALA_CODE_CODEX_APP_SERVER_FIXTURE_PATH?.trim() || DEFAULT_FIXTURE_APP_SERVER_PATH,
+        "--stdio",
+      ],
+      command:
+        explicitCommand?.trim() ||
+        env.KHALA_CODE_BUN_BINARY?.trim() ||
+        process.execPath,
+    }
+  }
+  return {
+    args: DEFAULT_CODEX_APP_SERVER_ARGS,
+    command: configuredCodexCommand(env, explicitCommand),
+  }
 }
 
 const appendDiagnostic = (
@@ -146,7 +188,9 @@ export function createCodexAppServerHost(
   options: CreateCodexAppServerHostOptions = {},
 ): CodexAppServerHost {
   const env = options.env ?? process.env
-  const codexCommand = configuredCodexCommand(env, options.codexCommand)
+  const codexLaunch = configuredLaunch(env, options.codexCommand, options.codexArgs)
+  const codexCommand = codexLaunch.command
+  const codexArgs = codexLaunch.args
   const codexHome = resolveCodexHomePath(options.codexHomePath, env)
   const spawnFn: SpawnFn =
     options.spawnFn ??
@@ -364,7 +408,7 @@ export function createCodexAppServerHost(
     stdoutBuffer = ""
     stderrBuffer = ""
     try {
-      const spawned = spawnFn(codexCommand, ["app-server", "--stdio"], {
+      const spawned = spawnFn(codexCommand, codexArgs, {
         env: {
           ...env,
           CODEX_HOME: codexHome,

--- a/clients/khala-code-desktop/src/bun/codex-parity-contract.ts
+++ b/clients/khala-code-desktop/src/bun/codex-parity-contract.ts
@@ -120,6 +120,17 @@ export const KHALA_CODE_CODEX_PARITY_COVERAGE: readonly KhalaCodeCodexParityCove
     ],
   },
   {
+    id: "fixture-app-server-process",
+    harness: "codex_wrapper_fixture",
+    testFile: "clients/khala-code-desktop/tests/fixture-codex-app-server.test.ts",
+    covers: [
+      "spawned fixture Codex app-server stdio process",
+      "recorded notification script replay",
+      "server-to-client approval request and resolution",
+      "background terminal command output",
+    ],
+  },
+  {
     id: "headless-jsonl",
     harness: "codex_wrapper_fixture",
     testFile: "clients/khala-code-desktop/tests/headless.test.ts",

--- a/clients/khala-code-desktop/src/bun/fixture-codex-app-server.ts
+++ b/clients/khala-code-desktop/src/bun/fixture-codex-app-server.ts
@@ -1,0 +1,639 @@
+import { readFile } from "node:fs/promises"
+import { createInterface } from "node:readline"
+
+type JsonRpcId = number | string
+type JsonObject = Record<string, unknown>
+
+type FixtureScript = Readonly<{
+  model: string
+  modelProvider: string
+  name: string
+  schema: "khala-code-desktop.fixture-codex-app-server-script.v1"
+  steps: readonly FixtureScriptStep[]
+}>
+
+type FixtureScriptStep =
+  | Readonly<{
+      kind: "notification"
+      method: string
+      params: JsonObject
+    }>
+  | Readonly<{
+      kind: "serverRequest"
+      method: string
+      params: JsonObject
+      requestId: string
+    }>
+
+type JsonRpcMessage = Readonly<{
+  id?: JsonRpcId
+  method?: string
+  params?: unknown
+  result?: unknown
+}>
+
+type ThreadRecord = {
+  archived: boolean
+  cwd: string
+  id: string
+  name: string | null
+  status: string
+  turns: TurnRecord[]
+  updatedAt: string
+}
+
+type TurnRecord = {
+  id: string
+  items: JsonObject[]
+  status: string
+}
+
+type ActiveTurn = {
+  completed: boolean
+  interrupted: boolean
+  threadId: string
+  turnId: string
+}
+
+type TemplateContext = Readonly<{
+  approvalResponse?: unknown
+  cwd: string
+  threadId: string
+  turnId: string
+}>
+
+const DEFAULT_SCRIPT_URL = new URL(
+  "../../fixtures/codex-app-server/default-notification-script.json",
+  import.meta.url,
+)
+
+const isoNow = (): string => new Date().toISOString()
+
+const isObject = (value: unknown): value is JsonObject =>
+  typeof value === "object" && value !== null && !Array.isArray(value)
+
+const stringField = (value: unknown, field: string): string | null => {
+  if (!isObject(value)) return null
+  const candidate = value[field]
+  return typeof candidate === "string" && candidate.length > 0 ? candidate : null
+}
+
+const numberField = (value: unknown, field: string): number | null => {
+  if (!isObject(value)) return null
+  const candidate = value[field]
+  return typeof candidate === "number" && Number.isFinite(candidate) ? candidate : null
+}
+
+const objectField = (value: unknown, field: string): JsonObject | null => {
+  if (!isObject(value)) return null
+  const candidate = value[field]
+  return isObject(candidate) ? candidate : null
+}
+
+const arrayField = (value: unknown, field: string): readonly unknown[] => {
+  if (!isObject(value)) return []
+  const candidate = value[field]
+  return Array.isArray(candidate) ? candidate : []
+}
+
+const cloneJson = <Value>(value: Value): Value =>
+  JSON.parse(JSON.stringify(value)) as Value
+
+const writeJsonLine = (value: unknown): void => {
+  process.stdout.write(`${JSON.stringify(value)}\n`)
+}
+
+const writeErrorLine = (message: string): void => {
+  process.stderr.write(`${JSON.stringify({
+    level: "debug",
+    target: "khala-code-fixture-codex-app-server",
+    message,
+  })}\n`)
+}
+
+const jsonRpcError = (
+  id: JsonRpcId | undefined,
+  code: number,
+  message: string,
+): void => {
+  if (id === undefined) return
+  writeJsonLine({ id, error: { code, message } })
+}
+
+const parseArgs = (
+  argv: readonly string[],
+  env: Readonly<Record<string, string | undefined>>,
+): { readonly scriptPath: string | URL } => {
+  let scriptPath: string | URL = env.KHALA_CODE_CODEX_APP_SERVER_FIXTURE_SCRIPT ?? DEFAULT_SCRIPT_URL
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index]
+    if (arg === "--script") {
+      const next = argv[index + 1]
+      if (next === undefined || next.trim().length === 0) {
+        throw new Error("--script requires a path")
+      }
+      scriptPath = next
+      index += 1
+    }
+  }
+  return { scriptPath }
+}
+
+const readFixtureScript = async (
+  scriptPath: string | URL,
+): Promise<FixtureScript> => {
+  const parsed = JSON.parse(await readFile(scriptPath, "utf8")) as unknown
+  if (!isObject(parsed) || parsed.schema !== "khala-code-desktop.fixture-codex-app-server-script.v1") {
+    throw new Error("Fixture app-server script has an unsupported schema.")
+  }
+  const steps = arrayField(parsed, "steps")
+  if (steps.length === 0) {
+    throw new Error("Fixture app-server script must include at least one step.")
+  }
+  return parsed as FixtureScript
+}
+
+const applyTemplateString = (
+  value: string,
+  context: TemplateContext,
+): string =>
+  value
+    .replaceAll("{{threadId}}", context.threadId)
+    .replaceAll("{{turnId}}", context.turnId)
+    .replaceAll("{{cwd}}", context.cwd)
+
+const applyTemplate = (
+  value: unknown,
+  context: TemplateContext,
+): unknown => {
+  if (typeof value === "string") return applyTemplateString(value, context)
+  if (Array.isArray(value)) return value.map(item => applyTemplate(item, context))
+  if (!isObject(value)) return value
+  return Object.fromEntries(
+    Object.entries(value).map(([key, entry]) => [key, applyTemplate(entry, context)]),
+  )
+}
+
+class FixtureCodexAppServer {
+  private readonly activeTurns = new Map<string, ActiveTurn>()
+  private readonly pendingServerResponses = new Map<JsonRpcId, (value: unknown) => void>()
+  private readonly threads = new Map<string, ThreadRecord>()
+  private nextThread = 0
+  private nextTurn = 0
+
+  constructor(
+    private readonly script: FixtureScript,
+    private readonly env: Readonly<Record<string, string | undefined>>,
+  ) {}
+
+  async handle(message: JsonRpcMessage): Promise<void> {
+    if (message.method === undefined && message.id !== undefined) {
+      this.resolveServerRequest(message.id, message.result ?? {})
+      return
+    }
+    if (typeof message.method !== "string") {
+      jsonRpcError(message.id, -32600, "Invalid JSON-RPC message.")
+      return
+    }
+    if (message.id === undefined) {
+      this.handleClientNotification(message.method)
+      return
+    }
+    try {
+      const result = await this.handleRequest(message.method, message.params ?? {})
+      writeJsonLine({ id: message.id, result })
+    } catch (error) {
+      jsonRpcError(
+        message.id,
+        -32000,
+        error instanceof Error ? error.message : String(error),
+      )
+    }
+  }
+
+  private handleClientNotification(method: string): void {
+    if (method !== "initialized") {
+      writeErrorLine(`ignored client notification: ${method}`)
+    }
+  }
+
+  private async handleRequest(method: string, params: unknown): Promise<unknown> {
+    switch (method) {
+      case "initialize":
+        return this.initializeResult()
+      case "model/list":
+        return this.modelListResult()
+      case "permissionProfile/list":
+        return this.permissionProfileListResult()
+      case "config/value/write":
+      case "config/mcpServer/reload":
+        return { ok: true, fixture: true }
+      case "thread/start":
+        return this.threadStart(params)
+      case "thread/resume":
+        return this.threadResume(params)
+      case "thread/list":
+        return this.threadList(params)
+      case "thread/read":
+        return this.threadRead(params)
+      case "thread/name/set":
+        return this.threadNameSet(params)
+      case "thread/archive":
+        return this.threadArchive(params, true)
+      case "thread/unarchive":
+        return this.threadArchive(params, false)
+      case "thread/delete":
+        return this.threadDelete(params)
+      case "thread/fork":
+        return this.threadFork(params)
+      case "thread/compact/start":
+        return this.threadCompactStart(params)
+      case "turn/start":
+        return this.turnStart(params)
+      case "turn/steer":
+        return this.turnSteer(params)
+      case "turn/interrupt":
+        return this.turnInterrupt(params)
+      default:
+        throw new Error(`Fixture Codex app-server does not implement ${method}.`)
+    }
+  }
+
+  private initializeResult(): JsonObject {
+    return {
+      protocolVersion: "khala-code-fixture-app-server-v1",
+      serverInfo: {
+        name: "khala-code-fixture-codex-app-server",
+        version: "0.1.0",
+      },
+      userAgent: "khala-code-fixture-codex-app-server/0.1.0",
+      codexHome: this.env.CODEX_HOME ?? null,
+      platformFamily: process.platform === "win32" ? "windows" : "unix",
+      platformOs: process.platform,
+      fixtureScript: this.script.name,
+    }
+  }
+
+  private modelListResult(): JsonObject {
+    return {
+      models: [{
+        id: this.script.model,
+        name: "Fixture Codex",
+        provider: this.script.modelProvider,
+      }],
+    }
+  }
+
+  private permissionProfileListResult(): JsonObject {
+    return {
+      profiles: [{
+        id: "fixture-read-write",
+        name: "Fixture read/write",
+        permissions: {
+          fileSystem: {
+            read: ["."],
+            write: ["."],
+          },
+          network: { enabled: false },
+        },
+      }],
+    }
+  }
+
+  private threadStart(params: unknown): JsonObject {
+    const thread = this.createThread(stringField(params, "cwd") ?? process.cwd())
+    return this.threadEnvelope(thread)
+  }
+
+  private threadResume(params: unknown): JsonObject {
+    const thread = this.requireThread(params)
+    return this.threadEnvelope(thread)
+  }
+
+  private threadList(params: unknown): JsonObject {
+    const archivedValue = isObject(params) ? params.archived : undefined
+    const limit = numberField(params, "limit") ?? 50
+    const archivedFilter = typeof archivedValue === "boolean" ? archivedValue : undefined
+    const data = [...this.threads.values()]
+      .filter(thread => archivedFilter === undefined || thread.archived === archivedFilter)
+      .sort((left, right) => right.updatedAt.localeCompare(left.updatedAt))
+      .slice(0, limit)
+      .map(thread => this.compactThread(thread))
+    return {
+      data,
+      backwardsCursor: null,
+      nextCursor: null,
+    }
+  }
+
+  private threadRead(params: unknown): JsonObject {
+    const thread = this.requireThread(params)
+    const includeTurns = isObject(params) && params.includeTurns === true
+    return this.threadEnvelope(thread, includeTurns)
+  }
+
+  private threadNameSet(params: unknown): JsonObject {
+    const thread = this.requireThread(params)
+    thread.name = stringField(params, "name") ?? thread.name
+    thread.updatedAt = isoNow()
+    return this.threadEnvelope(thread)
+  }
+
+  private threadArchive(params: unknown, archived: boolean): JsonObject {
+    const thread = this.requireThread(params)
+    thread.archived = archived
+    thread.updatedAt = isoNow()
+    return this.threadEnvelope(thread)
+  }
+
+  private threadDelete(params: unknown): JsonObject {
+    const thread = this.requireThread(params)
+    this.threads.delete(thread.id)
+    return { ok: true, threadId: thread.id }
+  }
+
+  private threadFork(params: unknown): JsonObject {
+    const source = this.requireThread(params)
+    const fork = this.createThread(stringField(params, "cwd") ?? source.cwd)
+    fork.turns = source.turns.map(turn => ({
+      id: `${turn.id}-fork`,
+      items: cloneJson(turn.items),
+      status: turn.status,
+    }))
+    fork.name = source.name === null ? null : `${source.name} (fixture fork)`
+    return this.threadEnvelope(fork, true)
+  }
+
+  private threadCompactStart(params: unknown): JsonObject {
+    const thread = this.requireThread(params)
+    const turn = this.createTurn(thread, "completed")
+    turn.items.push({
+      type: "contextCompaction",
+      id: `item-compact-${turn.id}`,
+    })
+    return {
+      turn: {
+        id: turn.id,
+        status: turn.status,
+      },
+    }
+  }
+
+  private turnStart(params: unknown): JsonObject {
+    const thread = this.requireThread(params)
+    const turn = this.createTurn(thread, "inProgress")
+    const input = arrayField(params, "input")
+    const clientUserMessageId = stringField(params, "clientUserMessageId") ?? `user-${turn.id}`
+    const userText = input
+      .filter(isObject)
+      .filter(item => item.type === "text")
+      .map(item => typeof item.text === "string" ? item.text : "")
+      .filter(Boolean)
+      .join("\n\n")
+    turn.items.push({
+      type: "userMessage",
+      id: clientUserMessageId,
+      content: [{ type: "text", text: userText }],
+    })
+    const active: ActiveTurn = {
+      completed: false,
+      interrupted: false,
+      threadId: thread.id,
+      turnId: turn.id,
+    }
+    this.activeTurns.set(turn.id, active)
+    queueMicrotask(() => {
+      void this.runScript(thread, turn, active).catch(error => {
+        writeErrorLine(error instanceof Error ? error.message : String(error))
+      })
+    })
+    return {
+      turn: {
+        id: turn.id,
+        status: turn.status,
+      },
+    }
+  }
+
+  private turnSteer(params: unknown): JsonObject {
+    const thread = this.requireThread(params)
+    const expectedTurnId = stringField(params, "expectedTurnId")
+    const active = expectedTurnId === null ? null : this.activeTurns.get(expectedTurnId)
+    if (active === undefined || active === null) {
+      throw new Error("No active fixture turn is available for steering.")
+    }
+    return {
+      turnId: active.turnId,
+      threadId: thread.id,
+    }
+  }
+
+  private turnInterrupt(params: unknown): JsonObject {
+    const thread = this.requireThread(params)
+    const turnId = stringField(params, "turnId")
+    if (turnId === null) throw new Error("turn/interrupt requires turnId.")
+    const active = this.activeTurns.get(turnId)
+    if (active === undefined) {
+      throw new Error(`No active fixture turn ${turnId}.`)
+    }
+    active.interrupted = true
+    active.completed = true
+    const turn = thread.turns.find(candidate => candidate.id === turnId)
+    if (turn !== undefined) turn.status = "interrupted"
+    this.notify("turn/completed", {
+      threadId: thread.id,
+      turn: {
+        id: turnId,
+        status: "interrupted",
+      },
+    })
+    return {
+      ok: true,
+      threadId: thread.id,
+      turnId,
+    }
+  }
+
+  private async runScript(
+    thread: ThreadRecord,
+    turn: TurnRecord,
+    active: ActiveTurn,
+  ): Promise<void> {
+    let approvalResponse: unknown
+    for (const step of this.script.steps) {
+      if (active.completed || active.interrupted) return
+      const context = {
+        approvalResponse,
+        cwd: thread.cwd,
+        threadId: thread.id,
+        turnId: turn.id,
+      }
+      if (step.kind === "notification") {
+        const params = applyTemplate(step.params, context)
+        this.recordCompletedItem(turn, step.method, params)
+        this.notify(step.method, params)
+        if (step.method === "turn/completed") {
+          turn.status = completedTurnStatus(params)
+          active.completed = true
+          this.activeTurns.delete(turn.id)
+        }
+      } else {
+        const requestId = applyTemplateString(step.requestId, context)
+        const params = applyTemplate(step.params, context)
+        approvalResponse = await this.requestClient(requestId, step.method, params)
+        if (active.completed || active.interrupted) return
+        this.notify("serverRequest/resolved", {
+          requestId,
+          threadId: thread.id,
+          turnId: turn.id,
+        })
+      }
+      await Promise.resolve()
+    }
+  }
+
+  private requestClient(
+    id: JsonRpcId,
+    method: string,
+    params: unknown,
+  ): Promise<unknown> {
+    writeJsonLine({ id, method, params })
+    return new Promise(resolve => {
+      this.pendingServerResponses.set(id, resolve)
+    })
+  }
+
+  private resolveServerRequest(id: JsonRpcId, result: unknown): void {
+    const resolve = this.pendingServerResponses.get(id)
+    if (resolve === undefined) {
+      writeErrorLine(`ignored response for unknown server request ${String(id)}`)
+      return
+    }
+    this.pendingServerResponses.delete(id)
+    resolve(result)
+  }
+
+  private notify(method: string, params: unknown): void {
+    writeJsonLine({ method, params })
+  }
+
+  private createThread(cwd: string): ThreadRecord {
+    this.nextThread += 1
+    const thread: ThreadRecord = {
+      archived: false,
+      cwd,
+      id: `fixture-thread-${this.nextThread}`,
+      name: null,
+      status: "running",
+      turns: [],
+      updatedAt: isoNow(),
+    }
+    this.threads.set(thread.id, thread)
+    return thread
+  }
+
+  private createTurn(thread: ThreadRecord, status: string): TurnRecord {
+    this.nextTurn += 1
+    const turn: TurnRecord = {
+      id: `fixture-turn-${this.nextTurn}`,
+      items: [],
+      status,
+    }
+    thread.turns.push(turn)
+    thread.updatedAt = isoNow()
+    return turn
+  }
+
+  private requireThread(params: unknown): ThreadRecord {
+    const threadId = stringField(params, "threadId")
+    if (threadId === null) throw new Error("Fixture app-server request requires threadId.")
+    const thread = this.threads.get(threadId)
+    if (thread === undefined) throw new Error(`Thread not found: ${threadId}`)
+    return thread
+  }
+
+  private threadEnvelope(thread: ThreadRecord, includeTurns = true): JsonObject {
+    return {
+      cwd: thread.cwd,
+      model: this.script.model,
+      modelProvider: this.script.modelProvider,
+      thread: this.fullThread(thread, includeTurns),
+    }
+  }
+
+  private compactThread(thread: ThreadRecord): JsonObject {
+    return {
+      archived: thread.archived,
+      cwd: thread.cwd,
+      id: thread.id,
+      name: thread.name,
+      status: thread.status,
+      updatedAt: thread.updatedAt,
+    }
+  }
+
+  private fullThread(thread: ThreadRecord, includeTurns: boolean): JsonObject {
+    return {
+      ...this.compactThread(thread),
+      ...(includeTurns
+        ? {
+            turns: thread.turns.map(turn => ({
+              id: turn.id,
+              status: turn.status,
+              items: cloneJson(turn.items),
+            })),
+          }
+        : {}),
+    }
+  }
+
+  private recordCompletedItem(turn: TurnRecord, method: string, params: unknown): void {
+    if (method !== "item/completed") return
+    const item = objectField(params, "item")
+    if (item === null) return
+    const id = stringField(item, "id")
+    if (id !== null) {
+      const existingIndex = turn.items.findIndex(candidate => stringField(candidate, "id") === id)
+      if (existingIndex !== -1) {
+        turn.items.splice(existingIndex, 1, cloneJson(item))
+        return
+      }
+    }
+    turn.items.push(cloneJson(item))
+  }
+}
+
+const completedTurnStatus = (params: unknown): string => {
+  const turn = objectField(params, "turn")
+  return stringField(turn, "status") ?? "completed"
+}
+
+export async function runFixtureCodexAppServer(
+  input: {
+    readonly argv?: readonly string[]
+    readonly env?: Readonly<Record<string, string | undefined>>
+  } = {},
+): Promise<void> {
+  const env = input.env ?? process.env
+  const args = parseArgs(input.argv ?? Bun.argv.slice(2), env)
+  const script = await readFixtureScript(args.scriptPath)
+  const server = new FixtureCodexAppServer(script, env)
+  const lines = createInterface({
+    crlfDelay: Infinity,
+    input: process.stdin,
+  })
+
+  for await (const line of lines) {
+    const trimmed = line.trim()
+    if (trimmed.length === 0) continue
+    try {
+      await server.handle(JSON.parse(trimmed) as JsonRpcMessage)
+    } catch (error) {
+      writeErrorLine(error instanceof Error ? error.message : String(error))
+    }
+  }
+}
+
+if (import.meta.main) {
+  await runFixtureCodexAppServer()
+}

--- a/clients/khala-code-desktop/src/bun/khala-codex-fleet-tools.ts
+++ b/clients/khala-code-desktop/src/bun/khala-codex-fleet-tools.ts
@@ -1052,10 +1052,18 @@ async function runPylonCommand(
     readonly timeoutMs: number
   },
 ): Promise<KhalaCodexFleetCommandResult> {
+  const commandEnv = pylonCommandEnv(input.env, input.paths.pylonHome)
+  const runnerEnv = args.includes("--base-url")
+    ? Object.fromEntries(
+        Object.entries(commandEnv).filter(([key]) =>
+          key !== "PYLON_OPENAGENTS_BASE_URL" && key !== "OPENAGENTS_BASE_URL"
+        ),
+      )
+    : commandEnv
   return (input.runner ?? defaultCommandRunner)({
     cmd: [input.paths.bunExecutable, "src/index.ts", ...args],
     cwd: input.paths.appPath,
-    env: pylonCommandEnv(input.env, input.paths.pylonHome),
+    env: runnerEnv,
     maxOutputBytes: input.maxOutputBytes ?? 80_000,
     onStderrLine: input.onStderrLine,
     timeoutMs: input.timeoutMs,

--- a/clients/khala-code-desktop/tests/fixture-codex-app-server.test.ts
+++ b/clients/khala-code-desktop/tests/fixture-codex-app-server.test.ts
@@ -1,0 +1,170 @@
+import { mkdtemp, rm } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { fileURLToPath } from "node:url"
+import { afterEach, describe, expect, test } from "bun:test"
+
+import {
+  createCodexAppServerChatRuntime,
+} from "../src/bun/codex-app-server-chat-runtime"
+import {
+  createCodexAppServerHost,
+  type CodexAppServerNotification,
+} from "../src/bun/codex-app-server-client"
+import type { KhalaCodeDesktopChatTurnEvent } from "../src/shared/rpc"
+
+const fixtureAppServerPath = fileURLToPath(
+  new URL("../src/bun/fixture-codex-app-server.ts", import.meta.url),
+)
+
+const tempDirs: string[] = []
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map(dir => rm(dir, { force: true, recursive: true })))
+})
+
+async function tempRoot(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "khala-code-fixture-app-server-"))
+  tempDirs.push(root)
+  return root
+}
+
+async function waitFor(
+  predicate: () => boolean,
+  label: string,
+): Promise<void> {
+  for (let index = 0; index < 200; index += 1) {
+    if (predicate()) return
+    await Bun.sleep(5)
+  }
+  throw new Error(`Timed out waiting for ${label}`)
+}
+
+describe("fixture Codex app-server process", () => {
+  test("spawns over stdio and streams approvals plus terminal output through the real runtime", async () => {
+    const root = await tempRoot()
+    const notifications: CodexAppServerNotification[] = []
+    const events: KhalaCodeDesktopChatTurnEvent[] = []
+    const host = createCodexAppServerHost({
+      codexArgs: [fixtureAppServerPath, "--stdio"],
+      codexCommand: process.execPath,
+      env: {
+        CODEX_HOME: join(root, "codex-home"),
+      } as NodeJS.ProcessEnv,
+      initializeTimeoutMs: 1_000,
+      requestTimeoutMs: 1_000,
+    })
+    host.subscribe(notification => {
+      notifications.push(notification)
+      if (
+        notification.method === "item/commandExecution/requestApproval" &&
+        notification.id !== undefined
+      ) {
+        queueMicrotask(() => {
+          host.respondToServerRequest(notification.id!, { decision: "accept" })
+        })
+      }
+    })
+    const runtime = createCodexAppServerChatRuntime({
+      host,
+      onEvent: event => events.push(event),
+      statePath: join(root, "codex-sessions.json"),
+      turnTimeoutMs: 2_000,
+      workingDirectory: root,
+    })
+
+    try {
+      const response = await runtime.startTurn({
+        messages: [{ body: "exercise the fixture app-server", id: "user-fixture", role: "user" }],
+        sessionId: "desktop-session-fixture",
+        turnId: "desktop-turn-fixture",
+      })
+
+      await waitFor(
+        () => notifications.some(notification => notification.method === "turn/completed"),
+        "fixture turn completion",
+      )
+
+      expect(response).toMatchObject({
+        backend: {
+          kind: "codex_app_server",
+          model: "gpt-5.1-codex-fixture",
+          threadId: "fixture-thread-1",
+          turnId: "fixture-turn-1",
+          turnStatus: "completed",
+        },
+        ok: true,
+        usage: {
+          cachedInput: 2,
+          input: 11,
+          output: 7,
+          reasoningOutput: 3,
+        },
+      })
+      expect(notifications.map(notification => notification.method)).toEqual([
+        "turn/started",
+        "item/commandExecution/requestApproval",
+        "serverRequest/resolved",
+        "item/started",
+        "item/commandExecution/outputDelta",
+        "item/completed",
+        "item/started",
+        "item/agentMessage/delta",
+        "item/completed",
+        "thread/tokenUsage/updated",
+        "turn/completed",
+      ])
+      expect(events.map(event => event.type)).toContain("message_delta")
+      expect(response.messages.some(message =>
+        message.codexItem?.itemType === "approval" &&
+        message.codexItem.status === "completed" &&
+        message.body.includes("Approval resolved.")
+      )).toBe(true)
+      expect(response.messages.some(message =>
+        message.codexItem?.itemType === "commandExecution" &&
+        message.body.includes("fixture terminal: booted")
+      )).toBe(true)
+      expect(response.messages.some(message =>
+        message.role === "assistant" &&
+        message.body === "Fixture app-server completed deterministically."
+      )).toBe(true)
+
+      const read = await runtime.readThread({
+        includeTurns: true,
+        threadId: "fixture-thread-1",
+      })
+      expect(read.messages?.map(message => message.id)).toContain("item-command-fixture-turn-1")
+      expect(read.messages?.map(message => message.id)).toContain("item-agent-fixture-turn-1")
+    } finally {
+      host.dispose()
+    }
+  })
+
+  test("can be selected through the host fixture environment switch", async () => {
+    const root = await tempRoot()
+    const host = createCodexAppServerHost({
+      env: {
+        CODEX_HOME: join(root, "codex-home"),
+        KHALA_CODE_BUN_BINARY: process.execPath,
+        KHALA_CODE_CODEX_APP_SERVER_FIXTURE: "1",
+        KHALA_CODE_CODEX_APP_SERVER_FIXTURE_PATH: fixtureAppServerPath,
+      } as NodeJS.ProcessEnv,
+      initializeTimeoutMs: 1_000,
+      requestTimeoutMs: 1_000,
+    })
+
+    try {
+      const start = await host.start()
+
+      expect(start.ok).toBe(true)
+      expect(start.status.initializeResult).toMatchObject({
+        fixtureScript: "default-live-shaped-turn",
+        serverInfo: {
+          name: "khala-code-fixture-codex-app-server",
+        },
+      })
+    } finally {
+      host.dispose()
+    }
+  })
+})


### PR DESCRIPTION
## Summary

- Add a small Bun fixture Codex app-server process that speaks line-delimited JSON-RPC over stdio.
- Add a recorded fixture notification script covering a turn lifecycle, server-to-client command approval, terminal command output, assistant output, token usage, and completion.
- Let the desktop app-server host launch the fixture via explicit args or `KHALA_CODE_CODEX_APP_SERVER_FIXTURE=1` while preserving the default `codex app-server --stdio` path.
- Harden Pylon subprocess env isolation when a command already carries an explicit `--base-url`.

Closes #7848

## Verification

Required verification ref `command.public.pylon_khala.verify.d32c71ee8e1025e99460d008` maps to:

```sh
bun run --cwd clients/khala-code-desktop test
```

Output:

```text
$ bun test tests/*.test.ts
bun test v1.3.11 (af24e281)

 310 pass
 0 fail
 2030 expect() calls
Ran 310 tests across 40 files. [4.51s]
```

Additional scoped package verification:

```sh
bun run --cwd clients/khala-code-desktop verify
```

Output excerpt:

```text
$ tsc -p tsconfig.typecheck.json --noEmit
bun test v1.3.11 (af24e281)

 310 pass
 0 fail
 2030 expect() calls
Ran 310 tests across 40 files. [4.17s]
$ vite build
✓ built in 262ms
Bundled 2272 modules in 173ms
```

`bun run check:deploy` was also run and failed on unrelated existing OpenAgents.com architecture guard debt:

```text
Zero-debt architecture check failed:
- raw time/id/random primitives: count 1, budget 0 (workers/api/src/inference/gym/mutalisk-khala-delegation-routes.ts)
- Worker Response return surfaces: count 132, budget 123
- workers/api/src/inference/gym/mutalisk-khala-delegation-routes.ts: 1 Effect.runPromise call(s) are outside the named temporary bridge allowlist.
- public projection route /api/public/gym/mutalisk-khala-delegation/runs is not in the projection-surface ledger.
```
