### PR TITLE
T16.2: Docs upkeep

### DIFF
--- a/docs/codex/2026-06-30-codex-to-khala-code-porting-audit.md
+++ b/docs/codex/2026-06-30-codex-to-khala-code-porting-audit.md
@@ -8,6 +8,13 @@ ships as **Khala Code**, and proposes a concrete, parallelizable "port Codex
 into our coding app overnight" plan. This doc flips no promise state, changes no
 runtime authority, and broadens no public copy.
 
+**July 1 architecture note:** this audit captured the pre-pivot porting plan.
+The current Khala Code architecture is the **Codex-wrapper** path: Khala Code
+wraps Codex app-server as the default harness and implements only small
+desktop-local adapters or documented upstream gap placeholders where app-server
+coverage is missing. Treat the lane plan below as historical donor analysis for
+fallback/native-runtime work, not the current product-center execution plan.
+
 Inputs:
 
 - `docs/research/terminal-agents/codex.md` — the deep Codex tool-layer study.
@@ -26,25 +33,16 @@ Inputs:
 
 ## 0. TL;DR
 
-**We are much further along than "we should build a coding agent."** Khala Code
-is a working agentic coding app: the desktop runs a real tool loop over a native
-Effect/Effect-Schema tool runtime (`@openagentsinc/khala-tools`) that already
-implements the full Codex-equivalent core catalog (`read`, `ls`, `glob`, `grep`,
-`edit`, `write`, `apply_patch`, `exec_command`, `write_stdin`, `ask_user`,
-`todo_write`, `view_image`, plus `web_fetch`/`web_search`/`browser` presets),
-four-lane results, an OpenAI-compatible tool adapter, scoped permission
-requests, and default-on Rampart PII redaction. ADR 0012's accepted plan has
-**shipped**.
+**Historical pre-pivot read:** Khala Code was already much further along than
+"we should build a coding agent." The desktop had a real tool loop over the
+native Effect/Effect-Schema runtime (`@openagentsinc/khala-tools`) and ADR
+0012's accepted native-runtime plan had shipped.
 
-So the porting question is not "copy Codex's tool catalog" — we have it. It is:
-**which of Codex's harder, lower-down execution-boundary machinery should we
-port next, where we currently have honest stubs or nothing.** Those are, in
-priority order: (1) real sandbox enforcement, (2) a central tool dispatcher with
-hooks/lifecycle/telemetry, (3) durable session persistence + resume/fork
-(rollout-style JSONL), (4) atomic `apply_patch`, (5) compaction, (6) a headless
-JSONL event schema, (7) MCP, (8) the planner/feature/config/provider polish, and
-— **last** — (9) a session-scoped approval cache + real product permission policy
-to replace `allowAllKhalaPermissionService`.
+**Current July 1 read:** the porting question changed. Khala Code should not
+clone Codex Core or rebuild Codex TUI behavior in TypeScript when Codex
+app-server already exposes the state or mutation. The default path is now:
+wrap Codex app-server, keep desktop adapters small and tested, and file narrow
+upstream app-server gaps for the missing TUI-owned semantics.
 
 **Deliberate stance for now: Khala Code runs permit-all ("YOLO"), for trusted
 local operators only.** The desktop keeps `allowAllKhalaPermissionService` as the

--- a/docs/khala-code/2026-06-30-khala-code-fleet-management-spec.md
+++ b/docs/khala-code/2026-06-30-khala-code-fleet-management-spec.md
@@ -7,6 +7,13 @@ the "manage many coding agents from one place" capability, maps each feature to
 what OpenAgents has **already built**, and lists the remaining gaps. This is a
 planning artifact: it flips no promise state and broadens no public copy.
 
+**July 1 architecture note:** this June 30 spec is pre-pivot context. The
+current Khala Code architecture is the **Codex-wrapper** path: desktop and CLI
+surfaces wrap Codex app-server as the default harness, while Pylon fleet
+delegation remains the owner-local capacity layer for linked Codex accounts.
+The native `@openagentsinc/khala-tools` runtime is now legacy/fallback for coding
+work, not the center of the default Khala Code execution path.
+
 ## 0. Identity note (read first)
 
 External landscape research conflated two unrelated projects both called
@@ -65,11 +72,9 @@ sending the owner's configs or code to a cloud. The capabilities:
   an Apple FM local backend.
 - **`@openagentsinc/khala-tools`**: the provider-neutral tool runtime — read/ls/
   glob/grep/edit/write/apply_patch/exec_command/write_stdin/ask_user/todo_write/
-  view_image/web_*/browser — now with the Codex-port lanes merged: central
-  dispatcher (A), macOS sandbox (C), atomic apply_patch (D), session rollout +
-  resume (E), headless JSONL events (F), compaction (G), MCP client+server (H),
-  tool planner + progressive disclosure (I), PTY exec (J), feature-flag registry
-  (K), and a product permission policy + session approval cache (B).
+  view_image/web_*/browser — pre-pivot native runtime coverage. After the July 1
+  Codex-wrapper pivot, this remains useful fallback/donor machinery; default
+  coding parity should come from Codex app-server methods first.
 - **Pylon delegation**: `khala request` / `assignment run-no-spend`, the
   workspace materializer, Codex/Claude executors with isolated per-account homes,
   the approval queue + bounded auto-approval policy, and the

--- a/docs/khala-code/2026-07-01-upstream-gap-filings.md
+++ b/docs/khala-code/2026-07-01-upstream-gap-filings.md
@@ -1,0 +1,171 @@
+# Khala Code Upstream Codex App-server Gap Filings
+
+Date: 2026-07-01
+Source matrix: `docs/khala-code/2026-07-01-codex-app-server-gap-matrix.md`
+Tracking context: OpenAgents issue #7903 / T16.2
+
+Status: draft upstream writeups for Codex app-server gaps. These are not public
+product copy and do not change Khala Code promise state. They are written so an
+operator can file narrow upstream Codex issues or PR notes without copying
+private OpenAgents runtime details.
+
+## Filing 1: `codex.app_server.gap.tui_preferences`
+
+Title: Expose app-server preference metadata for TUI-owned appearance controls
+
+Current Khala wrapper state:
+Khala Code can already persist preference values through Codex app-server
+`config/read`, `config/value/write`, and `config/batchWrite` for keymap, Vim
+default mode, statusline, theme, pets, pet anchor, and personality.
+
+Upstream gap:
+Codex TUI still owns richer picker metadata and validation affordances for
+`/keymap`, `/vim`, `/statusline`, `/theme`, `/pets`, and `/personality`. A
+desktop wrapper can write known config keys, but it cannot present the same
+option lists, labels, defaults, and validation semantics without duplicating TUI
+logic.
+
+Requested app-server shape:
+Add a read method that returns preference descriptors for these controls:
+stable key, current value, allowed values, display labels, default value,
+validation errors, and whether a restart or new turn is required.
+
+Acceptance:
+- Desktop clients can render the same available options as Codex TUI without
+  importing TUI picker code.
+- Writes still go through existing config mutation methods unless Codex wants a
+  dedicated preference mutation endpoint.
+- Invalid values produce typed app-server errors.
+
+## Filing 2: `codex.app_server.gap.memory_and_import_management`
+
+Title: Add app-server methods for memories and AGENTS.md init semantics
+
+Current Khala wrapper state:
+Khala Code wraps existing app-server methods for `skills/list`,
+`skills/config/write`, `skills/extraRoots/set`, `hooks/list`,
+`externalAgentConfig/detect`, `externalAgentConfig/import`,
+`externalAgentConfig/import/readHistories`, `fs/readFile`, `fs/writeFile`, and
+`fs/getMetadata`.
+
+Upstream gap:
+`/memories`, `/init`, `/debug-m-drop`, and `/debug-m-update` still depend on
+TUI-owned semantics. A desktop wrapper should not independently define memory
+list, memory mutation, debug-memory behavior, or AGENTS.md initialization rules.
+
+Requested app-server shape:
+Expose memory list/read/write/delete operations and a narrow AGENTS.md init
+operation that returns the intended file path, proposed contents or patch,
+conflict state, and confirmation requirements. Debug memory operations can be
+explicitly marked development-only.
+
+Acceptance:
+- Desktop clients can show memories and stage memory edits through app-server.
+- AGENTS.md initialization behavior matches Codex TUI behavior.
+- Debug memory commands are either available as typed development methods or
+  explicitly unavailable with a stable reason code.
+
+## Filing 3: `codex.app_server.gap.side_agent_plan_controls`
+
+Title: Expose app-server controls for plan editing, side conversations, and subagents
+
+Current Khala wrapper state:
+Khala Code sends `/btw` active-turn side notes through `turn/steer`. Other
+commands in this family return typed unavailable state rather than cloning TUI
+state.
+
+Upstream gap:
+`/approve`, `/plan`, `/agent`, `/subagents`, and `/side` combine TUI command
+parsing, popup state, turn state, and server-request state. Khala needs narrower
+app-server methods or metadata before presenting equivalent desktop controls.
+
+Requested app-server shape:
+Add methods for reading and updating the active plan, listing subagents or side
+threads, starting side conversations, injecting side-thread messages, and
+approving guardian-denied or auto-review actions with typed status.
+
+Acceptance:
+- Desktop clients can render plan state without parsing TUI transcript text.
+- Subagent and side-conversation controls round-trip through Codex-owned thread
+  or turn state.
+- Approval actions are explicit and typed; unavailable controls return stable
+  reason codes.
+
+## Filing 4: `codex.app_server.gap.ide_mentions_diff`
+
+Title: Expand app-server IDE, mention, and diff metadata beyond the current wrapper slice
+
+Current Khala wrapper state:
+Khala Code already uses `fuzzyFileSearch`, `gitDiffToRemote`,
+`fs/readDirectory`, `fs/readFile`, and `config/read` to project bounded mention
+candidates, remote diff content, and IDE status.
+
+Upstream gap:
+The current methods cover the basic wrapper path, but richer IDE mutation and
+metadata remain TUI or host-specific. Khala should not infer ignored-file
+semantics, IDE attachment state, or mention insertion behavior outside Codex's
+own workspace interpretation.
+
+Requested app-server shape:
+Expose richer IDE status and mention metadata: source, active workspace roots,
+ignored or hidden reasons, candidate ranking details, insertion payloads, and
+diff metadata suitable for desktop rendering.
+
+Acceptance:
+- Desktop clients can render mention and diff UI from app-server responses
+  without recreating Codex workspace rules.
+- IDE unavailable states are typed and distinguish no IDE, disabled IDE, and
+  unsupported host.
+- Diff metadata remains bounded and safe for UI display.
+
+## Filing 5: `codex.app_server.gap.windows_sandbox_read_roots`
+
+Title: Add app-server readable-root mutation for Windows sandbox setup
+
+Current Khala wrapper state:
+Khala Code can call `windowsSandbox/setupStart`, `windowsSandbox/readiness`,
+`config/read`, and `config/value/write` where those methods cover setup and
+readiness.
+
+Upstream gap:
+The `/sandbox-add-read-dir` behavior needs a precise app-server contract for
+readable-root mutation. Khala should not implement Windows sandbox root mutation
+by writing config heuristically or cloning TUI command behavior.
+
+Requested app-server shape:
+Add a method to validate and add a readable root, returning normalized path,
+deduplication status, resulting readiness, and any required restart or setup
+step.
+
+Acceptance:
+- Desktop clients can add readable roots through Codex-owned validation.
+- Duplicate, invalid, unsupported-platform, and setup-required cases return
+  typed errors or statuses.
+- Existing setup/readiness methods remain the source of truth for sandbox state.
+
+## Filing 6: `codex.app_server.gap.background_terminals`
+
+Title: Stabilize background terminal list, clean, and terminate app-server methods
+
+Current Khala wrapper state:
+Khala Code wraps Codex's experimental
+`thread/backgroundTerminals/list`, `thread/backgroundTerminals/clean`, and
+`thread/backgroundTerminals/terminate` methods for `/ps`, `/stop`, `/clean`, and
+explicit process termination. The adapter is bounded and tested, but product
+copy treats the methods as unstable.
+
+Upstream gap:
+Background terminal state is Codex-owned, but the relevant app-server methods
+are still experimental. Desktop wrappers need stable request/response shapes and
+termination semantics before presenting them as durable product behavior.
+
+Requested app-server shape:
+Stabilize list, clean, and terminate methods with stable process identifiers,
+thread/session association, command preview bounds, elapsed/runtime state,
+exit/termination status, pagination, and typed not-found/already-exited errors.
+
+Acceptance:
+- Desktop clients can list and terminate background terminals without scraping
+  transcript text or process tables.
+- Termination is idempotent and returns typed final state.
+- Experimental method names either become stable or return a migration path.

--- a/docs/ops/2026-06-29-khala-codex-fleet-manager-runbook.md
+++ b/docs/ops/2026-06-29-khala-codex-fleet-manager-runbook.md
@@ -6,18 +6,21 @@
 with programmatic controls, while preserving exact token accounting and enough
 resume state for the next operator after compaction, restart, or reboot.
 
-**Current lane as of 2026-06-30:** the fastest way to get a local Codex worker
-moving from the desktop app is **Khala Code Desktop** in
-`clients/khala-code-desktop`, using its owner-local tools:
+**Current lane as of 2026-07-01:** Khala Code is now the **Codex-wrapper**
+desktop path. The desktop app wraps Codex app-server as the default harness for
+coding turns and uses Pylon fleet delegation as the owner-local capacity layer
+for linked Codex accounts. The fastest way to get a local Codex worker moving
+from the desktop app remains **Khala Code Desktop** in
+`clients/khala-code-desktop`, using its owner-local fleet tools:
 
 - `pylon_ensure`
 - `codex_fleet_status`
 - `codex_spawn`
 
 The older `clients/openagents-desktop` controls below remain useful source
-material for the broader fanout manager, but the working MVP path today is
-Khala Code Desktop → local Pylon → hosted Khala assignment → local Codex runner
-→ no-spend closeout.
+material for the broader fanout manager, but the current working path is Khala
+Code Desktop Codex-wrapper UI → local Pylon fleet delegation → hosted Khala
+assignment envelope → local Codex runner → no-spend closeout.
 
 This replaces the shell-loop era runbook. The shell commands below are still
 included because they are the bridge the current Desktop process uses under the


### PR DESCRIPTION
Closes #7903

## Summary

- Refresh pre-pivot Khala Code docs to name the July 1 Codex-wrapper architecture as current.
- Add upstream-ready writeup drafts for the six `codex.app_server.gap.*` items from the desktop gap matrix.

## Verification

- `bun scripts/check-conflict-markers.mjs`