### PR TITLE
T14.2: Extend architecture scan to khala-code-desktop and khala-tools

### DIFF
--- a/apps/openagents.com/scripts/check-zero-debt-architecture.mjs
+++ b/apps/openagents.com/scripts/check-zero-debt-architecture.mjs
@@ -19,6 +19,18 @@ const sourceFiles = ['workers/api/src', 'packages', 'apps/web/src']
   .filter(path => !/\.scene\.test\.tsx?$/.test(path))
   .filter(path => !path.includes('workers/api/src/test/'))
 
+const khalaArchitectureScanFiles = [
+  '../../clients/khala-code-desktop',
+  '../../packages/khala-tools',
+]
+  .flatMap(listFiles)
+  .filter(path => /\.tsx?$/.test(path))
+  .filter(path => !/\.d\.ts$/.test(path))
+  .filter(path => !/\.test\.tsx?$/.test(path))
+  .filter(path => !/\.test-support\.tsx?$/.test(path))
+  .filter(path => !/\.story\.test\.tsx?$/.test(path))
+  .filter(path => !/\.scene\.test\.tsx?$/.test(path))
+
 const workerFiles = sourceFiles.filter(path =>
   path.startsWith('workers/api/src/'),
 )
@@ -99,6 +111,14 @@ const lineCount = path => {
 
 const formatDetails = results =>
   results.map(result => `${result.path}: ${result.count}`).join('\n')
+
+const formatRepoRootDetails = results =>
+  results
+    .map(
+      result =>
+        `${result.path.replace(/^\.\.\/\.\.\//, '')}: ${result.count}`,
+    )
+    .join('\n')
 
 const budgetChecks = [
   {
@@ -696,6 +716,60 @@ const deletedFileChecks = [
       'The deleted local login demo story must not return with the removed simulated auth flow.',
     name: 'loggedOut/page/login.story.test.ts deleted',
     path: 'apps/web/src/page/loggedOut/page/login.story.test.ts',
+  },
+]
+
+const reportOnlyArchitectureChecks = [
+  {
+    description:
+      'Khala desktop/tools modules should parse untyped JSON through Schema or named boundaries before casting.',
+    details: countByFile(
+      khalaArchitectureScanFiles,
+      /JSON\.parse\([\s\S]{0,240}?\)\s+as\b/g,
+    ),
+    name: 'Khala JSON.parse casts',
+  },
+  {
+    description:
+      'Khala desktop/tools modules should preserve failure information instead of swallowing empty catch blocks.',
+    details: countByFile(
+      khalaArchitectureScanFiles,
+      /\bcatch\s*(?:\([^)]*\)\s*)?\{\s*\}/g,
+    ),
+    name: 'Khala bare catch blocks',
+  },
+  {
+    description:
+      'Khala desktop/tools modules should route environment reads through config services or explicit boundaries.',
+    details: countByFile(
+      khalaArchitectureScanFiles,
+      /\b(?:process|Bun)\.env\b|\bimport\.meta\.env\b/g,
+    ),
+    name: 'Khala direct env reads',
+  },
+  {
+    description:
+      'Khala desktop/tools logic should use injected Clock/time services instead of Date.now().',
+    details: countByFile(khalaArchitectureScanFiles, /\bDate\.now\(\)/g),
+    name: 'Khala Date.now calls',
+  },
+  {
+    description:
+      'Khala desktop/tools modules should keep Effect.runPromise at named executable edges.',
+    details: countByFile(
+      khalaArchitectureScanFiles,
+      /\bEffect\.runPromise\(/g,
+    ),
+    name: 'Khala Effect.runPromise calls',
+  },
+  {
+    description:
+      'Khala desktop/tools process cleanup should use supervised lifecycles instead of setTimeout kill paths.',
+    details: countByFile(
+      khalaArchitectureScanFiles,
+      /\bsetTimeout\s*\([\s\S]{0,400}\b(?:killTree|process\.kill|kill|\.kill)\b/g,
+    ),
+    name: 'Khala setTimeout process kills',
   },
 ]
 
@@ -1398,6 +1472,17 @@ publicProjectionSurfaces.forEach(surface => {
   console.log(`  ${surface.status}: ${surface.route} (${surface.module})`)
 })
 console.log('')
+
+console.log(
+  'Khala architecture report-only scan (clients/khala-code-desktop + packages/khala-tools):',
+)
+reportOnlyArchitectureChecks.forEach(check => {
+  const count = totalCount(check.details)
+  console.log(`${check.name}: ${count} finding(s)`)
+  console.log(`  ${check.description}`)
+  console.log(formatRepoRootDetails(check.details) || '  none')
+  console.log('')
+})
 
 const problems = [
   ...budgetProblems,


### PR DESCRIPTION
## Summary

- Extends `apps/openagents.com/scripts/check-zero-debt-architecture.mjs` with a report-only Khala architecture scan over `clients/khala-code-desktop` and `packages/khala-tools`.
- Reports the requested patterns: `JSON.parse(...) as`, bare `catch {}`, direct env reads, `Date.now()`, stray `Effect.runPromise`, and `setTimeout` process-kill paths.
- Keeps the new Khala findings advisory only; they are printed in the architecture report and are not added to the hard-fail `problems` list.

Closes #7897

## Verification

- PASS: `git diff --check`

- FAIL: `bun run --cwd clients/khala-code-desktop typecheck` (required verification ref `command.public.pylon_khala.verify.07cda6414807b7e4b2584e92`)

  ```text
  $ tsc -p tsconfig.typecheck.json --noEmit
  .../node_modules/@openagentsinc/three-effect/packages/core/src/advancedMaterialPrimitives.ts(1,24): error TS2307: Cannot find module 'three' or its corresponding type declarations.
  .../node_modules/@openagentsinc/three-effect/packages/core/src/assetPrimitives.ts(1,30): error TS2307: Cannot find module 'effect' or its corresponding type declarations.
  .../node_modules/@openagentsinc/three-effect/packages/core/src/advancedMaterialPrimitives.ts(98,12): error TS4112: This member cannot have an 'override' modifier because its containing class 'DistortMaterial' does not extend another class.
  ```

- FAIL: `bun run --cwd apps/openagents.com check:architecture`

  The new report-only Khala section is emitted:

  ```text
  Khala JSON.parse casts: 20 finding(s)
  Khala bare catch blocks: 0 finding(s)
  Khala direct env reads: 59 finding(s)
  Khala Date.now calls: 66 finding(s)
  Khala Effect.runPromise calls: 44 finding(s)
  Khala setTimeout process kills: 4 finding(s)
  ```

  The hard-fail exit is from existing Worker architecture gates outside this change:

  ```text
  - raw time/id/random primitives: count 1, budget 0.
  workers/api/src/inference/gym/mutalisk-khala-delegation-routes.ts: 1
  - Worker Response return surfaces: count 132, budget 123.
  - workers/api/src/inference/gym/mutalisk-khala-delegation-routes.ts: 1 Effect.runPromise call(s) are outside the named temporary bridge allowlist.
  - public projection route /api/public/gym/mutalisk-khala-delegation/runs is not in the projection-surface ledger.
  ```

- FAIL: `bun run check:deploy`

  `check:deploy` reaches the same `check:architecture` failure above after the earlier visible checks pass (`check:conflict-markers`, `check:no-github-actions`, `check:effect-topology`).
