### PR TITLE
T9.1: khala fleet connect --harness claude

### DIFF
--- a/clients/khala-cli/src/cli.test.ts
+++ b/clients/khala-cli/src/cli.test.ts
@@ -49,15 +49,18 @@ describe("Khala CLI info diagnostics", () => {
     }
 
     expect(stdout).toContain("Khala fleet:")
-    expect(stdout).toContain("No Codex accounts connected yet.")
+    expect(stdout).toContain("No harness accounts connected yet.")
     expect(stdout).toContain("khala fleet connect")
+    expect(stdout).toContain("khala fleet connect --harness claude")
   })
 
-  test("lists connected Codex fleet accounts and readiness through the CLI alias", async () => {
+  test("lists connected fleet accounts and readiness through the CLI alias", async () => {
     const dir = mkdtempSync(join(tmpdir(), "khala-fleet-status-test-"))
     const pylonHome = join(dir, ".openagents", "pylon")
     const codexHome = join(pylonHome, "accounts", "codex", "codex")
+    const claudeHome = join(pylonHome, "accounts", "claude_agent", ".claude-claude")
     mkdirSync(codexHome, { recursive: true })
+    mkdirSync(claudeHome, { recursive: true })
     writeFileSync(
       join(codexHome, "auth.json"),
       JSON.stringify({
@@ -70,6 +73,7 @@ describe("Khala CLI info diagnostics", () => {
         },
       }),
     )
+    writeFileSync(join(claudeHome, "claude-oauth-token"), "sk-ant-oat-cli-status\n")
     writeFileSync(
       join(pylonHome, "config.json"),
       JSON.stringify({
@@ -77,6 +81,7 @@ describe("Khala CLI info diagnostics", () => {
           accounts: [
             { ref: "codex", provider: "codex", home: codexHome },
             { ref: "codex-2", provider: "codex", home: join(pylonHome, "accounts", "codex", "codex-2") },
+            { ref: "claude", provider: "claude_agent", home: claudeHome },
           ],
         },
       }),
@@ -97,11 +102,13 @@ describe("Khala CLI info diagnostics", () => {
       process.stdout.write = originalWrite
     }
 
-    expect(stdout).toContain("2 Codex account(s), 1 ready")
+    expect(stdout).toContain("3 account(s), 2 ready")
     expect(stdout).toContain("ACCOUNT")
+    expect(stdout).toContain("HARNESS")
     expect(stdout).toContain("READINESS")
     expect(stdout).toContain("EMAIL")
     expect(stdout).toContain("codex")
+    expect(stdout).toContain("claude")
     expect(stdout).toContain("ready")
     expect(stdout).toContain("fleet@example.com")
     expect(stdout).toContain("codex-2")

--- a/clients/khala-cli/src/cli.ts
+++ b/clients/khala-cli/src/cli.ts
@@ -35,12 +35,14 @@ import {
   type KhalaRouteSelection,
 } from "./codex.js"
 import {
+  ClaudeCliMissingError,
   CodexCliMissingError,
   connectFleetAccount,
   linkFleetPylon,
   listFleetAccounts,
   runOperatorFleetStatusLive,
   type KhalaFleetConnectResult,
+  type KhalaFleetHarness,
   type KhalaFleetLinkResult,
   type KhalaFleetStatus,
 } from "./fleet.js"
@@ -100,7 +102,7 @@ type ParsedCommand =
   | { readonly kind: "codexStatus" }
   | { readonly kind: "changelog" }
   | { readonly kind: "feedback"; readonly text: string | undefined }
-  | { readonly kind: "fleetConnect"; readonly accountRef: string | undefined; readonly force: boolean }
+  | { readonly kind: "fleetConnect"; readonly accountRef: string | undefined; readonly force: boolean; readonly harness: KhalaFleetHarness }
   | { readonly kind: "fleetRun" }
   | { readonly kind: "fleetLink" }
   | { readonly kind: "fleetStatus"; readonly live: boolean }
@@ -217,6 +219,7 @@ export async function runKhalaCli(argv: ReadonlyArray<string>, env: Record<strin
       try {
         const result = await connectFleetAccount({
           env,
+          harness: args.command.harness,
           accountRef: args.command.accountRef,
           force: args.command.force,
         })
@@ -228,6 +231,10 @@ export async function runKhalaCli(argv: ReadonlyArray<string>, env: Record<strin
         return 0
       } catch (error) {
         if (error instanceof CodexCliMissingError) {
+          process.stderr.write(`${terminalStyle.meta(error.message)}\n`)
+          return 1
+        }
+        if (error instanceof ClaudeCliMissingError) {
           process.stderr.write(`${terminalStyle.meta(error.message)}\n`)
           return 1
         }
@@ -455,6 +462,7 @@ function parseArgs(argv: ReadonlyArray<string>, env: Record<string, string | und
   let spawnWorkflow: KhalaSpawnWorkflow = "codex_agent_task"
   let fleetAccount: string | undefined
   let fleetForce = false
+  let fleetHarness: KhalaFleetHarness = "codex"
   let fleetLive = false
   const positional: Array<string> = []
 
@@ -575,6 +583,11 @@ function parseArgs(argv: ReadonlyArray<string>, env: Record<string, string | und
       index += 1
     } else if (arg.startsWith("--account=")) {
       fleetAccount = arg.slice("--account=".length)
+    } else if (arg === "--harness") {
+      fleetHarness = parseFleetHarness(requireValue(argv, index, arg))
+      index += 1
+    } else if (arg.startsWith("--harness=")) {
+      fleetHarness = parseFleetHarness(arg.slice("--harness=".length))
     } else if (arg === "--force") {
       fleetForce = true
     } else if (arg === "--live") {
@@ -627,6 +640,7 @@ function parseArgs(argv: ReadonlyArray<string>, env: Record<string, string | und
         kind: "fleetConnect",
         accountRef: fleetAccount ?? (positional[2]?.trim() || undefined),
         force: fleetForce,
+        harness: fleetHarness,
       }
     } else {
       throw new Error(`Unknown fleet command: ${sub}. Use \`khala fleet connect\`, \`khala fleet link\`, \`khala fleet status\`, or \`khala fleet run\`.`)
@@ -1554,6 +1568,11 @@ function parseSpawnWorkflow(value: string): KhalaSpawnWorkflow {
   throw new Error("--workflow must be claude_agent_task, cloud_coding_session, or codex_agent_task")
 }
 
+function parseFleetHarness(value: string): KhalaFleetHarness {
+  if (value === "codex" || value === "claude") return value
+  throw new Error("--harness must be codex or claude")
+}
+
 function requireValue(argv: ReadonlyArray<string>, index: number, flag: string): string {
   const value = argv[index + 1]
   if (value === undefined || value.startsWith("-")) {
@@ -1947,9 +1966,10 @@ function formatCodexStatus(status: KhalaCodexStatus): string {
 function formatFleetConnect(result: KhalaFleetConnectResult): string {
   const verb = result.status === "already_connected" ? "Already connected" : "Connected"
   const who = result.email ? `: ${result.email}` : ""
+  const label = result.harness === "claude" ? "Claude" : "Codex"
   return terminalStyle.meta([
-    `${terminalStyle.assistant("Khala fleet:")} ${verb} Codex account ${result.accountRef}${who}`,
-    "Your Codex credentials stay on this machine; OpenAgents orchestrates, your local Pylon executes.",
+    `${terminalStyle.assistant("Khala fleet:")} ${verb} ${label} account ${result.accountRef}${who}`,
+    `Your ${label} credentials stay on this machine; OpenAgents orchestrates, your local Pylon executes.`,
     "",
     "Next:",
     "  khala login               Sign in to Khala/OpenAgents",
@@ -1974,23 +1994,25 @@ function formatFleetLink(result: KhalaFleetLinkResult): string {
 function formatFleetStatus(status: KhalaFleetStatus): string {
   if (status.accounts.length === 0) {
     return terminalStyle.meta([
-      `${terminalStyle.assistant("Khala fleet:")} No Codex accounts connected yet.`,
-      "Connect one (paste-free device login):",
+      `${terminalStyle.assistant("Khala fleet:")} No harness accounts connected yet.`,
+      "Connect one:",
       "  khala fleet connect",
+      "  khala fleet connect --harness claude",
     ].join("\n"))
   }
   const rows = status.accounts.map(account => {
     const ready = account.readiness === "ready" ? "ready" : "credentials-missing"
     const email = account.email ?? "(email unavailable)"
-    return `  ${account.accountRef.padEnd(12)} ${ready.padEnd(18)} ${email}`
+    return `  ${account.accountRef.padEnd(12)} ${account.harness.padEnd(8)} ${ready.padEnd(18)} ${email}`
   })
   return terminalStyle.meta([
-    `${terminalStyle.assistant("Khala fleet:")} ${status.accounts.length} Codex account(s), ${status.readyCount} ready`,
-    `  ${"ACCOUNT".padEnd(12)} ${"READINESS".padEnd(18)} EMAIL`,
+    `${terminalStyle.assistant("Khala fleet:")} ${status.accounts.length} account(s), ${status.readyCount} ready`,
+    `  ${"ACCOUNT".padEnd(12)} ${"HARNESS".padEnd(8)} ${"READINESS".padEnd(18)} EMAIL`,
     ...rows,
     "",
     "Add another account for more throughput:",
     "  khala fleet connect",
+    "  khala fleet connect --harness claude",
   ].join("\n"))
 }
 
@@ -2294,6 +2316,7 @@ Usage:
   khala tokens
   khala fleet connect
   khala fleet connect --account codex-2
+  khala fleet connect --harness claude
   khala fleet link
   khala fleet status
   khala fleet run --repo owner/repo --issues 123,124 --verify "bun test" --dry-run
@@ -2361,7 +2384,8 @@ Flags:
   --verify <command>   Bounded verification command for --strategy pylon
   --workflow <name>    Pylon workflow: claude_agent_task, codex_agent_task, or cloud_coding_session
   --timeout <seconds>  Per-worker timeout for khala spawn
-  --account <ref>      Codex account ref for khala fleet connect (auto-assigned if omitted)
+  --account <ref>      Account ref for khala fleet connect (auto-assigned if omitted)
+  --harness <name>     Harness for khala fleet connect: codex or claude
   --force              Re-run device login for khala fleet connect even if already linked
   --issues <list>      Public issue numbers for khala fleet run, comma or space separated
   --per-account <n>    Fleet run slots per ready Codex account (default: 1)

--- a/clients/khala-cli/src/fleet-run.test.ts
+++ b/clients/khala-cli/src/fleet-run.test.ts
@@ -10,6 +10,7 @@ import {
   nextFleetSupervisorDelay,
   parseFleetIssueList,
   plannedReplenishmentRounds,
+  readyFleetAccountRefs,
   runKhalaFleetSupervisor,
   shouldDispatchReplenishment,
   validateFleetRunVerify,
@@ -254,5 +255,55 @@ describe("fleet run dry-run", () => {
       "codex-2:#6384",
     ])
     expect(result.rounds.every(round => round.workKind === "issue")).toBe(true)
+  })
+})
+
+describe("fleet run harness filtering", () => {
+  test("a ready Claude account contributes no Codex slot", () => {
+    const mixed: KhalaFleetStatus = {
+      accounts: [
+        {
+          accountRef: "codex-2",
+          email: null,
+          harness: "codex",
+          home: "/tmp/codex-2",
+          lastLinkedAt: null,
+          provider: "codex",
+          readiness: "ready",
+        },
+        {
+          accountRef: "claude",
+          email: null,
+          harness: "claude",
+          home: "/tmp/claude",
+          lastLinkedAt: null,
+          provider: "claude_agent",
+          readiness: "ready",
+        },
+      ],
+      configPath: "/tmp/pylon/config.json",
+      pylonHome: "/tmp/pylon",
+      readyCount: 2,
+    }
+    expect(readyFleetAccountRefs(mixed)).toEqual(["codex-2"])
+    const plan = buildFleetRunPlan({
+      commit,
+      issues: [6384, 6408],
+      mode: "dry_run",
+      readyAccounts: readyFleetAccountRefs(mixed),
+      repo: "OpenAgentsInc/openagents",
+      verify: "bun run --cwd apps/pylon test",
+    })
+    expect(plan.readyAccounts).toEqual(["codex-2"])
+    const codexOnly = buildFleetRunPlan({
+      commit,
+      issues: [6384, 6408],
+      mode: "dry_run",
+      readyAccounts: ["codex-2"],
+      repo: "OpenAgentsInc/openagents",
+      verify: "bun run --cwd apps/pylon test",
+    })
+    expect(plan.targetSlots).toBe(codexOnly.targetSlots)
+    expect(fleetRunCapacityEnv({}, plan).OPENAGENTS_PYLON_CODEX_CONCURRENCY).toBe(String(plan.targetSlots))
   })
 })

--- a/clients/khala-cli/src/fleet-run.test.ts
+++ b/clients/khala-cli/src/fleet-run.test.ts
@@ -35,8 +35,10 @@ function status(accountRefs: readonly string[]): KhalaFleetStatus {
     accounts: accountRefs.map(accountRef => ({
       accountRef,
       email: null,
+      harness: "codex",
       home: `/tmp/${accountRef}`,
       lastLinkedAt: null,
+      provider: "codex",
       readiness: "ready",
     })),
     configPath: "/tmp/pylon/config.json",

--- a/clients/khala-cli/src/fleet-run.ts
+++ b/clients/khala-cli/src/fleet-run.ts
@@ -214,8 +214,11 @@ export async function runKhalaFleetSupervisor(options: KhalaFleetRunOptions): Pr
     PYLON_OPENAGENTS_BASE_URL: options.baseUrl ?? env.PYLON_OPENAGENTS_BASE_URL ?? DEFAULT_BASE_URL,
   }
   const status = options.status ?? await listFleetAccounts({ env: commandEnv })
+  // Fleet-run slot planning dispatches codex_agent_task work and advertises
+  // Codex concurrency, so only Codex-harness accounts may contribute slots;
+  // a ready Claude account must never inflate the advertised Codex capacity.
   const readyAccounts = status.accounts
-    .filter(account => account.readiness === "ready")
+    .filter(account => account.readiness === "ready" && account.harness === "codex")
     .map(account => account.accountRef)
   const mode: KhalaFleetRunMode = options.dryRun ? "dry_run" : options.once ? "once" : "supervise"
   const pylonCommand = options.pylonCommand ?? pylonCommandFromEnv(env)
@@ -565,5 +568,5 @@ export function readyFleetAccountRefs(status: KhalaFleetStatus): readonly string
 }
 
 function isReadyFleetAccount(account: KhalaFleetAccount): boolean {
-  return account.readiness === "ready"
+  return account.readiness === "ready" && account.harness === "codex"
 }

--- a/clients/khala-cli/src/fleet.test.ts
+++ b/clients/khala-cli/src/fleet.test.ts
@@ -4,7 +4,9 @@ import { tmpdir } from "node:os"
 import { join } from "node:path"
 
 import {
+  ClaudeCliMissingError,
   CodexCliMissingError,
+  claudeAccountHome,
   codexAccountHome,
   codexConfigWithFileCredentialStore,
   connectFleetAccount,
@@ -13,11 +15,14 @@ import {
   formatOperatorFleetDashboard,
   linkFleetPylon,
   listFleetAccounts,
+  nextFleetAccountRef,
   nextCodexAccountRef,
   parseCodexAccounts,
+  parseFleetAccounts,
   pylonConfigPath,
   resolvePylonHome,
   upsertCodexAccount,
+  upsertFleetAccount,
 } from "./fleet.js"
 
 function idTokenFor(email: string): string {
@@ -32,6 +37,12 @@ describe("fleet ref assignment", () => {
     expect(nextCodexAccountRef(["codex"])).toBe("codex-2")
     expect(nextCodexAccountRef(["codex", "codex-2"])).toBe("codex-3")
     expect(nextCodexAccountRef(["codex", "codex-3"])).toBe("codex-2")
+  })
+
+  test("assigns claude, then claude-2, claude-3", () => {
+    expect(nextFleetAccountRef("claude", [])).toBe("claude")
+    expect(nextFleetAccountRef("claude", ["claude"])).toBe("claude-2")
+    expect(nextFleetAccountRef("claude", ["claude", "claude-2"])).toBe("claude-3")
   })
 })
 
@@ -108,6 +119,10 @@ describe("config parsing + upsert (Pylon-compatible shape)", () => {
       },
     }
     expect(parseCodexAccounts(config)).toEqual([{ ref: "codex", home: "/h/codex" }])
+    expect(parseFleetAccounts(config)).toEqual([
+      { ref: "codex", provider: "codex", harness: "codex", home: "/h/codex" },
+      { ref: "claude", provider: "claude_agent", harness: "claude", home: "/h/claude" },
+    ])
   })
 
   test("upsert adds a new account and is idempotent", () => {
@@ -119,6 +134,16 @@ describe("config parsing + upsert (Pylon-compatible shape)", () => {
     const moved = upsertCodexAccount(first.config, { ref: "codex", home: "/h/new" })
     expect(moved.changed).toBe(true)
     expect(parseCodexAccounts(moved.config)).toEqual([{ ref: "codex", home: "/h/new" }])
+  })
+
+  test("upsert adds a claude_agent account and is idempotent", () => {
+    const first = upsertFleetAccount({}, { provider: "claude_agent", ref: "claude", home: "/h/.claude-claude" })
+    expect(first.changed).toBe(true)
+    expect(first.config).toEqual({
+      dev: { accounts: [{ ref: "claude", provider: "claude_agent", home: "/h/.claude-claude" }] },
+    })
+    const second = upsertFleetAccount(first.config, { provider: "claude_agent", ref: "claude", home: "/h/.claude-claude" })
+    expect(second.changed).toBe(false)
   })
 })
 
@@ -213,6 +238,7 @@ describe("connect + status (with injected device login)", () => {
     const status = await listFleetAccounts({ env })
     expect(status.readyCount).toBe(2)
     expect(status.accounts.map(a => a.accountRef)).toEqual(["codex", "codex-2"])
+    expect(status.accounts.map(a => a.harness)).toEqual(["codex", "codex"])
     expect(status.accounts.map(a => a.readiness)).toEqual(["ready", "ready"])
 
     // The isolated home got the file credential store config.
@@ -220,12 +246,76 @@ describe("connect + status (with injected device login)", () => {
     expect(codexToml).toContain('cli_auth_credentials_store = "file"')
   }, 20000)
 
+  test("connects a Claude account with setup-token in an isolated CLAUDE_CONFIG_DIR home", async () => {
+    const base = await mkdtemp(join(tmpdir(), "khala-fleet-claude-"))
+    const pylonHome = join(base, ".openagents", "pylon")
+    const env = { PYLON_HOME: pylonHome }
+
+    let setupHome: string | undefined
+    let setupEnv: Record<string, string | undefined> | undefined
+    const result = await connectFleetAccount({
+      env,
+      harness: "claude",
+      runClaudeSetupToken: async input => {
+        setupHome = input.home
+        setupEnv = input.env
+        return { exitCode: 0, stdout: "sk-ant-oat-test-token\n" }
+      },
+    })
+
+    expect(result.accountRef).toBe("claude")
+    expect(result.status).toBe("connected")
+    expect(setupHome).toBe(claudeAccountHome(pylonHome, "claude"))
+    expect(setupHome).toContain(".claude-claude")
+    expect(setupHome).not.toBe(join(base, ".claude"))
+    expect(setupEnv).toEqual(env)
+
+    const token = await readFile(join(claudeAccountHome(pylonHome, "claude"), "claude-oauth-token"), "utf8")
+    expect(token).toBe("sk-ant-oat-test-token\n")
+
+    const config = JSON.parse(await readFile(pylonConfigPath(pylonHome), "utf8"))
+    expect(parseFleetAccounts(config)).toEqual([
+      {
+        ref: "claude",
+        provider: "claude_agent",
+        harness: "claude",
+        home: claudeAccountHome(pylonHome, "claude"),
+      },
+    ])
+
+    const second = await connectFleetAccount({
+      env,
+      harness: "claude",
+      runClaudeSetupToken: async () => ({ exitCode: 0, stdout: "sk-ant-oat-second\n" }),
+    })
+    expect(second.accountRef).toBe("claude-2")
+
+    const status = await listFleetAccounts({ env })
+    expect(status.readyCount).toBe(2)
+    expect(status.accounts.map(account => ({
+      harness: account.harness,
+      readiness: account.readiness,
+      ref: account.accountRef,
+    }))).toEqual([
+      { ref: "claude", harness: "claude", readiness: "ready" },
+      { ref: "claude-2", harness: "claude", readiness: "ready" },
+    ])
+  })
+
   test("surfaces a friendly error when the codex CLI is missing (exit 127)", async () => {
     const base = await mkdtemp(join(tmpdir(), "khala-fleet-"))
     const env = { PYLON_HOME: join(base, ".openagents", "pylon") }
     await expect(
       connectFleetAccount({ env, runDeviceLogin: async () => ({ exitCode: 127 }) }),
     ).rejects.toBeInstanceOf(CodexCliMissingError)
+  })
+
+  test("surfaces a friendly error when the claude CLI is missing (exit 127)", async () => {
+    const base = await mkdtemp(join(tmpdir(), "khala-fleet-claude-"))
+    const env = { PYLON_HOME: join(base, ".openagents", "pylon") }
+    await expect(
+      connectFleetAccount({ env, harness: "claude", runClaudeSetupToken: async () => ({ exitCode: 127 }) }),
+    ).rejects.toBeInstanceOf(ClaudeCliMissingError)
   })
 
   test("status reports credentials-missing for a registered home with no auth.json", async () => {
@@ -238,9 +328,39 @@ describe("connect + status (with injected device login)", () => {
     await writeFile(pylonConfigPath(pylonHome), JSON.stringify(config))
     const status = await listFleetAccounts({ env: { PYLON_HOME: pylonHome } })
     expect(status.accounts).toEqual([
-      { accountRef: "codex", home, email: null, readiness: "credentials_missing", lastLinkedAt: null },
+      {
+        accountRef: "codex",
+        harness: "codex",
+        provider: "codex",
+        home,
+        email: null,
+        readiness: "credentials_missing",
+        lastLinkedAt: null,
+      },
     ])
     void stat // keep import used across runtimes
+  })
+
+  test("status reports credentials-missing for a registered Claude home with no setup token", async () => {
+    const base = await mkdtemp(join(tmpdir(), "khala-fleet-claude-"))
+    const pylonHome = join(base, ".openagents", "pylon")
+    const home = claudeAccountHome(pylonHome, "claude")
+    await mkdir(home, { recursive: true })
+    const config = { dev: { accounts: [{ ref: "claude", provider: "claude_agent", home }] } }
+    await mkdir(pylonHome, { recursive: true })
+    await writeFile(pylonConfigPath(pylonHome), JSON.stringify(config))
+    const status = await listFleetAccounts({ env: { PYLON_HOME: pylonHome } })
+    expect(status.accounts).toEqual([
+      {
+        accountRef: "claude",
+        harness: "claude",
+        provider: "claude_agent",
+        home,
+        email: null,
+        readiness: "credentials_missing",
+        lastLinkedAt: null,
+      },
+    ])
   })
 })
 

--- a/clients/khala-cli/src/fleet.test.ts
+++ b/clients/khala-cli/src/fleet.test.ts
@@ -405,3 +405,17 @@ describe("operator fleet live status", () => {
     expect(rendered).toContain("[Brain]")
   })
 })
+
+describe("claude setup-token output guard", () => {
+  test("fails loudly when no token-shaped line is present instead of storing junk", async () => {
+    const base = await mkdtemp(join(tmpdir(), "khala-fleet-claude-junk-"))
+    const pylonHome = join(base, ".openagents", "pylon")
+    await expect(
+      connectFleetAccount({
+        env: { PYLON_HOME: pylonHome },
+        harness: "claude",
+        runClaudeSetupToken: async () => ({ exitCode: 0, stdout: "Login successful\n" }),
+      }),
+    ).rejects.toThrow(/claude-oauth-token was not written/)
+  })
+})

--- a/clients/khala-cli/src/fleet.ts
+++ b/clients/khala-cli/src/fleet.ts
@@ -585,8 +585,10 @@ const defaultClaudeSetupTokenRunner: KhalaClaudeSetupTokenRunner = async input =
 }
 
 function extractClaudeSetupToken(stdout: string | undefined): string | null {
+  // Only a token-shaped line may become the stored credential; falling back
+  // to an arbitrary trailing status line would persist junk as "ready" auth.
   const lines = (stdout ?? "").split(/\r?\n/).map(line => line.trim()).filter(Boolean)
-  return lines.find(line => /^sk-ant-oat-[A-Za-z0-9._-]+$/.test(line)) ?? lines.at(-1) ?? null
+  return lines.find(line => /^sk-ant-oat-[A-Za-z0-9._-]+$/.test(line)) ?? null
 }
 
 async function writeClaudeSetupToken(home: string, token: string): Promise<void> {

--- a/clients/khala-cli/src/fleet.ts
+++ b/clients/khala-cli/src/fleet.ts
@@ -24,11 +24,19 @@ import { DEFAULT_BASE_URL } from "./types.js"
 //   - Credentials stay local; we never read or print tokens.
 
 const CODEX_LOGIN_MISSING_EXIT = 127
+const CLAUDE_SETUP_TOKEN_MISSING_EXIT = 127
+const PYLON_CLAUDE_OAUTH_TOKEN_FILE = "claude-oauth-token"
+const CLAUDE_AGENT_CAPABILITY_REF = "capability.pylon.local_claude_agent"
+
+export type KhalaFleetHarness = "codex" | "claude"
+type PylonFleetProvider = "codex" | "claude_agent"
 
 export type KhalaFleetAccountReadiness = "ready" | "credentials_missing"
 
 export type KhalaFleetAccount = {
   readonly accountRef: string
+  readonly harness: KhalaFleetHarness
+  readonly provider: PylonFleetProvider
   readonly home: string
   readonly email: string | null
   readonly readiness: KhalaFleetAccountReadiness
@@ -44,6 +52,8 @@ export type KhalaFleetStatus = {
 
 export type KhalaFleetConnectResult = {
   readonly accountRef: string
+  readonly harness: KhalaFleetHarness
+  readonly provider: PylonFleetProvider
   readonly home: string
   readonly email: string | null
   readonly pylonHome: string
@@ -74,6 +84,11 @@ export type KhalaCodexDeviceLoginRunner = (input: {
   readonly home: string
 }) => Promise<{ readonly exitCode: number }>
 
+export type KhalaClaudeSetupTokenRunner = (input: {
+  readonly env: Record<string, string | undefined>
+  readonly home: string
+}) => Promise<{ readonly exitCode: number; readonly stdout?: string | undefined }>
+
 type ConfigRecord = Record<string, unknown>
 type FetchLike = (input: string | URL | Request, init?: RequestInit) => Promise<Response>
 
@@ -93,6 +108,17 @@ export class CodexCliMissingError extends Error {
         "  (or see https://github.com/openai/codex)",
     )
     this.name = "CodexCliMissingError"
+  }
+}
+
+export class ClaudeCliMissingError extends Error {
+  readonly _tag = "ClaudeCliMissingError"
+  constructor() {
+    super(
+      "The `claude` CLI is required to connect a Claude account but was not found on your PATH.\n" +
+        "Install Claude Code, then re-run `khala fleet connect --harness claude`.",
+    )
+    this.name = "ClaudeCliMissingError"
   }
 }
 
@@ -135,6 +161,10 @@ export function codexAccountHome(pylonHome: string, accountRef: string): string 
   return join(pylonHome, "accounts", "codex", accountRef)
 }
 
+export function claudeAccountHome(pylonHome: string, accountRef: string): string {
+  return join(pylonHome, "accounts", "claude_agent", `.claude-${accountRef}`)
+}
+
 function asRecord(value: unknown): ConfigRecord | null {
   return value !== null && typeof value === "object" && !Array.isArray(value)
     ? (value as ConfigRecord)
@@ -143,16 +173,29 @@ function asRecord(value: unknown): ConfigRecord | null {
 
 // Read the codex accounts already registered in a Pylon config object.
 export function parseCodexAccounts(config: ConfigRecord): Array<{ readonly ref: string; readonly home: string | null }> {
+  return parseFleetAccounts(config)
+    .filter(account => account.provider === "codex")
+    .map(account => ({ ref: account.ref, home: account.home }))
+}
+
+export function parseFleetAccounts(config: ConfigRecord): Array<{
+  readonly ref: string
+  readonly provider: PylonFleetProvider
+  readonly harness: KhalaFleetHarness
+  readonly home: string | null
+}> {
   const dev = asRecord(config.dev)
   const accounts = dev !== null && Array.isArray(dev.accounts) ? dev.accounts : []
-  const out: Array<{ ref: string; home: string | null }> = []
+  const out: Array<{ ref: string; provider: PylonFleetProvider; harness: KhalaFleetHarness; home: string | null }> = []
   for (const account of accounts) {
     const record = asRecord(account)
     if (record === null) continue
-    if (record.provider !== "codex") continue
+    if (record.provider !== "codex" && record.provider !== "claude_agent") continue
     if (typeof record.ref !== "string" || record.ref.trim() === "") continue
     out.push({
       ref: record.ref,
+      provider: record.provider,
+      harness: record.provider === "claude_agent" ? "claude" : "codex",
       home: typeof record.home === "string" && record.home.trim() !== "" ? record.home : null,
     })
   }
@@ -162,13 +205,18 @@ export function parseCodexAccounts(config: ConfigRecord): Array<{ readonly ref: 
 // Auto-assign the next codex account ref: "codex", then "codex-2", "codex-3"...
 // (mirrors Pylon's nextCodexAccountRef so refs never collide across the tools).
 export function nextCodexAccountRef(existingRefs: ReadonlyArray<string>): string {
+  return nextFleetAccountRef("codex", existingRefs)
+}
+
+export function nextFleetAccountRef(harness: KhalaFleetHarness, existingRefs: ReadonlyArray<string>): string {
+  const base = harness === "claude" ? "claude" : "codex"
   const existing = new Set(existingRefs)
-  if (!existing.has("codex")) return "codex"
+  if (!existing.has(base)) return base
   for (let index = 2; index < 10_000; index += 1) {
-    const candidate = `codex-${index}`
+    const candidate = `${base}-${index}`
     if (!existing.has(candidate)) return candidate
   }
-  return `codex-${Date.now()}`
+  return `${base}-${Date.now()}`
 }
 
 // Register (or update) a codex account in the Pylon config object. Pure: returns
@@ -178,12 +226,19 @@ export function upsertCodexAccount(
   config: ConfigRecord,
   input: { readonly ref: string; readonly home: string },
 ): { readonly config: ConfigRecord; readonly changed: boolean } {
+  return upsertFleetAccount(config, { provider: "codex", ref: input.ref, home: input.home })
+}
+
+export function upsertFleetAccount(
+  config: ConfigRecord,
+  input: { readonly provider: PylonFleetProvider; readonly ref: string; readonly home: string },
+): { readonly config: ConfigRecord; readonly changed: boolean } {
   const dev = asRecord(config.dev) ?? {}
   const accounts = Array.isArray(dev.accounts) ? [...dev.accounts] : []
-  const nextEntry = { ref: input.ref, provider: "codex", home: input.home }
+  const nextEntry = { ref: input.ref, provider: input.provider, home: input.home }
   const index = accounts.findIndex(account => {
     const record = asRecord(account)
-    return record !== null && record.ref === input.ref && record.provider === "codex"
+    return record !== null && record.ref === input.ref && record.provider === input.provider
   })
   if (index === -1) {
     accounts.push(nextEntry)
@@ -380,11 +435,19 @@ async function readRuntimeCapabilityRefs(pylonHome: string): Promise<string[]> {
 async function capabilityRefsForFleetLink(pylonHome: string): Promise<string[]> {
   const refs = await readRuntimeCapabilityRefs(pylonHome)
   const config = await readPylonConfig(pylonConfigPath(pylonHome))
-  const accounts = parseCodexAccounts(config)
+  const accounts = parseFleetAccounts(config)
   const readyAccounts = await Promise.all(
-    accounts.map(async account => codexHomeHasLogin(account.home ?? codexAccountHome(pylonHome, account.ref))),
+    accounts.map(async account => {
+      const home = account.home ?? defaultAccountHomeForHarness(pylonHome, account.harness, account.ref)
+      return account.provider === "claude_agent" ? claudeHomeHasLogin(home) : codexHomeHasLogin(home)
+    }),
   )
-  if (readyAccounts.some(Boolean)) refs.push(CODEX_AGENT_CAPABILITY_REF)
+  if (readyAccounts.some((ready, index) => ready && accounts[index]?.provider === "codex")) {
+    refs.push(CODEX_AGENT_CAPABILITY_REF)
+  }
+  if (readyAccounts.some((ready, index) => ready && accounts[index]?.provider === "claude_agent")) {
+    refs.push(CLAUDE_AGENT_CAPABILITY_REF)
+  }
   return [...new Set(refs)]
 }
 
@@ -451,6 +514,19 @@ async function codexHomeHasLogin(home: string): Promise<boolean> {
   }
 }
 
+async function claudeHomeHasLogin(home: string): Promise<boolean> {
+  try {
+    const info = await stat(join(home, PYLON_CLAUDE_OAUTH_TOKEN_FILE))
+    return info.isFile() && info.size > 0
+  } catch {
+    return false
+  }
+}
+
+function defaultAccountHomeForHarness(pylonHome: string, harness: KhalaFleetHarness, accountRef: string): string {
+  return harness === "claude" ? claudeAccountHome(pylonHome, accountRef) : codexAccountHome(pylonHome, accountRef)
+}
+
 async function readCodexAccountDetails(
   home: string,
 ): Promise<{ email: string | null; lastLinkedAt: string | null; present: boolean }> {
@@ -470,6 +546,18 @@ async function readCodexAccountDetails(
   }
 }
 
+async function readClaudeAccountDetails(
+  home: string,
+): Promise<{ email: string | null; lastLinkedAt: string | null; present: boolean }> {
+  const tokenPath = join(home, PYLON_CLAUDE_OAUTH_TOKEN_FILE)
+  try {
+    const info = await stat(tokenPath)
+    return { email: null, lastLinkedAt: info.mtime.toISOString(), present: info.isFile() && info.size > 0 }
+  } catch {
+    return { email: null, lastLinkedAt: null, present: false }
+  }
+}
+
 const defaultCodexDeviceLoginRunner: KhalaCodexDeviceLoginRunner = async input => {
   // Inherit stdio so the `codex` CLI shows its device URL + short code, opens
   // the browser, and polls for completion itself. CODEX_HOME pins the isolated
@@ -483,6 +571,29 @@ const defaultCodexDeviceLoginRunner: KhalaCodexDeviceLoginRunner = async input =
   return { exitCode: await child.exited }
 }
 
+const defaultClaudeSetupTokenRunner: KhalaClaudeSetupTokenRunner = async input => {
+  // Capture stdout because `claude setup-token` emits the account OAuth token
+  // there. Stderr/stdin stay inherited for the interactive login prompts.
+  const child = spawnProcess(["claude", "setup-token"], {
+    env: { ...process.env, ...input.env, CLAUDE_CONFIG_DIR: input.home },
+    stdin: "inherit",
+    stdout: "pipe",
+    stderr: "inherit",
+  })
+  const [exitCode, stdout] = await Promise.all([child.exited, child.stdout])
+  return { exitCode, stdout }
+}
+
+function extractClaudeSetupToken(stdout: string | undefined): string | null {
+  const lines = (stdout ?? "").split(/\r?\n/).map(line => line.trim()).filter(Boolean)
+  return lines.find(line => /^sk-ant-oat-[A-Za-z0-9._-]+$/.test(line)) ?? lines.at(-1) ?? null
+}
+
+async function writeClaudeSetupToken(home: string, token: string): Promise<void> {
+  await mkdir(home, { recursive: true })
+  await writeFile(join(home, PYLON_CLAUDE_OAUTH_TOKEN_FILE), `${token.trim()}\n`, { mode: 0o600 })
+}
+
 // List the connected Codex accounts in the user's fleet with readiness.
 export async function listFleetAccounts(
   options: { readonly env?: Record<string, string | undefined> } = {},
@@ -491,13 +602,17 @@ export async function listFleetAccounts(
   const pylonHome = resolvePylonHome(env)
   const configPath = pylonConfigPath(pylonHome)
   const config = await readPylonConfig(configPath)
-  const registered = parseCodexAccounts(config)
+  const registered = parseFleetAccounts(config)
   const accounts: KhalaFleetAccount[] = []
   for (const entry of registered) {
-    const home = entry.home ?? codexAccountHome(pylonHome, entry.ref)
-    const details = await readCodexAccountDetails(home)
+    const home = entry.home ?? defaultAccountHomeForHarness(pylonHome, entry.harness, entry.ref)
+    const details = entry.provider === "claude_agent"
+      ? await readClaudeAccountDetails(home)
+      : await readCodexAccountDetails(home)
     accounts.push({
       accountRef: entry.ref,
+      harness: entry.harness,
+      provider: entry.provider,
       home,
       email: details.email,
       readiness: details.present ? "ready" : "credentials_missing",
@@ -517,33 +632,38 @@ export async function listFleetAccounts(
 export async function connectFleetAccount(
   options: {
     readonly env?: Record<string, string | undefined>
+    readonly harness?: KhalaFleetHarness | undefined
     readonly accountRef?: string | undefined
     readonly force?: boolean | undefined
     readonly runDeviceLogin?: KhalaCodexDeviceLoginRunner | undefined
+    readonly runClaudeSetupToken?: KhalaClaudeSetupTokenRunner | undefined
   } = {},
 ): Promise<KhalaFleetConnectResult> {
   const env = options.env ?? process.env
+  const harness = options.harness ?? "codex"
+  const provider: PylonFleetProvider = harness === "claude" ? "claude_agent" : "codex"
   const pylonHome = resolvePylonHome(env)
   const configPath = pylonConfigPath(pylonHome)
   const config = await readPylonConfig(configPath)
-  const existing = parseCodexAccounts(config)
+  const existing = parseFleetAccounts(config).filter(account => account.harness === harness)
 
   const requested = options.accountRef?.trim()
   const accountRef = requested && requested.length > 0
     ? requested
-    : nextCodexAccountRef(existing.map(account => account.ref))
+    : nextFleetAccountRef(harness, existing.map(account => account.ref))
 
-  if (accountRef === "default" || accountRef === ".codex") {
-    throw new Error(`Refusing to use account ref "${accountRef}" — it could collide with the default Codex home.`)
+  if (accountRef === "default" || accountRef === ".codex" || accountRef === ".claude") {
+    throw new Error(`Refusing to use account ref "${accountRef}" — it could collide with a default agent home.`)
   }
 
-  const home = codexAccountHome(pylonHome, accountRef)
-  await forceCodexFileCredentialStore(home)
+  const home = defaultAccountHomeForHarness(pylonHome, harness, accountRef)
+  if (harness === "codex") await forceCodexFileCredentialStore(home)
 
   let status: KhalaFleetConnectResult["status"] = "connected"
-  if (!options.force && (await codexHomeHasLogin(home))) {
+  const hasLogin = harness === "claude" ? claudeHomeHasLogin : codexHomeHasLogin
+  if (!options.force && (await hasLogin(home))) {
     status = "already_connected"
-  } else {
+  } else if (harness === "codex") {
     const runner = options.runDeviceLogin ?? defaultCodexDeviceLoginRunner
     const result = await runner({ env, home })
     if (result.exitCode === CODEX_LOGIN_MISSING_EXIT) {
@@ -555,16 +675,34 @@ export async function connectFleetAccount(
     if (!(await codexHomeHasLogin(home))) {
       throw new Error("codex login completed but auth.json was not written in the isolated account home")
     }
+  } else {
+    const runner = options.runClaudeSetupToken ?? defaultClaudeSetupTokenRunner
+    const result = await runner({ env, home })
+    if (result.exitCode === CLAUDE_SETUP_TOKEN_MISSING_EXIT) {
+      throw new ClaudeCliMissingError()
+    }
+    if (result.exitCode !== 0) {
+      throw new Error(`claude setup-token exited with status ${result.exitCode}`)
+    }
+    const token = extractClaudeSetupToken(result.stdout)
+    if (token !== null && token.trim().length > 0) {
+      await writeClaudeSetupToken(home, token)
+    }
+    if (!(await claudeHomeHasLogin(home))) {
+      throw new Error("claude setup-token completed but claude-oauth-token was not written in the isolated account home")
+    }
   }
 
-  const upserted = upsertCodexAccount(config, { ref: accountRef, home })
+  const upserted = upsertFleetAccount(config, { provider, ref: accountRef, home })
   if (upserted.changed) {
     await writePylonConfig(configPath, upserted.config)
   }
 
-  const details = await readCodexAccountDetails(home)
+  const details = harness === "claude" ? await readClaudeAccountDetails(home) : await readCodexAccountDetails(home)
   return {
     accountRef,
+    harness,
+    provider,
     home,
     email: details.email,
     pylonHome,


### PR DESCRIPTION
Closes #7870

## Summary
- Add `khala fleet connect --harness claude` with isolated `CLAUDE_CONFIG_DIR` account homes under the Pylon account registry.
- Capture `claude setup-token` into the local `claude-oauth-token` file consumed by Pylon, without touching the default `~/.claude` home or printing token material.
- Show Codex/Claude harness readiness in `khala fleet status` and preserve Codex connect behavior.

## Verification
- PASS: `bun run --cwd clients/khala-cli test`
  - `91 pass`, `0 fail`, `362 expect() calls`
  - This is `command.public.pylon_khala.verify.c09b0f1b9e61cf08b69dfb7a`.
- PASS: `bun run --cwd clients/khala-cli typecheck`
- PASS: `git diff --check`
- BLOCKED/UNRELATED: `bun run check:deploy` fails in `apps/openagents.com` `check:architecture` before this Khala CLI change is exercised. Reported existing blockers: raw time/id/random primitive in `workers/api/src/inference/gym/mutalisk-khala-delegation-routes.ts`, Worker Response return surface count `132/123`, an unallowlisted `Effect.runPromise` in the same Mutalisk route, and missing projection ledger entry for `/api/public/gym/mutalisk-khala-delegation/runs`.
