### PR TITLE
T1.2: Shared Pylon lifecycle wire contract

### DIFF
--- a/apps/pylon/src/assignment.ts
+++ b/apps/pylon/src/assignment.ts
@@ -9,6 +9,10 @@ import {
   TASSADAR_EXECUTOR_TRACE_HOMEWORK_JOB_KIND,
   TASSADAR_EXECUTOR_TRACE_JOB_KIND,
 } from "@openagentsinc/tassadar-executor"
+import {
+  encodePylonAssignmentRunLifecycleEvent,
+  type PylonAssignmentRunLifecycleEvent,
+} from "@openagentsinc/agent-runtime-schema"
 import type { BootstrapSummary } from "./bootstrap.js"
 import {
   loadClaudeAgentConfig,
@@ -190,37 +194,7 @@ export type AssignmentClientOptions = {
   runtimeProgressIntervalMs?: number
 }
 
-export type AssignmentRunLifecycleEvent = {
-  schema: "openagents.pylon.assignment_run_lifecycle_event.v0.1"
-  event:
-    | "assignment_run.poll_complete"
-    | "assignment_run.accepted"
-    | "assignment_run.runtime_started"
-    | "assignment_run.runtime_progress"
-    | "assignment_run.runtime_failed"
-    | "assignment_run.progress_submitted"
-    | "assignment_run.artifacts_submitted"
-    | "assignment_run.closeout_submitted"
-    | "assignment_run.completed"
-    | "assignment_run.no_assignment"
-  observedAt: string
-  assignmentRef?: string
-  leaseRef?: string
-  leaseCount?: number
-  candidateCount?: number
-  status?: AssignmentStatus | AssignmentProgress["status"]
-  statusRef?: string
-  progressRef?: string
-  artifactRef?: string
-  closeoutRef?: string
-  accountRefHash?: string
-  elapsedMs?: number
-  phase?: "runtime_active" | CodexAgentRuntimePhase
-  tokensSoFar?: number
-  tokenCountKind?: "exact" | "estimated"
-  lastProgressEvent?: AssignmentRunLifecycleEvent["event"] | string
-  blockerRefs?: string[]
-}
+export type AssignmentRunLifecycleEvent = PylonAssignmentRunLifecycleEvent
 
 export type AssignmentRecoveryDiagnostic = {
   schema: "openagents.pylon.assignment_recovery_diagnostic.v0.1"
@@ -1691,8 +1665,9 @@ export async function runNoSpendAssignment(summary: BootstrapSummary, options: A
         observedAt: (options.now?.() ?? new Date()).toISOString(),
         ...event,
       }
-      assertPublicProjectionSafe(lifecycleEvent)
-      await options.onLifecycleEvent(lifecycleEvent)
+      const encodedLifecycleEvent = encodePylonAssignmentRunLifecycleEvent(lifecycleEvent)
+      assertPublicProjectionSafe(encodedLifecycleEvent)
+      await options.onLifecycleEvent(encodedLifecycleEvent)
       if (event.event !== "assignment_run.runtime_progress") {
         lastProgressEvent = event.event
       }

--- a/apps/pylon/src/khala-spawn.ts
+++ b/apps/pylon/src/khala-spawn.ts
@@ -1,3 +1,9 @@
+import {
+  encodePylonKhalaSpawnWorkerEvent,
+  PylonKhalaSpawnWorkerEventSchemaLiteral,
+  type PylonKhalaSpawnWorkerEvent as SharedPylonKhalaSpawnWorkerEvent,
+  type PylonKhalaSpawnWorkerState,
+} from "@openagentsinc/agent-runtime-schema"
 import type { BootstrapSummary } from "./bootstrap.js"
 import type { AssignmentClientOptions, AssignmentRunLifecycleEvent } from "./assignment.js"
 import { runNoSpendAssignment } from "./assignment.js"
@@ -15,19 +21,7 @@ import { assertPublicProjectionSafe } from "./state.js"
 
 export const PYLON_KHALA_SPAWN_PLAN_SCHEMA = "openagents.pylon.khala_spawn_plan.v0.1"
 export const PYLON_KHALA_SPAWN_RUN_SCHEMA = "openagents.pylon.khala_spawn_run.v0.1"
-export const PYLON_KHALA_SPAWN_WORKER_EVENT_SCHEMA = "openagents.pylon.khala_spawn_worker_event.v0.1"
-
-export type PylonKhalaSpawnWorkerState =
-  | "queued"
-  | "requesting"
-  | "assignment_created"
-  | "running"
-  | "closeout_submitted"
-  | "proof_checked"
-  | "accepted"
-  | "rejected"
-  | "failed"
-  | "cancelled"
+export const PYLON_KHALA_SPAWN_WORKER_EVENT_SCHEMA = PylonKhalaSpawnWorkerEventSchemaLiteral
 
 export type PylonKhalaSpawnAccount = {
   accountRef: string | null
@@ -87,18 +81,7 @@ export type PylonKhalaSpawnPlanLike<Slot extends PylonKhalaSpawnSlotLike = Pylon
     slots: readonly Slot[]
   }
 
-export type PylonKhalaSpawnWorkerEvent = {
-  schema: typeof PYLON_KHALA_SPAWN_WORKER_EVENT_SCHEMA
-  assignmentEvent?: AssignmentRunLifecycleEvent["event"]
-  assignmentRef?: string
-  closeoutRef?: string
-  leaseRef?: string
-  message: string
-  observedAt: string
-  slotIndex: number
-  state: PylonKhalaSpawnWorkerState
-  status?: string
-}
+export type PylonKhalaSpawnWorkerEvent = SharedPylonKhalaSpawnWorkerEvent
 
 export type PylonKhalaSpawnProofProjection = {
   cacheReadTokens: number
@@ -631,8 +614,9 @@ async function backfillMissingProofs<Slot extends PylonKhalaSpawnSlotLike>(input
         state: "proof_checked",
         status: "proof.khala_spawn.backfilled",
       }
-      assertPublicProjectionSafe(event)
-      await input.deps?.onWorkerLifecycle?.(event, slot)
+      const encodedEvent = encodePylonKhalaSpawnWorkerEvent(event)
+      assertPublicProjectionSafe(encodedEvent)
+      await input.deps?.onWorkerLifecycle?.(encodedEvent, slot)
       const state =
         proofBlockers.length > 0
           ? "failed"
@@ -772,9 +756,10 @@ async function runPylonKhalaSpawnSlot<Slot extends PylonKhalaSpawnSlotLike>(inpu
       state,
       ...patch,
     }
-    assertPublicProjectionSafe(event)
-    events.push(event)
-    await input.deps?.onWorkerLifecycle?.(event, input.slot)
+    const encodedEvent = encodePylonKhalaSpawnWorkerEvent(event)
+    assertPublicProjectionSafe(encodedEvent)
+    events.push(encodedEvent)
+    await input.deps?.onWorkerLifecycle?.(encodedEvent, input.slot)
   }
 
   const blockerRefs: string[] = []

--- a/apps/pylon/tests/assignment.test.ts
+++ b/apps/pylon/tests/assignment.test.ts
@@ -2,6 +2,7 @@ import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
 import { join } from "node:path"
 import { tmpdir } from "node:os"
 import { afterEach, describe, expect, test } from "bun:test"
+import { decodePylonLifecycleWireEventJson } from "@openagentsinc/agent-runtime-schema"
 import { createBootstrapSummary, parseBootstrapArgs } from "../src/bootstrap"
 import {
   acceptAssignment,
@@ -469,7 +470,7 @@ describe("Pylon assignment lease flow", () => {
       expect(result.lease.assignmentRef).toBe(cliLease.assignmentRef)
       expect(stdout).not.toContain("assignment_run.")
 
-      const events = stderr.trim().split("\n").map((line) => JSON.parse(line))
+      const events = stderr.trim().split("\n").map((line) => decodePylonLifecycleWireEventJson(line))
       expect(events.map((event) => event.event)).toEqual([
         "assignment_run.poll_complete",
         "assignment_run.accepted",

--- a/bun.lock
+++ b/bun.lock
@@ -371,6 +371,7 @@
       "name": "@openagentsinc/khala-code-desktop",
       "version": "0.0.1",
       "dependencies": {
+        "@openagentsinc/agent-runtime-schema": "workspace:*",
         "@openagentsinc/arbiter-effect": "workspace:*",
         "@openagentsinc/composer-state": "workspace:*",
         "@openagentsinc/khala-tools": "workspace:*",

--- a/clients/khala-code-desktop/package.json
+++ b/clients/khala-code-desktop/package.json
@@ -22,6 +22,7 @@
     "dev:hmr": "concurrently \"vite --port 5173 --strictPort\" \"bun run dev\""
   },
   "dependencies": {
+    "@openagentsinc/agent-runtime-schema": "workspace:*",
     "@openagentsinc/arbiter-effect": "workspace:*",
     "@openagentsinc/composer-state": "workspace:*",
     "@openagentsinc/khala-tools": "workspace:*",

--- a/clients/khala-code-desktop/src/bun/khala-codex-fleet-tools.ts
+++ b/clients/khala-code-desktop/src/bun/khala-codex-fleet-tools.ts
@@ -4,7 +4,12 @@ import { readFile, readdir, rename, rm, stat, writeFile } from "node:fs/promises
 import { homedir } from "node:os"
 import { dirname, join, resolve } from "node:path"
 import type { Readable } from "node:stream"
-import { Effect, Schema as S, Stream } from "effect"
+import { Effect, Stream } from "effect"
+import {
+  decodePylonLifecycleWireEvent,
+  decodePylonLifecycleWireEventJson,
+  type PylonLifecycleWireEvent,
+} from "@openagentsinc/agent-runtime-schema"
 import {
   KhalaFleetDelegateModuleError,
   khalaFleetDelegationParametersFromEnv,
@@ -247,8 +252,6 @@ type AssignmentLifecycleEvent = {
   readonly status?: string | undefined
 }
 
-type PylonLifecycleWireEvent = typeof PylonLifecycleWireEvent.Type
-
 const MAX_SPAWN_COUNT = 10
 const DEFAULT_COMMAND_TIMEOUT_MS = 45_000
 const DEFAULT_SPAWN_TIMEOUT_MS = 1_800_000
@@ -257,35 +260,6 @@ const DEFAULT_CODEX_ACCOUNT_CONCURRENCY = MAX_SPAWN_COUNT
 const DEFAULT_OPENAGENTS_BASE_URL = "https://openagents.com"
 const MAX_MODEL_OUTPUT_BYTES = 4_000
 const MAX_STREAMED_LIFECYCLE_EVENTS = 200
-
-const PylonAssignmentLifecycleWireEvent = S.Struct({
-  schema: S.Literal("openagents.pylon.assignment_run_lifecycle_event.v0.1"),
-  event: S.String,
-  observedAt: S.String,
-  assignmentRef: S.optional(S.String),
-  leaseRef: S.optional(S.String),
-  phase: S.optional(S.String),
-  status: S.optional(S.String),
-})
-
-const PylonSpawnWorkerLifecycleWireEvent = S.Struct({
-  schema: S.Literal("openagents.pylon.khala_spawn_worker_event.v0.1"),
-  message: S.String,
-  observedAt: S.String,
-  slotIndex: S.Number,
-  state: S.String,
-  assignmentEvent: S.optional(S.String),
-  assignmentRef: S.optional(S.String),
-  leaseRef: S.optional(S.String),
-  phase: S.optional(S.String),
-  status: S.optional(S.String),
-})
-
-const PylonLifecycleWireEvent = S.Union([
-  PylonAssignmentLifecycleWireEvent,
-  PylonSpawnWorkerLifecycleWireEvent,
-])
-const decodePylonLifecycleWireEvent = S.decodeUnknownSync(PylonLifecycleWireEvent)
 
 const pylonEnsureToolDefinition: KhalaToolDefinition = {
   authority: "owner_full_access",
@@ -2678,7 +2652,7 @@ export function parsePylonLifecycleNdjsonLine(line: string): Record<string, unkn
   const trimmed = line.trim()
   if (!trimmed.startsWith("{") || !trimmed.endsWith("}")) return null
   try {
-    const decoded: PylonLifecycleWireEvent = decodePylonLifecycleWireEvent(JSON.parse(trimmed) as unknown)
+    const decoded: PylonLifecycleWireEvent = decodePylonLifecycleWireEventJson(trimmed)
     return record(decoded)
   } catch {
     return null
@@ -2686,36 +2660,25 @@ export function parsePylonLifecycleNdjsonLine(line: string): Record<string, unkn
 }
 
 function lifecycleEventFromUnknown(value: unknown): AssignmentLifecycleEvent | null {
-  let event = record(value)
-  if (event === null) return null
   try {
-    const decoded: PylonLifecycleWireEvent = decodePylonLifecycleWireEvent(event)
-    event = record(decoded)
-    if (event === null) return null
+    const decoded: PylonLifecycleWireEvent = decodePylonLifecycleWireEvent(value)
+    if (decoded.schema === "openagents.pylon.assignment_run_lifecycle_event.v0.1") {
+      return {
+        ...(decoded.assignmentRef === undefined ? {} : { assignmentRef: decoded.assignmentRef }),
+        event: decoded.event,
+        ...(decoded.leaseRef === undefined ? {} : { leaseRef: decoded.leaseRef }),
+        ...(decoded.phase === undefined ? {} : { phase: decoded.phase }),
+        ...(decoded.status === undefined ? {} : { status: decoded.status }),
+      }
+    }
+    return {
+      ...(decoded.assignmentRef === undefined ? {} : { assignmentRef: decoded.assignmentRef }),
+      event: decoded.assignmentEvent ?? decoded.state,
+      ...(decoded.leaseRef === undefined ? {} : { leaseRef: decoded.leaseRef }),
+      ...(decoded.status === undefined ? {} : { status: decoded.status }),
+    }
   } catch {
     return null
-  }
-  const schema = stringField(event, "schema")
-  if (
-    schema !== "openagents.pylon.assignment_run_lifecycle_event.v0.1" &&
-    schema !== "openagents.pylon.khala_spawn_worker_event.v0.1"
-  ) return null
-  const eventName =
-    stringField(event, "event") ??
-    stringField(event, "assignmentEvent") ??
-    stringField(event, "state") ??
-    stringField(event, "message")
-  if (eventName === null) return null
-  const assignmentRef = stringField(event, "assignmentRef")
-  const leaseRef = stringField(event, "leaseRef")
-  const phase = stringField(event, "phase")
-  const status = stringField(event, "status")
-  return {
-    ...(assignmentRef === null ? {} : { assignmentRef }),
-    event: eventName,
-    ...(leaseRef === null ? {} : { leaseRef }),
-    ...(phase === null ? {} : { phase }),
-    ...(status === null ? {} : { status }),
   }
 }
 

--- a/clients/khala-code-desktop/tests/khala-codex-fleet-tools.test.ts
+++ b/clients/khala-code-desktop/tests/khala-codex-fleet-tools.test.ts
@@ -177,6 +177,18 @@ describe("Khala Code Codex fleet tools", () => {
       event: "assignment_run.runtime_progress",
       schema: "unknown",
     }))).toBeNull()
+    expect(parsePylonLifecycleNdjsonLine(JSON.stringify({
+      event: "assignment_run.not_real",
+      observedAt: "2026-06-30T00:00:02.000Z",
+      schema: "openagents.pylon.assignment_run_lifecycle_event.v0.1",
+    }))).toBeNull()
+    expect(parsePylonLifecycleNdjsonLine(JSON.stringify({
+      message: "assignment lifecycle event",
+      observedAt: "2026-06-30T00:00:03.000Z",
+      schema: "openagents.pylon.khala_spawn_worker_event.v0.1",
+      slotIndex: 0,
+      state: "made_up_state",
+    }))).toBeNull()
   })
 
   test("ensureLocalPylon starts a missing local Pylon and re-probes it", async () => {
@@ -1983,7 +1995,6 @@ describe("Khala Code Codex fleet tools", () => {
             leaseRef: "assignment.public.codex_agent_task.timeout",
             message: "assignment lifecycle event",
             observedAt: "2026-06-30T00:00:00.000Z",
-            phase: "runtime_active",
             schema: "openagents.pylon.khala_spawn_worker_event.v0.1",
             slotIndex: 0,
             state: "running",
@@ -2006,6 +2017,6 @@ describe("Khala Code Codex fleet tools", () => {
     expect(result.modelOutput.text).toContain("Codex spawn: accepted 0/1")
     expect(result.modelOutput.text).toContain("command timed out")
     expect(result.modelOutput.text).toContain("assignment_run.runtime_started")
-    expect(result.modelOutput.text).toContain("phase=runtime_active")
+    expect(result.modelOutput.text).not.toContain("phase=runtime_active")
   })
 })

--- a/packages/agent-runtime-schema/src/index.test.ts
+++ b/packages/agent-runtime-schema/src/index.test.ts
@@ -2,6 +2,10 @@ import { describe, expect, test } from "bun:test"
 import {
   AgentRuntimeEvent,
   AgentRuntimeRun,
+  PylonLifecycleWireEventFromJsonString,
+  decodePylonLifecycleWireEventJson,
+  encodePylonAssignmentRunLifecycleEvent,
+  encodePylonKhalaSpawnWorkerEvent,
   agentRuntimeAdapterKinds,
   agentRuntimeEventTags,
   agentRuntimeLoopKinds,
@@ -162,5 +166,55 @@ describe("@openagentsinc/agent-runtime-schema", () => {
       reviewActionRefs: ["review.public.agent_runtime.blocker.agent_runtime.test_fixture.failed"],
     })
     expect(agentRuntimeSurfaceStatusHasUnsafeMaterial(row)).toBe(false)
+  })
+
+  test("round-trips Pylon lifecycle wire events through shared JSON string schemas", () => {
+    const assignmentEvent = encodePylonAssignmentRunLifecycleEvent({
+      schema: "openagents.pylon.assignment_run_lifecycle_event.v0.1",
+      event: "assignment_run.runtime_progress",
+      observedAt: "2026-07-01T00:00:00.000Z",
+      assignmentRef: "assignment.public.schema_test",
+      leaseRef: "lease.public.schema_test",
+      elapsedMs: 1200,
+      phase: "runtime_active",
+      tokenCountKind: "estimated",
+      tokensSoFar: 42,
+    })
+    const workerEvent = encodePylonKhalaSpawnWorkerEvent({
+      schema: "openagents.pylon.khala_spawn_worker_event.v0.1",
+      assignmentEvent: "assignment_run.completed",
+      assignmentRef: "assignment.public.schema_test",
+      leaseRef: "lease.public.schema_test",
+      message: "assignment lifecycle event",
+      observedAt: "2026-07-01T00:00:01.000Z",
+      slotIndex: 0,
+      state: "accepted",
+      status: "accepted",
+    })
+
+    expect(decodePylonLifecycleWireEventJson(JSON.stringify(assignmentEvent))).toEqual(assignmentEvent)
+    expect(decodePylonLifecycleWireEventJson(JSON.stringify(workerEvent))).toEqual(workerEvent)
+    expect(JSON.stringify(PylonLifecycleWireEventFromJsonString.ast)).toContain(
+      "openagents.pylon.assignment_run_lifecycle_event.v0.1",
+    )
+  })
+
+  test("rejects malformed Pylon lifecycle wire events", () => {
+    expect(() =>
+      decodePylonLifecycleWireEventJson(JSON.stringify({
+        schema: "openagents.pylon.assignment_run_lifecycle_event.v0.1",
+        event: "assignment_run.unknown",
+        observedAt: "2026-07-01T00:00:00.000Z",
+      })),
+    ).toThrow()
+    expect(() =>
+      decodePylonLifecycleWireEventJson(JSON.stringify({
+        schema: "openagents.pylon.khala_spawn_worker_event.v0.1",
+        message: "assignment lifecycle event",
+        observedAt: "2026-07-01T00:00:00.000Z",
+        slotIndex: 0,
+        state: "mystery",
+      })),
+    ).toThrow()
   })
 })

--- a/packages/agent-runtime-schema/src/index.ts
+++ b/packages/agent-runtime-schema/src/index.ts
@@ -308,6 +308,119 @@ export const decodeAgentRuntimeRun = S.decodeUnknownSync(AgentRuntimeRun)
 export const decodeAgentRuntimeEvent = S.decodeUnknownSync(AgentRuntimeEvent)
 export const decodeAgentRuntimeEventLog = S.decodeUnknownSync(AgentRuntimeEventLog)
 
+export const PylonAssignmentRunLifecycleEventSchemaLiteral =
+  "openagents.pylon.assignment_run_lifecycle_event.v0.1" as const
+
+export const PylonKhalaSpawnWorkerEventSchemaLiteral =
+  "openagents.pylon.khala_spawn_worker_event.v0.1" as const
+
+export const PylonAssignmentStatus = S.Literals([
+  "offered",
+  "accepted",
+  "running",
+  "closed",
+  "rejected",
+  "cancelled",
+  "timed-out",
+  "stale",
+])
+export type PylonAssignmentStatus = typeof PylonAssignmentStatus.Type
+
+export const PylonAssignmentProgressStatus = S.Literals([
+  "accepted",
+  "running",
+  "artifact-ready",
+  "proof-ready",
+  "closeout-submitted",
+])
+export type PylonAssignmentProgressStatus = typeof PylonAssignmentProgressStatus.Type
+
+export const PylonCodexAgentRuntimePhase = S.String
+export type PylonCodexAgentRuntimePhase = typeof PylonCodexAgentRuntimePhase.Type
+
+export const PylonAssignmentRunLifecycleEventName = S.Literals([
+  "assignment_run.poll_complete",
+  "assignment_run.accepted",
+  "assignment_run.runtime_started",
+  "assignment_run.runtime_progress",
+  "assignment_run.runtime_failed",
+  "assignment_run.progress_submitted",
+  "assignment_run.artifacts_submitted",
+  "assignment_run.closeout_submitted",
+  "assignment_run.completed",
+  "assignment_run.no_assignment",
+])
+export type PylonAssignmentRunLifecycleEventName = typeof PylonAssignmentRunLifecycleEventName.Type
+
+export const PylonAssignmentRunLifecycleEvent = S.Struct({
+  schema: S.Literal(PylonAssignmentRunLifecycleEventSchemaLiteral),
+  event: PylonAssignmentRunLifecycleEventName,
+  observedAt: S.String,
+  assignmentRef: S.optional(S.String),
+  leaseRef: S.optional(S.String),
+  leaseCount: S.optional(S.Number),
+  candidateCount: S.optional(S.Number),
+  status: S.optional(S.Union([PylonAssignmentStatus, PylonAssignmentProgressStatus])),
+  statusRef: S.optional(S.String),
+  progressRef: S.optional(S.String),
+  artifactRef: S.optional(S.String),
+  closeoutRef: S.optional(S.String),
+  accountRefHash: S.optional(S.String),
+  elapsedMs: S.optional(S.Number),
+  phase: S.optional(S.Union([S.Literal("runtime_active"), PylonCodexAgentRuntimePhase])),
+  tokensSoFar: S.optional(S.Number),
+  tokenCountKind: S.optional(S.Literals(["exact", "estimated"])),
+  lastProgressEvent: S.optional(S.Union([PylonAssignmentRunLifecycleEventName, S.String])),
+  blockerRefs: S.optional(S.Array(S.String)),
+})
+export type PylonAssignmentRunLifecycleEvent = typeof PylonAssignmentRunLifecycleEvent.Type
+
+export const PylonKhalaSpawnWorkerState = S.Literals([
+  "queued",
+  "requesting",
+  "assignment_created",
+  "running",
+  "closeout_submitted",
+  "proof_checked",
+  "accepted",
+  "rejected",
+  "failed",
+  "cancelled",
+])
+export type PylonKhalaSpawnWorkerState = typeof PylonKhalaSpawnWorkerState.Type
+
+export const PylonKhalaSpawnWorkerEvent = S.Struct({
+  schema: S.Literal(PylonKhalaSpawnWorkerEventSchemaLiteral),
+  assignmentEvent: S.optional(PylonAssignmentRunLifecycleEventName),
+  assignmentRef: S.optional(S.String),
+  closeoutRef: S.optional(S.String),
+  leaseRef: S.optional(S.String),
+  message: S.String,
+  observedAt: S.String,
+  slotIndex: S.Number,
+  state: PylonKhalaSpawnWorkerState,
+  status: S.optional(S.String),
+})
+export type PylonKhalaSpawnWorkerEvent = typeof PylonKhalaSpawnWorkerEvent.Type
+
+export const PylonLifecycleWireEvent = S.Union([
+  PylonAssignmentRunLifecycleEvent,
+  PylonKhalaSpawnWorkerEvent,
+])
+export type PylonLifecycleWireEvent = typeof PylonLifecycleWireEvent.Type
+
+export const PylonLifecycleWireEventFromJsonString = S.fromJsonString(PylonLifecycleWireEvent)
+
+export const decodePylonAssignmentRunLifecycleEvent =
+  S.decodeUnknownSync(PylonAssignmentRunLifecycleEvent)
+export const encodePylonAssignmentRunLifecycleEvent =
+  S.encodeUnknownSync(PylonAssignmentRunLifecycleEvent)
+export const decodePylonKhalaSpawnWorkerEvent = S.decodeUnknownSync(PylonKhalaSpawnWorkerEvent)
+export const encodePylonKhalaSpawnWorkerEvent = S.encodeUnknownSync(PylonKhalaSpawnWorkerEvent)
+export const decodePylonLifecycleWireEvent = S.decodeUnknownSync(PylonLifecycleWireEvent)
+export const decodePylonLifecycleWireEventJson =
+  S.decodeUnknownSync(PylonLifecycleWireEventFromJsonString)
+
 const unsafePublicMaterialPattern =
   /(@|\/Users\/|\/home\/|access[_-]?token|api[_-]?key|auth\.json|bearer|callback[_-]?token|cookie|customer[_-]?(email|name|phone|prompt|record|value)|email[_-]?(address|body|html|raw|text)|gho_[A-Za-z0-9_]+|ghp_[A-Za-z0-9_]+|github\.com\/[^:/]+\/private|invoice[_-]?(id|raw)|lnbc|lntb|lnbcrt|lno1|lnurl|local[_-]?path|macaroon|mdk[_-]?(access[_-]?token|mnemonic|webhook[_-]?secret)|mnemonic|oauth|opencode_auth_content|payment[_-]?(hash|id|invoice|preimage|proof|raw|secret)|payout[_-]?(address|destination|private|raw|target)|preimage|private[_-]?(archive|customer|key|repo|source|trace|wallet)|provider[_-]?(account|credential|grant|payload|secret|token)|raw[_-]?(artifact|auth|command|customer|email|invoice|log|payment|payload|prompt|provider|record|repo|runner|run[_-]?log|shell|source|state|target|text|trace|webhook)|recovery[_-]?phrase|secret|seed[_-]?phrase|sk-[a-z0-9]|token[_-]?secret|wallet[._-]?(key|material|mnemonic|payment|preimage|secret|seed))/i
 


### PR DESCRIPTION
Closes #7823

## Summary
- Promote Pylon assignment lifecycle and Khala spawn worker lifecycle wire events into @openagentsinc/agent-runtime-schema Effect schemas.
- Encode Pylon lifecycle emissions through the shared schema before observer/NDJSON output.
- Decode Khala Code Desktop lifecycle NDJSON through the shared Schema.fromJsonString decoder and remove the desktop-local schema/fallback probing path.

## Verification
- bun run --cwd packages/agent-runtime-schema test && bun run --cwd packages/agent-runtime-schema typecheck
- bun test --cwd apps/pylon tests/assignment.test.ts
- bun test --cwd clients/khala-code-desktop tests/khala-codex-fleet-tools.test.ts
- bun run --cwd apps/pylon typecheck
- bun run --cwd clients/khala-code-desktop typecheck
- command.public.pylon_khala.verify.28484fe0b746db06b92c2eb2: bun run --cwd apps/pylon test => 1981 pass, 3 skip, 0 fail
