### PR TITLE
Fix claude workspace-escape guard .. false positives

### DIFF
--- a/apps/pylon/src/claude-agent-executor.ts
+++ b/apps/pylon/src/claude-agent-executor.ts
@@ -215,8 +215,8 @@ function boundedNumber(value: number | undefined, fallback: number, max: number)
 /**
  * Returns true when a tool call targets anything outside the bounded
  * workspace. Path fields must resolve under the workspace; Bash commands
- * may not contain parent-directory traversal or absolute paths that leave
- * it. Deny-by-default sandbox policy for the bounded fixture lane.
+ * resolve path-like tokens under the same root and deny only real escapes.
+ * Deny-by-default sandbox policy for the bounded fixture lane.
  */
 export function toolInputEscapesWorkspace(
   toolName: string | undefined,
@@ -251,11 +251,9 @@ export function toolInputEscapesWorkspace(
   if (toolName === "Bash") {
     const command = input.command
     if (typeof command === "string") {
-      if (command.includes("..")) return true
       const systemPrefixes = ["/dev/", "/usr/", "/bin/", "/sbin/", "/opt/"]
-      const absolutePaths = command.match(/(?:^|[\s='"])(\/[^\s'"]+)/g) ?? []
-      for (const match of absolutePaths) {
-        const candidate = resolve(match.replace(/^[\s='"]+/, ""))
+      for (const token of bashPathLikeTokens(command)) {
+        const candidate = isAbsolute(token) ? resolve(token) : resolve(workspaceRealRoot, token)
         const allowed =
           insideWorkspace(candidate) ||
           systemPrefixes.some((prefix) => candidate.startsWith(prefix))
@@ -265,6 +263,59 @@ export function toolInputEscapesWorkspace(
   }
 
   return false
+}
+
+function bashPathLikeTokens(command: string): string[] {
+  const tokens: string[] = []
+  let current = ""
+  let quote: "'" | "\"" | null = null
+  let escaped = false
+
+  const push = () => {
+    const token = shellPathTokenFrom(current)
+    if (token !== null) tokens.push(token)
+    current = ""
+  }
+
+  for (const char of command) {
+    if (escaped) {
+      current += char
+      escaped = false
+      continue
+    }
+    if (char === "\\" && quote !== "'") {
+      escaped = true
+      continue
+    }
+    if ((char === "'" || char === "\"") && quote === null) {
+      quote = char
+      continue
+    }
+    if (char === quote) {
+      quote = null
+      continue
+    }
+    if (quote === null && /\s/.test(char)) {
+      push()
+      continue
+    }
+    current += char
+  }
+  if (escaped) current += "\\"
+  push()
+  return tokens
+}
+
+function shellPathTokenFrom(rawToken: string): string | null {
+  const token = rawToken
+    .replace(/^[;|&(){}[\]<>]+/, "")
+    .replace(/[;|&(){}[\]<>]+$/, "")
+    .replace(/^[A-Za-z_][A-Za-z0-9_]*=/, "")
+  if (token.length === 0) return null
+  if (token === "." || token === "..") return token
+  if (token.startsWith("/") || token.startsWith("./") || token.startsWith("../")) return token
+  if (token.includes("/")) return token
+  return null
 }
 
 async function runCommand(input: { args: string[]; cwd: string }) {

--- a/apps/pylon/src/claude-agent-executor.ts
+++ b/apps/pylon/src/claude-agent-executor.ts
@@ -311,6 +311,11 @@ function shellPathTokenFrom(rawToken: string): string | null {
     .replace(/^[;|&(){}[\]<>]+/, "")
     .replace(/[;|&(){}[\]<>]+$/, "")
     .replace(/^[A-Za-z_][A-Za-z0-9_]*=/, "")
+    // A dash-flag glued to a value (`--output=../x`, `-o../x`) executes with
+    // the flag prefix stripped, so evaluate the value as the path candidate;
+    // resolving the literal `--output=..` segment would hide the traversal.
+    .replace(/^-{1,2}[A-Za-z0-9][\w-]*=/, "")
+    .replace(/^-[A-Za-z](?=\.{1,2}\/)/, "")
   if (token.length === 0) return null
   if (token === "." || token === "..") return token
   if (token.startsWith("/") || token.startsWith("./") || token.startsWith("../")) return token

--- a/apps/pylon/tests/claude-agent-executor.test.ts
+++ b/apps/pylon/tests/claude-agent-executor.test.ts
@@ -343,10 +343,19 @@ describe("workspace boundary checks", () => {
 
   test("bash commands with traversal or foreign absolute paths escape", () => {
     expect(toolInputEscapesWorkspace("Bash", { command: "cat ../secrets" }, workspace)).toBe(true)
+    expect(toolInputEscapesWorkspace("Bash", { command: "cat ../../etc/hosts" }, workspace)).toBe(true)
+    expect(toolInputEscapesWorkspace("Bash", { command: "cd .." }, workspace)).toBe(true)
     expect(toolInputEscapesWorkspace("Bash", { command: "cat /etc/passwd" }, workspace)).toBe(true)
     expect(toolInputEscapesWorkspace("Bash", { command: "bun test sum.test.ts" }, workspace)).toBe(false)
     expect(toolInputEscapesWorkspace("Bash", { command: `cat ${workspace}/sum.ts` }, workspace)).toBe(false)
     expect(toolInputEscapesWorkspace("Bash", { command: "/usr/bin/env bun test" }, workspace)).toBe(false)
+  })
+
+  test("bash commands with benign dot-dot syntax do not escape", () => {
+    expect(toolInputEscapesWorkspace("Bash", { command: "for n in {1..5}; do echo $n; done" }, workspace)).toBe(false)
+    expect(toolInputEscapesWorkspace("Bash", { command: "git diff main..HEAD" }, workspace)).toBe(false)
+    expect(toolInputEscapesWorkspace("Bash", { command: "printf 'working... done\\n'" }, workspace)).toBe(false)
+    expect(toolInputEscapesWorkspace("Bash", { command: "cat src/../sum.ts" }, workspace)).toBe(false)
   })
 
   test("symlinked workspace roots accept realpath spellings without widening", async () => {

--- a/apps/pylon/tests/claude-agent-executor.test.ts
+++ b/apps/pylon/tests/claude-agent-executor.test.ts
@@ -358,6 +358,17 @@ describe("workspace boundary checks", () => {
     expect(toolInputEscapesWorkspace("Bash", { command: "cat src/../sum.ts" }, workspace)).toBe(false)
   })
 
+  test("dash-flag glued traversal is denied while benign flag values pass", () => {
+    const workspace = "/private/tmp/pylon-claude-guard-ws"
+    expect(toolInputEscapesWorkspace("Bash", { command: "curl --output=../secret http://x" }, workspace)).toBe(true)
+    expect(toolInputEscapesWorkspace("Bash", { command: "tar --directory=../../evil -xf a.tar" }, workspace)).toBe(true)
+    expect(toolInputEscapesWorkspace("Bash", { command: "git --git-dir=../../.git log" }, workspace)).toBe(true)
+    expect(toolInputEscapesWorkspace("Bash", { command: "cc -o../escape main.c" }, workspace)).toBe(true)
+    expect(toolInputEscapesWorkspace("Bash", { command: "curl --output=out/result.bin http://x" }, workspace)).toBe(false)
+    expect(toolInputEscapesWorkspace("Bash", { command: "bun test --filter=sum src/sum.test.ts" }, workspace)).toBe(false)
+    expect(toolInputEscapesWorkspace("Bash", { command: `cp file ${workspace}/dest.txt` }, workspace)).toBe(false)
+  })
+
   test("symlinked workspace roots accept realpath spellings without widening", async () => {
     // macOS /tmp is a symlink to /private/tmp; the SDK canonicalizes its cwd,
     // so tool paths arrive realpath'd. Found live on 2026-06-11: the first


### PR DESCRIPTION
Closes #7914

## Summary
- replace the Claude Bash workspace guard's raw `..` substring block with path-like token resolution against the workspace root
- preserve deny-on-first-real-escape for Bash paths outside the workspace and outside the existing allowed system prefixes
- add regressions for benign `..` syntax and real traversal escapes

## Verification
- `bun run --cwd apps/pylon test` (1982 pass, 3 skip, 0 fail)