### PR TITLE
T6.11: Property-based tests

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -388,6 +388,7 @@
         "@types/three": "0.184.0",
         "bun-types": "^1.0.0",
         "concurrently": "^9.2.1",
+        "fast-check": "^4.8.0",
         "tailwindcss": "^4.2.4",
         "typescript": "catalog:",
         "vite": "^8.0.10",

--- a/clients/khala-code-desktop/package.json
+++ b/clients/khala-code-desktop/package.json
@@ -39,6 +39,7 @@
     "@types/three": "0.184.0",
     "bun-types": "^1.0.0",
     "concurrently": "^9.2.1",
+    "fast-check": "^4.8.0",
     "tailwindcss": "^4.2.4",
     "typescript": "catalog:",
     "vite": "^8.0.10"

--- a/clients/khala-code-desktop/tests/codex-thread-item-projector.property.test.ts
+++ b/clients/khala-code-desktop/tests/codex-thread-item-projector.property.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, test } from "bun:test"
+import fc from "fast-check"
+
+import {
+  createCodexThreadItemEventProjector,
+} from "../src/bun/codex-thread-item-projector"
+import type { CodexAppServerNotification } from "../src/bun/codex-app-server-client"
+
+type DeltaFamily = "agent" | "command" | "file" | "plan" | "reasoning"
+
+type DeltaOp = Readonly<{
+  family: DeltaFamily
+  itemId: string
+  value: string
+}>
+
+const safeId = fc
+  .stringMatching(/[a-z][a-z0-9_-]{0,10}/)
+  .filter(value => value !== "reasoning")
+
+const shortText = fc.string({ minLength: 1, maxLength: 80 })
+
+const deltaOpArbitrary: fc.Arbitrary<DeltaOp> = fc.record({
+  family: fc.constantFrom("agent", "command", "file", "plan", "reasoning"),
+  itemId: safeId,
+  value: shortText,
+})
+
+const note = (
+  method: string,
+  params: Record<string, unknown>,
+): CodexAppServerNotification => ({
+  method,
+  params: {
+    threadId: "thread-property",
+    turnId: "turn-property",
+    ...params,
+  },
+  receivedAt: "2026-07-01T17:00:00.000Z",
+})
+
+const notificationFor = (op: DeltaOp): CodexAppServerNotification => {
+  switch (op.family) {
+    case "agent":
+      return note("item/agentMessage/delta", {
+        itemId: op.itemId,
+        delta: op.value,
+      })
+    case "command":
+      return note("item/commandExecution/outputDelta", {
+        itemId: op.itemId,
+        delta: op.value,
+      })
+    case "file":
+      return note("item/fileChange/patchUpdated", {
+        itemId: op.itemId,
+        changes: [{
+          path: `src/${op.itemId}.ts`,
+          kind: "update",
+          diff: `--- a/src/${op.itemId}.ts\n+++ b/src/${op.itemId}.ts\n@@ -1 +1 @@\n-old\n+${op.value}\n`,
+        }],
+      })
+    case "plan":
+      return note("item/plan/delta", {
+        itemId: op.itemId,
+        delta: op.value,
+      })
+    case "reasoning":
+      return note("item/reasoning/delta", {
+        itemId: op.itemId,
+        delta: op.value,
+      })
+  }
+}
+
+describe("Codex ThreadItem projector properties", () => {
+  test("keeps stable cards for arbitrary interleavings of item delta families", () => {
+    fc.assert(
+      fc.property(fc.array(deltaOpArbitrary, { maxLength: 80 }), (ops) => {
+        const projector = createCodexThreadItemEventProjector({
+          desktopTurnId: "desktop-turn-property",
+        })
+
+        for (const op of ops) {
+          expect(() => projector.accept(notificationFor(op))).not.toThrow()
+        }
+
+        const messages = projector.messages()
+        const ids = messages.map(message => message.id)
+        expect(new Set(ids).size).toBe(ids.length)
+
+        const latestFamilyById = new Map<string, DeltaFamily>()
+        const bodyById = new Map<string, string>()
+        for (const op of ops) {
+          if (op.family === "reasoning") continue
+          latestFamilyById.set(op.itemId, op.family)
+          if (op.family === "file") {
+            bodyById.set(op.itemId, op.value)
+          } else {
+            bodyById.set(op.itemId, `${bodyById.get(op.itemId) ?? ""}${op.value}`)
+          }
+        }
+
+        expect(messages).toHaveLength(latestFamilyById.size)
+        for (const message of messages) {
+          const family = latestFamilyById.get(message.id)
+          expect(family).toBeDefined()
+          expect(message.codexItem?.itemId ?? message.id).toBe(message.id)
+          expect(message.body).toContain(bodyById.get(message.id) ?? "")
+          if (family === "agent") {
+            expect(message.role).toBe("assistant")
+            expect(message.codexItem).toBeUndefined()
+          } else {
+            expect(message.role).toBe(family === "plan" ? "assistant" : "tool")
+            expect(message.codexItem).toMatchObject({
+              itemId: message.id,
+              status: "running",
+              threadId: "thread-property",
+              turnId: "turn-property",
+            })
+          }
+        }
+      }),
+      { numRuns: 150 },
+    )
+  })
+})

--- a/clients/khala-code-desktop/tests/composer-draft-model.property.test.ts
+++ b/clients/khala-code-desktop/tests/composer-draft-model.property.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, test } from "bun:test"
+import fc from "fast-check"
+
+import {
+  applyComposerTransaction,
+  composerBlockId,
+  emptyComposerState,
+  runComposerInputRules,
+  serializeComposerMarkdown,
+  type ComposerState,
+  type ComposerTransaction,
+} from "@openagentsinc/composer-state"
+
+type DraftAction = Readonly<{
+  kind: "type" | "paste" | "slash"
+  text: string
+  cursorBias: number
+}>
+
+const draftText = fc.string({ maxLength: 50 })
+
+const draftActionArbitrary: fc.Arbitrary<DraftAction> = fc.record({
+  kind: fc.constantFrom("type", "paste", "slash"),
+  text: draftText,
+  cursorBias: fc.integer({ min: 0, max: 1_000 }),
+})
+
+const firstBlockText = (state: ComposerState): string => {
+  const block = state.doc.blocks[0]
+  if (block === undefined || block.kind === "attachmentRef" || block.kind === "list") return ""
+  return block.text
+}
+
+const apply = (state: ComposerState, transaction: ComposerTransaction): ComposerState => {
+  const result = applyComposerTransaction(state, transaction)
+  expect(result.ok).toBe(true)
+  if (!result.ok) return state
+  return result.state
+}
+
+const insertText = (
+  state: ComposerState,
+  text: string,
+  source: ComposerTransaction["meta"]["source"],
+  cursorBias: number,
+): ComposerState => {
+  const current = firstBlockText(state)
+  const offset = current.length === 0 ? 0 : cursorBias % (current.length + 1)
+  return apply(state, {
+    steps: [{
+      _tag: "InsertText",
+      at: { blockId: composerBlockId("block-1"), offset },
+      text,
+    }],
+    meta: { source, time: 1 },
+  })
+}
+
+const runInputRules = (state: ComposerState, insertedText: string): ComposerState => {
+  const transaction = runComposerInputRules(state, insertedText)
+  return transaction === null ? state : apply(state, transaction)
+}
+
+describe("composer draft model properties", () => {
+  test("arbitrary type, paste, and slash sequences preserve committed text", () => {
+    fc.assert(
+      fc.property(fc.array(draftActionArbitrary, { maxLength: 120 }), (actions) => {
+        let state = emptyComposerState()
+        let model = ""
+
+        for (const action of actions) {
+          const text = action.kind === "slash" ? `/${action.text}` : action.text
+          const offset = model.length === 0 ? 0 : action.cursorBias % (model.length + 1)
+          model = `${model.slice(0, offset)}${text}${model.slice(offset)}`
+          state = insertText(
+            state,
+            text,
+            action.kind === "paste" ? "paste" : "input",
+            action.cursorBias,
+          )
+          state = runInputRules(state, text)
+        }
+
+        expect(firstBlockText(state)).toBe(model)
+        expect(serializeComposerMarkdown(state.doc)).toContain(model)
+      }),
+      { numRuns: 150 },
+    )
+  })
+})

--- a/clients/khala-code-desktop/tests/transcript-render.property.test.ts
+++ b/clients/khala-code-desktop/tests/transcript-render.property.test.ts
@@ -1,0 +1,123 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test"
+import fc from "fast-check"
+import { Window } from "happy-dom"
+
+import {
+  diffElement,
+  markdownElement,
+  renderMessageBody,
+} from "../src/ui/transcript-render"
+import type { KhalaCodeDesktopCodexItemCard } from "../src/shared/rpc"
+
+const hostileLiteral = fc.constantFrom(
+  "<script>alert(1)</script>",
+  "<img src=x onerror=alert(1)>",
+  "<svg onload=alert(1)>x</svg>",
+  "<a href=\"javascript:alert(1)\">bad</a>",
+)
+
+const hostileInput = fc
+  .tuple(fc.string({ maxLength: 80 }), hostileLiteral, fc.string({ maxLength: 80 }))
+  .map(([before, hostile, after]) => `${before}${hostile}${after}`)
+
+const diffInput = fc.record({
+  file: fc.stringMatching(/[a-z][a-z0-9_-]{0,8}\.ts/),
+  before: hostileInput,
+  after: hostileInput,
+}).map(({ file, before, after }) =>
+  `--- a/${file}\n+++ b/${file}\n@@ -1 +1 @@\n-${before}\n+${after}\n`)
+
+const toolCard: KhalaCodeDesktopCodexItemCard = {
+  itemId: "item-property",
+  itemType: "commandExecution",
+  status: "completed",
+  title: "Ran command",
+}
+
+let previousDocument: typeof globalThis.document | undefined
+let previousWindow: typeof globalThis.window | undefined
+let previousNavigator: typeof globalThis.navigator | undefined
+let previousRequestAnimationFrame: typeof globalThis.requestAnimationFrame | undefined
+
+const installDom = (): void => {
+  const window = new Window()
+  previousDocument = globalThis.document
+  previousWindow = globalThis.window
+  previousNavigator = globalThis.navigator
+  previousRequestAnimationFrame = globalThis.requestAnimationFrame
+  Object.defineProperty(globalThis, "window", { configurable: true, value: window })
+  Object.defineProperty(globalThis, "document", { configurable: true, value: window.document })
+  Object.defineProperty(globalThis, "navigator", {
+    configurable: true,
+    value: { clipboard: { writeText: async () => undefined } },
+  })
+  Object.defineProperty(globalThis, "requestAnimationFrame", {
+    configurable: true,
+    value: (callback: FrameRequestCallback) => {
+      callback(0)
+      return 0
+    },
+  })
+}
+
+const restoreDom = (): void => {
+  Object.defineProperty(globalThis, "window", { configurable: true, value: previousWindow })
+  Object.defineProperty(globalThis, "document", { configurable: true, value: previousDocument })
+  Object.defineProperty(globalThis, "navigator", { configurable: true, value: previousNavigator })
+  Object.defineProperty(globalThis, "requestAnimationFrame", {
+    configurable: true,
+    value: previousRequestAnimationFrame,
+  })
+}
+
+const expectEscaped = (nodes: readonly HTMLElement[]): void => {
+  const root = document.createElement("div")
+  root.append(...nodes.map(node => node.cloneNode(true)))
+  expect(root.querySelector("script")).toBeNull()
+  expect(root.querySelector("img")).toBeNull()
+  for (const element of root.querySelectorAll("*")) {
+    for (const attribute of element.getAttributeNames()) {
+      expect(attribute.toLowerCase().startsWith("on")).toBe(false)
+      expect(element.getAttribute(attribute)?.toLowerCase().startsWith("javascript:")).toBe(false)
+    }
+  }
+}
+
+describe("transcript renderer properties", () => {
+  beforeAll(installDom)
+  afterAll(restoreDom)
+
+  test("arbitrary markdown input never crashes or injects raw HTML", () => {
+    fc.assert(
+      fc.property(hostileInput, (markdown) => {
+        const node = markdownElement({ markdown })
+        expect(node.textContent).toContain("<")
+        expectEscaped([node])
+      }),
+      { numRuns: 150 },
+    )
+  })
+
+  test("arbitrary diff input never crashes or injects raw HTML", () => {
+    fc.assert(
+      fc.property(diffInput, (patch) => {
+        const node = diffElement({ patch })
+        expect(node.textContent).toContain("<")
+        expectEscaped([node])
+      }),
+      { numRuns: 150 },
+    )
+  })
+
+  test("message body rendering escapes markdown, diff, tool, and card bodies", () => {
+    fc.assert(
+      fc.property(hostileInput, diffInput, (markdown, patch) => {
+        expectEscaped(renderMessageBody(markdown, "assistant"))
+        expectEscaped(renderMessageBody(patch, "assistant"))
+        expectEscaped(renderMessageBody(markdown, "tool"))
+        expectEscaped(renderMessageBody(markdown, "tool", toolCard))
+      }),
+      { numRuns: 100 },
+    )
+  })
+})


### PR DESCRIPTION
Closes #7855

Summary:
- Add fast-check property coverage for Codex thread item projector delta interleavings.
- Add composer draft model property coverage for arbitrary type, paste, and slash input sequences.
- Add transcript markdown/diff renderer properties for hostile input crash resistance and raw HTML injection checks.

Verification:
- command.public.pylon_khala.verify.d32c71ee8e1025e99460d008 = `bun run --cwd clients/khala-code-desktop test` (316 pass, 0 fail)
- `bun run --cwd clients/khala-code-desktop typecheck`

No failing property seeds were found, so no skipped bug-regression cases were added.