### PR TITLE
T10.1: Runner-neutral status spine into the orchestration store

### DIFF
--- a/apps/pylon/src/orchestration/status-control.ts
+++ b/apps/pylon/src/orchestration/status-control.ts
@@ -9,7 +9,9 @@ import {
 import type { DispatchContext, OrchestrationTask } from "./store.js"
 
 const stableRef = (prefix: string, value: string): string =>
-  `${prefix}.${createHash("sha256").update(value).digest("hex").slice(0, 24)}`
+  value.startsWith(`${prefix}.`)
+    ? value
+    : `${prefix}.${createHash("sha256").update(value).digest("hex").slice(0, 24)}`
 
 export function neutralStateForDispatchContext(
   context: DispatchContext,
@@ -34,6 +36,8 @@ export function agentRunnerStatusEventForDispatchContext(input: {
   const updatedAt = (input.now ?? new Date(input.context.updatedAt)).toISOString()
   const state = neutralStateForDispatchContext(input.context, input.task)
   const taskId = input.task?.id ?? input.context.currentTaskId ?? undefined
+  const publicTaskId = taskId === undefined ? undefined : stableRef("task.public.pylon", taskId)
+  const publicDispatchContextId = stableRef("dispatch-context.public.pylon", input.context.id)
   const runnerRef = stableRef(
     "runner.public.pylon",
     `${input.pylonRef ?? "pylon.local"}:${input.context.id}:${input.context.runnerKind}`,
@@ -49,12 +53,12 @@ export function agentRunnerStatusEventForDispatchContext(input: {
     state,
     stateStartedAt: input.context.updatedAt,
     updatedAt,
-    ...(input.assignmentRef === undefined ? {} : { assignmentRef: input.assignmentRef }),
-    ...(taskId === undefined ? {} : { taskId }),
-    dispatchContextId: input.context.id,
-    assigneeHandle: input.context.assigneeHandle,
-    ...(input.pylonRef === undefined ? {} : { pylonRef: input.pylonRef }),
-    ...(input.context.worktreeId === null ? {} : { worktreeId: input.context.worktreeId }),
+    ...(input.assignmentRef === undefined
+      ? {}
+      : { assignmentRef: stableRef("assignment.public.pylon", input.assignmentRef) }),
+    ...(publicTaskId === undefined ? {} : { taskId: publicTaskId }),
+    dispatchContextId: publicDispatchContextId,
+    ...(input.pylonRef === undefined ? {} : { pylonRef: stableRef("pylon.public", input.pylonRef) }),
     ...(input.context.worktreePath === null
       ? {}
       : { worktreeRef: stableRef("worktree.public.pylon", `${input.context.id}:${input.context.worktreePath}`) }),

--- a/apps/pylon/src/orchestration/store.ts
+++ b/apps/pylon/src/orchestration/store.ts
@@ -4,6 +4,14 @@ import { existsSync } from "node:fs"
 import { mkdir, readFile, writeFile } from "node:fs/promises"
 import { join } from "node:path"
 import { Schema as S } from "effect"
+import {
+  PYLON_AGENT_RUNNER_CONTROL_VERBS,
+  PYLON_AGENT_RUNNER_STATUS_EVENT_SCHEMA_VERSION,
+  type AgentRunnerControlVerb,
+  type AgentRunnerNeutralState,
+  type AgentRunnerStatusEvent,
+  type AgentRunnerStatusHistoryEntry,
+} from "../agent-status-reporter.js"
 
 export const ORCHESTRATION_SCHEMA_VERSION = 2
 
@@ -228,6 +236,25 @@ export type PublicDispatchContext = Omit<DispatchContext, "worktreePath"> & {
   worktreePath: null
 }
 
+export type AgentRunnerStatusRetentionState = "live" | "retained"
+
+export type OrchestrationAgentRunnerStatusEntry = AgentRunnerStatusEvent & {
+  schemaVersion: typeof PYLON_AGENT_RUNNER_STATUS_EVENT_SCHEMA_VERSION
+  retentionState: AgentRunnerStatusRetentionState
+  retainedAt: string | null
+}
+
+export type IngestAgentRunnerStatusEventInput = {
+  event: AgentRunnerStatusEvent
+  now?: Date
+  historyLimit?: number
+}
+
+export type DecayAgentRunnerStatusesInput = {
+  now?: Date
+  staleAfterMs?: number
+}
+
 export type OrchestrationMessageKind =
   | "dispatch"
   | "worker_done"
@@ -308,6 +335,23 @@ const DEFAULT_FLEET_RUN_REFILL_POLICY: FleetRunRefillPolicy = {
 const parseJsonArray = (value: string): string[] => {
   const parsed: unknown = JSON.parse(value)
   return Array.isArray(parsed) ? parsed.filter((entry): entry is string => typeof entry === "string") : []
+}
+
+const parseControlVerbs = (value: string): AgentRunnerControlVerb[] =>
+  parseJsonArray(value).filter((verb): verb is AgentRunnerControlVerb =>
+    PYLON_AGENT_RUNNER_CONTROL_VERBS.includes(verb as AgentRunnerControlVerb),
+  )
+
+const parseStateHistory = (value: string): AgentRunnerStatusHistoryEntry[] => {
+  const parsed: unknown = JSON.parse(value)
+  if (!Array.isArray(parsed)) return []
+  return parsed.flatMap((entry): AgentRunnerStatusHistoryEntry[] => {
+    if (typeof entry !== "object" || entry === null) return []
+    const candidate = entry as Partial<AgentRunnerStatusHistoryEntry>
+    return typeof candidate.state === "string" && typeof candidate.stateStartedAt === "string"
+      ? [{ state: candidate.state as AgentRunnerNeutralState, stateStartedAt: candidate.stateStartedAt }]
+      : []
+  })
 }
 
 const parsePendingTaskIds = (value: string): string[] => [...new Set(parseJsonArray(value))]
@@ -476,6 +520,27 @@ type DispatchContextRow = {
   updated_at: string
 }
 
+type AgentRunnerStatusRow = {
+  event_ref: string
+  runner_ref: string
+  runner_kind: string
+  state: AgentRunnerNeutralState
+  state_started_at: string
+  updated_at: string
+  assignment_ref: string | null
+  task_id: string | null
+  dispatch_context_id: string | null
+  pylon_ref: string | null
+  worktree_ref: string | null
+  capability_refs_json: string
+  supported_control_verbs_json: string
+  refs_json: string
+  blocker_refs_json: string
+  state_history_json: string
+  retention_state: AgentRunnerStatusRetentionState
+  retained_at: string | null
+}
+
 type VirtualHeadRow = {
   repo: string
   branch: string
@@ -620,6 +685,101 @@ const isLiveClaimUniqueConstraintError = (error: unknown): boolean =>
   (error.message.includes("idx_pylon_orchestration_work_claims_live_unit") ||
     error.message.includes("pylon_orchestration_work_claims.work_unit_ref"))
 
+const stablePublicRef = (prefix: string, value: string): string =>
+  value.startsWith(`${prefix}.`)
+    ? value
+    : `${prefix}.${createHash("sha256").update(value).digest("hex").slice(0, 24)}`
+
+const rollingStateHistory = (
+  previous: ReadonlyArray<AgentRunnerStatusHistoryEntry>,
+  state: AgentRunnerNeutralState,
+  stateStartedAt: string,
+  limit: number,
+): AgentRunnerStatusHistoryEntry[] => {
+  const history = [...previous]
+  const last = history.at(-1)
+  if (last === undefined || last.state !== state || last.stateStartedAt !== stateStartedAt) {
+    history.push({ state, stateStartedAt })
+  }
+  return history.slice(-Math.max(1, limit))
+}
+
+const publicRefArray = (prefix: string, values: ReadonlyArray<string> | undefined): string[] =>
+  [...new Set((values ?? []).map((value) => stablePublicRef(prefix, value)))].slice(0, 64)
+
+const publicStatusEventFrom = (
+  event: AgentRunnerStatusEvent,
+  previous: OrchestrationAgentRunnerStatusEntry | null,
+  historyLimit: number,
+): AgentRunnerStatusEvent => {
+  const stateChanged = previous === null || previous.state !== event.state
+  const stateStartedAt = stateChanged ? event.stateStartedAt : previous.stateStartedAt
+  const previousHistory = event.stateHistory ?? previous?.stateHistory ?? []
+  return {
+    eventRef: stablePublicRef("event.public.pylon.runner_status", event.eventRef),
+    runnerRef: stablePublicRef("runner.public.pylon", event.runnerRef),
+    runnerKind: event.runnerKind,
+    state: event.state,
+    stateStartedAt,
+    updatedAt: event.updatedAt,
+    ...(event.assignmentRef === undefined
+      ? {}
+      : { assignmentRef: stablePublicRef("assignment.public.pylon", event.assignmentRef) }),
+    ...(event.taskId === undefined ? {} : { taskId: stablePublicRef("task.public.pylon", event.taskId) }),
+    ...(event.dispatchContextId === undefined
+      ? {}
+      : { dispatchContextId: stablePublicRef("dispatch-context.public.pylon", event.dispatchContextId) }),
+    ...(event.pylonRef === undefined ? {} : { pylonRef: stablePublicRef("pylon.public", event.pylonRef) }),
+    ...(event.worktreeRef === undefined
+      ? event.worktreeId === undefined
+        ? {}
+        : { worktreeRef: stablePublicRef("worktree.public.pylon", event.worktreeId) }
+      : { worktreeRef: stablePublicRef("worktree.public.pylon", event.worktreeRef) }),
+    capabilityRefs: publicRefArray("capability.public.pylon", event.capabilityRefs),
+    supportedControlVerbs: (event.supportedControlVerbs ?? PYLON_AGENT_RUNNER_CONTROL_VERBS)
+      .filter((verb): verb is AgentRunnerControlVerb =>
+        PYLON_AGENT_RUNNER_CONTROL_VERBS.includes(verb as AgentRunnerControlVerb),
+      ),
+    refs: publicRefArray("ref.public.pylon", event.refs),
+    blockerRefs: publicRefArray("blocker.public.pylon", event.blockerRefs),
+    stateHistory: rollingStateHistory(previousHistory, event.state, stateStartedAt, historyLimit),
+  }
+}
+
+const statusEntryFromRow = (row: AgentRunnerStatusRow): OrchestrationAgentRunnerStatusEntry => ({
+  schemaVersion: PYLON_AGENT_RUNNER_STATUS_EVENT_SCHEMA_VERSION,
+  eventRef: row.event_ref,
+  runnerRef: row.runner_ref,
+  runnerKind: row.runner_kind,
+  state: row.state,
+  stateStartedAt: row.state_started_at,
+  updatedAt: row.updated_at,
+  ...(row.assignment_ref === null ? {} : { assignmentRef: row.assignment_ref }),
+  ...(row.task_id === null ? {} : { taskId: row.task_id }),
+  ...(row.dispatch_context_id === null ? {} : { dispatchContextId: row.dispatch_context_id }),
+  ...(row.pylon_ref === null ? {} : { pylonRef: row.pylon_ref }),
+  ...(row.worktree_ref === null ? {} : { worktreeRef: row.worktree_ref }),
+  capabilityRefs: parseJsonArray(row.capability_refs_json),
+  supportedControlVerbs: parseControlVerbs(row.supported_control_verbs_json),
+  refs: parseJsonArray(row.refs_json),
+  blockerRefs: parseJsonArray(row.blocker_refs_json),
+  stateHistory: parseStateHistory(row.state_history_json),
+  retentionState: row.retention_state,
+  retainedAt: row.retained_at,
+})
+
+const dispatchStatusForNeutralState = (state: AgentRunnerNeutralState): DispatchContextStatus => {
+  if (state === "blocked") return "blocked"
+  if (state === "failed") return "failed"
+  if (state === "done") return "completed"
+  if (state === "offline") return "circuit_broken"
+  if (state === "working" || state === "waiting") return "dispatched"
+  return "idle"
+}
+
+const shouldDecayRunnerState = (state: AgentRunnerNeutralState): boolean =>
+  state === "queued" || state === "working" || state === "waiting"
+
 export class PylonOrchestrationStore {
   constructor(private readonly db: SqliteDatabase) {}
 
@@ -663,6 +823,30 @@ export class PylonOrchestrationStore {
         ON pylon_orchestration_dispatch_contexts(status, updated_at);
       CREATE INDEX IF NOT EXISTS idx_pylon_orchestration_contexts_worktree
         ON pylon_orchestration_dispatch_contexts(worktree_id);
+      CREATE TABLE IF NOT EXISTS pylon_orchestration_runner_statuses (
+        event_ref TEXT PRIMARY KEY,
+        runner_ref TEXT NOT NULL,
+        runner_kind TEXT NOT NULL,
+        state TEXT NOT NULL CHECK (state IN ('idle', 'queued', 'working', 'waiting', 'blocked', 'done', 'failed', 'offline')),
+        state_started_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL,
+        assignment_ref TEXT,
+        task_id TEXT,
+        dispatch_context_id TEXT,
+        pylon_ref TEXT,
+        worktree_ref TEXT,
+        capability_refs_json TEXT NOT NULL,
+        supported_control_verbs_json TEXT NOT NULL,
+        refs_json TEXT NOT NULL,
+        blocker_refs_json TEXT NOT NULL,
+        state_history_json TEXT NOT NULL,
+        retention_state TEXT NOT NULL CHECK (retention_state IN ('live', 'retained')),
+        retained_at TEXT
+      );
+      CREATE INDEX IF NOT EXISTS idx_pylon_orchestration_runner_statuses_live
+        ON pylon_orchestration_runner_statuses(runner_ref, retention_state, updated_at);
+      CREATE INDEX IF NOT EXISTS idx_pylon_orchestration_runner_statuses_state
+        ON pylon_orchestration_runner_statuses(state, retention_state, updated_at);
       CREATE TABLE IF NOT EXISTS pylon_orchestration_messages (
         id TEXT PRIMARY KEY,
         thread_id TEXT NOT NULL,
@@ -1112,6 +1296,170 @@ export class PylonOrchestrationStore {
         .query("SELECT * FROM pylon_orchestration_dispatch_contexts WHERE status = $status ORDER BY created_at ASC")
         .all({ $status: status })
     return (rows as DispatchContextRow[]).map(contextFromRow)
+  }
+
+  getAgentRunnerStatusEvent(eventRef: string): OrchestrationAgentRunnerStatusEntry | null {
+    const row = this.db
+      .query("SELECT * FROM pylon_orchestration_runner_statuses WHERE event_ref = $eventRef")
+      .get({ $eventRef: eventRef }) as AgentRunnerStatusRow | null
+    return row === null ? null : statusEntryFromRow(row)
+  }
+
+  getLiveAgentRunnerStatusByRunnerRef(runnerRef: string): OrchestrationAgentRunnerStatusEntry | null {
+    const publicRunnerRef = stablePublicRef("runner.public.pylon", runnerRef)
+    const row = this.db
+      .query(`
+        SELECT * FROM pylon_orchestration_runner_statuses
+         WHERE runner_ref = $runnerRef AND retention_state = 'live'
+         ORDER BY updated_at DESC, event_ref DESC
+         LIMIT 1
+      `)
+      .get({ $runnerRef: publicRunnerRef }) as AgentRunnerStatusRow | null
+    return row === null ? null : statusEntryFromRow(row)
+  }
+
+  listAgentRunnerStatusEvents(input: {
+    retentionState?: AgentRunnerStatusRetentionState
+    runnerRef?: string
+  } = {}): OrchestrationAgentRunnerStatusEntry[] {
+    const runnerRef = input.runnerRef === undefined ? undefined : stablePublicRef("runner.public.pylon", input.runnerRef)
+    if (input.retentionState === undefined && runnerRef === undefined) {
+      return (this.db
+        .query("SELECT * FROM pylon_orchestration_runner_statuses ORDER BY updated_at ASC, event_ref ASC")
+        .all() as AgentRunnerStatusRow[]).map(statusEntryFromRow)
+    }
+    if (input.retentionState !== undefined && runnerRef === undefined) {
+      return (this.db
+        .query(`
+          SELECT * FROM pylon_orchestration_runner_statuses
+           WHERE retention_state = $retentionState
+           ORDER BY updated_at ASC, event_ref ASC
+        `)
+        .all({ $retentionState: input.retentionState }) as AgentRunnerStatusRow[]).map(statusEntryFromRow)
+    }
+    if (input.retentionState === undefined && runnerRef !== undefined) {
+      return (this.db
+        .query(`
+          SELECT * FROM pylon_orchestration_runner_statuses
+           WHERE runner_ref = $runnerRef
+           ORDER BY updated_at ASC, event_ref ASC
+        `)
+        .all({ $runnerRef: runnerRef }) as AgentRunnerStatusRow[]).map(statusEntryFromRow)
+    }
+    if (input.retentionState === undefined || runnerRef === undefined) return []
+    const rows = this.db
+      .query(`
+        SELECT * FROM pylon_orchestration_runner_statuses
+         WHERE runner_ref = $runnerRef AND retention_state = $retentionState
+         ORDER BY updated_at ASC, event_ref ASC
+      `)
+      .all({ $runnerRef: runnerRef, $retentionState: input.retentionState })
+    return (rows as AgentRunnerStatusRow[]).map(statusEntryFromRow)
+  }
+
+  ingestAgentRunnerStatusEvent(input: IngestAgentRunnerStatusEventInput): OrchestrationAgentRunnerStatusEntry {
+    const now = input.now ?? new Date(input.event.updatedAt)
+    const at = iso(now)
+    const historyLimit = input.historyLimit ?? 20
+    const existing = this.getAgentRunnerStatusEvent(stablePublicRef("event.public.pylon.runner_status", input.event.eventRef))
+    if (existing !== null) return existing
+    const previous = this.getLiveAgentRunnerStatusByRunnerRef(input.event.runnerRef)
+    const event = publicStatusEventFrom(input.event, previous, historyLimit)
+
+    this.db.run("BEGIN IMMEDIATE")
+    try {
+      this.db
+        .query(`
+          UPDATE pylon_orchestration_runner_statuses
+             SET retention_state = 'retained',
+                 retained_at = $retainedAt
+           WHERE runner_ref = $runnerRef AND retention_state = 'live'
+        `)
+        .run({ $runnerRef: event.runnerRef, $retainedAt: at })
+      this.db
+        .query(`
+          INSERT INTO pylon_orchestration_runner_statuses
+            (event_ref, runner_ref, runner_kind, state, state_started_at, updated_at,
+             assignment_ref, task_id, dispatch_context_id, pylon_ref, worktree_ref,
+             capability_refs_json, supported_control_verbs_json, refs_json,
+             blocker_refs_json, state_history_json, retention_state, retained_at)
+          VALUES
+            ($eventRef, $runnerRef, $runnerKind, $state, $stateStartedAt, $updatedAt,
+             $assignmentRef, $taskId, $dispatchContextId, $pylonRef, $worktreeRef,
+             $capabilityRefs, $supportedControlVerbs, $refs, $blockerRefs,
+             $stateHistory, 'live', NULL)
+        `)
+        .run({
+          $eventRef: event.eventRef,
+          $runnerRef: event.runnerRef,
+          $runnerKind: event.runnerKind,
+          $state: event.state,
+          $stateStartedAt: event.stateStartedAt,
+          $updatedAt: event.updatedAt,
+          $assignmentRef: event.assignmentRef ?? null,
+          $taskId: event.taskId ?? null,
+          $dispatchContextId: event.dispatchContextId ?? null,
+          $pylonRef: event.pylonRef ?? null,
+          $worktreeRef: event.worktreeRef ?? null,
+          $capabilityRefs: JSON.stringify(event.capabilityRefs ?? []),
+          $supportedControlVerbs: JSON.stringify(event.supportedControlVerbs ?? []),
+          $refs: JSON.stringify(event.refs ?? []),
+          $blockerRefs: JSON.stringify(event.blockerRefs ?? []),
+          $stateHistory: JSON.stringify(event.stateHistory ?? []),
+        })
+      if (input.event.dispatchContextId !== undefined && this.getDispatchContext(input.event.dispatchContextId) !== null) {
+        const contextStatus = dispatchStatusForNeutralState(input.event.state)
+        const taskId = contextStatus === "dispatched" ? input.event.taskId ?? null : null
+        this.db
+          .query(`
+            UPDATE pylon_orchestration_dispatch_contexts
+               SET status = $status,
+                   current_task_id = $taskId,
+                   last_heartbeat_at = $updatedAt,
+                   updated_at = $updatedAt
+             WHERE id = $contextId
+          `)
+          .run({
+            $contextId: input.event.dispatchContextId,
+            $status: contextStatus,
+            $taskId: taskId,
+            $updatedAt: input.event.updatedAt,
+          })
+      }
+      this.db.run("COMMIT")
+    } catch (error) {
+      this.db.run("ROLLBACK")
+      throw error
+    }
+
+    const stored = this.getAgentRunnerStatusEvent(event.eventRef)
+    if (stored === null) throw new Error(`failed to ingest agent runner status event ${event.eventRef}`)
+    return stored
+  }
+
+  decayAgentRunnerStatuses(input: DecayAgentRunnerStatusesInput = {}): OrchestrationAgentRunnerStatusEntry[] {
+    const now = input.now ?? new Date()
+    const staleAfterMs = input.staleAfterMs ?? 5 * 60 * 1000
+    const decayed: OrchestrationAgentRunnerStatusEntry[] = []
+    for (const live of this.listAgentRunnerStatusEvents({ retentionState: "live" })) {
+      if (!shouldDecayRunnerState(live.state)) continue
+      if (now.getTime() - Date.parse(live.updatedAt) < staleAfterMs) continue
+      decayed.push(this.ingestAgentRunnerStatusEvent({
+        event: {
+          eventRef: `${live.eventRef}.decay.${now.getTime()}`,
+          runnerRef: live.runnerRef,
+          runnerKind: live.runnerKind,
+          state: "idle",
+          stateStartedAt: iso(now),
+          updatedAt: iso(now),
+          supportedControlVerbs: live.supportedControlVerbs,
+          refs: live.refs,
+          stateHistory: live.stateHistory,
+        },
+        now,
+      }))
+    }
+    return decayed
   }
 
   recordHeartbeat(id: string, input: { at?: Date; baseBehindBy?: number; status?: DispatchContextStatus } = {}): DispatchContext {

--- a/apps/pylon/src/orchestration/supervisor-orchestration.test.ts
+++ b/apps/pylon/src/orchestration/supervisor-orchestration.test.ts
@@ -210,13 +210,168 @@ describe("Pylon supervisor orchestration store", () => {
     expect(event).toMatchObject({
       runnerKind: "codex",
       state: "working",
-      taskId: "task.7809",
-      dispatchContextId: "ctx.codex.7809",
-      pylonRef: "pylon.public.runner-status",
       supportedControlVerbs: ["status.list", "task.list", "task.update", "task.dispatch", "dispatch.cancel"],
     })
+    expect(String(event.taskId)).toStartWith("task.public.pylon.")
+    expect(String(event.dispatchContextId)).toStartWith("dispatch-context.public.pylon.")
+    expect(String(event.pylonRef)).toStartWith("pylon.public.")
     expect(String(event.worktreeRef)).toStartWith("worktree.public.pylon.")
+    expect(JSON.stringify(event)).not.toContain("ctx.codex.7809")
     expect(JSON.stringify(event)).not.toContain("/Users/private/worktree")
+  })
+
+  test("ingests agent runner status events as live status and updates dispatch contexts", () => {
+    const now = new Date("2026-07-01T12:00:00.000Z")
+    const store = createPylonOrchestrationStore(new Database(":memory:"))
+    store.createTask({
+      id: "task.status-spine",
+      spec: { ...baseTaskSpec, title: "Status spine", runnerKind: "codex" },
+      now,
+    })
+    store.createDispatchContext({
+      id: "ctx.status-spine",
+      assigneeHandle: "codex-1",
+      runnerKind: "codex",
+      worktreeId: "wt-status-spine",
+      worktreePath: "/Users/private/status-spine",
+      lastHeartbeatAt: now,
+      now,
+    })
+
+    const status = store.ingestAgentRunnerStatusEvent({
+      event: {
+        eventRef: "event.raw.status-spine.1",
+        runnerRef: "runner.raw.codex-1",
+        runnerKind: "codex",
+        state: "working",
+        stateStartedAt: "2026-07-01T12:01:00.000Z",
+        updatedAt: "2026-07-01T12:01:00.000Z",
+        assignmentRef: "assignment.secret.local",
+        taskId: "task.status-spine",
+        dispatchContextId: "ctx.status-spine",
+        pylonRef: "pylon.local.secret",
+        worktreeId: "wt-status-spine",
+        refs: ["local:/Users/private/status-spine"],
+      },
+      now: new Date("2026-07-01T12:01:00.000Z"),
+    })
+
+    expect(status.retentionState).toBe("live")
+    expect(status.state).toBe("working")
+    expect(String(status.assignmentRef)).toStartWith("assignment.public.pylon.")
+    expect(String(status.taskId)).toStartWith("task.public.pylon.")
+    expect(String(status.dispatchContextId)).toStartWith("dispatch-context.public.pylon.")
+    expect(String(status.refs?.[0])).toStartWith("ref.public.pylon.")
+    expect(status.stateStartedAt).toBe("2026-07-01T12:01:00.000Z")
+    expect(status.updatedAt).toBe("2026-07-01T12:01:00.000Z")
+    expect(store.getDispatchContext("ctx.status-spine")).toMatchObject({
+      status: "dispatched",
+      currentTaskId: "task.status-spine",
+      lastHeartbeatAt: "2026-07-01T12:01:00.000Z",
+    })
+    expect(JSON.stringify(status)).not.toContain("/Users/private")
+    expect(JSON.stringify(status)).not.toContain("assignment.secret.local")
+  })
+
+  test("retains previous live status entries and rolls state history", () => {
+    const store = createPylonOrchestrationStore(new Database(":memory:"))
+    const base = {
+      runnerRef: "runner.raw.codex-history",
+      runnerKind: "codex",
+      dispatchContextId: "ctx.history",
+    }
+
+    const working = store.ingestAgentRunnerStatusEvent({
+      event: {
+        ...base,
+        eventRef: "event.history.working",
+        state: "working",
+        stateStartedAt: "2026-07-01T12:00:00.000Z",
+        updatedAt: "2026-07-01T12:00:00.000Z",
+      },
+      now: new Date("2026-07-01T12:00:00.000Z"),
+    })
+    const waiting = store.ingestAgentRunnerStatusEvent({
+      event: {
+        ...base,
+        eventRef: "event.history.waiting",
+        state: "waiting",
+        stateStartedAt: "2026-07-01T12:02:00.000Z",
+        updatedAt: "2026-07-01T12:02:00.000Z",
+      },
+      now: new Date("2026-07-01T12:02:00.000Z"),
+    })
+
+    expect(store.getAgentRunnerStatusEvent(working.eventRef)?.retentionState).toBe("retained")
+    expect(store.getAgentRunnerStatusEvent(working.eventRef)?.retainedAt).toBe("2026-07-01T12:02:00.000Z")
+    expect(waiting.retentionState).toBe("live")
+    expect(waiting.stateHistory).toEqual([
+      { state: "working", stateStartedAt: "2026-07-01T12:00:00.000Z" },
+      { state: "waiting", stateStartedAt: "2026-07-01T12:02:00.000Z" },
+    ])
+    expect(store.listAgentRunnerStatusEvents({ retentionState: "live" })).toHaveLength(1)
+    expect(store.listAgentRunnerStatusEvents({ retentionState: "retained" })).toHaveLength(1)
+  })
+
+  test("caps runner status history at the requested rolling limit", () => {
+    const store = createPylonOrchestrationStore(new Database(":memory:"))
+    let latest = null as ReturnType<typeof store.ingestAgentRunnerStatusEvent> | null
+    for (let index = 0; index < 25; index += 1) {
+      const state = index % 2 === 0 ? "working" : "waiting"
+      const at = new Date(Date.UTC(2026, 6, 1, 12, index, 0))
+      latest = store.ingestAgentRunnerStatusEvent({
+        event: {
+          eventRef: `event.rolling.${index}`,
+          runnerRef: "runner.raw.rolling",
+          runnerKind: "codex",
+          state,
+          stateStartedAt: at.toISOString(),
+          updatedAt: at.toISOString(),
+        },
+        now: at,
+        historyLimit: 20,
+      })
+    }
+
+    expect(latest?.stateHistory).toHaveLength(20)
+    expect(latest?.stateHistory?.[0]).toEqual({
+      state: "waiting",
+      stateStartedAt: "2026-07-01T12:05:00.000Z",
+    })
+    expect(latest?.stateHistory?.at(-1)).toEqual({
+      state: "working",
+      stateStartedAt: "2026-07-01T12:24:00.000Z",
+    })
+  })
+
+  test("decays stale live runner statuses to idle while retaining the active entry", () => {
+    const store = createPylonOrchestrationStore(new Database(":memory:"))
+    const working = store.ingestAgentRunnerStatusEvent({
+      event: {
+        eventRef: "event.decay.working",
+        runnerRef: "runner.raw.decay",
+        runnerKind: "codex",
+        state: "working",
+        stateStartedAt: "2026-07-01T12:00:00.000Z",
+        updatedAt: "2026-07-01T12:00:00.000Z",
+      },
+      now: new Date("2026-07-01T12:00:00.000Z"),
+    })
+
+    const decayed = store.decayAgentRunnerStatuses({
+      now: new Date("2026-07-01T12:06:00.000Z"),
+      staleAfterMs: 5 * 60 * 1000,
+    })
+
+    expect(decayed).toHaveLength(1)
+    expect(decayed[0]?.state).toBe("idle")
+    expect(decayed[0]?.stateStartedAt).toBe("2026-07-01T12:06:00.000Z")
+    expect(store.getAgentRunnerStatusEvent(working.eventRef)?.retentionState).toBe("retained")
+    expect(store.listAgentRunnerStatusEvents({ retentionState: "live" }).map((entry) => entry.state)).toEqual(["idle"])
+    expect(decayed[0]?.stateHistory?.at(-1)).toEqual({
+      state: "idle",
+      stateStartedAt: "2026-07-01T12:06:00.000Z",
+    })
   })
 
   test("normalizes legacy runner aliases through the AgentRunner registry vocabulary", () => {


### PR DESCRIPTION
Closes #7877

## Summary
- add local orchestration-store ingest for agent_runner_status_event.v1 with live/retained rows
- keep stateStartedAt distinct from updatedAt, roll stateHistory, and decay stale active states to idle
- hash public projection refs for runner/task/assignment/context/worktree/status refs

## Verification
- bun run --cwd apps/pylon typecheck
- bun --cwd apps/pylon test src/orchestration/supervisor-orchestration.test.ts
- bun run --cwd apps/pylon test