### PR TITLE
T4.1: Typed work planner with skip reasons

### DIFF
--- a/apps/pylon/src/orchestration/work-planner.test.ts
+++ b/apps/pylon/src/orchestration/work-planner.test.ts
@@ -125,8 +125,8 @@ describe("typed work planner", () => {
     const result = await planGithubBacklogWork({ kind: "github_backlog", repo }, gh, { now })
 
     expect(called).toEqual([
-      ["issue", "list", "--repo", repo, "--state", "all", "--json", "number,title,state,labels,body,url"],
-      ["pr", "list", "--repo", repo, "--state", "all", "--json", "number,title,state,labels,body,url,mergedAt"],
+      ["issue", "list", "--repo", repo, "--state", "all", "--limit", "1000", "--json", "number,title,state,labels,body,url"],
+      ["pr", "list", "--repo", repo, "--state", "all", "--limit", "1000", "--json", "number,title,state,labels,body,url,mergedAt"],
     ])
     expect(result.units).toHaveLength(7)
     expect(result.claimable.map((unit) => unit.workUnitRef)).toEqual([

--- a/apps/pylon/src/orchestration/work-planner.test.ts
+++ b/apps/pylon/src/orchestration/work-planner.test.ts
@@ -1,0 +1,201 @@
+import { describe, expect, test } from "bun:test"
+import { Database } from "bun:sqlite"
+
+import { createPylonOrchestrationStore } from "./store.js"
+import {
+  githubBacklogCandidates,
+  planFixtureWork,
+  planGithubBacklogWork,
+  planIssueListWork,
+  planWorkCandidates,
+  type GithubBacklogGhRunner,
+  type WorkPlannerSkipReason,
+} from "./work-planner.js"
+
+const now = new Date("2026-07-01T12:00:00.000Z")
+const repo = "OpenAgentsInc/openagents"
+
+describe("typed work planner", () => {
+  test("issue_list emits claimable units and typed skips with no silent drops", () => {
+    const store = createPylonOrchestrationStore(new Database(":memory:"))
+    store.tryClaimWorkUnit({
+      claimRef: "claim.issue.101",
+      workUnitRef: "github:OpenAgentsInc/openagents:issue:101",
+      runRef: "run.t4-1",
+      workerAccountRef: "codex-1",
+      ttl: 60_000,
+      now,
+    })
+
+    const result = planIssueListWork(
+      {
+        kind: "issue_list",
+        repo,
+        issues: [
+          { number: 100, title: "fresh issue" },
+          { number: 101, title: "claimed issue" },
+          { number: 102, title: "owner gated", labels: ["needs-owner"] },
+          { number: 103, title: "excluded label", labels: ["wontfix"] },
+          { number: 104, title: "closed issue", state: "closed" },
+          { number: 105, title: "has PR already" },
+        ],
+        pullRequests: [
+          { number: 900, title: "Implement #105", state: "open", body: "Closes #105" },
+        ],
+      },
+      { claimRegistry: store, excludedLabels: ["wontfix"], now },
+    )
+
+    expect(result).toMatchObject({
+      schema: "openagents.khala_code.work_planner.v1",
+      source: "issue_list",
+      generatedAt: "2026-07-01T12:00:00.000Z",
+    })
+    expect(result.units).toHaveLength(7)
+    expect(result.claimable.map((unit) => unit.workUnitRef)).toEqual([
+      "github:OpenAgentsInc/openagents:issue:100",
+      "github:OpenAgentsInc/openagents:pr:900",
+    ])
+    expect(skipReasonsByNumber(result.skipped)).toEqual({
+      101: "already_claimed",
+      102: "needs_owner",
+      103: "label_excluded",
+      104: "closed",
+      105: "pr_exists",
+    })
+    expect(result.skipped.every((unit) => unit.skipReason !== undefined)).toBe(true)
+  })
+
+  test("fixture adapter produces fixture-only units and never reads the real claim registry", () => {
+    const registry = {
+      getLiveWorkClaim() {
+        throw new Error("fixture planning must not inspect real claims")
+      },
+    }
+
+    const result = planFixtureWork(
+      {
+        kind: "fixture",
+        units: [
+          { ref: "one", title: "First fixture" },
+          { ref: "two", title: "Second fixture", labels: ["needs-owner"] },
+          { ref: "three", title: "Third fixture", labels: ["skip-me"] },
+        ],
+      },
+      {
+        excludedLabels: ["skip-me"],
+        needsOwnerLabels: ["needs-owner"],
+        // @ts-expect-error fixture source intentionally rejects real claim registries.
+        claimRegistry: registry,
+        now,
+      },
+    )
+
+    expect(result.units.map((unit) => unit.workUnitRef)).toEqual([
+      "fixture:one",
+      "fixture:two",
+      "fixture:three",
+    ])
+    expect(result.claimable.map((unit) => unit.kind)).toEqual(["fixture"])
+    expect(skipReasonsByRef(result.skipped)).toEqual({
+      "fixture:two": "needs_owner",
+      "fixture:three": "label_excluded",
+    })
+  })
+
+  test("github_backlog lists issues and PRs through the injected gh runner", async () => {
+    const called: string[][] = []
+    const gh: GithubBacklogGhRunner = async (args) => {
+      called.push([...args])
+      if (args[0] === "issue") {
+        return JSON.stringify([
+          { number: 200, title: "Fresh backlog item", state: "OPEN", labels: [{ name: "bug" }], url: "https://github.test/200" },
+          { number: 201, title: "Needs owner", state: "OPEN", labels: [{ name: "needs-owner" }] },
+          { number: 202, title: "Already has PR", state: "OPEN", labels: [] },
+          { number: 203, title: "Closed upstream", state: "CLOSED", labels: [] },
+        ])
+      }
+      return JSON.stringify([
+        { number: 901, title: "Fixes #202", state: "OPEN", labels: [], body: "Fixes #202", mergedAt: null },
+        { number: 902, title: "Old merged PR", state: "MERGED", labels: [], body: "", mergedAt: "2026-07-01T11:00:00Z" },
+        { number: 903, title: "Closed PR", state: "CLOSED", labels: [], body: "" },
+      ])
+    }
+
+    const result = await planGithubBacklogWork({ kind: "github_backlog", repo }, gh, { now })
+
+    expect(called).toEqual([
+      ["issue", "list", "--repo", repo, "--state", "all", "--json", "number,title,state,labels,body,url"],
+      ["pr", "list", "--repo", repo, "--state", "all", "--json", "number,title,state,labels,body,url,mergedAt"],
+    ])
+    expect(result.units).toHaveLength(7)
+    expect(result.claimable.map((unit) => unit.workUnitRef)).toEqual([
+      "github:OpenAgentsInc/openagents:issue:200",
+      "github:OpenAgentsInc/openagents:pr:901",
+    ])
+    expect(skipReasonsByNumber(result.skipped)).toEqual({
+      201: "needs_owner",
+      202: "pr_exists",
+      203: "closed",
+      902: "merged",
+      903: "closed",
+    })
+  })
+
+  test("github_backlog candidate adapter rejects non-array gh JSON", async () => {
+    await expect(
+      githubBacklogCandidates({ kind: "github_backlog", repo }, async () => JSON.stringify({ items: [] })),
+    ).rejects.toThrow(/non-array JSON/)
+  })
+
+  test("skip priority is deterministic and includes merged PR siblings", () => {
+    const store = createPylonOrchestrationStore(new Database(":memory:"))
+    store.tryClaimWorkUnit({
+      claimRef: "claim.priority",
+      workUnitRef: "github:OpenAgentsInc/openagents:issue:300",
+      runRef: "run.t4-1",
+      workerAccountRef: "codex-1",
+      ttl: 60_000,
+      now,
+    })
+
+    const result = planWorkCandidates(
+      "issue_list",
+      [
+        {
+          workUnitRef: "github:OpenAgentsInc/openagents:issue:300",
+          kind: "github_issue",
+          source: "issue_list",
+          repo,
+          number: 300,
+          title: "Merged PR wins before claim",
+          state: "open",
+        },
+        {
+          workUnitRef: "github:OpenAgentsInc/openagents:pr:930",
+          kind: "github_pr",
+          source: "issue_list",
+          repo,
+          number: 930,
+          title: "Closes #300",
+          body: "Closes #300",
+          state: "merged",
+        },
+      ],
+      { claimRegistry: store, now },
+    )
+
+    expect(skipReasonsByNumber(result.skipped)).toEqual({
+      300: "merged",
+      930: "merged",
+    })
+  })
+})
+
+function skipReasonsByNumber(units: readonly { number?: number; skipReason: WorkPlannerSkipReason }[]) {
+  return Object.fromEntries(units.map((unit) => [unit.number, unit.skipReason]))
+}
+
+function skipReasonsByRef(units: readonly { workUnitRef: string; skipReason: WorkPlannerSkipReason }[]) {
+  return Object.fromEntries(units.map((unit) => [unit.workUnitRef, unit.skipReason]))
+}

--- a/apps/pylon/src/orchestration/work-planner.ts
+++ b/apps/pylon/src/orchestration/work-planner.ts
@@ -1,0 +1,354 @@
+import { Schema as S } from "effect"
+
+import type { PylonOrchestrationStore } from "./store.js"
+
+export const WORK_PLANNER_SCHEMA = "openagents.khala_code.work_planner.v1" as const
+
+export const WorkPlannerSourceKindSchema = S.Literals(["github_backlog", "issue_list", "fixture"])
+export type WorkPlannerSourceKind = typeof WorkPlannerSourceKindSchema.Type
+
+export const WorkPlannerUnitKindSchema = S.Literals(["github_issue", "github_pr", "fixture"])
+export type WorkPlannerUnitKind = typeof WorkPlannerUnitKindSchema.Type
+
+export const WorkPlannerSkipReasonSchema = S.Literals([
+  "already_claimed",
+  "pr_exists",
+  "merged",
+  "closed",
+  "needs_owner",
+  "label_excluded",
+])
+export type WorkPlannerSkipReason = typeof WorkPlannerSkipReasonSchema.Type
+
+export type WorkPlannerCandidateState = "open" | "closed" | "merged"
+
+export type WorkPlannerCandidate = {
+  readonly workUnitRef: string
+  readonly kind: WorkPlannerUnitKind
+  readonly title: string
+  readonly source: WorkPlannerSourceKind
+  readonly repo?: string
+  readonly number?: number
+  readonly url?: string
+  readonly labels?: readonly string[]
+  readonly state?: WorkPlannerCandidateState
+  readonly body?: string
+}
+
+export type WorkPlannerClaimableUnit = WorkPlannerCandidate & {
+  readonly status: "claimable"
+}
+
+export type WorkPlannerSkippedUnit = WorkPlannerCandidate & {
+  readonly status: "skipped"
+  readonly skipReason: WorkPlannerSkipReason
+  readonly detail?: string
+}
+
+export type WorkPlannerUnit = WorkPlannerClaimableUnit | WorkPlannerSkippedUnit
+
+export type WorkPlannerOutput = {
+  readonly schema: typeof WORK_PLANNER_SCHEMA
+  readonly source: WorkPlannerSourceKind
+  readonly generatedAt: string
+  readonly units: readonly WorkPlannerUnit[]
+  readonly claimable: readonly WorkPlannerClaimableUnit[]
+  readonly skipped: readonly WorkPlannerSkippedUnit[]
+}
+
+export type WorkPlannerClaimRegistry = Pick<PylonOrchestrationStore, "getLiveWorkClaim">
+
+export type WorkPlannerOptions = {
+  readonly now?: Date
+  readonly claimRegistry?: WorkPlannerClaimRegistry
+  readonly excludedLabels?: readonly string[]
+  readonly needsOwnerLabels?: readonly string[]
+  readonly pullRequests?: readonly WorkPlannerCandidate[]
+}
+
+export type IssueListWorkSource = {
+  readonly kind: "issue_list"
+  readonly repo: string
+  readonly issues: readonly (number | IssueListItem)[]
+  readonly pullRequests?: readonly IssueListItem[]
+}
+
+export type IssueListItem = {
+  readonly number: number
+  readonly title?: string
+  readonly state?: WorkPlannerCandidateState | "OPEN" | "CLOSED" | "MERGED"
+  readonly labels?: readonly string[]
+  readonly body?: string
+  readonly url?: string
+  readonly kind?: "issue" | "pr"
+}
+
+export type FixtureWorkSource = {
+  readonly kind: "fixture"
+  readonly count?: number
+  readonly units?: readonly FixtureWorkUnit[]
+}
+
+export type FixtureWorkUnit = {
+  readonly ref: string
+  readonly title?: string
+  readonly labels?: readonly string[]
+  readonly state?: WorkPlannerCandidateState
+}
+
+export type GithubBacklogWorkSource = {
+  readonly kind: "github_backlog"
+  readonly repo: string
+}
+
+export type GithubBacklogGhRunner = (args: readonly string[]) => Promise<string>
+
+type GithubLabel = { readonly name?: unknown }
+type GhIssueRecord = {
+  readonly number?: unknown
+  readonly title?: unknown
+  readonly state?: unknown
+  readonly labels?: unknown
+  readonly body?: unknown
+  readonly url?: unknown
+}
+type GhPullRequestRecord = GhIssueRecord & {
+  readonly mergedAt?: unknown
+}
+
+const DEFAULT_NEEDS_OWNER_LABELS = ["needs-owner", "needs owner", "owner-needed", "owner needed"]
+
+const normalizeState = (value: unknown): WorkPlannerCandidateState => {
+  const normalized = typeof value === "string" ? value.trim().toLowerCase() : ""
+  if (normalized === "merged") return "merged"
+  if (normalized === "closed") return "closed"
+  return "open"
+}
+
+const normalizeLabel = (label: string): string => label.trim().toLowerCase()
+
+const normalizeLabels = (labels: unknown): string[] => {
+  if (!Array.isArray(labels)) return []
+  return labels
+    .map((label) => {
+      if (typeof label === "string") return label
+      if (typeof label === "object" && label !== null && typeof (label as GithubLabel).name === "string") {
+        return (label as { name: string }).name
+      }
+      return ""
+    })
+    .map((label) => label.trim())
+    .filter((label) => label.length > 0)
+}
+
+const issueWorkUnitRef = (repo: string, issueNumber: number): string => `github:${repo}:issue:${issueNumber}`
+const prWorkUnitRef = (repo: string, prNumber: number): string => `github:${repo}:pr:${prNumber}`
+
+const issueRefPatterns = (issueNumber: number): RegExp[] => [
+  new RegExp(`(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\\s+#${issueNumber}(?!\\d)`, "i"),
+  new RegExp(`#${issueNumber}(?!\\d)`, "i"),
+]
+
+const prReferencesIssue = (pr: WorkPlannerCandidate, issueNumber: number): boolean => {
+  const haystack = `${pr.title}\n${pr.body ?? ""}`
+  return issueRefPatterns(issueNumber).some((pattern) => pattern.test(haystack))
+}
+
+const skipForPrSibling = (
+  candidate: WorkPlannerCandidate,
+  pullRequests: readonly WorkPlannerCandidate[],
+): WorkPlannerSkippedUnit | null => {
+  if (candidate.kind !== "github_issue" || candidate.number === undefined) return null
+  const matching = pullRequests.find((pr) => prReferencesIssue(pr, candidate.number!))
+  if (matching === undefined) return null
+  if (matching.state === "merged") {
+    return skipped(candidate, "merged", `matching PR ${matching.number ?? matching.workUnitRef} is merged`)
+  }
+  if (matching.state === "closed") {
+    return skipped(candidate, "closed", `matching PR ${matching.number ?? matching.workUnitRef} is closed`)
+  }
+  return skipped(candidate, "pr_exists", `matching PR ${matching.number ?? matching.workUnitRef} is open`)
+}
+
+const skipped = (
+  candidate: WorkPlannerCandidate,
+  skipReason: WorkPlannerSkipReason,
+  detail?: string,
+): WorkPlannerSkippedUnit => ({
+  ...candidate,
+  status: "skipped",
+  skipReason,
+  ...(detail === undefined ? {} : { detail }),
+})
+
+export const normalizeIssueListCandidate = (repo: string, item: number | IssueListItem): WorkPlannerCandidate => {
+  const issue = typeof item === "number" ? { number: item } : item
+  const kind: WorkPlannerUnitKind = issue.kind === "pr" ? "github_pr" : "github_issue"
+  return {
+    workUnitRef: kind === "github_pr" ? prWorkUnitRef(repo, issue.number) : issueWorkUnitRef(repo, issue.number),
+    kind,
+    source: "issue_list",
+    repo,
+    number: issue.number,
+    title: issue.title ?? `${kind === "github_pr" ? "PR" : "Issue"} #${issue.number}`,
+    state: normalizeState(issue.state),
+    labels: [...(issue.labels ?? [])],
+    body: issue.body,
+    url: issue.url,
+  }
+}
+
+export const fixtureCandidates = (source: FixtureWorkSource): WorkPlannerCandidate[] => {
+  const units: readonly FixtureWorkUnit[] = source.units ?? Array.from({ length: source.count ?? 10 }, (_, index) => ({
+    ref: `fixture.unit.${index + 1}`,
+    title: `Fixture unit ${index + 1}`,
+  }))
+  return units.map((unit) => ({
+    workUnitRef: `fixture:${unit.ref}`,
+    kind: "fixture",
+    source: "fixture",
+    title: unit.title ?? unit.ref,
+    labels: [...(unit.labels ?? [])],
+    state: unit.state ?? "open",
+  }))
+}
+
+export const issueListCandidates = (source: IssueListWorkSource): WorkPlannerCandidate[] => [
+  ...source.issues.map((issue) => normalizeIssueListCandidate(source.repo, issue)),
+  ...(source.pullRequests ?? []).map((pr) => normalizeIssueListCandidate(source.repo, { ...pr, kind: "pr" })),
+]
+
+const ghIssueRecordToCandidate = (repo: string, record: GhIssueRecord): WorkPlannerCandidate | null => {
+  if (typeof record.number !== "number") return null
+  return {
+    workUnitRef: issueWorkUnitRef(repo, record.number),
+    kind: "github_issue",
+    source: "github_backlog",
+    repo,
+    number: record.number,
+    title: typeof record.title === "string" && record.title.trim() ? record.title : `Issue #${record.number}`,
+    state: normalizeState(record.state),
+    labels: normalizeLabels(record.labels),
+    body: typeof record.body === "string" ? record.body : undefined,
+    url: typeof record.url === "string" ? record.url : undefined,
+  }
+}
+
+const ghPullRequestRecordToCandidate = (repo: string, record: GhPullRequestRecord): WorkPlannerCandidate | null => {
+  if (typeof record.number !== "number") return null
+  const state = typeof record.mergedAt === "string" && record.mergedAt.trim() ? "merged" : normalizeState(record.state)
+  return {
+    workUnitRef: prWorkUnitRef(repo, record.number),
+    kind: "github_pr",
+    source: "github_backlog",
+    repo,
+    number: record.number,
+    title: typeof record.title === "string" && record.title.trim() ? record.title : `PR #${record.number}`,
+    state,
+    labels: normalizeLabels(record.labels),
+    body: typeof record.body === "string" ? record.body : undefined,
+    url: typeof record.url === "string" ? record.url : undefined,
+  }
+}
+
+const parseGhJsonArray = (raw: string, command: string): unknown[] => {
+  const parsed: unknown = JSON.parse(raw)
+  if (!Array.isArray(parsed)) throw new Error(`gh ${command} returned non-array JSON`)
+  return parsed
+}
+
+export const githubBacklogCandidates = async (
+  source: GithubBacklogWorkSource,
+  gh: GithubBacklogGhRunner,
+): Promise<WorkPlannerCandidate[]> => {
+  const issueArgs = [
+    "issue",
+    "list",
+    "--repo",
+    source.repo,
+    "--state",
+    "all",
+    "--json",
+    "number,title,state,labels,body,url",
+  ]
+  const prArgs = [
+    "pr",
+    "list",
+    "--repo",
+    source.repo,
+    "--state",
+    "all",
+    "--json",
+    "number,title,state,labels,body,url,mergedAt",
+  ]
+  const [issuesRaw, prsRaw] = await Promise.all([gh(issueArgs), gh(prArgs)])
+  const issues = parseGhJsonArray(issuesRaw, "issue list")
+    .map((record) => ghIssueRecordToCandidate(source.repo, record as GhIssueRecord))
+    .filter((candidate): candidate is WorkPlannerCandidate => candidate !== null)
+  const prs = parseGhJsonArray(prsRaw, "pr list")
+    .map((record) => ghPullRequestRecordToCandidate(source.repo, record as GhPullRequestRecord))
+    .filter((candidate): candidate is WorkPlannerCandidate => candidate !== null)
+  return [...issues, ...prs]
+}
+
+export const planWorkCandidates = (
+  source: WorkPlannerSourceKind,
+  candidates: readonly WorkPlannerCandidate[],
+  options: WorkPlannerOptions = {},
+): WorkPlannerOutput => {
+  const now = options.now ?? new Date()
+  const excludedLabels = new Set((options.excludedLabels ?? []).map(normalizeLabel))
+  const needsOwnerLabels = new Set((options.needsOwnerLabels ?? DEFAULT_NEEDS_OWNER_LABELS).map(normalizeLabel))
+  const pullRequests = options.pullRequests ?? candidates.filter((candidate) => candidate.kind === "github_pr")
+
+  const units = candidates.map((candidate): WorkPlannerUnit => {
+    const labels = new Set((candidate.labels ?? []).map(normalizeLabel))
+    const excludedLabel = [...labels].find((label) => excludedLabels.has(label))
+    if (excludedLabel !== undefined) return skipped(candidate, "label_excluded", excludedLabel)
+    const needsOwnerLabel = [...labels].find((label) => needsOwnerLabels.has(label))
+    if (needsOwnerLabel !== undefined) return skipped(candidate, "needs_owner", needsOwnerLabel)
+    if (candidate.state === "merged") return skipped(candidate, "merged")
+    if (candidate.state === "closed") return skipped(candidate, "closed")
+    const prSkip = skipForPrSibling(candidate, pullRequests)
+    if (prSkip !== null) return prSkip
+    const claim = options.claimRegistry?.getLiveWorkClaim(candidate.workUnitRef, now)
+    if (claim !== undefined && claim !== null) return skipped(candidate, "already_claimed", claim.claimRef)
+    return { ...candidate, status: "claimable" }
+  })
+
+  const claimable = units.filter((unit): unit is WorkPlannerClaimableUnit => unit.status === "claimable")
+  const skippedUnits = units.filter((unit): unit is WorkPlannerSkippedUnit => unit.status === "skipped")
+  return {
+    schema: WORK_PLANNER_SCHEMA,
+    source,
+    generatedAt: now.toISOString(),
+    units,
+    claimable,
+    skipped: skippedUnits,
+  }
+}
+
+export const planIssueListWork = (
+  source: IssueListWorkSource,
+  options: WorkPlannerOptions = {},
+): WorkPlannerOutput => {
+  const candidates = issueListCandidates(source)
+  return planWorkCandidates(source.kind, candidates, options)
+}
+
+export const planFixtureWork = (
+  source: FixtureWorkSource,
+  options: Omit<WorkPlannerOptions, "claimRegistry"> = {},
+): WorkPlannerOutput => {
+  const { claimRegistry: _claimRegistry, ...safeOptions } = options as WorkPlannerOptions
+  return planWorkCandidates(source.kind, fixtureCandidates(source), safeOptions)
+}
+
+export const planGithubBacklogWork = async (
+  source: GithubBacklogWorkSource,
+  gh: GithubBacklogGhRunner,
+  options: WorkPlannerOptions = {},
+): Promise<WorkPlannerOutput> => {
+  const candidates = await githubBacklogCandidates(source, gh)
+  return planWorkCandidates(source.kind, candidates, options)
+}

--- a/apps/pylon/src/orchestration/work-planner.ts
+++ b/apps/pylon/src/orchestration/work-planner.ts
@@ -99,6 +99,9 @@ export type FixtureWorkUnit = {
 export type GithubBacklogWorkSource = {
   readonly kind: "github_backlog"
   readonly repo: string
+  // gh defaults to 30 items, which silently truncates a real backlog; the
+  // planner must see the whole candidate set (no silent drops).
+  readonly limit?: number
 }
 
 export type GithubBacklogGhRunner = (args: readonly string[]) => Promise<string>
@@ -261,6 +264,7 @@ export const githubBacklogCandidates = async (
   source: GithubBacklogWorkSource,
   gh: GithubBacklogGhRunner,
 ): Promise<WorkPlannerCandidate[]> => {
+  const limit = String(source.limit ?? 1000)
   const issueArgs = [
     "issue",
     "list",
@@ -268,6 +272,8 @@ export const githubBacklogCandidates = async (
     source.repo,
     "--state",
     "all",
+    "--limit",
+    limit,
     "--json",
     "number,title,state,labels,body,url",
   ]
@@ -278,6 +284,8 @@ export const githubBacklogCandidates = async (
     source.repo,
     "--state",
     "all",
+    "--limit",
+    limit,
     "--json",
     "number,title,state,labels,body,url,mergedAt",
   ]


### PR DESCRIPTION
Closes #7834

## Summary
- Adds a typed Pylon orchestration work planner with github_backlog, issue_list, and fixture adapters.
- Emits pure-data claimable/skipped units with typed skip reasons for claims, PR siblings, terminal state, owner-gated labels, and excluded labels.
- Covers adapters and skip reasons with mocked gh runner tests.

## Verification
- bun run --cwd apps/pylon test
- bun test apps/pylon/src/orchestration/work-planner.test.ts
- git diff --check