### PR TITLE
T7.4: khala-tools substrate fixes

### DIFF
--- a/docs/fable/2026-07-01-khala-code-effect-integration-audit.md
+++ b/docs/fable/2026-07-01-khala-code-effect-integration-audit.md
@@ -158,17 +158,20 @@ progress callbacks.
 
 ### 3.3 khala-tools substrate debt
 
-- Services/layers: only `redaction.ts` is a real `Context.Service` + `Layer`
-  (`redaction.ts:48-55`); `makeKhalaToolServices` assembles a plain record
-  with `??` fallbacks (`index.ts:1078`).
-- **Zero `Clock` usage package-wide**: `Date.now()` in the dispatcher's
-  duration accounting and event IDs (`dispatcher.ts:134,611` — IDs also use
-  `Math.random()`), exec, sandbox, session-rollout. Nothing is
-  TestClock-able or seed-reproducible.
-- **Zero `Scope`/`acquireRelease` package-wide**: `process-sandbox-macos.ts`
-  spawns detached process groups guarded by manual `setTimeout`s
-  (L98-180) with cleanup on `.then(...)`; interrupt leaks the process group
-  and the mkdtemp seatbelt profile.
+**T7.4 update (2026-07-01):** the first substrate pass landed for
+`packages/khala-tools`. `KhalaToolRuntimeService` now provides injected
+Clock/random for dispatcher duration accounting and event IDs, with a
+deterministic runtime used by tests. `makeKhalaToolServices` now exposes a
+Layer-backed `KhalaToolServicesService` while preserving the plain factory for
+existing callers. The one-shot unsandboxed and macOS Seatbelt exec paths wrap
+process groups and mkdtemp seatbelt profiles in `Effect.acquireRelease`, and
+`exec-command.ts` keeps permission, workdir, process, and artifact calls in the
+Effect chain instead of nesting `Effect.runPromise` inside `Effect.promise`.
+
+Remaining debt in this subsection is outside T7.4's landed slice: older
+helpers such as todo/network timestamps and some long-lived session pumps still
+need deeper service migration, and `session-rollout.ts` still uses direct
+wall-clock/UUID helpers.
 - The bright spots to grow from: `permission-policy.ts:54-98` (real
   `Effect.gen` + `catchTag` composition) and `fleet-delegate-program.ts`
   (typed `KhalaFleetDelegateModuleError`, Schema-class parameters, pure
@@ -297,13 +300,13 @@ migration they de-risk.
    subprocess service and the shared schema from phase 1, replacing
    argv+stdout string coupling. Stub layer for fixtures; this is also what
    the fleet-fan-out instructions' supervisor should consume.
-8. **khala-tools substrate fixes**: inject `Clock` (dispatcher durations,
-   IDs from injected random — copy
-   `apps/autopilot-desktop/src/testing/deterministic-env.ts`); wrap
-   sandbox/exec process groups in `acquireRelease`; delete the
-   `runPromise`-inside-`Effect.promise` nesting by keeping permission/
-   process calls in the Effect chain (mirror `permission-policy.ts`);
-   layerize `makeKhalaToolServices` following `redaction.ts`.
+8. **khala-tools substrate fixes** (T7.4 landed 2026-07-01): dispatcher
+   durations and event IDs now use injected runtime Clock/random; one-shot
+   sandbox/exec process groups use `acquireRelease`; `exec-command.ts` keeps
+   permission/process/artifact calls in the Effect chain; and
+   `makeKhalaToolServices` has a Layer-backed service form following
+   `redaction.ts`. Follow-up work should migrate the remaining older helpers
+   called out in §3.3.
 9. **Make token reporting an Effect with retry + typed failure** (
    `Effect.retry(Schedule.exponential(...))`, escalate persistent failure to
    an Inbox flag) — closes #5 and #18 against the exact-accounting

--- a/docs/fable/ROADMAP.md
+++ b/docs/fable/ROADMAP.md
@@ -151,7 +151,7 @@ Source: Effect integration audit §5 Phase 2. Feeds WS-3/5/8 as it lands.
 | T7.1 | `KhalaProcess` scoped subprocess service on `effect/unstable/process` (kill-on-scope-close, stdin Sink / stdout Stream, one timeout/kill policy); replace all five hand-rolled spawn implementations | T1.3 soft | MED |
 | T7.2 | `CodexAppServer` as `Context.Service`: typed tagged errors, Schema-decoded responses/notifications (generate candidates from `codex app-server generate-ts`), notifications as `Stream` (subscriber isolation by construction), timeout policy that fires `turn/interrupt`, scoped supervision | T7.1 | MED |
 | T7.3 | Typed `PylonService` (`request`, `runAssignment`, `lifecycle: Stream`), backed by T7.1 + T1.2 schemas; stub layer for fixtures; the supervisor (T3.1) migrates onto it | T7.1, T1.2 | MED |
-| T7.4 | khala-tools substrate: inject `Clock` (durations, IDs), `acquireRelease` for sandbox/exec process groups, delete `runPromise`-inside-`Effect.promise` nesting, layerize `makeKhalaToolServices` | — | MED |
+| T7.4 | **Done in PR "T7.4: khala-tools substrate fixes"**: khala-tools substrate now injects runtime `Clock`/random for dispatcher durations and IDs, wraps one-shot sandbox/exec process groups in `acquireRelease`, removes `runPromise`-inside-`Effect.promise` nesting from `exec-command.ts`, and exposes a Layer-backed `KhalaToolServicesService` while keeping tool-result errors as data | — | MED |
 | T7.5 | Token reporting as Effect with `Schedule.exponential` retry + Inbox flag on persistent failure; attachment temp files as scoped resources; corrupt session-state file recovery (no rethrow-brick) | T7.2 soft | HIGH |
 
 ### WS-8 — Claude chat harness (Claude-parity Phases 0–3, = Axis A)

--- a/packages/khala-tools/src/dispatcher.test.ts
+++ b/packages/khala-tools/src/dispatcher.test.ts
@@ -4,6 +4,7 @@ import {
   createKhalaToolTurnAccounting,
   executeKhalaTool,
   khalaToolOk,
+  makeDeterministicKhalaToolRuntimeService,
   makeKhalaToolDispatcher,
   makeKhalaToolRegistry,
   makeKhalaToolServices,
@@ -84,6 +85,43 @@ describe("KhalaToolDispatcher", () => {
       toolName: "echo",
       turnId: "turn_1",
     })
+  })
+
+  test("uses injected runtime for event ids and duration accounting", async () => {
+    const runtime = makeDeterministicKhalaToolRuntimeService({ nowMs: 1_000, seed: "dispatcher" })
+    const afterDurations: number[] = []
+    const dispatcher = makeKhalaToolDispatcher({
+      hooks: {
+        afterTool: context => Effect.sync(() => {
+          afterDurations.push(context.durationMs)
+        }),
+      },
+    })
+
+    const dispatched = await Effect.runPromise(
+      dispatcher.dispatch({
+        invocation: { arguments: { text: "hello" }, id: "call_clock", name: "echo", sessionId: "session_1" },
+        registry: makeKhalaToolRegistry([
+          {
+            definition: echoDefinition,
+            execute: (_input, context) =>
+              Effect.gen(function* () {
+                yield* context.services.runtime.sleep(125)
+                return khalaToolOk({ modelText: "done" })
+              }),
+          },
+        ]),
+        services: makeKhalaToolServices({ runtime }),
+      }),
+    )
+
+    expect(afterDurations).toEqual([125])
+    expect(dispatched.events.map(event => event.eventId)).toEqual([
+      "khala.tool.tool_started.rs.fmdonmx0",
+      "khala.tool.tool_progress.rs.j6tor2dg",
+      "khala.tool.tool_progress.rs.nip47e1g",
+      "khala.tool.tool_completed.v9.rixc72xg",
+    ])
   })
 
   test("returns typed model-visible errors for dispatcher failures", async () => {

--- a/packages/khala-tools/src/dispatcher.ts
+++ b/packages/khala-tools/src/dispatcher.ts
@@ -1,6 +1,7 @@
 import { Buffer } from "node:buffer"
 import { Effect } from "effect"
 import { redactKhalaPublicText } from "./redaction.js"
+import { makeKhalaToolRuntimeService, type KhalaToolRuntimeServiceShape } from "./runtime.js"
 import type {
   KhalaPermissionRequest,
   KhalaPublicSafety,
@@ -131,7 +132,8 @@ function dispatchKhalaTool(
   options: KhalaToolDispatcherOptions,
 ): Effect.Effect<KhalaToolDispatchResult, never> {
   return Effect.gen(function* () {
-    const startedAt = Date.now()
+    const runtime = input.services.runtime ?? makeKhalaToolRuntimeService()
+    const startedAt = yield* runtime.currentTimeMillis
     const localEvents: KhalaToolEvent[] = []
     const baseTelemetryTags = telemetryTagsFor(input, options)
     const accounting = options.turnAccounting === undefined
@@ -152,9 +154,8 @@ function dispatchKhalaTool(
       phase: KhalaToolDispatchPhase,
       definition: KhalaToolDefinition | undefined = undefined,
     ) =>
-      finalize({
+      finalizeWithDuration(runtime, startedAt, {
         definition,
-        durationMs: Date.now() - startedAt,
         events: localEvents,
         input,
         options,
@@ -253,7 +254,7 @@ function dispatchKhalaTool(
       })
       return yield* finalize({
         definition,
-        durationMs: Date.now() - startedAt,
+        durationMs: (yield* runtime.currentTimeMillis) - startedAt,
         events: localEvents,
         input,
         options,
@@ -287,7 +288,7 @@ function dispatchKhalaTool(
       })
       return yield* finalize({
         definition,
-        durationMs: Date.now() - startedAt,
+        durationMs: (yield* runtime.currentTimeMillis) - startedAt,
         events: localEvents,
         input,
         options,
@@ -344,7 +345,7 @@ function dispatchKhalaTool(
     })
     return yield* finalize({
       definition,
-      durationMs: Date.now() - startedAt,
+      durationMs: (yield* runtime.currentTimeMillis) - startedAt,
       events: localEvents,
       input,
       options,
@@ -435,7 +436,7 @@ function emitToolEvent(input: Readonly<{
 }>): Effect.Effect<void, never> {
   return Effect.gen(function* () {
     const event: KhalaToolEvent = {
-      eventId: nextToolEventId(input.kind),
+      eventId: yield* nextToolEventId(input.input.services.runtime, input.kind),
       invocationId: input.input.invocation.id,
       kind: input.kind,
       payload: {
@@ -446,6 +447,25 @@ function emitToolEvent(input: Readonly<{
     }
     input.events.push(event)
     yield* (input.options.hooks?.onEvent?.({ event, telemetryTags: input.telemetryTags }) ?? Effect.void)
+  })
+}
+
+function finalizeWithDuration(inputRuntime: KhalaToolRuntimeServiceShape, startedAt: number, input: Readonly<{
+  definition: KhalaToolDefinition | undefined
+  events: KhalaToolEvent[]
+  input: KhalaToolDispatchInput
+  options: KhalaToolDispatcherOptions
+  phase: KhalaToolDispatchPhase
+  result: KhalaToolResult
+  telemetryTags: KhalaToolTelemetryTags
+  tool: RegisteredKhalaTool | undefined
+}>): Effect.Effect<KhalaToolDispatchResult, never> {
+  return Effect.gen(function* () {
+    const finishedAt = yield* inputRuntime.currentTimeMillis
+    return yield* finalize({
+      ...input,
+      durationMs: finishedAt - startedAt,
+    })
   })
 }
 
@@ -607,6 +627,9 @@ function isRecord(value: unknown): value is Readonly<Record<string, unknown>> {
   return typeof value === "object" && value !== null && !Array.isArray(value)
 }
 
-function nextToolEventId(kind: KhalaToolEventKind): string {
-  return `khala.tool.${kind}.${Date.now().toString(36)}.${Math.random().toString(36).slice(2, 10)}`
+function nextToolEventId(
+  runtime: KhalaToolRuntimeServiceShape | undefined,
+  kind: KhalaToolEventKind,
+): Effect.Effect<string, never> {
+  return (runtime ?? makeKhalaToolRuntimeService()).eventId(`khala.tool.${kind}`)
 }

--- a/packages/khala-tools/src/exec-command.ts
+++ b/packages/khala-tools/src/exec-command.ts
@@ -8,6 +8,7 @@ import {
   type KhalaPermissionRequest,
   type KhalaProcessEvent,
   type KhalaProcessExecResult,
+  type KhalaToolRuntimeError,
   type KhalaToolArtifact,
   type KhalaToolDefinition,
   type KhalaToolExecuteContext,
@@ -120,60 +121,59 @@ function executeExecCommandTool(
   context: KhalaToolExecuteContext,
   options: KhalaExecCommandToolOptions,
 ): Effect.Effect<KhalaToolResult, never> {
-  return Effect.promise(async () => {
-    try {
+  return Effect.gen(function* () {
       const args = decodeExecInput(input, options)
-      const cwd = await resolveWorkdir(args.workdir, context)
+      const cwd = yield* resolveWorkdir(args.workdir, context)
       if (cwd._tag === "denied") {
         return khalaToolDenied("exec_external_cwd_denied", "command working directory outside the workspace was denied")
       }
-      const shellDecision = await Effect.runPromise(
-        context.services.permission.decide(shellPermission(args, cwd.displayPath, context)),
-      )
+      const shellDecision = yield* context.services.permission.decide(shellPermission(args, cwd.displayPath, context))
       if (shellDecision === "deny") return khalaToolDenied("exec_shell_denied", "shell command approval was denied")
       if (networkLikeCommand(args.command)) {
-        const networkDecision = await Effect.runPromise(
-          context.services.permission.decide(networkPermission(args, cwd.displayPath, context)),
-        )
+        const networkDecision = yield* context.services.permission.decide(networkPermission(args, cwd.displayPath, context))
         if (networkDecision === "deny") return khalaToolDenied("exec_network_denied", "network command approval was denied")
       }
 
-      const result = await Effect.runPromise(
-        args.tty
-          ? context.services.process.startSession({
-              ...(args.argv === undefined ? {} : { argv: args.argv }),
-              ...(args.cancelAfterMs === undefined ? {} : { cancelAfterMs: args.cancelAfterMs }),
-              command: args.command,
-              cwd: cwd.realPath,
-              khalaSessionId: context.invocation.sessionId,
-              maxCaptureBytes: options.maxCaptureBytes ?? 256 * 1024,
-              timeoutMs: args.timeoutMs,
-              workspaceRoot: await realpath(context.services.workspace.workingDirectory),
-              yieldTimeMs: args.yieldTimeMs ?? 250,
-            })
-          : context.services.process.execCommand({
-              ...(args.argv === undefined ? {} : { argv: args.argv }),
-              ...(args.cancelAfterMs === undefined ? {} : { cancelAfterMs: args.cancelAfterMs }),
-              command: args.command,
-              cwd: cwd.realPath,
-              maxCaptureBytes: options.maxCaptureBytes ?? 256 * 1024,
-              timeoutMs: args.timeoutMs,
-              workspaceRoot: await realpath(context.services.workspace.workingDirectory),
-            }),
-      )
-      return await renderExecResult(args, cwd.displayPath, result, context)
-    } catch (error) {
-      return khalaToolError("exec_command_failed", error instanceof Error ? error.message : String(error))
-    }
-  })
+      const workspaceRoot = yield* Effect.promise(() => realpath(context.services.workspace.workingDirectory))
+      const result = yield* (args.tty
+        ? context.services.process.startSession({
+            ...(args.argv === undefined ? {} : { argv: args.argv }),
+            ...(args.cancelAfterMs === undefined ? {} : { cancelAfterMs: args.cancelAfterMs }),
+            command: args.command,
+            cwd: cwd.realPath,
+            khalaSessionId: context.invocation.sessionId,
+            maxCaptureBytes: options.maxCaptureBytes ?? 256 * 1024,
+            timeoutMs: args.timeoutMs,
+            workspaceRoot,
+            yieldTimeMs: args.yieldTimeMs ?? 250,
+          })
+        : context.services.process.execCommand({
+            ...(args.argv === undefined ? {} : { argv: args.argv }),
+            ...(args.cancelAfterMs === undefined ? {} : { cancelAfterMs: args.cancelAfterMs }),
+            command: args.command,
+            cwd: cwd.realPath,
+            maxCaptureBytes: options.maxCaptureBytes ?? 256 * 1024,
+            timeoutMs: args.timeoutMs,
+            workspaceRoot,
+          }))
+      return yield* renderExecResult(args, cwd.displayPath, result, context)
+  }).pipe(
+    Effect.catchTag("KhalaToolRuntimeError", error =>
+      Effect.succeed(khalaToolError("exec_command_failed", error.reason)),
+    ),
+    Effect.catchDefect(defect =>
+      Effect.succeed(khalaToolError("exec_command_failed", defect instanceof Error ? defect.message : String(defect))),
+    ),
+  )
 }
 
-async function renderExecResult(
+function renderExecResult(
   args: ExecCommandInput,
   cwd: string,
   result: KhalaProcessExecResult,
   context: KhalaToolExecuteContext,
-): Promise<KhalaToolResult> {
+): Effect.Effect<KhalaToolResult, never> {
+  return Effect.gen(function* () {
   const sessionId = "sessionId" in result ? result.sessionId : undefined
   const stdoutBytes = Buffer.byteLength(result.stdout, "utf8")
   const stderrBytes = Buffer.byteLength(result.stderr, "utf8")
@@ -185,13 +185,19 @@ async function renderExecResult(
   const shouldSpill = preview.truncated || result.stdoutTruncated || result.stderrTruncated
   const artifacts: KhalaToolArtifact[] = []
   if (shouldSpill) {
-    const artifact = await Effect.runPromise(
-      context.services.outputStore.writeArtifact({
+    const artifact = yield* context.services.outputStore.writeArtifact({
         bytes: Buffer.from(combined, "utf8"),
         mediaType: "text/plain; charset=utf-8",
         summary: `exec_command output for ${args.command}`,
-      }),
-    )
+      }).pipe(
+        Effect.catchTag("KhalaToolRuntimeError", error =>
+          Effect.succeed({
+            artifactRef: `artifact.unavailable.${context.invocation.id}`,
+            private: true,
+            summary: `artifact write failed: ${error.reason}`,
+          }),
+        ),
+      )
     artifacts.push(artifact)
   }
 
@@ -235,6 +241,7 @@ async function renderExecResult(
     publicSafety: "private",
   })
   return failed ? { ...ok, status: "failed" } : ok
+  })
 }
 
 function decodeExecInput(input: Readonly<Record<string, unknown>>, options: KhalaExecCommandToolOptions): ExecCommandInput {
@@ -272,20 +279,19 @@ function decodeArgv(value: unknown): ReadonlyArray<string> | undefined {
   return value
 }
 
-async function resolveWorkdir(
+function resolveWorkdir(
   rawWorkdir: string,
   context: KhalaToolExecuteContext,
-): Promise<Readonly<{ _tag: "ok"; displayPath: string; realPath: string }> | Readonly<{ _tag: "denied" }>> {
-  const workspaceRoot = await realpath(context.services.workspace.workingDirectory)
+): Effect.Effect<Readonly<{ _tag: "ok"; displayPath: string; realPath: string }> | Readonly<{ _tag: "denied" }>, KhalaToolRuntimeError> {
+  return Effect.gen(function* () {
+  const workspaceRoot = yield* Effect.promise(() => realpath(context.services.workspace.workingDirectory))
   const candidate = isAbsolute(rawWorkdir) ? rawWorkdir : resolve(workspaceRoot, rawWorkdir)
-  const target = await realpath(candidate)
-  const info = await stat(target)
+  const target = yield* Effect.promise(() => realpath(candidate))
+  const info = yield* Effect.promise(() => stat(target))
   if (!info.isDirectory()) throw new Error("exec_command workdir must be a directory")
   const inside = pathIsInside(workspaceRoot, target)
   if (!inside) {
-    const decision = await Effect.runPromise(
-      context.services.permission.decide(externalDirectoryPermission(rawWorkdir, context)),
-    )
+    const decision = yield* context.services.permission.decide(externalDirectoryPermission(rawWorkdir, context))
     if (decision === "deny") return { _tag: "denied" }
   }
   return {
@@ -293,6 +299,7 @@ async function resolveWorkdir(
     displayPath: inside ? toWorkspaceRelative(workspaceRoot, target) : rawWorkdir,
     realPath: target,
   }
+  })
 }
 
 function shellPermission(args: ExecCommandInput, cwd: string, context: KhalaToolExecuteContext): KhalaPermissionRequest {

--- a/packages/khala-tools/src/index.ts
+++ b/packages/khala-tools/src/index.ts
@@ -1,10 +1,11 @@
 import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process"
 import { existsSync } from "node:fs"
-import { Effect, Schema as S } from "effect"
+import { Context, Effect, Layer, Schema as S } from "effect"
 import { makeKhalaToolDispatcher, type KhalaToolDispatcherOptions } from "./dispatcher.js"
 import { makeKhalaPermissionPolicyService } from "./permission-policy.js"
 import { createMacosSeatbeltKhalaProcessService } from "./process-sandbox-macos.js"
 import { redactKhalaPublicText } from "./redaction.js"
+import { makeKhalaToolRuntimeService, type KhalaToolRuntimeServiceShape } from "./runtime.js"
 
 export {
   approvalCacheKeysFor,
@@ -138,6 +139,14 @@ export {
   type KhalaRampartGuard,
   type KhalaRampartGuardFactory,
 } from "./redaction.js"
+
+export {
+  KhalaToolRuntimeLive,
+  KhalaToolRuntimeService,
+  makeDeterministicKhalaToolRuntimeService,
+  makeKhalaToolRuntimeService,
+  type KhalaToolRuntimeServiceShape,
+} from "./runtime.js"
 
 export const KhalaToolAuthority = S.Literals([
   "read",
@@ -587,6 +596,7 @@ export interface KhalaToolServices {
   readonly outputStore: KhalaOutputStore
   readonly permission: KhalaPermissionService
   readonly process: KhalaProcessService
+  readonly runtime: KhalaToolRuntimeServiceShape
   readonly search: KhalaWebSearchService
   readonly todo: KhalaTodoService
   readonly workspace: KhalaWorkspaceService
@@ -942,11 +952,14 @@ export const inMemoryKhalaOutputStore = (): KhalaOutputStore & {
   }
 }
 
-export const nonInteractiveKhalaInteractionService: KhalaInteractionService = {
-  askUser: input =>
-    Effect.sync(() => {
-      const requestId = createInteractionRequestId(input.invocationId)
-      const requestedAt = Date.now()
+export function makeNonInteractiveKhalaInteractionService(
+  runtime: KhalaToolRuntimeServiceShape = makeKhalaToolRuntimeService(),
+): KhalaInteractionService {
+  return {
+    askUser: input =>
+      Effect.gen(function* () {
+        const requestId = yield* createInteractionRequestId(input.invocationId, runtime)
+        const requestedAt = yield* runtime.currentTimeMillis
       return {
         events: [
           {
@@ -967,9 +980,12 @@ export const nonInteractiveKhalaInteractionService: KhalaInteractionService = {
         requestId,
         status: "unavailable",
       }
-    }),
-  marker: "khala.interaction_service",
+      }),
+    marker: "khala.interaction_service",
+  }
 }
+
+export const nonInteractiveKhalaInteractionService: KhalaInteractionService = makeNonInteractiveKhalaInteractionService()
 
 export function inMemoryKhalaTodoService(): KhalaTodoService {
   const sessions = new Map<string, Readonly<{ revision: number; todos: ReadonlyArray<KhalaTodoItem> }>>()
@@ -1075,24 +1091,40 @@ export const unconfiguredKhalaBrowserService: KhalaBrowserService = {
   waitFor: () => browserUnavailable(),
 }
 
-export function makeKhalaToolServices(input: {
+export type KhalaToolServicesInput = {
   readonly browser?: KhalaBrowserService
   readonly interaction?: KhalaInteractionService
   readonly network?: KhalaNetworkService
   readonly permission?: KhalaPermissionService
   readonly process?: KhalaProcessService
+  readonly runtime?: KhalaToolRuntimeServiceShape
   readonly search?: KhalaWebSearchService
   readonly todo?: KhalaTodoService
   readonly workingDirectory?: string
-} = {}): KhalaToolServices {
-  const interaction = input.interaction ?? nonInteractiveKhalaInteractionService
+}
+
+export class KhalaToolServicesService extends Context.Service<
+  KhalaToolServicesService,
+  KhalaToolServices
+>()("@openagentsinc/khala-tools/KhalaToolServicesService") {
+  static readonly Default = Layer.effect(KhalaToolServicesService, Effect.sync(() => makeKhalaToolServices()))
+}
+
+export function makeKhalaToolServicesLayer(input: KhalaToolServicesInput = {}): Layer.Layer<KhalaToolServicesService> {
+  return Layer.succeed(KhalaToolServicesService, makeKhalaToolServices(input))
+}
+
+export function makeKhalaToolServices(input: KhalaToolServicesInput = {}): KhalaToolServices {
+  const runtime = input.runtime ?? makeKhalaToolRuntimeService()
+  const interaction = input.interaction ?? makeNonInteractiveKhalaInteractionService(runtime)
   return {
     browser: input.browser ?? unconfiguredKhalaBrowserService,
     interaction,
     network: input.network ?? createFetchKhalaNetworkService(),
     outputStore: inMemoryKhalaOutputStore(),
     permission: input.permission ?? makeKhalaPermissionPolicyService({ interaction }),
-    process: input.process ?? defaultKhalaProcessService,
+    process: input.process ?? (input.runtime === undefined ? defaultKhalaProcessService : createDefaultKhalaProcessService(runtime)),
+    runtime,
     search: input.search ?? unconfiguredKhalaWebSearchService,
     todo: input.todo ?? inMemoryKhalaTodoService(),
     workspace: { workingDirectory: input.workingDirectory ?? process.cwd() },
@@ -1106,9 +1138,12 @@ function browserUnavailable(): Effect.Effect<never, KhalaToolRuntimeError> {
   }))
 }
 
-function createInteractionRequestId(invocationId: string): string {
+function createInteractionRequestId(
+  invocationId: string,
+  runtime: KhalaToolRuntimeServiceShape = makeKhalaToolRuntimeService(),
+): Effect.Effect<string, never> {
   const safeInvocation = invocationId.replace(/[^A-Za-z0-9_.-]/gu, "_").slice(0, 80) || "request"
-  return `khala.ask.${safeInvocation}.${Date.now().toString(36)}`
+  return runtime.eventId(`khala.ask.${safeInvocation}`)
 }
 
 function interactionRequestPayload(
@@ -1175,34 +1210,46 @@ async function readNetworkResponseBody(
   }
 }
 
-export const unsandboxedKhalaProcessService: KhalaProcessService = {
-  execCommand: input =>
-    Effect.promise(async () => {
-      const started = Date.now()
+export function createUnsandboxedKhalaProcessService(
+  runtime: KhalaToolRuntimeServiceShape = makeKhalaToolRuntimeService(),
+): KhalaProcessService {
+  return {
+    execCommand: input =>
+      Effect.scoped(Effect.gen(function* () {
+        const started = yield* runtime.currentTimeMillis
       let timedOut = false
       let cancelled = false
-      const proc = spawnProcessGroup(input, "pipes")
+      const proc = yield* Effect.acquireRelease(
+        Effect.sync(() => spawnProcessGroup(input, "pipes")),
+        proc => Effect.sync(() => killProcessGroup(proc)),
+      )
       const kill = (reason: "cancelled" | "timedOut"): void => {
         if (reason === "cancelled") cancelled = true
         else timedOut = true
         killProcessGroup(proc)
       }
-      const timeout = setTimeout(() => kill("timedOut"), input.timeoutMs)
+      const timeout = yield* Effect.forkScoped(runtime.sleep(input.timeoutMs).pipe(Effect.tap(() => Effect.sync(() => kill("timedOut")))))
       const cancel = input.cancelAfterMs === undefined
         ? undefined
-        : setTimeout(() => kill("cancelled"), input.cancelAfterMs)
+        : yield* Effect.forkScoped(runtime.sleep(input.cancelAfterMs).pipe(Effect.tap(() => Effect.sync(() => kill("cancelled")))))
+      void cancel
       const events: KhalaProcessEvent[] = []
-      const exit = waitForChildExit(proc)
-      const [stdout, stderr, exitResult] = await Promise.all([
-        readNodeProcessStream(proc.stdout, "stdout", input.maxCaptureBytes, events, () => killProcessGroup(proc)),
-        readNodeProcessStream(proc.stderr, "stderr", input.maxCaptureBytes, events, () => killProcessGroup(proc)),
-        exit,
-      ])
-      clearTimeout(timeout)
-      if (cancel !== undefined) clearTimeout(cancel)
+      const [stdout, stderr, exitResult] = yield* Effect.tryPromise({
+        catch: error => new KhalaToolRuntimeError({
+          code: "process_exec_failed",
+          reason: error instanceof Error ? error.message : String(error),
+        }),
+        try: () =>
+          Promise.all([
+            readNodeProcessStream(proc.stdout, "stdout", input.maxCaptureBytes, events, () => killProcessGroup(proc), runtime),
+            readNodeProcessStream(proc.stderr, "stderr", input.maxCaptureBytes, events, () => killProcessGroup(proc), runtime),
+            waitForChildExit(proc),
+          ]),
+      })
+      void timeout
       return {
         cancelled,
-        durationMs: Date.now() - started,
+        durationMs: (yield* runtime.currentTimeMillis) - started,
         events,
         exitCode: exitResult.exitCode,
         sandbox: {
@@ -1217,15 +1264,15 @@ export const unsandboxedKhalaProcessService: KhalaProcessService = {
         stdoutTruncated: stdout.truncated,
         timedOut,
       }
-    }),
-  marker: "khala.process_service",
-  startSession: input =>
-    Effect.promise(async () => {
-      const started = Date.now()
+      })),
+    marker: "khala.process_service",
+    startSession: input =>
+      Effect.gen(function* () {
+        const started = yield* runtime.currentTimeMillis
       let timedOut = false
       let cancelled = false
       const proc = spawnProcessGroup(input, "pty")
-      const sessionId = `khala.proc.${Date.now().toString(36)}.${Math.random().toString(36).slice(2)}`
+      const sessionId = yield* runtime.eventId("khala.proc")
       const session: DefaultKhalaProcessSession = {
         cancelled: false,
         command: input.command,
@@ -1245,26 +1292,28 @@ export const unsandboxedKhalaProcessService: KhalaProcessService = {
         timedOut: false,
       }
       defaultProcessSessions.set(sessionId, session)
-      void pumpSessionStream(session, proc.stdout, "stdout")
-      void pumpSessionStream(session, proc.stderr, "stderr")
+      void pumpSessionStream(session, proc.stdout, "stdout", runtime)
+      void pumpSessionStream(session, proc.stderr, "stderr", runtime)
       void waitForChildExit(proc).then(exit => {
         session.exitCode = exit.exitCode
         session.signal = exit.signal
       })
-      setTimeout(() => {
-        if (session.exitCode === null) {
-          timedOut = true
-          session.timedOut = true
-          killProcessGroup(proc)
-        }
-      }, input.timeoutMs)
-      await sleep(input.yieldTimeMs)
+      yield* Effect.forkDetach(runtime.sleep(input.timeoutMs).pipe(
+        Effect.tap(() => Effect.sync(() => {
+          if (session.exitCode === null) {
+            timedOut = true
+            session.timedOut = true
+            killProcessGroup(proc)
+          }
+        })),
+      ))
+      yield* runtime.sleep(input.yieldTimeMs)
       timedOut = session.timedOut
       cancelled = session.cancelled
-      return sessionSnapshot(session, Date.now() - started, timedOut, cancelled)
-    }),
-  writeStdin: input =>
-    Effect.promise(async () => {
+      return sessionSnapshot(session, (yield* runtime.currentTimeMillis) - started, timedOut, cancelled)
+      }),
+    writeStdin: input =>
+      Effect.gen(function* () {
       const session = defaultProcessSessions.get(input.sessionId)
       if (session === undefined) throw new Error(`unknown process session: ${input.sessionId}`)
       if (session.khalaSessionId !== input.khalaSessionId) {
@@ -1279,21 +1328,31 @@ export const unsandboxedKhalaProcessService: KhalaProcessService = {
           if (session.proc.stdin.destroyed) throw new Error(`process session stdin is closed: ${input.sessionId}`)
           session.proc.stdin.write(input.chars)
         }
-        session.events.push({ channel: "stdin", text: input.chars, timestampMs: Date.now() })
+        session.events.push({ channel: "stdin", text: input.chars, timestampMs: yield* runtime.currentTimeMillis })
       }
-      await sleep(input.yieldTimeMs)
+      yield* runtime.sleep(input.yieldTimeMs)
       return sessionSnapshot(
         session,
-        Date.now() - session.createdAtMs,
+        (yield* runtime.currentTimeMillis) - session.createdAtMs,
         session.timedOut,
         session.cancelled,
       )
-    }),
+      }),
+  }
 }
 
-export const defaultKhalaProcessService: KhalaProcessService = process.platform === "darwin"
-  ? createMacosSeatbeltKhalaProcessService({ fallback: unsandboxedKhalaProcessService })
-  : unsandboxedKhalaProcessService
+export const unsandboxedKhalaProcessService: KhalaProcessService = createUnsandboxedKhalaProcessService()
+
+export function createDefaultKhalaProcessService(
+  runtime: KhalaToolRuntimeServiceShape = makeKhalaToolRuntimeService(),
+): KhalaProcessService {
+  const unsandboxed = createUnsandboxedKhalaProcessService(runtime)
+  return process.platform === "darwin"
+    ? createMacosSeatbeltKhalaProcessService({ fallback: unsandboxed, runtime })
+    : unsandboxed
+}
+
+export const defaultKhalaProcessService: KhalaProcessService = createDefaultKhalaProcessService()
 
 type DefaultKhalaProcessSession = {
   cancelled: boolean
@@ -1320,10 +1379,11 @@ async function pumpSessionStream(
   session: DefaultKhalaProcessSession,
   stream: NodeJS.ReadableStream,
   channel: "stdout" | "stderr",
+  runtime: KhalaToolRuntimeServiceShape = makeKhalaToolRuntimeService(),
 ): Promise<void> {
   for await (const value of stream) {
     const chunk = Buffer.from(value as Buffer).toString("utf8")
-    session.events.push({ channel, text: chunk, timestampMs: Date.now() })
+    session.events.push({ channel, text: chunk, timestampMs: await Effect.runPromise(runtime.currentTimeMillis) })
     if (channel === "stdout") {
       if (Buffer.byteLength(session.stdout + chunk, "utf8") > session.maxCaptureBytes) {
         session.stdoutTruncated = true
@@ -1370,10 +1430,6 @@ function tailByBytes(text: string, maxBytes: number): string {
   const bytes = Buffer.from(text, "utf8")
   if (bytes.byteLength <= maxBytes) return text
   return bytes.subarray(bytes.byteLength - maxBytes).toString("utf8")
-}
-
-function sleep(ms: number): Promise<void> {
-  return new Promise(resolve => setTimeout(resolve, ms))
 }
 
 type ChildExitResult = Readonly<{
@@ -1508,6 +1564,7 @@ async function readNodeProcessStream(
   maxBytes: number,
   events: KhalaProcessEvent[],
   onTruncate: () => void,
+  runtime: KhalaToolRuntimeServiceShape = makeKhalaToolRuntimeService(),
 ): Promise<Readonly<{ text: string; truncated: boolean }>> {
   const chunks: Buffer[] = []
   let bytes = 0
@@ -1519,7 +1576,7 @@ async function readNodeProcessStream(
       if (remaining > 0) {
         const kept = chunk.slice(0, remaining)
         chunks.push(Buffer.from(kept))
-        events.push({ channel, text: Buffer.from(kept).toString("utf8"), timestampMs: Date.now() })
+        events.push({ channel, text: Buffer.from(kept).toString("utf8"), timestampMs: await Effect.runPromise(runtime.currentTimeMillis) })
       }
       truncated = true
       onTruncate()
@@ -1527,7 +1584,7 @@ async function readNodeProcessStream(
     }
     bytes += chunk.byteLength
     chunks.push(Buffer.from(chunk))
-    events.push({ channel, text: Buffer.from(chunk).toString("utf8"), timestampMs: Date.now() })
+    events.push({ channel, text: Buffer.from(chunk).toString("utf8"), timestampMs: await Effect.runPromise(runtime.currentTimeMillis) })
   }
   return {
     text: Buffer.concat(chunks).toString("utf8"),

--- a/packages/khala-tools/src/process-sandbox-macos.ts
+++ b/packages/khala-tools/src/process-sandbox-macos.ts
@@ -2,6 +2,8 @@ import { mkdtemp, realpath, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { Effect } from "effect"
+import { KhalaToolRuntimeError } from "./index.js"
+import { makeKhalaToolRuntimeService, type KhalaToolRuntimeServiceShape } from "./runtime.js"
 import type {
   KhalaProcessEvent,
   KhalaProcessExecInput,
@@ -15,6 +17,7 @@ import type {
 export type MacosSeatbeltProcessServiceOptions = Readonly<{
   deniedReadPaths?: ReadonlyArray<string>
   fallback?: KhalaProcessService
+  runtime?: KhalaToolRuntimeServiceShape
   sandboxExecPath?: string
 }>
 
@@ -26,90 +29,107 @@ export function createMacosSeatbeltKhalaProcessService(
   const sessions = new Map<string, MacosSeatbeltProcessSession>()
   const sandboxExecPath = options.sandboxExecPath ?? "/usr/bin/sandbox-exec"
   const fallback = options.fallback
+  const runtime = options.runtime ?? makeKhalaToolRuntimeService()
 
   return {
     execCommand: input =>
-      Effect.promise(async () => {
+      Effect.gen(function* () {
         if (process.platform !== "darwin") {
-          if (fallback !== undefined) return await Effect.runPromise(fallback.execCommand(input))
-          throw new Error("macOS Seatbelt sandbox is only available on Darwin")
+          if (fallback !== undefined) return yield* fallback.execCommand(input)
+          return yield* processRuntimeError("process_sandbox_unavailable", "macOS Seatbelt sandbox is only available on Darwin")
         }
-        return runSandboxedCommand(input, sandboxExecPath, options.deniedReadPaths ?? [])
+        return yield* runSandboxedCommand(input, sandboxExecPath, options.deniedReadPaths ?? [], runtime)
       }),
     marker: "khala.process_service",
     startSession: input =>
-      Effect.promise(async () => {
+      Effect.gen(function* () {
         if (process.platform !== "darwin") {
-          if (fallback !== undefined) return await Effect.runPromise(fallback.startSession(input))
-          throw new Error("macOS Seatbelt sandbox is only available on Darwin")
+          if (fallback !== undefined) return yield* fallback.startSession(input)
+          return yield* processRuntimeError("process_sandbox_unavailable", "macOS Seatbelt sandbox is only available on Darwin")
         }
-        return startSandboxedSession(input, sandboxExecPath, options.deniedReadPaths ?? [], sessions)
+        return yield* startSandboxedSession(input, sandboxExecPath, options.deniedReadPaths ?? [], sessions, runtime)
       }),
     writeStdin: input =>
-      Effect.promise(async () => {
+      Effect.gen(function* () {
         const session = sessions.get(input.sessionId)
         if (session === undefined) {
-          if (fallback !== undefined) return await Effect.runPromise(fallback.writeStdin(input))
-          throw new Error(`unknown process session: ${input.sessionId}`)
+          if (fallback !== undefined) return yield* fallback.writeStdin(input)
+          return yield* processRuntimeError("process_session_unknown", `unknown process session: ${input.sessionId}`)
         }
         if (session.khalaSessionId !== input.khalaSessionId) {
-          throw new Error("process session does not belong to the active Khala session")
+          return yield* processRuntimeError("process_session_mismatch", "process session does not belong to the active Khala session")
         }
         if (input.chars !== undefined && input.chars.length > 0) {
-          if (session.exitCode !== null) throw new Error(`process session is closed: ${input.sessionId}`)
+          if (session.exitCode !== null) {
+            return yield* processRuntimeError("process_session_closed", `process session is closed: ${input.sessionId}`)
+          }
           if (input.chars === "\u0003") {
             session.cancelled = true
             killSandboxedProcessGroup(session.proc)
           } else {
             const stdin = session.proc.stdin as unknown as BunFileSink | undefined
-            if (stdin === undefined) throw new Error(`process session stdin is closed: ${input.sessionId}`)
+            if (stdin === undefined) {
+              return yield* processRuntimeError("process_session_stdin_closed", `process session stdin is closed: ${input.sessionId}`)
+            }
             stdin.write(input.chars)
             stdin.flush()
           }
-          session.events.push({ channel: "stdin", text: input.chars, timestampMs: Date.now() })
+          session.events.push({ channel: "stdin", text: input.chars, timestampMs: yield* runtime.currentTimeMillis })
         }
-        await sleep(input.yieldTimeMs)
-        return sessionSnapshot(session, Date.now() - session.createdAtMs)
+        yield* runtime.sleep(input.yieldTimeMs)
+        return sessionSnapshot(session, (yield* runtime.currentTimeMillis) - session.createdAtMs)
       }),
   }
 }
 
-async function runSandboxedCommand(
+function runSandboxedCommand(
   input: KhalaProcessExecInput,
   sandboxExecPath: string,
   deniedReadPaths: ReadonlyArray<string>,
-): Promise<KhalaProcessExecResult> {
-  const started = Date.now()
-  let timedOut = false
-  let cancelled = false
-  const sandbox = await makeSandboxArgs(input, sandboxExecPath, deniedReadPaths)
-  try {
-    const proc = Bun.spawn([...sandbox.prefix, ...commandArgs(input)], {
-      cwd: input.cwd,
-      detached: true,
-      stderr: "pipe",
-      stdout: "pipe",
-    })
+  runtime: KhalaToolRuntimeServiceShape,
+): Effect.Effect<KhalaProcessExecResult, KhalaToolRuntimeError> {
+  return Effect.scoped(Effect.gen(function* () {
+    const started = yield* runtime.currentTimeMillis
+    let timedOut = false
+    let cancelled = false
+    const sandbox = yield* Effect.acquireRelease(
+      Effect.tryPromise({
+        catch: error => processRuntimeFailure("process_sandbox_profile_failed", error),
+        try: () => makeSandboxArgs(input, sandboxExecPath, deniedReadPaths),
+      }),
+      sandbox => Effect.promise(() => sandbox.cleanup()).pipe(Effect.orDie),
+    )
+    const proc = yield* Effect.acquireRelease(
+      Effect.sync(() => Bun.spawn([...sandbox.prefix, ...commandArgs(input)], {
+        cwd: input.cwd,
+        detached: true,
+        stderr: "pipe",
+        stdout: "pipe",
+      })),
+      proc => Effect.sync(() => killSandboxedProcessGroup(proc)),
+    )
     const kill = (reason: "cancelled" | "timedOut"): void => {
       if (reason === "cancelled") cancelled = true
       else timedOut = true
       killSandboxedProcessGroup(proc)
     }
-    const timeout = setTimeout(() => kill("timedOut"), input.timeoutMs)
+    yield* Effect.forkScoped(runtime.sleep(input.timeoutMs).pipe(Effect.tap(() => Effect.sync(() => kill("timedOut")))))
     const cancel = input.cancelAfterMs === undefined
       ? undefined
-      : setTimeout(() => kill("cancelled"), input.cancelAfterMs)
+      : yield* Effect.forkScoped(runtime.sleep(input.cancelAfterMs).pipe(Effect.tap(() => Effect.sync(() => kill("cancelled")))))
+    void cancel
     const events: KhalaProcessEvent[] = []
-    const [stdout, stderr, exitCode] = await Promise.all([
-      readProcessStream(proc.stdout, "stdout", input.maxCaptureBytes, events, () => killSandboxedProcessGroup(proc)),
-      readProcessStream(proc.stderr, "stderr", input.maxCaptureBytes, events, () => killSandboxedProcessGroup(proc)),
-      proc.exited.catch(() => null),
-    ])
-    clearTimeout(timeout)
-    if (cancel !== undefined) clearTimeout(cancel)
+    const [stdout, stderr, exitCode] = yield* Effect.tryPromise({
+      catch: error => processRuntimeFailure("process_exec_failed", error),
+      try: () => Promise.all([
+        readProcessStream(proc.stdout, "stdout", input.maxCaptureBytes, events, () => killSandboxedProcessGroup(proc), runtime),
+        readProcessStream(proc.stderr, "stderr", input.maxCaptureBytes, events, () => killSandboxedProcessGroup(proc), runtime),
+        proc.exited.catch(() => null),
+      ]),
+    })
     return {
       cancelled,
-      durationMs: Date.now() - started,
+      durationMs: (yield* runtime.currentTimeMillis) - started,
       events: events.sort((a, b) => a.timestampMs - b.timestampMs),
       exitCode,
       sandbox: {
@@ -124,19 +144,22 @@ async function runSandboxedCommand(
       stdoutTruncated: stdout.truncated,
       timedOut,
     }
-  } finally {
-    await sandbox.cleanup()
-  }
+  }))
 }
 
-async function startSandboxedSession(
+function startSandboxedSession(
   input: KhalaProcessSessionStartInput,
   sandboxExecPath: string,
   deniedReadPaths: ReadonlyArray<string>,
   sessions: Map<string, MacosSeatbeltProcessSession>,
-): Promise<KhalaProcessSessionResult> {
-  const started = Date.now()
-  const sandbox = await makeSandboxArgs(input, sandboxExecPath, deniedReadPaths)
+  runtime: KhalaToolRuntimeServiceShape,
+): Effect.Effect<KhalaProcessSessionResult, KhalaToolRuntimeError> {
+  return Effect.gen(function* () {
+  const started = yield* runtime.currentTimeMillis
+  const sandbox = yield* Effect.tryPromise({
+    catch: error => processRuntimeFailure("process_sandbox_profile_failed", error),
+    try: () => makeSandboxArgs(input, sandboxExecPath, deniedReadPaths),
+  })
   const proc = Bun.spawn([...sandbox.prefix, ...commandArgs(input)], {
     cwd: input.cwd,
     detached: true,
@@ -144,7 +167,7 @@ async function startSandboxedSession(
     stdin: "pipe",
     stdout: "pipe",
   })
-  const sessionId = `khala.proc.${Date.now().toString(36)}.${Math.random().toString(36).slice(2)}`
+  const sessionId = yield* runtime.eventId("khala.proc")
   const session: MacosSeatbeltProcessSession = {
     cancelled: false,
     cleanup: sandbox.cleanup,
@@ -163,8 +186,8 @@ async function startSandboxedSession(
     timedOut: false,
   }
   sessions.set(sessionId, session)
-  void pumpSessionStream(session, proc.stdout, "stdout")
-  void pumpSessionStream(session, proc.stderr, "stderr")
+  void pumpSessionStream(session, proc.stdout, "stdout", runtime)
+  void pumpSessionStream(session, proc.stderr, "stderr", runtime)
   void proc.exited.then(exitCode => {
     session.exitCode = exitCode
     void session.cleanup()
@@ -172,14 +195,15 @@ async function startSandboxedSession(
     session.exitCode = null
     void session.cleanup()
   })
-  setTimeout(() => {
+  yield* Effect.forkDetach(runtime.sleep(input.timeoutMs).pipe(Effect.tap(() => Effect.sync(() => {
     if (session.exitCode === null) {
       session.timedOut = true
       killSandboxedProcessGroup(proc)
     }
-  }, input.timeoutMs)
-  await sleep(input.yieldTimeMs)
-  return sessionSnapshot(session, Date.now() - started)
+  }))))
+  yield* runtime.sleep(input.yieldTimeMs)
+  return sessionSnapshot(session, (yield* runtime.currentTimeMillis) - started)
+  })
 }
 
 async function makeSandboxArgs(
@@ -223,6 +247,17 @@ function commandArgs(input: KhalaProcessExecInput): ReadonlyArray<string> {
 
 function quoteSeatbeltString(value: string): string {
   return JSON.stringify(value)
+}
+
+function processRuntimeError(code: string, reason: string): Effect.Effect<never, KhalaToolRuntimeError> {
+  return Effect.fail(new KhalaToolRuntimeError({ code, reason }))
+}
+
+function processRuntimeFailure(code: string, error: unknown): KhalaToolRuntimeError {
+  return new KhalaToolRuntimeError({
+    code,
+    reason: error instanceof Error ? error.message : String(error),
+  })
 }
 
 type MacosSeatbeltProcessSession = {
@@ -273,13 +308,14 @@ async function pumpSessionStream(
   session: MacosSeatbeltProcessSession,
   stream: ReadableStream<Uint8Array>,
   channel: "stdout" | "stderr",
+  runtime: KhalaToolRuntimeServiceShape = makeKhalaToolRuntimeService(),
 ): Promise<void> {
   const reader = stream.getReader()
   while (true) {
     const read = await reader.read()
     if (read.done) break
     const chunk = Buffer.from(read.value).toString("utf8")
-    session.events.push({ channel, text: chunk, timestampMs: Date.now() })
+    session.events.push({ channel, text: chunk, timestampMs: await Effect.runPromise(runtime.currentTimeMillis) })
     if (channel === "stdout") {
       if (Buffer.byteLength(session.stdout + chunk, "utf8") > session.maxCaptureBytes) {
         session.stdoutTruncated = true
@@ -302,6 +338,7 @@ async function readProcessStream(
   maxBytes: number,
   events: KhalaProcessEvent[],
   onTruncate: () => void,
+  runtime: KhalaToolRuntimeServiceShape = makeKhalaToolRuntimeService(),
 ): Promise<Readonly<{ text: string; truncated: boolean }>> {
   const reader = stream.getReader()
   const chunks: Buffer[] = []
@@ -316,7 +353,7 @@ async function readProcessStream(
       if (remaining > 0) {
         const kept = chunk.slice(0, remaining)
         chunks.push(Buffer.from(kept))
-        events.push({ channel, text: Buffer.from(kept).toString("utf8"), timestampMs: Date.now() })
+        events.push({ channel, text: Buffer.from(kept).toString("utf8"), timestampMs: await Effect.runPromise(runtime.currentTimeMillis) })
       }
       truncated = true
       onTruncate()
@@ -324,7 +361,7 @@ async function readProcessStream(
     }
     bytes += chunk.byteLength
     chunks.push(Buffer.from(chunk))
-    events.push({ channel, text: Buffer.from(chunk).toString("utf8"), timestampMs: Date.now() })
+    events.push({ channel, text: Buffer.from(chunk).toString("utf8"), timestampMs: await Effect.runPromise(runtime.currentTimeMillis) })
   }
   return {
     text: Buffer.concat(chunks).toString("utf8"),
@@ -344,8 +381,4 @@ function killSandboxedProcessGroup(proc: ReturnType<typeof Bun.spawn>, signal: N
   } catch {
     proc.kill(signal)
   }
-}
-
-function sleep(ms: number): Promise<void> {
-  return new Promise(resolve => setTimeout(resolve, ms))
 }

--- a/packages/khala-tools/src/runtime.ts
+++ b/packages/khala-tools/src/runtime.ts
@@ -1,0 +1,82 @@
+import { Context, Effect, Layer, Random } from "effect"
+
+export type KhalaToolRuntimeServiceShape = {
+  readonly currentTimeMillis: Effect.Effect<number, never>
+  readonly eventId: (prefix: string) => Effect.Effect<string, never>
+  readonly randomIdPart: (length: number) => Effect.Effect<string, never>
+  readonly sleep: (ms: number) => Effect.Effect<void, never>
+}
+
+const randomAlphabet = "0123456789abcdefghijklmnopqrstuvwxyz"
+
+export class KhalaToolRuntimeService extends Context.Service<
+  KhalaToolRuntimeService,
+  KhalaToolRuntimeServiceShape
+>()("@openagentsinc/khala-tools/KhalaToolRuntimeService") {
+  static readonly Default = Layer.succeed(KhalaToolRuntimeService, makeKhalaToolRuntimeService())
+}
+
+export const KhalaToolRuntimeLive = KhalaToolRuntimeService.Default
+
+export function makeKhalaToolRuntimeService(): KhalaToolRuntimeServiceShape {
+  return {
+    currentTimeMillis: Effect.clockWith(clock => clock.currentTimeMillis),
+    eventId: prefix =>
+      Effect.gen(function* () {
+        const now = yield* Effect.clockWith(clock => clock.currentTimeMillis)
+        const suffix = yield* randomIdPart(8)
+        return `${prefix}.${now.toString(36)}.${suffix}`
+      }),
+    randomIdPart,
+    sleep: ms => Effect.sleep(`${Math.max(0, Math.trunc(ms))} millis`),
+  }
+}
+
+export function makeDeterministicKhalaToolRuntimeService(input: {
+  readonly nowMs?: number
+  readonly seed?: string
+} = {}): KhalaToolRuntimeServiceShape {
+  let now = input.nowMs ?? 0
+  let state = hashSeed(input.seed ?? "khala-tools")
+  const next = (): number => {
+    state = (Math.imul(state, 1664525) + 1013904223) >>> 0
+    return state
+  }
+  return {
+    currentTimeMillis: Effect.sync(() => now),
+    eventId: prefix =>
+      Effect.sync(() => {
+        const suffix = Array.from({ length: 8 }, () => randomAlphabet[next() % randomAlphabet.length]).join("")
+        return `${prefix}.${now.toString(36)}.${suffix}`
+      }),
+    randomIdPart: length =>
+      Effect.sync(() => Array.from(
+        { length: Math.max(0, Math.trunc(length)) },
+        () => randomAlphabet[next() % randomAlphabet.length],
+      ).join("")),
+    sleep: ms =>
+      Effect.sync(() => {
+        now += Math.max(0, Math.trunc(ms))
+      }),
+  }
+}
+
+function randomIdPart(length: number): Effect.Effect<string, never> {
+  return Effect.gen(function* () {
+    const chars: string[] = []
+    for (let index = 0; index < Math.max(0, Math.trunc(length)); index += 1) {
+      const offset = yield* Random.nextIntBetween(0, randomAlphabet.length - 1)
+      chars.push(randomAlphabet[offset] ?? "0")
+    }
+    return chars.join("")
+  })
+}
+
+function hashSeed(seed: string): number {
+  let hash = 2166136261
+  for (const char of seed) {
+    hash ^= char.charCodeAt(0)
+    hash = Math.imul(hash, 16777619)
+  }
+  return hash >>> 0
+}

--- a/packages/khala-tools/src/write-stdin.ts
+++ b/packages/khala-tools/src/write-stdin.ts
@@ -103,9 +103,17 @@ function executeWriteStdinTool(
       )
       return await renderWriteStdinResult(args, result, context)
     } catch (error) {
-      return khalaToolError("write_stdin_failed", error instanceof Error ? error.message : String(error))
+      return khalaToolError("write_stdin_failed", runtimeErrorReason(error))
     }
   })
+}
+
+function runtimeErrorReason(error: unknown): string {
+  if (error instanceof Error && error.message.length > 0) return error.message
+  if (typeof error === "object" && error !== null && "reason" in error && typeof error.reason === "string") {
+    return error.reason
+  }
+  return String(error)
 }
 
 async function renderWriteStdinResult(


### PR DESCRIPTION
Closes #7863

## Summary
- Add injected khala-tools runtime Clock/random service and Layer-backed KhalaToolServicesService.
- Move dispatcher duration/event IDs and exec-command permission/process/artifact flow into the Effect chain.
- Scope one-shot unsandboxed and macOS Seatbelt process groups/profile cleanup with acquireRelease while preserving tool-result errors-as-data.
- Update Fable roadmap/audit notes for T7.4.

## Verification
- bun run --cwd packages/khala-tools typecheck
- bun run --cwd packages/khala-tools test
- command.public.pylon_khala.verify.8eaeb8c5cc9222b7b1bd6096 => bun run --cwd packages/khala-tools test

Do not merge.