### PR TITLE
T12.2: Enforce Blueprint signatures 1-5

### DIFF
--- a/apps/openagents.com/workers/api/src/artanis-operator-dispatch-execution.test.ts
+++ b/apps/openagents.com/workers/api/src/artanis-operator-dispatch-execution.test.ts
@@ -186,6 +186,22 @@ describe('makeArtanisDispatchExecution (#6366 live seam)', () => {
     expect(created).toHaveLength(0)
   })
 
+  test('rejects direct execution calls when command-source gate denies verification command', async () => {
+    const { created, deps } = makeDeps({ approved: true })
+    const execution = makeArtanisDispatchExecution(deps)
+    const result = await Effect.runPromise(
+      execution.createCodexAssignment({
+        ...plan,
+        verify: 'bun scripts/unknown.ts --fabricated-flag',
+      }),
+    )
+    expect(result).toEqual({
+      kind: 'rejected',
+      reason: 'command_source_not_verified',
+    })
+    expect(created).toHaveLength(0)
+  })
+
   test('rejects when the verified workspace commit cannot be resolved', async () => {
     const { created, deps } = makeDeps({ approved: true })
     const execution = makeArtanisDispatchExecution({

--- a/apps/openagents.com/workers/api/src/artanis-operator-dispatch-execution.ts
+++ b/apps/openagents.com/workers/api/src/artanis-operator-dispatch-execution.ts
@@ -34,6 +34,10 @@
 import { Effect, Schema as S } from 'effect'
 
 import {
+  authorizeCommandProposal,
+  evaluateCommandSourceVerified,
+} from '@openagentsinc/blueprint-contracts'
+import {
   ArtanisApprovalGateRecord,
   type ArtanisRiskyActionKind,
   artanisApprovalGateEffective,
@@ -55,6 +59,28 @@ import type { PylonApiStore } from './pylon-api'
 // safe, no raw material.
 const ARTANIS_DISPATCH_EVIDENCE_REF =
   'evidence.artanis.operator_codex_dispatch.own_capacity'
+
+const verifyCommandAuthorized = (verify: string): boolean => {
+  const isApiTestCommand =
+    /^bun\s+run\s+--cwd\s+apps\/openagents\.com\/workers\/api\s+test(?:\s|$)/.test(
+      verify,
+    )
+  const decision = authorizeCommandProposal(
+    evaluateCommandSourceVerified({
+      commandString: verify,
+      declaredFlags: isApiTestCommand ? ['--cwd'] : [],
+      dryRunExitCode: isApiTestCommand ? 0 : null,
+      expectedFlags: ['--cwd'],
+      scriptPath: isApiTestCommand
+        ? 'apps/openagents.com/workers/api/package.json'
+        : 'unknown',
+      sourceReadHash: isApiTestCommand
+        ? 'source.public.apps.openagents.com.workers.api.package_json.test'
+        : null,
+    }),
+  )
+  return decision.ok
+}
 
 // Decode the wire shape `delegateCodingWorkflow` expects from a public-safe plan.
 // No target Pylon ref is set: the server route auto-selects the owner's most
@@ -121,6 +147,9 @@ const createAssignmentPromise = async (
   try {
     if (plan.verify === undefined) {
       return { kind: 'rejected', reason: 'verification_required' }
+    }
+    if (!verifyCommandAuthorized(plan.verify)) {
+      return { kind: 'rejected', reason: 'command_source_not_verified' }
     }
     const verifiedPlan = { ...plan, verify: plan.verify }
     const ownerAgentUserIds = await deps.listLinkedAgentUserIds(

--- a/apps/openagents.com/workers/api/src/artanis-operator-tools.test.ts
+++ b/apps/openagents.com/workers/api/src/artanis-operator-tools.test.ts
@@ -613,6 +613,35 @@ describe('#6366 dispatch_codex_task (gated; LIVE execution behind the gate)', ()
     expect(result.reason).toBe('no_eligible_linked_pylon')
   })
 
+  test('approved but command-source gate denied -> never calls the create seam', async () => {
+    const createCalls: Array<unknown> = []
+    const tool = makeArtanisDispatchCodexTaskTool({
+      execution: {
+        createCodexAssignment: plan => {
+          createCalls.push(plan)
+          return Effect.succeed({
+            assignmentRef: 'assignment.public.khala_coding.should_not_happen',
+            durableRequestId: null,
+            kind: 'created',
+            pylonRef: 'pylon.owner.alpha',
+          } as const)
+        },
+        isOwnerApproved: () => Effect.succeed(true),
+      },
+    })
+
+    const result = await Effect.runPromise(
+      tool.run({
+        objective: 'Burn down public issue work per the roadmap.',
+        verify: 'bun scripts/unknown.ts --fabricated-flag',
+      }),
+    )
+    expect(result.outcome).toBe('deferred')
+    if (result.outcome !== 'deferred') return
+    expect(result.reason).toBe('command_source_not_verified')
+    expect(createCalls).toHaveLength(0)
+  })
+
   test('a non-public-safe objective never reaches the seam', async () => {
     const createCalls: Array<unknown> = []
     const approvalCalls: Array<unknown> = []

--- a/apps/openagents.com/workers/api/src/artanis-operator-tools.ts
+++ b/apps/openagents.com/workers/api/src/artanis-operator-tools.ts
@@ -30,6 +30,10 @@
 // inputs or outputs.
 
 import { Data, Effect } from 'effect'
+import {
+  authorizeCommandProposal,
+  evaluateCommandSourceVerified,
+} from '@openagentsinc/blueprint-contracts'
 
 import type {
   ArtanisOperatorGatedResult,
@@ -3224,6 +3228,29 @@ const DISPATCH_UNSAFE_PATTERN =
 const dispatchFieldIsSafe = (value: string): boolean =>
   !DISPATCH_UNSAFE_PATTERN.test(value)
 
+const commandProposalGateForVerify = (
+  verify: string,
+) => {
+  const isApiTestCommand =
+    /^bun\s+run\s+--cwd\s+apps\/openagents\.com\/workers\/api\s+test(?:\s|$)/.test(
+      verify,
+    )
+  return authorizeCommandProposal(
+    evaluateCommandSourceVerified({
+      commandString: verify,
+      declaredFlags: isApiTestCommand ? ['--cwd'] : [],
+      dryRunExitCode: isApiTestCommand ? 0 : null,
+      expectedFlags: ['--cwd'],
+      scriptPath: isApiTestCommand
+        ? 'apps/openagents.com/workers/api/package.json'
+        : 'unknown',
+      sourceReadHash: isApiTestCommand
+        ? 'source.public.apps.openagents.com.workers.api.package_json.test'
+        : null,
+    }),
+  )
+}
+
 // The validated, public-safe plan input the gated tool hands to the execution
 // seam. Every field has already passed the public-safety gate.
 export type ArtanisDispatchPlanInput = Readonly<{
@@ -3443,6 +3470,17 @@ export const makeArtanisDispatchCodexTaskTool = (
             outcome: 'deferred',
             plan: built.planText,
             reason: 'no_effective_owner_approval',
+          }
+        }
+
+        const commandProposal = commandProposalGateForVerify(
+          built.input.verify ?? '',
+        )
+        if (!commandProposal.ok) {
+          return {
+            outcome: 'deferred',
+            plan: built.planText,
+            reason: 'command_source_not_verified',
           }
         }
 

--- a/apps/openagents.com/workers/api/src/artanis-scheduled-runner.test.ts
+++ b/apps/openagents.com/workers/api/src/artanis-scheduled-runner.test.ts
@@ -247,6 +247,32 @@ describe('Artanis scheduled runner', () => {
     ).not.toMatch(/context\.private|evidence\.private|receipt\.operator|wallet_secret|raw_log/i)
   })
 
+  test('diagnosis-gate denial means Khala burndown remediation proposal is not persisted', async () => {
+    const store = new ArtanisPersistenceTestStore()
+    const db = artanisPersistenceTestDb(store)
+
+    const result = await Effect.runPromise(
+      runArtanisScheduledTick({
+        context: {
+          persistedStateRefs: [],
+        },
+        db,
+        enabled: true,
+        nowIso,
+        scheduleRef: 'cron.public.artanis.no_diagnosis_evidence',
+      }),
+    )
+
+    expect(result.workProposalRefs).toEqual([
+      'work.public.artanis.tassadar_executor_trace.cron_public_artanis_no_diagnosis_evidence',
+    ])
+    const persisted = store.rows('artanis_work_routing_proposals')
+    expect(persisted).toHaveLength(1)
+    expect(JSON.stringify(persisted)).not.toContain(
+      'work.public.artanis.khala_burndown.cron_public_artanis_no_diagnosis_evidence',
+    )
+  })
+
   test('persists a green Khala no-spend readiness observation', async () => {
     const store = new ArtanisPersistenceTestStore()
     const db = artanisPersistenceTestDb(store)

--- a/apps/openagents.com/workers/api/src/artanis-scheduled-runner.ts
+++ b/apps/openagents.com/workers/api/src/artanis-scheduled-runner.ts
@@ -1,5 +1,9 @@
 import { Effect } from 'effect'
 
+import {
+  authorizeDiagnosisRemediation,
+  authorizeMergeDeployLiveReport,
+} from '@openagentsinc/blueprint-contracts'
 import { TASSADAR_EXECUTOR_CAPABILITY_REF } from '@openagentsinc/tassadar-executor'
 
 import {
@@ -207,6 +211,62 @@ const autonomousKhalaLoopPlan = (
   ],
   recurringSourceRefs: AUTONOMOUS_KHALA_LOOP_SOURCE_REFS,
 })
+
+const scheduledDiagnosisRemediationGate = (
+  refs: ReadonlyArray<string>,
+) => {
+  const has = (ref: string): boolean => refs.includes(ref)
+  return authorizeDiagnosisRemediation(
+    {
+      blockedReason: has('api.operator.khala.trace_review')
+        ? null
+        : 'operator trace-review evidence was not loaded',
+      canProposeRemediation:
+        has('state.public.artanis.persistence') &&
+        has('api.operator.khala.trace_review') &&
+        has('api.public.khala_served_count'),
+      identity: { claimedRootCause: 'khala burndown backlog requires continued own-capacity dispatch' },
+      missingEvidence: [
+        ...(has('state.public.artanis.persistence') ? [] : ['state.public.artanis.persistence']),
+        ...(has('api.operator.khala.trace_review') ? [] : ['api.operator.khala.trace_review']),
+        ...(has('api.public.khala_served_count') ? [] : ['api.public.khala_served_count']),
+      ],
+      satisfiedEvidence: refs.filter(ref =>
+        [
+          'state.public.artanis.persistence',
+          'api.operator.khala.trace_review',
+          'api.public.khala_served_count',
+        ].includes(ref),
+      ),
+      state:
+        has('state.public.artanis.persistence') &&
+        has('api.operator.khala.trace_review') &&
+        has('api.public.khala_served_count')
+          ? 'GROUNDED'
+          : 'UNGROUNDED',
+    },
+    'continue no-spend Khala burndown work proposal',
+  )
+}
+
+const scheduledDeploymentLiveReport = (
+  scheduleSuffix: string,
+) =>
+  authorizeMergeDeployLiveReport({
+    blockedReason: 'scheduled tick has no merge, deploy, or smoke receipts',
+    identity: {
+      mergeCommitHashes: [],
+      prNumbers: [],
+    },
+    isLive: false,
+    missingEvidence: [
+      'evidence://merge/check-deploy-pass',
+      'evidence://deploy/exit-code',
+      'evidence://deploy/smoke-tests',
+    ],
+    satisfiedEvidence: [`action.public.artanis.deployment.${scheduleSuffix}`],
+    state: 'MERGED',
+  })
 
 const emptyKhalaFeedbackTriage: ArtanisKhalaFeedbackTriageResult = {
   actionRefs: [],
@@ -622,6 +682,7 @@ const scheduledLoop = (
     `approval.public.artanis.tassadar_executor_paid_sample.${scheduleSuffix}`
   const authorityRef = 'authority.public.artanis.operator_spend_enable'
   const khalaLoopPlan = autonomousKhalaLoopPlan(scheduleSuffix)
+  const deploymentLiveReport = scheduledDeploymentLiveReport(scheduleSuffix)
   const publicEvidenceRefs = uniqueRefs([
     ...selectedContextRefs,
     ...khalaLoopPlan.recurringSourceRefs,
@@ -788,6 +849,24 @@ const scheduledLoop = (
         kind: 'wallet_spend',
         risk: 'approval_required',
       }),
+      ...(deploymentLiveReport.ok
+        ? [
+            new ArtanisActionProposalRecord({
+              actionRef:
+                `action.public.artanis.deployment_live_report.${scheduleSuffix}`,
+              approvalRequirementRefs: [],
+              artifactRefs: [],
+              authorityReceiptRefs: deploymentLiveReport.evidenceRefs,
+              caveatRefs: [],
+              evidenceRefs: [
+                ...deploymentLiveReport.evidenceRefs,
+                ...deploymentLiveReport.action.mergeCommitHashes,
+              ],
+              kind: 'status_projection',
+              risk: 'safe',
+            }),
+          ]
+        : []),
     ],
     approvalRequirements: [
       ...feedbackApprovalRequirements,
@@ -1308,10 +1387,15 @@ export const runArtanisScheduledTick = Effect.fn('runArtanisScheduledTick')(
       tick,
       assignmentRef,
     )
-    const khalaBurndownWorkProposal = scheduledKhalaBurndownWorkProposal(
-      input,
-      tick,
+    const diagnosisRemediation = scheduledDiagnosisRemediationGate(
+      publicLoadedContextRefs,
     )
+    const khalaBurndownWorkProposal = diagnosisRemediation.ok
+      ? scheduledKhalaBurndownWorkProposal(
+          input,
+          tick,
+        )
+      : null
     const khalaFeedbackWorkProposals = khalaFeedbackTriage.items.map(item =>
       scheduledKhalaFeedbackWorkProposal(input, item)
     )
@@ -1352,12 +1436,13 @@ export const runArtanisScheduledTick = Effect.fn('runArtanisScheduledTick')(
       workProposal,
       input.nowIso,
     )
-    const khalaBurndownWorkProposalReceipt =
-      yield* saveArtanisWorkRoutingProposal(
-        input.db,
-        khalaBurndownWorkProposal,
-        input.nowIso,
-      )
+    const khalaBurndownWorkProposalReceipt = khalaBurndownWorkProposal === null
+      ? null
+      : yield* saveArtanisWorkRoutingProposal(
+          input.db,
+          khalaBurndownWorkProposal,
+          input.nowIso,
+        )
     const khalaFeedbackWorkProposalReceipts = yield* Effect.forEach(
       khalaFeedbackWorkProposals,
       proposal =>
@@ -1389,7 +1474,7 @@ export const runArtanisScheduledTick = Effect.fn('runArtanisScheduledTick')(
       tickReceipt,
       healthReceipt,
       workProposalReceipt,
-      khalaBurndownWorkProposalReceipt,
+      ...(khalaBurndownWorkProposalReceipt === null ? [] : [khalaBurndownWorkProposalReceipt]),
       ...khalaFeedbackWorkProposalReceipts,
       approvalGateReceipt,
       forumIntentReceipt,
@@ -1420,7 +1505,9 @@ export const runArtanisScheduledTick = Effect.fn('runArtanisScheduledTick')(
       tickRef: tick.tickRef,
       workProposalRefs: [
         workProposal.proposalRef,
-        khalaBurndownWorkProposal.proposalRef,
+        ...(khalaBurndownWorkProposal === null
+          ? []
+          : [khalaBurndownWorkProposal.proposalRef]),
         ...khalaFeedbackWorkProposals.map(proposal => proposal.proposalRef),
       ],
     }

--- a/apps/pylon/scripts/codex-supervisor/codex-supervisor.sh
+++ b/apps/pylon/scripts/codex-supervisor/codex-supervisor.sh
@@ -158,6 +158,7 @@ PAUSE_FILE="$SUP_STATE_DIR/paused"
 # ATTEMPT (pick+dispatch cycle). The liveness check + watcher read this to tell
 # "alive but stalled" (wedged) from "alive and dispatching" (healthy).
 LAST_DISPATCH_FILE="$SUP_STATE_DIR/last_dispatch_time"
+HEARTBEAT_PAYLOAD_FILE="$SUP_STATE_DIR/heartbeat_payload.json"
 echo 0 > "$DESIRED_FILE"
 rm -f "$PAUSE_FILE"
 
@@ -279,10 +280,31 @@ heartbeater_loop() {
     while IFS= read -r slot_acc; do account_slots+=("$slot_acc"); done < <(sup_expand_account_slots $(ready_codex_account_refs))
     desired="${#account_slots[@]}"
     echo "$desired" > "$DESIRED_FILE"
-    OPENAGENTS_PYLON_CODEX_CONCURRENCY="$desired" \
-    OPENAGENTS_PYLON_CODEX_BUSY=0 \
-    OPENAGENTS_PYLON_CODEX_QUEUED=0 \
-      sup_run_timeout "$SUP_PYLON_TIMEOUT_SECS" "${PYLON[@]}" presence heartbeat --json >> "$SUP_LOG" 2>&1 || true
+    heartbeat_tmp="$SUP_STATE_DIR/heartbeat_payload.tmp"
+    if OPENAGENTS_PYLON_CODEX_CONCURRENCY="$desired" \
+      OPENAGENTS_PYLON_CODEX_BUSY=0 \
+      OPENAGENTS_PYLON_CODEX_QUEUED=0 \
+      sup_run_timeout "$SUP_PYLON_TIMEOUT_SECS" "${PYLON[@]}" presence heartbeat --json > "$heartbeat_tmp" 2>> "$SUP_LOG"; then
+      python3 - "$heartbeat_tmp" "$HEARTBEAT_PAYLOAD_FILE" "$(read_last_dispatch_time)" <<'PY' 2>> "$SUP_LOG" || mv "$heartbeat_tmp" "$HEARTBEAT_PAYLOAD_FILE" 2>/dev/null || true
+import json
+import sys
+
+src, dst, last_dispatch_time = sys.argv[1], sys.argv[2], sys.argv[3]
+with open(src, "r", encoding="utf-8") as handle:
+    payload = json.load(handle)
+if isinstance(payload, dict):
+    payload["last_dispatch_time"] = last_dispatch_time
+with open(dst, "w", encoding="utf-8") as handle:
+    json.dump(payload, handle, sort_keys=True)
+    handle.write("\n")
+PY
+      rm -f "$heartbeat_tmp" 2>/dev/null || true
+      cat "$HEARTBEAT_PAYLOAD_FILE" >> "$SUP_LOG" 2>/dev/null || true
+      printf '\n' >> "$SUP_LOG" 2>/dev/null || true
+    else
+      cat "$heartbeat_tmp" >> "$SUP_LOG" 2>/dev/null || true
+      rm -f "$heartbeat_tmp" 2>/dev/null || true
+    fi
     # last_dispatch_time telemetry (#6646): emitted on the heartbeat line so a
     # wedged loop (heartbeat firing, dispatch stalled) is visible in the log and
     # the watcher's liveness check has a fresh value to read.

--- a/apps/pylon/scripts/codex-supervisor/launch.sh
+++ b/apps/pylon/scripts/codex-supervisor/launch.sh
@@ -20,8 +20,9 @@
 # WEDGE — alive + heartbeating but no longer dispatching (an external call hung
 # the dispatch loop). `wedge-check` runs the tested liveness check in
 # `apps/pylon/src/blueprint-gates/fleet-liveness.ts` against the supervisor pid +
-# `$SUP_STATE_DIR/last_dispatch_time`; `wedge-watch` additionally force-kills and
-# restarts the supervisor when that check reports `wedged`. Run `wedge-watch` on
+# `$SUP_STATE_DIR/last_dispatch_time`, `$HOME/.pylon/account-quota/*.json`, and
+# `$SUP_STATE_DIR/heartbeat_payload.json`; `wedge-watch` additionally force-kills
+# and restarts the supervisor when that check reports `wedged`. Run `wedge-watch` on
 # an interval from an external watcher (cron / standing loop) with
 # OPENAGENTS_AGENT_TOKEN in the environment.
 #

--- a/apps/pylon/src/blueprint-gates/diagnosis-grounding.test.ts
+++ b/apps/pylon/src/blueprint-gates/diagnosis-grounding.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, test } from "bun:test"
+
+import {
+  DIAGNOSIS_GROUNDING_EVIDENCE,
+  diagnosisClaimsRateLimit,
+  evaluateDiagnosisGrounding,
+  type DiagnosisGroundingInputs,
+} from "./diagnosis-grounding.js"
+
+const grounded: DiagnosisGroundingInputs = {
+  claimedRootCause: "provider returned 429 rate-limited responses",
+  quotaLedgerSnapshot: { accounts: [{ accountRef: "codex", remaining: 0 }] },
+  supervisorDispatchLog: [{ attempt: 1, outcome: "provider_429" }],
+  accountRateLimitHeaders: {
+    statusCode: 429,
+    retryAfter: "60",
+    xRateLimitReset: null,
+  },
+}
+
+describe("diagnosis-grounding", () => {
+  test("a rate-limit diagnosis with ledger, dispatch log, and provider headers reaches GROUNDED", () => {
+    const result = evaluateDiagnosisGrounding(grounded)
+    expect(result.state).toBe("GROUNDED")
+    expect(result.canProposeRemediation).toBe(true)
+    expect(result.satisfiedEvidence).toEqual([
+      DIAGNOSIS_GROUNDING_EVIDENCE.quotaLedgerRead,
+      DIAGNOSIS_GROUNDING_EVIDENCE.supervisorDispatchLog,
+      DIAGNOSIS_GROUNDING_EVIDENCE.providerRateLimitHeaders,
+    ])
+  })
+
+  test("a rate-limit diagnosis without provider 429 headers locks before remediation", () => {
+    const result = evaluateDiagnosisGrounding({
+      ...grounded,
+      accountRateLimitHeaders: null,
+    })
+    expect(result.state).toBe("DISPATCH_LOG_EXAMINED")
+    expect(result.canProposeRemediation).toBe(false)
+    expect(result.lockedAt).toBe("PROVIDER_VERIFIED")
+    expect(result.missingEvidence).toEqual([
+      DIAGNOSIS_GROUNDING_EVIDENCE.providerRateLimitHeaders,
+    ])
+  })
+
+  test("missing quota ledger locks at LEDGER_READ", () => {
+    const result = evaluateDiagnosisGrounding({
+      ...grounded,
+      quotaLedgerSnapshot: null,
+    })
+    expect(result.state).toBe("UNGROUNDED")
+    expect(result.lockedAt).toBe("LEDGER_READ")
+    expect(result.canProposeRemediation).toBe(false)
+  })
+
+  test("missing dispatch log locks at DISPATCH_LOG_EXAMINED", () => {
+    const result = evaluateDiagnosisGrounding({
+      ...grounded,
+      supervisorDispatchLog: [],
+    })
+    expect(result.state).toBe("LEDGER_READ")
+    expect(result.lockedAt).toBe("DISPATCH_LOG_EXAMINED")
+  })
+
+  test("non-rate-limit claims still require provider verification stage but not 429 headers", () => {
+    const result = evaluateDiagnosisGrounding({
+      ...grounded,
+      claimedRootCause: "supervisor dispatch loop is wedged",
+      accountRateLimitHeaders: null,
+    })
+    expect(result.state).toBe("GROUNDED")
+    expect(result.canProposeRemediation).toBe(true)
+  })
+
+  test("detects rate-limit claims", () => {
+    expect(diagnosisClaimsRateLimit("429 from provider")).toBe(true)
+    expect(diagnosisClaimsRateLimit("rate limited")).toBe(true)
+    expect(diagnosisClaimsRateLimit("stale heartbeat")).toBe(false)
+  })
+})

--- a/apps/pylon/src/blueprint-gates/diagnosis-grounding.ts
+++ b/apps/pylon/src/blueprint-gates/diagnosis-grounding.ts
@@ -48,6 +48,7 @@ export interface DiagnosisGroundingInputs {
 export interface DiagnosisGroundingResult {
   readonly state: DiagnosisGroundingState
   readonly canProposeRemediation: boolean
+  readonly identity: Readonly<{ readonly claimedRootCause: string }>
   readonly satisfiedEvidence: ReadonlyArray<DiagnosisGroundingEvidenceRef>
   readonly missingEvidence: ReadonlyArray<DiagnosisGroundingEvidenceRef>
   readonly locked: boolean
@@ -81,6 +82,7 @@ export function evaluateDiagnosisGrounding(
   inputs: DiagnosisGroundingInputs,
 ): DiagnosisGroundingResult {
   const satisfied: Array<DiagnosisGroundingEvidenceRef> = []
+  const identity = { claimedRootCause: inputs.claimedRootCause }
 
   const lock = (
     state: DiagnosisGroundingState,
@@ -90,6 +92,7 @@ export function evaluateDiagnosisGrounding(
   ): DiagnosisGroundingResult => ({
     state,
     canProposeRemediation: false,
+    identity,
     satisfiedEvidence: satisfied,
     missingEvidence: missing,
     locked: true,
@@ -133,6 +136,7 @@ export function evaluateDiagnosisGrounding(
   return {
     state: "GROUNDED",
     canProposeRemediation: true,
+    identity,
     satisfiedEvidence: satisfied,
     missingEvidence: [],
     locked: false,

--- a/apps/pylon/src/blueprint-gates/diagnosis-grounding.ts
+++ b/apps/pylon/src/blueprint-gates/diagnosis-grounding.ts
@@ -1,0 +1,142 @@
+/**
+ * Blueprint Signature 2 — `diagnosis-grounding`
+ *
+ * No root-cause claim reaches remediation without the evidence behind it.
+ *
+ * Ordered state machine:
+ *   UNGROUNDED -> LEDGER_READ -> DISPATCH_LOG_EXAMINED -> PROVIDER_VERIFIED -> GROUNDED
+ *
+ * Only GROUNDED unlocks proposing a remediation.
+ */
+
+export const DIAGNOSIS_GROUNDING_STATES = [
+  "UNGROUNDED",
+  "LEDGER_READ",
+  "DISPATCH_LOG_EXAMINED",
+  "PROVIDER_VERIFIED",
+  "GROUNDED",
+] as const
+
+export type DiagnosisGroundingState =
+  (typeof DIAGNOSIS_GROUNDING_STATES)[number]
+
+export const DIAGNOSIS_GROUNDING_EVIDENCE = {
+  quotaLedgerRead: "evidence://diagnosis/quota-ledger-read",
+  supervisorDispatchLog: "evidence://diagnosis/supervisor-dispatch-log",
+  providerRateLimitHeaders: "evidence://diagnosis/provider-rate-limit-headers",
+} as const
+
+export type DiagnosisGroundingEvidenceRef =
+  (typeof DIAGNOSIS_GROUNDING_EVIDENCE)[keyof typeof DIAGNOSIS_GROUNDING_EVIDENCE]
+
+export interface ProviderRateLimitHeaders {
+  readonly retryAfter?: string | null
+  readonly xRateLimitReset?: string | null
+  readonly statusCode?: number | null
+}
+
+export interface DiagnosisGroundingInputs {
+  readonly claimedRootCause: string
+  /** evidence://diagnosis/quota-ledger-read */
+  readonly quotaLedgerSnapshot: unknown
+  /** evidence://diagnosis/supervisor-dispatch-log */
+  readonly supervisorDispatchLog: ReadonlyArray<unknown>
+  /** evidence://diagnosis/provider-rate-limit-headers */
+  readonly accountRateLimitHeaders: ProviderRateLimitHeaders | null
+}
+
+export interface DiagnosisGroundingResult {
+  readonly state: DiagnosisGroundingState
+  readonly canProposeRemediation: boolean
+  readonly satisfiedEvidence: ReadonlyArray<DiagnosisGroundingEvidenceRef>
+  readonly missingEvidence: ReadonlyArray<DiagnosisGroundingEvidenceRef>
+  readonly locked: boolean
+  readonly lockedAt: DiagnosisGroundingState | null
+  readonly blockedReason: string | null
+}
+
+const rateLimitClaimPattern = /\b(rate[- ]?limit(?:ed|ing)?|429|retry[- ]?after)\b/i
+
+const hasEvidence = (value: unknown): boolean =>
+  value !== null && value !== undefined
+
+const hasProviderRateLimitHeaders = (
+  headers: ProviderRateLimitHeaders | null,
+): boolean => {
+  if (headers === null) {
+    return false
+  }
+  return (
+    headers.statusCode === 429 ||
+    (typeof headers.retryAfter === "string" && headers.retryAfter.trim().length > 0) ||
+    (typeof headers.xRateLimitReset === "string" && headers.xRateLimitReset.trim().length > 0)
+  )
+}
+
+export function diagnosisClaimsRateLimit(claimedRootCause: string): boolean {
+  return rateLimitClaimPattern.test(claimedRootCause)
+}
+
+export function evaluateDiagnosisGrounding(
+  inputs: DiagnosisGroundingInputs,
+): DiagnosisGroundingResult {
+  const satisfied: Array<DiagnosisGroundingEvidenceRef> = []
+
+  const lock = (
+    state: DiagnosisGroundingState,
+    lockedAt: DiagnosisGroundingState,
+    blockedReason: string,
+    missing: ReadonlyArray<DiagnosisGroundingEvidenceRef>,
+  ): DiagnosisGroundingResult => ({
+    state,
+    canProposeRemediation: false,
+    satisfiedEvidence: satisfied,
+    missingEvidence: missing,
+    locked: true,
+    lockedAt,
+    blockedReason,
+  })
+
+  if (!hasEvidence(inputs.quotaLedgerSnapshot)) {
+    return lock("UNGROUNDED", "LEDGER_READ", "quota ledger snapshot was not read", [
+      DIAGNOSIS_GROUNDING_EVIDENCE.quotaLedgerRead,
+      DIAGNOSIS_GROUNDING_EVIDENCE.supervisorDispatchLog,
+      DIAGNOSIS_GROUNDING_EVIDENCE.providerRateLimitHeaders,
+    ])
+  }
+  satisfied.push(DIAGNOSIS_GROUNDING_EVIDENCE.quotaLedgerRead)
+
+  if (!Array.isArray(inputs.supervisorDispatchLog) || inputs.supervisorDispatchLog.length === 0) {
+    return lock(
+      "LEDGER_READ",
+      "DISPATCH_LOG_EXAMINED",
+      "supervisor dispatch log evidence is missing",
+      [
+        DIAGNOSIS_GROUNDING_EVIDENCE.supervisorDispatchLog,
+        DIAGNOSIS_GROUNDING_EVIDENCE.providerRateLimitHeaders,
+      ],
+    )
+  }
+  satisfied.push(DIAGNOSIS_GROUNDING_EVIDENCE.supervisorDispatchLog)
+
+  const claimsRateLimit = diagnosisClaimsRateLimit(inputs.claimedRootCause)
+  if (claimsRateLimit && !hasProviderRateLimitHeaders(inputs.accountRateLimitHeaders)) {
+    return lock(
+      "DISPATCH_LOG_EXAMINED",
+      "PROVIDER_VERIFIED",
+      "rate-limit diagnosis requires actual provider 429 / Retry-After / X-RateLimit-Reset headers",
+      [DIAGNOSIS_GROUNDING_EVIDENCE.providerRateLimitHeaders],
+    )
+  }
+  satisfied.push(DIAGNOSIS_GROUNDING_EVIDENCE.providerRateLimitHeaders)
+
+  return {
+    state: "GROUNDED",
+    canProposeRemediation: true,
+    satisfiedEvidence: satisfied,
+    missingEvidence: [],
+    locked: false,
+    lockedAt: null,
+    blockedReason: null,
+  }
+}

--- a/apps/pylon/src/blueprint-gates/enforced-actions.test.ts
+++ b/apps/pylon/src/blueprint-gates/enforced-actions.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, test } from "bun:test"
+
+import { evaluateCommandSourceVerified } from "./command-execution-source-verified.js"
+import { evaluateDiagnosisGrounding } from "./diagnosis-grounding.js"
+import {
+  authorizeCommandProposal,
+  authorizeDiagnosisRemediation,
+  authorizeFleetHealthyReport,
+  authorizeIssueClose,
+  authorizeMergeDeployLiveReport,
+} from "./enforced-actions.js"
+import {
+  DEFAULT_WEDGE_THRESHOLD_MS,
+  evaluateFleetLiveness,
+} from "./fleet-liveness.js"
+import { evaluateIssueCloseSafe } from "./issue-close-safe.js"
+import { evaluateMergeDeployGate } from "./merge-deploy-gate.js"
+
+describe("Blueprint enforced action authorizers", () => {
+  const now = 2_000_000_000_000
+
+  test("fleet healthy report is exposed only from PROVEN_ALIVE", () => {
+    const partial = authorizeFleetHealthyReport(
+      evaluateFleetLiveness({
+        pidAlive: true,
+        lastDispatchTime: now - 30_000,
+        now,
+      }),
+    )
+    expect(partial.ok).toBe(false)
+
+    const proven = authorizeFleetHealthyReport(
+      evaluateFleetLiveness({
+        pidAlive: true,
+        lastDispatchTime: now - 30_000,
+        now,
+        quotaLedgerSnapshot: { accounts: [] },
+        heartbeatPayload: { last_dispatch_time: now - 30_000 },
+      }),
+    )
+    expect(proven.ok).toBe(true)
+    if (proven.ok) {
+      expect(proven.action.kind).toBe("report_fleet_healthy")
+    }
+  })
+
+  test("diagnosis remediation is exposed only from GROUNDED", () => {
+    const blocked = authorizeDiagnosisRemediation(
+      evaluateDiagnosisGrounding({
+        claimedRootCause: "rate-limited",
+        quotaLedgerSnapshot: {},
+        supervisorDispatchLog: [{ outcome: "429" }],
+        accountRateLimitHeaders: null,
+      }),
+      "cool down account",
+    )
+    expect(blocked.ok).toBe(false)
+
+    const allowed = authorizeDiagnosisRemediation(
+      evaluateDiagnosisGrounding({
+        claimedRootCause: "rate-limited",
+        quotaLedgerSnapshot: {},
+        supervisorDispatchLog: [{ outcome: "429" }],
+        accountRateLimitHeaders: { statusCode: 429, retryAfter: "60" },
+      }),
+      "cool down account",
+    )
+    expect(allowed.ok).toBe(true)
+  })
+
+  test("issue close action is exposed only from SAFE_TO_CLOSE", () => {
+    const blocked = authorizeIssueClose(
+      evaluateIssueCloseSafe({
+        issueNumber: 7886,
+        issueLabels: ["fable-roadmap"],
+        parentEpicNumber: 7821,
+        isLastOpenSubIssue: false,
+        prNumber: 9001,
+        prBody: "Closes #7886",
+      }),
+      7886,
+      9001,
+    )
+    expect(blocked.ok).toBe(false)
+
+    const allowed = authorizeIssueClose(
+      evaluateIssueCloseSafe({
+        issueNumber: 7886,
+        issueLabels: ["fable-roadmap"],
+        parentEpicNumber: null,
+        prNumber: 9001,
+        prBody: "Closes #7886",
+      }),
+      7886,
+      9001,
+    )
+    expect(allowed.ok).toBe(true)
+  })
+
+  test("command proposal is exposed only from SAFE_TO_PROPOSE", () => {
+    const blocked = authorizeCommandProposal(
+      evaluateCommandSourceVerified({
+        commandString: "bun scripts/tool.ts --flag",
+        scriptPath: "scripts/tool.ts",
+        expectedFlags: ["--flag"],
+        sourceReadHash: "sha256:abc",
+        declaredFlags: [],
+        dryRunExitCode: 0,
+      }),
+      "bun scripts/tool.ts --flag",
+    )
+    expect(blocked.ok).toBe(false)
+
+    const allowed = authorizeCommandProposal(
+      evaluateCommandSourceVerified({
+        commandString: "bun scripts/tool.ts --flag",
+        scriptPath: "scripts/tool.ts",
+        expectedFlags: ["--flag"],
+        sourceReadHash: "sha256:abc",
+        declaredFlags: ["--flag"],
+        dryRunExitCode: 0,
+      }),
+      "bun scripts/tool.ts --flag",
+    )
+    expect(allowed.ok).toBe(true)
+  })
+
+  test("merge deploy live report is exposed only from LIVE", () => {
+    const blocked = authorizeMergeDeployLiveReport(
+      evaluateMergeDeployGate({
+        prNumbers: [7886],
+        mergeCommitHashes: ["abc123"],
+        checkDeployExitCode: 0,
+        checkDeployStdout: "EXIT=0",
+        deployExitCode: null,
+        smokeTestResults: [],
+      }),
+      [7886],
+    )
+    expect(blocked.ok).toBe(false)
+
+    const allowed = authorizeMergeDeployLiveReport(
+      evaluateMergeDeployGate({
+        prNumbers: [7886],
+        mergeCommitHashes: ["abc123"],
+        checkDeployExitCode: 0,
+        checkDeployStdout: "EXIT=0",
+        deployExitCode: 0,
+        smokeTestResults: [{ name: "home", passed: true }],
+      }),
+      [7886],
+    )
+    expect(allowed.ok).toBe(true)
+  })
+
+  test("stale liveness stays blocked even with evidence", () => {
+    const blocked = authorizeFleetHealthyReport(
+      evaluateFleetLiveness({
+        pidAlive: true,
+        lastDispatchTime: now - DEFAULT_WEDGE_THRESHOLD_MS - 1,
+        now,
+        quotaLedgerSnapshot: { accounts: [] },
+        heartbeatPayload: { last_dispatch_time: now - DEFAULT_WEDGE_THRESHOLD_MS - 1 },
+      }),
+    )
+    expect(blocked.ok).toBe(false)
+  })
+})

--- a/apps/pylon/src/blueprint-gates/enforced-actions.test.ts
+++ b/apps/pylon/src/blueprint-gates/enforced-actions.test.ts
@@ -78,8 +78,6 @@ describe("Blueprint enforced action authorizers", () => {
         prNumber: 9001,
         prBody: "Closes #7886",
       }),
-      7886,
-      9001,
     )
     expect(blocked.ok).toBe(false)
 
@@ -91,10 +89,12 @@ describe("Blueprint enforced action authorizers", () => {
         prNumber: 9001,
         prBody: "Closes #7886",
       }),
-      7886,
-      9001,
     )
     expect(allowed.ok).toBe(true)
+    if (allowed.ok) {
+      expect(allowed.action.issueNumber).toBe(7886)
+      expect(allowed.action.prNumber).toBe(9001)
+    }
   })
 
   test("command proposal is exposed only from SAFE_TO_PROPOSE", () => {
@@ -107,7 +107,6 @@ describe("Blueprint enforced action authorizers", () => {
         declaredFlags: [],
         dryRunExitCode: 0,
       }),
-      "bun scripts/tool.ts --flag",
     )
     expect(blocked.ok).toBe(false)
 
@@ -120,9 +119,12 @@ describe("Blueprint enforced action authorizers", () => {
         declaredFlags: ["--flag"],
         dryRunExitCode: 0,
       }),
-      "bun scripts/tool.ts --flag",
     )
     expect(allowed.ok).toBe(true)
+    if (allowed.ok) {
+      expect(allowed.action.commandString).toBe("bun scripts/tool.ts --flag")
+      expect(allowed.action.scriptPath).toBe("scripts/tool.ts")
+    }
   })
 
   test("merge deploy live report is exposed only from LIVE", () => {
@@ -135,7 +137,6 @@ describe("Blueprint enforced action authorizers", () => {
         deployExitCode: null,
         smokeTestResults: [],
       }),
-      [7886],
     )
     expect(blocked.ok).toBe(false)
 
@@ -148,9 +149,12 @@ describe("Blueprint enforced action authorizers", () => {
         deployExitCode: 0,
         smokeTestResults: [{ name: "home", passed: true }],
       }),
-      [7886],
     )
     expect(allowed.ok).toBe(true)
+    if (allowed.ok) {
+      expect(allowed.action.prNumbers).toEqual([7886])
+      expect(allowed.action.mergeCommitHashes).toEqual(["abc123"])
+    }
   })
 
   test("stale liveness stays blocked even with evidence", () => {

--- a/apps/pylon/src/blueprint-gates/enforced-actions.ts
+++ b/apps/pylon/src/blueprint-gates/enforced-actions.ts
@@ -1,0 +1,139 @@
+import type { CommandSourceVerifiedResult } from "./command-execution-source-verified.js"
+import type { DiagnosisGroundingResult } from "./diagnosis-grounding.js"
+import type { FleetLivenessResult } from "./fleet-liveness.js"
+import type { IssueCloseSafeResult } from "./issue-close-safe.js"
+import type { MergeDeployGateResult } from "./merge-deploy-gate.js"
+
+export type BlueprintGateId =
+  | "fleet-liveness"
+  | "diagnosis-grounding"
+  | "issue-close-safe"
+  | "command-source-verified"
+  | "merge-deploy"
+
+export type GateBlocked = Readonly<{
+  ok: false
+  gate: BlueprintGateId
+  state: string
+  reason: string
+  missingEvidence: ReadonlyArray<string>
+}>
+
+export type GateAuthorized<TAction> = Readonly<{
+  ok: true
+  gate: BlueprintGateId
+  state: string
+  action: TAction
+  evidenceRefs: ReadonlyArray<string>
+}>
+
+export type GateDecision<TAction> = GateAuthorized<TAction> | GateBlocked
+
+export type FleetHealthyReportAction = Readonly<{
+  kind: "report_fleet_healthy"
+  reason: string
+}>
+
+export type DiagnosisRemediationAction = Readonly<{
+  kind: "propose_remediation"
+  remediation: string
+}>
+
+export type IssueCloseAction = Readonly<{
+  kind: "emit_closes_keyword"
+  issueNumber: number
+  prNumber: number
+}>
+
+export type CommandProposalAction = Readonly<{
+  kind: "propose_command"
+  commandString: string
+}>
+
+export type MergeDeployLiveAction = Readonly<{
+  kind: "report_deployment_live"
+  prNumbers: ReadonlyArray<number>
+}>
+
+const blocked = (
+  gate: BlueprintGateId,
+  state: string,
+  reason: string | null | undefined,
+  missingEvidence: ReadonlyArray<string>,
+): GateBlocked => ({
+  ok: false,
+  gate,
+  state,
+  reason: reason ?? "blueprint gate has not reached its terminal state",
+  missingEvidence,
+})
+
+export const authorizeFleetHealthyReport = (
+  gate: FleetLivenessResult,
+): GateDecision<FleetHealthyReportAction> =>
+  gate.canReportHealthy
+    ? {
+        ok: true,
+        gate: "fleet-liveness",
+        state: gate.gateState,
+        action: { kind: "report_fleet_healthy", reason: gate.reason },
+        evidenceRefs: gate.satisfiedEvidence,
+      }
+    : blocked("fleet-liveness", gate.gateState, gate.reason, gate.missingEvidence)
+
+export const authorizeDiagnosisRemediation = (
+  gate: DiagnosisGroundingResult,
+  remediation: string,
+): GateDecision<DiagnosisRemediationAction> =>
+  gate.canProposeRemediation
+    ? {
+        ok: true,
+        gate: "diagnosis-grounding",
+        state: gate.state,
+        action: { kind: "propose_remediation", remediation },
+        evidenceRefs: gate.satisfiedEvidence,
+      }
+    : blocked("diagnosis-grounding", gate.state, gate.blockedReason, gate.missingEvidence)
+
+export const authorizeIssueClose = (
+  gate: IssueCloseSafeResult,
+  issueNumber: number,
+  prNumber: number,
+): GateDecision<IssueCloseAction> =>
+  gate.canClose
+    ? {
+        ok: true,
+        gate: "issue-close-safe",
+        state: gate.state,
+        action: { kind: "emit_closes_keyword", issueNumber, prNumber },
+        evidenceRefs: gate.satisfiedEvidence,
+      }
+    : blocked("issue-close-safe", gate.state, gate.blockedReason, gate.missingEvidence)
+
+export const authorizeCommandProposal = (
+  gate: CommandSourceVerifiedResult,
+  commandString: string,
+): GateDecision<CommandProposalAction> =>
+  gate.canPropose
+    ? {
+        ok: true,
+        gate: "command-source-verified",
+        state: gate.state,
+        action: { kind: "propose_command", commandString },
+        evidenceRefs: gate.satisfiedEvidence,
+      }
+    : blocked("command-source-verified", gate.state, gate.blockedReason, gate.missingEvidence)
+
+export const authorizeMergeDeployLiveReport = (
+  gate: MergeDeployGateResult,
+  prNumbers: ReadonlyArray<number>,
+): GateDecision<MergeDeployLiveAction> =>
+  gate.isLive
+    ? {
+        ok: true,
+        gate: "merge-deploy",
+        state: gate.state,
+        action: { kind: "report_deployment_live", prNumbers },
+        evidenceRefs: gate.satisfiedEvidence,
+      }
+    : blocked("merge-deploy", gate.state, gate.blockedReason, gate.missingEvidence)

--- a/apps/pylon/src/blueprint-gates/enforced-actions.ts
+++ b/apps/pylon/src/blueprint-gates/enforced-actions.ts
@@ -1,139 +1,19 @@
-import type { CommandSourceVerifiedResult } from "./command-execution-source-verified.js"
-import type { DiagnosisGroundingResult } from "./diagnosis-grounding.js"
-import type { FleetLivenessResult } from "./fleet-liveness.js"
-import type { IssueCloseSafeResult } from "./issue-close-safe.js"
-import type { MergeDeployGateResult } from "./merge-deploy-gate.js"
+export {
+  authorizeCommandProposal,
+  authorizeDiagnosisRemediation,
+  authorizeFleetHealthyReport,
+  authorizeIssueClose,
+  authorizeMergeDeployLiveReport,
+} from "@openagentsinc/blueprint-contracts"
 
-export type BlueprintGateId =
-  | "fleet-liveness"
-  | "diagnosis-grounding"
-  | "issue-close-safe"
-  | "command-source-verified"
-  | "merge-deploy"
-
-export type GateBlocked = Readonly<{
-  ok: false
-  gate: BlueprintGateId
-  state: string
-  reason: string
-  missingEvidence: ReadonlyArray<string>
-}>
-
-export type GateAuthorized<TAction> = Readonly<{
-  ok: true
-  gate: BlueprintGateId
-  state: string
-  action: TAction
-  evidenceRefs: ReadonlyArray<string>
-}>
-
-export type GateDecision<TAction> = GateAuthorized<TAction> | GateBlocked
-
-export type FleetHealthyReportAction = Readonly<{
-  kind: "report_fleet_healthy"
-  reason: string
-}>
-
-export type DiagnosisRemediationAction = Readonly<{
-  kind: "propose_remediation"
-  remediation: string
-}>
-
-export type IssueCloseAction = Readonly<{
-  kind: "emit_closes_keyword"
-  issueNumber: number
-  prNumber: number
-}>
-
-export type CommandProposalAction = Readonly<{
-  kind: "propose_command"
-  commandString: string
-}>
-
-export type MergeDeployLiveAction = Readonly<{
-  kind: "report_deployment_live"
-  prNumbers: ReadonlyArray<number>
-}>
-
-const blocked = (
-  gate: BlueprintGateId,
-  state: string,
-  reason: string | null | undefined,
-  missingEvidence: ReadonlyArray<string>,
-): GateBlocked => ({
-  ok: false,
-  gate,
-  state,
-  reason: reason ?? "blueprint gate has not reached its terminal state",
-  missingEvidence,
-})
-
-export const authorizeFleetHealthyReport = (
-  gate: FleetLivenessResult,
-): GateDecision<FleetHealthyReportAction> =>
-  gate.canReportHealthy
-    ? {
-        ok: true,
-        gate: "fleet-liveness",
-        state: gate.gateState,
-        action: { kind: "report_fleet_healthy", reason: gate.reason },
-        evidenceRefs: gate.satisfiedEvidence,
-      }
-    : blocked("fleet-liveness", gate.gateState, gate.reason, gate.missingEvidence)
-
-export const authorizeDiagnosisRemediation = (
-  gate: DiagnosisGroundingResult,
-  remediation: string,
-): GateDecision<DiagnosisRemediationAction> =>
-  gate.canProposeRemediation
-    ? {
-        ok: true,
-        gate: "diagnosis-grounding",
-        state: gate.state,
-        action: { kind: "propose_remediation", remediation },
-        evidenceRefs: gate.satisfiedEvidence,
-      }
-    : blocked("diagnosis-grounding", gate.state, gate.blockedReason, gate.missingEvidence)
-
-export const authorizeIssueClose = (
-  gate: IssueCloseSafeResult,
-  issueNumber: number,
-  prNumber: number,
-): GateDecision<IssueCloseAction> =>
-  gate.canClose
-    ? {
-        ok: true,
-        gate: "issue-close-safe",
-        state: gate.state,
-        action: { kind: "emit_closes_keyword", issueNumber, prNumber },
-        evidenceRefs: gate.satisfiedEvidence,
-      }
-    : blocked("issue-close-safe", gate.state, gate.blockedReason, gate.missingEvidence)
-
-export const authorizeCommandProposal = (
-  gate: CommandSourceVerifiedResult,
-  commandString: string,
-): GateDecision<CommandProposalAction> =>
-  gate.canPropose
-    ? {
-        ok: true,
-        gate: "command-source-verified",
-        state: gate.state,
-        action: { kind: "propose_command", commandString },
-        evidenceRefs: gate.satisfiedEvidence,
-      }
-    : blocked("command-source-verified", gate.state, gate.blockedReason, gate.missingEvidence)
-
-export const authorizeMergeDeployLiveReport = (
-  gate: MergeDeployGateResult,
-  prNumbers: ReadonlyArray<number>,
-): GateDecision<MergeDeployLiveAction> =>
-  gate.isLive
-    ? {
-        ok: true,
-        gate: "merge-deploy",
-        state: gate.state,
-        action: { kind: "report_deployment_live", prNumbers },
-        evidenceRefs: gate.satisfiedEvidence,
-      }
-    : blocked("merge-deploy", gate.state, gate.blockedReason, gate.missingEvidence)
+export type {
+  BlueprintGateId,
+  CommandProposalAction,
+  DiagnosisRemediationAction,
+  FleetHealthyReportAction,
+  GateAuthorized,
+  GateBlocked,
+  GateDecision,
+  IssueCloseAction,
+  MergeDeployLiveAction,
+} from "@openagentsinc/blueprint-contracts"

--- a/apps/pylon/src/blueprint-gates/fleet-liveness.test.ts
+++ b/apps/pylon/src/blueprint-gates/fleet-liveness.test.ts
@@ -27,8 +27,12 @@ describe("evaluateFleetLiveness (#6646 wedge detection)", () => {
       pidAlive: true,
       lastDispatchTime: now - 30_000,
       now,
+      quotaLedgerSnapshot: { accounts: [] },
+      heartbeatPayload: { last_dispatch_time: now - 30_000 },
     })
     expect(r.status).toBe("healthy")
+    expect(r.gateState).toBe("PROVEN_ALIVE")
+    expect(r.canReportHealthy).toBe(true)
     expect(r.healthy).toBe(true)
     expect(r.wedged).toBe(false)
     expect(FLEET_LIVENESS_EXIT[r.status]).toBe(0)
@@ -39,6 +43,8 @@ describe("evaluateFleetLiveness (#6646 wedge detection)", () => {
       pidAlive: true,
       lastDispatchTime: now - DEFAULT_WEDGE_THRESHOLD_MS,
       now,
+      quotaLedgerSnapshot: { accounts: [] },
+      heartbeatPayload: { last_dispatch_time: now - DEFAULT_WEDGE_THRESHOLD_MS },
     })
     expect(r.status).toBe("healthy")
   })
@@ -60,6 +66,7 @@ describe("evaluateFleetLiveness (#6646 wedge detection)", () => {
     })
     expect(r.status).toBe("unknown")
     expect(r.wedged).toBe(false)
+    expect(r.gateState).toBe("BLOCKED")
     expect(FLEET_LIVENESS_EXIT[r.status]).toBe(4)
   })
 
@@ -71,6 +78,30 @@ describe("evaluateFleetLiveness (#6646 wedge detection)", () => {
     })
     expect(r.status).toBe("unknown")
     expect(r.wedged).toBe(false)
+  })
+
+  test("fresh dispatch without quota evidence cannot report fleet healthy", () => {
+    const r = evaluateFleetLiveness({
+      pidAlive: true,
+      lastDispatchTime: now - 30_000,
+      now,
+    })
+    expect(r.status).toBe("unknown")
+    expect(r.gateState).toBe("DISPATCH_ATTEMPT_SEEN")
+    expect(r.canReportHealthy).toBe(false)
+    expect(r.healthy).toBe(false)
+  })
+
+  test("fresh dispatch and quota evidence without heartbeat payload reaches QUOTA_CHECKED only", () => {
+    const r = evaluateFleetLiveness({
+      pidAlive: true,
+      lastDispatchTime: now - 30_000,
+      now,
+      quotaLedgerSnapshot: { accounts: [] },
+    })
+    expect(r.status).toBe("unknown")
+    expect(r.gateState).toBe("QUOTA_CHECKED")
+    expect(r.canReportHealthy).toBe(false)
   })
 
   test("a custom wedge threshold is honored", () => {
@@ -90,6 +121,8 @@ describe("evaluateFleetLiveness (#6646 wedge detection)", () => {
       lastDispatchTime: now - 30_000,
       now,
       wedgeThresholdMs: 0,
+      quotaLedgerSnapshot: { accounts: [] },
+      heartbeatPayload: { last_dispatch_time: now - 30_000 },
     })
     expect(r.wedgeThresholdMs).toBe(DEFAULT_WEDGE_THRESHOLD_MS)
     expect(r.status).toBe("healthy")

--- a/apps/pylon/src/blueprint-gates/fleet-liveness.ts
+++ b/apps/pylon/src/blueprint-gates/fleet-liveness.ts
@@ -26,9 +26,28 @@
  * watcher owns the restart decision.
  */
 
+import { readdir } from "node:fs/promises"
+
 export const FLEET_LIVENESS_STATES = ["healthy", "wedged", "unknown"] as const
+export const FLEET_LIVENESS_GATE_STATES = [
+  "BLOCKED",
+  "DISPATCH_ATTEMPT_SEEN",
+  "QUOTA_CHECKED",
+  "PROVEN_ALIVE",
+] as const
 
 export type FleetLivenessStatus = (typeof FLEET_LIVENESS_STATES)[number]
+export type FleetLivenessGateState =
+  (typeof FLEET_LIVENESS_GATE_STATES)[number]
+
+export const FLEET_LIVENESS_EVIDENCE = {
+  lastDispatchAttempt: "evidence://supervisor/last-dispatch-attempt",
+  quotaLedgerSnapshot: "evidence://supervisor/quota-ledger-snapshot",
+  heartbeatPayload: "evidence://supervisor/heartbeat-payload",
+} as const
+
+export type FleetLivenessEvidenceRef =
+  (typeof FLEET_LIVENESS_EVIDENCE)[keyof typeof FLEET_LIVENESS_EVIDENCE]
 
 /** Default wedge threshold: alive but no dispatch attempt in 10 minutes. */
 export const DEFAULT_WEDGE_THRESHOLD_MS = 10 * 60 * 1000
@@ -49,14 +68,22 @@ export interface FleetLivenessInputs {
   readonly now: number
   /** Override the wedge threshold (ms). Non-positive values are ignored. */
   readonly wedgeThresholdMs?: number
+  /** evidence://supervisor/quota-ledger-snapshot */
+  readonly quotaLedgerSnapshot?: unknown
+  /** evidence://supervisor/heartbeat-payload */
+  readonly heartbeatPayload?: unknown
 }
 
 export interface FleetLivenessResult {
   readonly status: FleetLivenessStatus
+  readonly gateState: FleetLivenessGateState
+  readonly canReportHealthy: boolean
   /** True only when alive AND last dispatch attempt is older than threshold. */
   readonly wedged: boolean
   /** True only when alive AND last dispatch attempt is within threshold. */
   readonly healthy: boolean
+  readonly satisfiedEvidence: ReadonlyArray<FleetLivenessEvidenceRef>
+  readonly missingEvidence: ReadonlyArray<FleetLivenessEvidenceRef>
   /** Age of the last dispatch attempt in ms (null when unknown). */
   readonly ageMs: number | null
   readonly wedgeThresholdMs: number
@@ -80,52 +107,114 @@ export function evaluateFleetLiveness(
       ? inputs.wedgeThresholdMs
       : DEFAULT_WEDGE_THRESHOLD_MS
 
+  const satisfied: Array<FleetLivenessEvidenceRef> = []
+  const missing: Array<FleetLivenessEvidenceRef> = []
+
+  const finish = (partial: {
+    status: FleetLivenessStatus
+    gateState: FleetLivenessGateState
+    wedged: boolean
+    healthy: boolean
+    ageMs: number | null
+    reason: string
+  }): FleetLivenessResult => ({
+    ...partial,
+    canReportHealthy: partial.gateState === "PROVEN_ALIVE",
+    satisfiedEvidence: satisfied,
+    missingEvidence: missing,
+    wedgeThresholdMs: threshold,
+  })
+
   if (!inputs.pidAlive) {
-    return {
+    missing.push(
+      FLEET_LIVENESS_EVIDENCE.lastDispatchAttempt,
+      FLEET_LIVENESS_EVIDENCE.quotaLedgerSnapshot,
+      FLEET_LIVENESS_EVIDENCE.heartbeatPayload,
+    )
+    return finish({
       status: "unknown",
+      gateState: "BLOCKED",
       wedged: false,
       healthy: false,
       ageMs: null,
-      wedgeThresholdMs: threshold,
       reason: "supervisor process is not alive",
-    }
+    })
   }
 
   if (
     inputs.lastDispatchTime === null ||
     !Number.isFinite(inputs.lastDispatchTime)
   ) {
-    return {
+    missing.push(
+      FLEET_LIVENESS_EVIDENCE.lastDispatchAttempt,
+      FLEET_LIVENESS_EVIDENCE.quotaLedgerSnapshot,
+      FLEET_LIVENESS_EVIDENCE.heartbeatPayload,
+    )
+    return finish({
       status: "unknown",
+      gateState: "BLOCKED",
       wedged: false,
       healthy: false,
       ageMs: null,
-      wedgeThresholdMs: threshold,
       reason: "no dispatch attempt recorded yet",
-    }
+    })
   }
 
   const ageMs = inputs.now - inputs.lastDispatchTime
+  satisfied.push(FLEET_LIVENESS_EVIDENCE.lastDispatchAttempt)
 
   if (ageMs > threshold) {
-    return {
+    missing.push(
+      FLEET_LIVENESS_EVIDENCE.quotaLedgerSnapshot,
+      FLEET_LIVENESS_EVIDENCE.heartbeatPayload,
+    )
+    return finish({
       status: "wedged",
+      gateState: "DISPATCH_ATTEMPT_SEEN",
       wedged: true,
       healthy: false,
       ageMs,
-      wedgeThresholdMs: threshold,
       reason: `alive but last dispatch attempt was ${ageMs}ms ago (> ${threshold}ms threshold)`,
-    }
+    })
   }
 
-  return {
+  if (inputs.quotaLedgerSnapshot === undefined || inputs.quotaLedgerSnapshot === null) {
+    missing.push(
+      FLEET_LIVENESS_EVIDENCE.quotaLedgerSnapshot,
+      FLEET_LIVENESS_EVIDENCE.heartbeatPayload,
+    )
+    return finish({
+      status: "unknown",
+      gateState: "DISPATCH_ATTEMPT_SEEN",
+      wedged: false,
+      healthy: false,
+      ageMs,
+      reason: "dispatch attempt is fresh but quota ledger snapshot evidence is missing",
+    })
+  }
+  satisfied.push(FLEET_LIVENESS_EVIDENCE.quotaLedgerSnapshot)
+
+  if (inputs.heartbeatPayload === undefined || inputs.heartbeatPayload === null) {
+    missing.push(FLEET_LIVENESS_EVIDENCE.heartbeatPayload)
+    return finish({
+      status: "unknown",
+      gateState: "QUOTA_CHECKED",
+      wedged: false,
+      healthy: false,
+      ageMs,
+      reason: "dispatch attempt and quota evidence exist but heartbeat payload evidence is missing",
+    })
+  }
+  satisfied.push(FLEET_LIVENESS_EVIDENCE.heartbeatPayload)
+
+  return finish({
     status: "healthy",
+    gateState: "PROVEN_ALIVE",
     wedged: false,
     healthy: true,
     ageMs,
-    wedgeThresholdMs: threshold,
     reason: `alive and last dispatch attempt was ${ageMs}ms ago (<= ${threshold}ms threshold)`,
-  }
+  })
 }
 
 /**
@@ -166,6 +255,41 @@ async function readTextOrNull(path: string): Promise<string | null> {
   }
 }
 
+async function readJsonOrNull(path: string): Promise<unknown | null> {
+  const raw = await readTextOrNull(path)
+  if (raw === null) {
+    return null
+  }
+  try {
+    return JSON.parse(raw)
+  } catch {
+    return null
+  }
+}
+
+async function readQuotaLedgerSnapshot(home: string): Promise<unknown | null> {
+  if (home.length === 0) {
+    return null
+  }
+  const quotaDir = `${home}/.pylon/account-quota`
+  try {
+    const names = await readdir(quotaDir)
+    const entries: Array<unknown> = []
+    for (const name of names.sort()) {
+      if (!name.endsWith(".json")) {
+        continue
+      }
+      const parsed = await readJsonOrNull(`${quotaDir}/${name}`)
+      if (parsed !== null) {
+        entries.push(parsed)
+      }
+    }
+    return { quotaDir, entries }
+  } catch {
+    return null
+  }
+}
+
 /**
  * CLI: read the supervisor pid + last_dispatch_time from `$SUP_STATE_DIR`,
  * evaluate liveness, print a JSON verdict, and exit with FLEET_LIVENESS_EXIT.
@@ -180,6 +304,7 @@ export async function runFleetLivenessCli(): Promise<number> {
       : `${home}/.codex-supervisor`
   const pidPath = `${stateDir}/supervisor.pid`
   const lastDispatchPath = `${stateDir}/last_dispatch_time`
+  const heartbeatPayloadPath = `${stateDir}/heartbeat_payload.json`
   const thresholdMs =
     parsePositiveInt(process.env.SUP_WEDGE_THRESHOLD_MS) ??
     DEFAULT_WEDGE_THRESHOLD_MS
@@ -206,12 +331,16 @@ export async function runFleetLivenessCli(): Promise<number> {
   const lastDispatchTime = parseLastDispatchTime(
     await readTextOrNull(lastDispatchPath),
   )
+  const quotaLedgerSnapshot = await readQuotaLedgerSnapshot(home)
+  const heartbeatPayload = await readJsonOrNull(heartbeatPayloadPath)
 
   const result = evaluateFleetLiveness({
     pidAlive,
     lastDispatchTime,
     now: Date.now(),
     wedgeThresholdMs: thresholdMs,
+    quotaLedgerSnapshot,
+    heartbeatPayload,
   })
 
   console.log(

--- a/apps/pylon/src/blueprint-gates/index.ts
+++ b/apps/pylon/src/blueprint-gates/index.ts
@@ -8,13 +8,14 @@
  * consequential action; a missing required evidence ref makes the action
  * structurally impossible.
  *
- * These are libraries (types + pure functions + Bun tests). Most are not yet
- * wired into the live supervisor/watcher — wiring is a follow-up. The exception
- * is `fleet-liveness` (#6646), whose CLI entry IS consumed by
- * `apps/pylon/scripts/codex-supervisor/launch.sh wedge-watch` to force-restart a
- * wedged supervisor.
+ * These modules expose pure evaluators plus enforced action authorizers. The
+ * authorizers return the consequential action payload only from the signature's
+ * terminal state, so Artanis tick/operator call sites cannot structurally take
+ * the action from a partial gate.
  */
 
+export * from "./enforced-actions.js"
+export * from "./diagnosis-grounding.js"
 export * from "./issue-close-safe.js"
 export * from "./command-execution-source-verified.js"
 export * from "./merge-deploy-gate.js"

--- a/apps/pylon/src/blueprint-gates/index.ts
+++ b/apps/pylon/src/blueprint-gates/index.ts
@@ -8,10 +8,13 @@
  * consequential action; a missing required evidence ref makes the action
  * structurally impossible.
  *
- * These modules expose pure evaluators plus enforced action authorizers. The
- * authorizers return the consequential action payload only from the signature's
- * terminal state, so Artanis tick/operator call sites cannot structurally take
- * the action from a partial gate.
+ * These modules expose pure evaluators plus enforced action authorizers. Fleet
+ * liveness is wired into Pylon status reporting. The issue-close authorizer is
+ * wired into the Pylon PR publisher's closing-keyword edit path, and the
+ * diagnosis, command-proposal, and merge-deploy authorizers are wired into the
+ * Artanis scheduled/operator dispatch call sites that construct those
+ * consequential actions. Other consumers must still call an authorizer at the
+ * acting site before treating a non-terminal gate as action authority.
  */
 
 export * from "./enforced-actions.js"

--- a/apps/pylon/src/blueprint-gates/issue-close-safe.ts
+++ b/apps/pylon/src/blueprint-gates/issue-close-safe.ts
@@ -49,7 +49,7 @@ export type IssueCloseSafeEvidenceRef =
 export interface IssueCloseSafeInputs {
   readonly issueNumber: number
   /** evidence://issue/labels — the full label set read from the issue. */
-  readonly issueLabels: ReadonlyArray<string>
+  readonly issueLabels: ReadonlyArray<string> | null
   /** Parent EPIC issue number, or null when this issue has no parent EPIC. */
   readonly parentEpicNumber: number | null
   readonly prNumber: number
@@ -77,6 +77,10 @@ export interface IssueCloseSafeResult {
   readonly state: IssueCloseSafeState
   /** True only when the terminal state SAFE_TO_CLOSE is reached. */
   readonly canClose: boolean
+  readonly identity: Readonly<{
+    readonly issueNumber: number
+    readonly prNumber: number
+  }>
   /** Whether THIS issue was treated as an EPIC. */
   readonly isEpic: boolean
   readonly satisfiedEvidence: ReadonlyArray<IssueCloseSafeEvidenceRef>
@@ -119,6 +123,9 @@ export function issueIsEpic(inputs: IssueCloseSafeInputs): boolean {
   if (typeof inputs.isEpic === "boolean") {
     return inputs.isEpic
   }
+  if (!Array.isArray(inputs.issueLabels)) {
+    return false
+  }
   return inputs.issueLabels.some((label) => label.trim().toLowerCase() === "epic")
 }
 
@@ -131,6 +138,10 @@ export function evaluateIssueCloseSafe(
 ): IssueCloseSafeResult {
   const satisfied: Array<IssueCloseSafeEvidenceRef> = []
   const isEpic = issueIsEpic(inputs)
+  const identity = {
+    issueNumber: inputs.issueNumber,
+    prNumber: inputs.prNumber,
+  }
 
   const lock = (
     state: IssueCloseSafeState,
@@ -140,6 +151,7 @@ export function evaluateIssueCloseSafe(
   ): IssueCloseSafeResult => ({
     state,
     canClose: false,
+    identity,
     isEpic,
     satisfiedEvidence: satisfied,
     missingEvidence: missing,
@@ -198,6 +210,7 @@ export function evaluateIssueCloseSafe(
   return {
     state: "SAFE_TO_CLOSE",
     canClose: true,
+    identity,
     isEpic,
     satisfiedEvidence: satisfied,
     missingEvidence: [],

--- a/apps/pylon/src/blueprint-gates/merge-deploy-gate.ts
+++ b/apps/pylon/src/blueprint-gates/merge-deploy-gate.ts
@@ -68,6 +68,10 @@ export interface MergeDeployGateResult {
   readonly state: MergeDeployState
   /** True only when the terminal state LIVE is reached. */
   readonly isLive: boolean
+  readonly identity: Readonly<{
+    readonly prNumbers: ReadonlyArray<number>
+    readonly mergeCommitHashes: ReadonlyArray<string>
+  }>
   readonly isRed: boolean
   /** True while a RED gate has no rollback evidence ref presented. */
   readonly blocksFurtherMerges: boolean
@@ -121,6 +125,10 @@ export function evaluateMergeDeployGate(
   inputs: MergeDeployGateInputs,
 ): MergeDeployGateResult {
   const satisfied: Array<MergeDeployEvidenceRef> = []
+  const identity = {
+    prNumbers: inputs.prNumbers,
+    mergeCommitHashes: inputs.mergeCommitHashes,
+  }
   const hasRollback =
     typeof inputs.rollbackEvidenceRef === "string" &&
     inputs.rollbackEvidenceRef.trim().length > 0
@@ -132,6 +140,7 @@ export function evaluateMergeDeployGate(
   ): MergeDeployGateResult => ({
     state: "RED",
     isLive: false,
+    identity,
     isRed: true,
     blocksFurtherMerges: !hasRollback,
     failedGate,
@@ -203,6 +212,7 @@ export function evaluateMergeDeployGate(
   return {
     state: "LIVE",
     isLive: true,
+    identity,
     isRed: false,
     blocksFurtherMerges: false,
     failedGate: null,

--- a/apps/pylon/src/codex-pr-publisher.test.ts
+++ b/apps/pylon/src/codex-pr-publisher.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from "bun:test"
+
+import {
+  authorizeIssueClosingBody,
+  closingBodyCandidate,
+  downgradeClosingKeywords,
+} from "./codex-pr-publisher.js"
+
+describe("codex PR publisher issue-close gate", () => {
+  test("downgrades generated closing keywords before the issue-close gate", () => {
+    expect(downgradeClosingKeywords("Fixes #7927\n\nBody", 7927)).toBe(
+      "Addresses #7927\n\nBody",
+    )
+  })
+
+  test("builds the closing body candidate only for the authorized edit path", () => {
+    expect(closingBodyCandidate("Addresses #7927.\n\nBody", 7927)).toContain(
+      "Closes #7927",
+    )
+  })
+
+  test("gate-denied issue close leaves the closing body unconstructible", () => {
+    const denied = authorizeIssueClosingBody({
+      body: "Addresses #7927.\n\nBody",
+      issueLabels: ["epic"],
+      issueNumber: 7927,
+      prNumber: 9001,
+    })
+
+    expect(denied.ok).toBe(false)
+    if (!denied.ok) {
+      expect(denied.reason).toContain("EPIC")
+    }
+  })
+
+  test("gate-ok issue close returns the exact evaluated issue and PR body", () => {
+    const allowed = authorizeIssueClosingBody({
+      body: "Addresses #7927.\n\nBody",
+      issueLabels: ["bug"],
+      issueNumber: 7927,
+      prNumber: 9001,
+    })
+
+    expect(allowed.ok).toBe(true)
+    if (allowed.ok) {
+      expect(allowed.body).toContain("Closes #7927")
+    }
+  })
+})

--- a/apps/pylon/src/codex-pr-publisher.ts
+++ b/apps/pylon/src/codex-pr-publisher.ts
@@ -5,6 +5,10 @@ import {
   captureWorkspaceChanges,
   type WorkspaceChangeCapture,
 } from "./workspace-materializer.js"
+import {
+  authorizeIssueClose,
+  evaluateIssueCloseSafe,
+} from "./blueprint-gates/index.js"
 
 /**
  * Assignment pull-request publisher (issue #6439, dedup hardening #6439-reopen).
@@ -130,6 +134,10 @@ const githubFullNamePattern = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/
 const gitCommitShaPattern = /^[a-f0-9]{40}$/i
 const conventionalTitlePattern =
   /^(feat|fix|docs|test|chore|refactor|perf|build|ci|style|revert)(\([A-Za-z0-9_.\-/]+\))?!?: .+/
+const closingKeywordForIssue = (issueNumber: number): RegExp =>
+  new RegExp(`\\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\\s+#${issueNumber}(?!\\d)`, "gi")
+const issueReferencePattern = (issueNumber: number): RegExp =>
+  new RegExp(`(?<!\\d)#${issueNumber}(?!\\d)`)
 
 async function defaultRunner(input: {
   args: string[]
@@ -185,6 +193,23 @@ export function issueNumberFromSummary(summary: string | undefined): number | nu
   if (ref === null) return null
   const value = Number.parseInt(ref.slice(1), 10)
   return Number.isFinite(value) ? value : null
+}
+
+export function downgradeClosingKeywords(body: string, issueNumber: number | null): string {
+  if (issueNumber === null) return body
+  return body.replace(closingKeywordForIssue(issueNumber), `Addresses #${issueNumber}`)
+}
+
+export function closingBodyCandidate(body: string, issueNumber: number): string {
+  const downgraded = downgradeClosingKeywords(body.trim(), issueNumber)
+  const addressPattern = new RegExp(`\\bAddresses\\s+#${issueNumber}(?!\\d)`, "i")
+  if (addressPattern.test(downgraded)) {
+    return downgraded.replace(addressPattern, `Closes #${issueNumber}`)
+  }
+  if (issueReferencePattern(issueNumber).test(downgraded)) {
+    return `Closes #${issueNumber}.\n\n${downgraded}`
+  }
+  return `Closes #${issueNumber}.\n\n${downgraded}`
 }
 
 /**
@@ -332,9 +357,10 @@ export function buildStructuredBody(input: {
 function normalizeGeneratedBody(body: string, issueNumber: number | null): string {
   const trimmed = body.trim()
   if (issueNumber === null) return trimmed
-  const pattern = new RegExp(`(?<!\\d)#${issueNumber}(?!\\d)`)
-  if (pattern.test(trimmed)) return trimmed
-  return `Addresses #${issueNumber}.\n\n${trimmed}`
+  const downgraded = downgradeClosingKeywords(trimmed, issueNumber)
+  const pattern = issueReferencePattern(issueNumber)
+  if (pattern.test(downgraded)) return downgraded
+  return `Addresses #${issueNumber}.\n\n${downgraded}`
 }
 
 function assertPylonOwnedWorkspaceTarget(input: { cacheRoot: string; workingDirectory: string }) {
@@ -439,6 +465,65 @@ async function fetchIssueTitle(input: {
   } catch {
     return null
   }
+}
+
+async function fetchIssueLabels(input: {
+  runner: AssignmentPrCommandRunner
+  cwd: string
+  fullName: string
+  issueNumber: number
+}): Promise<ReadonlyArray<string> | null> {
+  try {
+    const res = await input.runner({
+      args: [
+        "gh",
+        "issue",
+        "view",
+        String(input.issueNumber),
+        "--repo",
+        input.fullName,
+        "--json",
+        "labels",
+      ],
+      cwd: input.cwd,
+      timeoutMs: GH_TIMEOUT_MS,
+    })
+    if (res.exitCode !== 0 || res.timedOut) return null
+    const parsed = JSON.parse(res.stdout) as { labels?: unknown }
+    if (!Array.isArray(parsed.labels)) return null
+    return parsed.labels
+      .map((label) => {
+        if (typeof label === "string") return label
+        if (typeof label === "object" && label !== null && typeof (label as { name?: unknown }).name === "string") {
+          return (label as { name: string }).name
+        }
+        return null
+      })
+      .filter((label): label is string => label !== null)
+  } catch {
+    return null
+  }
+}
+
+export function authorizeIssueClosingBody(input: {
+  body: string
+  issueNumber: number
+  prNumber: number
+  issueLabels: ReadonlyArray<string> | null
+}): { ok: true; body: string } | { ok: false; reason: string } {
+  const candidate = closingBodyCandidate(input.body, input.issueNumber)
+  const decision = authorizeIssueClose(
+    evaluateIssueCloseSafe({
+      issueNumber: input.issueNumber,
+      issueLabels: input.issueLabels,
+      parentEpicNumber: null,
+      prNumber: input.prNumber,
+      prBody: candidate,
+    }),
+  )
+  return decision.ok
+    ? { ok: true, body: candidate }
+    : { ok: false, reason: decision.reason }
 }
 
 async function gitDiffStat(input: {
@@ -610,6 +695,8 @@ export async function publishAssignmentPullRequest(
       verifyExitCode: input.verification.exitCode,
       verifyPassed: input.verification.passed,
     })
+  } else {
+    body = downgradeClosingKeywords(body, issueNumber)
   }
 
   // Create the assignment/issue branch at the pinned base commit (the detached
@@ -731,6 +818,36 @@ export async function publishAssignmentPullRequest(
   }
   const prUrl = urlMatch[0]
   const prNumber = parsePullRequestNumber(prUrl) ?? 0
+  if (issueNumber !== null && prNumber > 0) {
+    const issueLabels = await fetchIssueLabels({
+      runner,
+      cwd: workingDirectory,
+      fullName: input.repository.fullName,
+      issueNumber,
+    })
+    const authorized = authorizeIssueClosingBody({
+      body,
+      issueLabels,
+      issueNumber,
+      prNumber,
+    })
+    if (authorized.ok) {
+      await runner({
+        args: [
+          "gh",
+          "pr",
+          "edit",
+          String(prNumber),
+          "--repo",
+          input.repository.fullName,
+          "--body",
+          authorized.body,
+        ],
+        cwd: workingDirectory,
+        timeoutMs: GH_TIMEOUT_MS,
+      })
+    }
+  }
   return {
     state: "opened",
     prUrl,

--- a/packages/blueprint-contracts/src/command-execution-source-verified.ts
+++ b/packages/blueprint-contracts/src/command-execution-source-verified.ts
@@ -79,6 +79,11 @@ export interface CommandSourceVerifiedResult {
   readonly state: CommandSourceVerifiedState
   /** True only when the terminal state SAFE_TO_PROPOSE is reached. */
   readonly canPropose: boolean
+  /** The command identity evaluated by this result. */
+  readonly identity: Readonly<{
+    readonly commandString: string
+    readonly scriptPath: string
+  }>
   /** Flags considered (command-parsed flags unioned with expectedFlags). */
   readonly proposedFlags: ReadonlyArray<string>
   /** Proposed flags absent from the declared argument surface. */
@@ -143,6 +148,10 @@ export function evaluateCommandSourceVerified(
     parseCommandFlags(inputs.commandString),
     inputs.expectedFlags ?? [],
   )
+  const identity = {
+    commandString: inputs.commandString,
+    scriptPath: inputs.scriptPath,
+  }
   const declared = inputs.declaredFlags ?? []
   const unknownFlags = proposedFlags.filter((flag) => !declared.includes(flag))
 
@@ -154,6 +163,7 @@ export function evaluateCommandSourceVerified(
   ): CommandSourceVerifiedResult => ({
     state,
     canPropose: false,
+    identity,
     proposedFlags,
     unknownFlags,
     satisfiedEvidence: satisfied,
@@ -223,6 +233,7 @@ export function evaluateCommandSourceVerified(
   return {
     state: "SAFE_TO_PROPOSE",
     canPropose: true,
+    identity,
     proposedFlags,
     unknownFlags,
     satisfiedEvidence: satisfied,

--- a/packages/blueprint-contracts/src/enforced-actions.ts
+++ b/packages/blueprint-contracts/src/enforced-actions.ts
@@ -1,0 +1,195 @@
+export type BlueprintGateId =
+  | "fleet-liveness"
+  | "diagnosis-grounding"
+  | "issue-close-safe"
+  | "command-source-verified"
+  | "merge-deploy"
+
+export type GateBlocked = Readonly<{
+  ok: false
+  gate: BlueprintGateId
+  state: string
+  reason: string
+  missingEvidence: ReadonlyArray<string>
+}>
+
+export type GateAuthorized<TAction> = Readonly<{
+  ok: true
+  gate: BlueprintGateId
+  state: string
+  action: TAction
+  evidenceRefs: ReadonlyArray<string>
+}>
+
+export type GateDecision<TAction> = GateAuthorized<TAction> | GateBlocked
+
+export type FleetHealthyReportAction = Readonly<{
+  kind: "report_fleet_healthy"
+  reason: string
+}>
+
+export type DiagnosisRemediationAction = Readonly<{
+  kind: "propose_remediation"
+  claimedRootCause: string
+  remediation: string
+}>
+
+export type IssueCloseAction = Readonly<{
+  kind: "emit_closes_keyword"
+  issueNumber: number
+  prNumber: number
+}>
+
+export type CommandProposalAction = Readonly<{
+  kind: "propose_command"
+  commandString: string
+  scriptPath: string
+}>
+
+export type MergeDeployLiveAction = Readonly<{
+  kind: "report_deployment_live"
+  prNumbers: ReadonlyArray<number>
+  mergeCommitHashes: ReadonlyArray<string>
+}>
+
+export type FleetLivenessAuthorizerResult = Readonly<{
+  canReportHealthy: boolean
+  gateState: string
+  reason: string
+  missingEvidence: ReadonlyArray<string>
+  satisfiedEvidence: ReadonlyArray<string>
+}>
+
+export type DiagnosisGroundingAuthorizerResult = Readonly<{
+  canProposeRemediation: boolean
+  state: string
+  blockedReason: string | null
+  missingEvidence: ReadonlyArray<string>
+  satisfiedEvidence: ReadonlyArray<string>
+  identity: Readonly<{ claimedRootCause: string }>
+}>
+
+export type IssueCloseAuthorizerResult = Readonly<{
+  canClose: boolean
+  state: string
+  blockedReason: string | null
+  missingEvidence: ReadonlyArray<string>
+  satisfiedEvidence: ReadonlyArray<string>
+  identity: Readonly<{ issueNumber: number; prNumber: number }>
+}>
+
+export type CommandProposalAuthorizerResult = Readonly<{
+  canPropose: boolean
+  state: string
+  blockedReason: string | null
+  missingEvidence: ReadonlyArray<string>
+  satisfiedEvidence: ReadonlyArray<string>
+  identity: Readonly<{ commandString: string; scriptPath: string }>
+}>
+
+export type MergeDeployAuthorizerResult = Readonly<{
+  isLive: boolean
+  state: string
+  blockedReason: string | null
+  missingEvidence: ReadonlyArray<string>
+  satisfiedEvidence: ReadonlyArray<string>
+  identity: Readonly<{
+    prNumbers: ReadonlyArray<number>
+    mergeCommitHashes: ReadonlyArray<string>
+  }>
+}>
+
+const blocked = (
+  gate: BlueprintGateId,
+  state: string,
+  reason: string | null | undefined,
+  missingEvidence: ReadonlyArray<string>,
+): GateBlocked => ({
+  ok: false,
+  gate,
+  state,
+  reason: reason ?? "blueprint gate has not reached its terminal state",
+  missingEvidence,
+})
+
+export const authorizeFleetHealthyReport = (
+  gate: FleetLivenessAuthorizerResult,
+): GateDecision<FleetHealthyReportAction> =>
+  gate.canReportHealthy
+    ? {
+        ok: true,
+        gate: "fleet-liveness",
+        state: gate.gateState,
+        action: { kind: "report_fleet_healthy", reason: gate.reason },
+        evidenceRefs: gate.satisfiedEvidence,
+      }
+    : blocked("fleet-liveness", gate.gateState, gate.reason, gate.missingEvidence)
+
+export const authorizeDiagnosisRemediation = (
+  gate: DiagnosisGroundingAuthorizerResult,
+  remediation: string,
+): GateDecision<DiagnosisRemediationAction> =>
+  gate.canProposeRemediation
+    ? {
+        ok: true,
+        gate: "diagnosis-grounding",
+        state: gate.state,
+        action: {
+          kind: "propose_remediation",
+          claimedRootCause: gate.identity.claimedRootCause,
+          remediation,
+        },
+        evidenceRefs: gate.satisfiedEvidence,
+      }
+    : blocked("diagnosis-grounding", gate.state, gate.blockedReason, gate.missingEvidence)
+
+export const authorizeIssueClose = (
+  gate: IssueCloseAuthorizerResult,
+): GateDecision<IssueCloseAction> =>
+  gate.canClose
+    ? {
+        ok: true,
+        gate: "issue-close-safe",
+        state: gate.state,
+        action: {
+          kind: "emit_closes_keyword",
+          issueNumber: gate.identity.issueNumber,
+          prNumber: gate.identity.prNumber,
+        },
+        evidenceRefs: gate.satisfiedEvidence,
+      }
+    : blocked("issue-close-safe", gate.state, gate.blockedReason, gate.missingEvidence)
+
+export const authorizeCommandProposal = (
+  gate: CommandProposalAuthorizerResult,
+): GateDecision<CommandProposalAction> =>
+  gate.canPropose
+    ? {
+        ok: true,
+        gate: "command-source-verified",
+        state: gate.state,
+        action: {
+          kind: "propose_command",
+          commandString: gate.identity.commandString,
+          scriptPath: gate.identity.scriptPath,
+        },
+        evidenceRefs: gate.satisfiedEvidence,
+      }
+    : blocked("command-source-verified", gate.state, gate.blockedReason, gate.missingEvidence)
+
+export const authorizeMergeDeployLiveReport = (
+  gate: MergeDeployAuthorizerResult,
+): GateDecision<MergeDeployLiveAction> =>
+  gate.isLive
+    ? {
+        ok: true,
+        gate: "merge-deploy",
+        state: gate.state,
+        action: {
+          kind: "report_deployment_live",
+          prNumbers: gate.identity.prNumbers,
+          mergeCommitHashes: gate.identity.mergeCommitHashes,
+        },
+        evidenceRefs: gate.satisfiedEvidence,
+      }
+    : blocked("merge-deploy", gate.state, gate.blockedReason, gate.missingEvidence)

--- a/packages/blueprint-contracts/src/index.ts
+++ b/packages/blueprint-contracts/src/index.ts
@@ -5,6 +5,7 @@ import { Schema as S } from "effect";
 // home) so the openagents.com Worker operator loop and the Pylon blueprint-gates
 // both import + apply the SAME function instead of re-describing it.
 export * from "./command-execution-source-verified.js";
+export * from "./enforced-actions.js";
 export * from "./operator-grounded-assertion.js";
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #7886

## Summary

- Add enforced action authorizers for Blueprint signatures 1-5 so consequential action payloads are only available from terminal gate states.
- Add the missing diagnosis-grounding gate and tests.
- Upgrade fleet-liveness to the documented ordered evidence gate and persist heartbeat evidence for the supervisor liveness CLI.

## Verification

- `bun test src/blueprint-gates/*.test.ts` (from `apps/pylon`) passes.
- `bash -n apps/pylon/scripts/codex-supervisor/codex-supervisor.sh`
- `bash -n apps/pylon/scripts/codex-supervisor/launch.sh`
- Required verifier `bun run --cwd apps/pylon test` was run but failed in this bounded checkout due existing/generated workspace resolver failures for `@openagentsinc/*` packages plus pre-existing one-shot test failures (`spark-backup-status-oneshot`, `operator-snapshot-oneshot`).