### PR TITLE
T3.1: FleetRunSupervisor

### DIFF
--- a/apps/pylon/src/orchestration/store.ts
+++ b/apps/pylon/src/orchestration/store.ts
@@ -1452,9 +1452,9 @@ export class PylonOrchestrationStore {
           state: "idle",
           stateStartedAt: iso(now),
           updatedAt: iso(now),
-          supportedControlVerbs: live.supportedControlVerbs,
-          refs: live.refs,
-          stateHistory: live.stateHistory,
+          ...(live.supportedControlVerbs === undefined ? {} : { supportedControlVerbs: live.supportedControlVerbs }),
+          ...(live.refs === undefined ? {} : { refs: live.refs }),
+          ...(live.stateHistory === undefined ? {} : { stateHistory: live.stateHistory }),
         },
         now,
       }))

--- a/apps/pylon/src/orchestration/work-planner.ts
+++ b/apps/pylon/src/orchestration/work-planner.ts
@@ -196,8 +196,8 @@ export const normalizeIssueListCandidate = (repo: string, item: number | IssueLi
     title: issue.title ?? `${kind === "github_pr" ? "PR" : "Issue"} #${issue.number}`,
     state: normalizeState(issue.state),
     labels: [...(issue.labels ?? [])],
-    body: issue.body,
-    url: issue.url,
+    ...(issue.body === undefined ? {} : { body: issue.body }),
+    ...(issue.url === undefined ? {} : { url: issue.url }),
   }
 }
 
@@ -232,8 +232,8 @@ const ghIssueRecordToCandidate = (repo: string, record: GhIssueRecord): WorkPlan
     title: typeof record.title === "string" && record.title.trim() ? record.title : `Issue #${record.number}`,
     state: normalizeState(record.state),
     labels: normalizeLabels(record.labels),
-    body: typeof record.body === "string" ? record.body : undefined,
-    url: typeof record.url === "string" ? record.url : undefined,
+    ...(typeof record.body === "string" ? { body: record.body } : {}),
+    ...(typeof record.url === "string" ? { url: record.url } : {}),
   }
 }
 
@@ -249,8 +249,8 @@ const ghPullRequestRecordToCandidate = (repo: string, record: GhPullRequestRecor
     title: typeof record.title === "string" && record.title.trim() ? record.title : `PR #${record.number}`,
     state,
     labels: normalizeLabels(record.labels),
-    body: typeof record.body === "string" ? record.body : undefined,
-    url: typeof record.url === "string" ? record.url : undefined,
+    ...(typeof record.body === "string" ? { body: record.body } : {}),
+    ...(typeof record.url === "string" ? { url: record.url } : {}),
   }
 }
 

--- a/clients/khala-code-desktop/src/bun/fleet-run-supervisor.ts
+++ b/clients/khala-code-desktop/src/bun/fleet-run-supervisor.ts
@@ -170,7 +170,10 @@ const liveClaimsForRun = (store: PylonOrchestrationStore, runRef: string, now: D
 
 const activeByAccount = (claims: readonly WorkClaim[]): Map<string, number> => {
   const counts = new Map<string, number>()
-  for (const claim of claims) counts.set(claim.workerAccountRef, (counts.get(claim.workerAccountRef) ?? 0) + 1)
+  for (const claim of claims) {
+    if (claim.state === "closeout") continue
+    counts.set(claim.workerAccountRef, (counts.get(claim.workerAccountRef) ?? 0) + 1)
+  }
   return counts
 }
 
@@ -197,8 +200,8 @@ const taskIdFor = (runRef: string, claimRef: string): string =>
 const contextIdFor = (accountRef: string, taskId: string): string =>
   `${accountRef}.ctx.${taskId}`.replace(/[^a-zA-Z0-9_.-]/g, "_")
 
-const claimRefFor = (runRef: string, workUnitRef: string, now: Date): string =>
-  `${runRef}.claim.${workUnitRef.replace(/[^a-zA-Z0-9_.-]/g, "_")}.${now.getTime()}`
+const claimRefFor = (runRef: string, workUnitRef: string, now: Date, ordinal: number): string =>
+  `${runRef}.claim.${workUnitRef.replace(/[^a-zA-Z0-9_.-]/g, "_")}.${now.getTime()}.${ordinal}`
 
 const emit = async (
   sink: FleetRunSupervisorOptions["onLifecycle"],
@@ -220,7 +223,19 @@ export async function tickFleetRunSupervisor(
   const claimTtlMs = options.claimTtlMs ?? 30 * 60 * 1000
 
   store.reconcileWorkClaims({ now })
-  const run = store.reconcileFleetRun(options.runRef, now)
+  const expectedWorkUnitsTotal = store.getFleetRun(options.runRef)?.counters.workUnitsTotal ?? 0
+  let run = store.reconcileFleetRun(options.runRef, now)
+  if (run.state !== "running" && run.counters.workUnitsTotal < expectedWorkUnitsTotal) {
+    run = store.upsertFleetRun({
+      ...run,
+      state: "running",
+      counters: {
+        ...run.counters,
+        workUnitsTotal: expectedWorkUnitsTotal,
+      },
+      updatedAt: now.toISOString(),
+    })
+  }
   if (run.state !== "running") {
     return {
       activeAssignments: activeAssignmentsForRun(store, run.runRef),
@@ -254,15 +269,17 @@ export async function tickFleetRunSupervisor(
   }
 
   const plan = await options.planner.plan({ run, now })
+  const plannedWorkUnitsTotal = Math.max(expectedWorkUnitsTotal, run.counters.workUnitsTotal)
   let claimed = 0
   let dispatched = 0
+  const claimOrdinalBase = store.listWorkClaims({ runRef: run.runRef }).length
 
   for (const workUnit of plan.claimable) {
     if (dispatched >= freeSlots) break
     const account = pickAccount(accounts, activeCounts, now)
     if (account === null) break
     const claim = store.tryClaimWorkUnit({
-      claimRef: claimRefFor(run.runRef, workUnit.workUnitRef, now),
+      claimRef: claimRefFor(run.runRef, workUnit.workUnitRef, now, claimOrdinalBase + claimed),
       workUnitRef: workUnit.workUnitRef,
       runRef: run.runRef,
       workerAccountRef: account.accountRef,
@@ -301,8 +318,36 @@ export async function tickFleetRunSupervisor(
     store.markDispatched(taskId, contextId, now)
     store.updateWorkClaimState(claim.claimRef, "in_progress", now)
 
-    const result = await options.runner.dispatch({ accountRef: account.accountRef, claim, run, taskId, workUnit })
-    dispatched += 1
+    let result: FleetRunSupervisorDispatchResult
+    try {
+      result = await options.runner.dispatch({ accountRef: account.accountRef, claim, run, taskId, workUnit })
+      dispatched += 1
+    } catch (error) {
+      dispatched += 1
+      store.recordWorkerDone({
+        contextId,
+        taskId,
+        status: "failed",
+        result: JSON.stringify({
+          assignmentRef: null,
+          summary: error instanceof Error ? error.message : String(error),
+        }),
+        now,
+      })
+      store.releaseWorkClaim(claim.claimRef, now)
+      activeCounts.set(account.accountRef, Math.max(0, (activeCounts.get(account.accountRef) ?? 1) - 1))
+      await emit(options.onLifecycle, {
+        kind: "dispatch",
+        runRef: run.runRef,
+        taskId,
+        claimRef: claim.claimRef,
+        workUnitRef: workUnit.workUnitRef,
+        accountRef: account.accountRef,
+        assignmentRef: null,
+        status: "failed",
+      })
+      continue
+    }
 
     for (const event of result.lifecycle) {
       await emit(options.onLifecycle, {
@@ -357,7 +402,21 @@ export async function tickFleetRunSupervisor(
     })
   }
 
-  const reconciled = store.reconcileFleetRun(run.runRef, clock.now())
+  let reconciled = store.reconcileFleetRun(run.runRef, clock.now())
+  const hasClaimableBacklog = plan.claimable.length > claimed
+  if (reconciled.counters.workUnitsTotal < plannedWorkUnitsTotal) {
+    reconciled = store.upsertFleetRun({
+      ...reconciled,
+      state: hasClaimableBacklog ? "running" : reconciled.state,
+      counters: {
+        ...reconciled.counters,
+        workUnitsTotal: plannedWorkUnitsTotal,
+      },
+      updatedAt: clock.now().toISOString(),
+    })
+  } else if (reconciled.state !== "running" && hasClaimableBacklog) {
+    reconciled = store.updateFleetRunState(run.runRef, "running", clock.now())
+  }
   if (reconciled.state === "completed") {
     await emit(options.onLifecycle, { kind: "completed", runRef: run.runRef, reason: "drained" })
   }
@@ -392,7 +451,7 @@ export function makeFleetRunSupervisor(
 ): Effect.Effect<FleetRunSupervisorHandle, FleetRunSupervisorError> {
   return Effect.sync(() => {
     const existing = activeSupervisors.get(options.pylonRef)
-    if (existing !== undefined && existing !== options.runRef) {
+    if (existing !== undefined) {
       throw new FleetRunSupervisorError(`fleet run supervisor already active for pylon ${options.pylonRef}: ${existing}`)
     }
     activeSupervisors.set(options.pylonRef, options.runRef)
@@ -423,15 +482,26 @@ export function startFleetRunSupervisor(
   return Effect.gen(function* () {
     const handle = yield* makeFleetRunSupervisor(options)
     const scope = yield* Effect.scope
-    yield* Scope.addFinalizer(scope, handle.stop())
-    yield* Effect.forkScoped(
-      Effect.forever(
-        Effect.gen(function* () {
-          yield* handle.tick()
-          yield* Effect.promise(() => ({ ...defaultClock, ...options.clock }).sleep(options.tickIntervalMs ?? 1000))
-        }),
-      ),
+    let loopStopped = false
+    yield* Scope.addFinalizer(
+      scope,
+      Effect.gen(function* () {
+        loopStopped = true
+        yield* handle.stop()
+      }),
     )
+    // tickFleetRunSupervisor intentionally bypasses the one-supervisor guard as the direct test seam.
+    void (async () => {
+      const clock = { ...defaultClock, ...options.clock }
+      while (!loopStopped) {
+        try {
+          await Effect.runPromise(handle.tick())
+        } catch {
+          // Keep the scoped supervisor alive; individual dispatch failures are recorded by tick.
+        }
+        if (!loopStopped) await clock.sleep(options.tickIntervalMs ?? 1000)
+      }
+    })()
     return handle
   })
 }

--- a/clients/khala-code-desktop/src/bun/fleet-run-supervisor.ts
+++ b/clients/khala-code-desktop/src/bun/fleet-run-supervisor.ts
@@ -1,0 +1,437 @@
+import { Effect, Scope } from "effect"
+
+import type {
+  FleetRun,
+  OrchestrationTaskStatus,
+  PylonOrchestrationStore,
+  WorkClaim,
+} from "../../../../apps/pylon/src/orchestration/store.js"
+import type {
+  WorkPlannerClaimableUnit,
+  WorkPlannerOutput,
+} from "../../../../apps/pylon/src/orchestration/work-planner.js"
+
+export const FLEET_RUN_SUPERVISOR_MAX_SPAWN_COUNT = 10
+
+export type FleetRunSupervisorAccount = {
+  readonly accountRef: string
+  readonly advertisedCapacity: number
+  readonly cooldownUntil?: Date | string | null
+}
+
+export type FleetRunSupervisorLifecycleEvent = {
+  readonly assignmentRef?: string | null
+  readonly event: string
+  readonly phase?: string | null
+  readonly status?: string | null
+}
+
+export type FleetRunSupervisorDispatchInput = {
+  readonly accountRef: string
+  readonly claim: WorkClaim
+  readonly run: FleetRun
+  readonly taskId: string
+  readonly workUnit: WorkPlannerClaimableUnit
+}
+
+export type FleetRunSupervisorDispatchResult = {
+  readonly assignmentRef: string | null
+  readonly lifecycle: readonly FleetRunSupervisorLifecycleEvent[]
+  readonly status: "accepted" | "blocked" | "failed" | "completed"
+  readonly summary?: string | null
+}
+
+export type FleetRunSupervisorRunner = {
+  readonly dispatch: (input: FleetRunSupervisorDispatchInput) => Promise<FleetRunSupervisorDispatchResult>
+}
+
+export type FleetRunSupervisorPlanner = {
+  readonly plan: (input: { readonly run: FleetRun; readonly now: Date }) => Promise<WorkPlannerOutput>
+}
+
+export type FleetRunSupervisorCapacity = {
+  readonly accounts: (input: { readonly run: FleetRun; readonly now: Date }) => Promise<readonly FleetRunSupervisorAccount[]>
+}
+
+export type FleetRunSupervisorClock = {
+  readonly now: () => Date
+  readonly sleep: (ms: number) => Promise<void>
+}
+
+export type FleetRunSupervisorOptions = {
+  readonly store: PylonOrchestrationStore
+  readonly pylonRef: string
+  readonly runRef: string
+  readonly planner: FleetRunSupervisorPlanner
+  readonly runner: FleetRunSupervisorRunner
+  readonly capacity: FleetRunSupervisorCapacity
+  readonly clock?: Partial<FleetRunSupervisorClock>
+  readonly tickIntervalMs?: number
+  readonly claimTtlMs?: number
+  readonly maxSpawnPerTick?: number
+  readonly onLifecycle?: (event: FleetRunSupervisorObservedEvent) => void | Promise<void>
+}
+
+export type FleetRunSupervisorObservedEvent =
+  | {
+    readonly kind: "tick"
+    readonly runRef: string
+    readonly activeAssignments: number
+    readonly freeSlots: number
+  }
+  | {
+    readonly kind: "dispatch"
+    readonly runRef: string
+    readonly taskId: string
+    readonly claimRef: string
+    readonly workUnitRef: string
+    readonly accountRef: string
+    readonly assignmentRef: string | null
+    readonly status: FleetRunSupervisorDispatchResult["status"]
+  }
+  | {
+    readonly kind: "lifecycle"
+    readonly runRef: string
+    readonly taskId: string
+    readonly claimRef: string
+    readonly accountRef: string
+    readonly event: FleetRunSupervisorLifecycleEvent
+  }
+  | {
+    readonly kind: "completed"
+    readonly runRef: string
+    readonly reason: "backlog_empty" | "drained"
+  }
+
+export type FleetRunSupervisorTickResult = {
+  readonly activeAssignments: number
+  readonly claimed: number
+  readonly dispatched: number
+  readonly freeSlots: number
+  readonly run: FleetRun
+}
+
+export type FleetRunSupervisorHandle = {
+  readonly pylonRef: string
+  readonly runRef: string
+  readonly stop: () => Effect.Effect<void>
+  readonly tick: () => Effect.Effect<FleetRunSupervisorTickResult, FleetRunSupervisorError>
+}
+
+export class FleetRunSupervisorError extends Error {
+  readonly _tag = "FleetRunSupervisorError"
+  override readonly cause: unknown
+
+  constructor(message: string, cause?: unknown) {
+    super(message)
+    this.name = "FleetRunSupervisorError"
+    this.cause = cause
+  }
+}
+
+const activeSupervisors = new Map<string, string>()
+
+const defaultClock: FleetRunSupervisorClock = {
+  now: () => new Date(),
+  sleep: ms => new Promise(resolve => setTimeout(resolve, ms)),
+}
+
+const liveTaskStatuses = new Set<OrchestrationTaskStatus>(["dispatched"])
+
+const terminalStatusForDispatch = (
+  result: FleetRunSupervisorDispatchResult,
+): Extract<OrchestrationTaskStatus, "completed" | "failed" | "blocked"> | null => {
+  if (result.status === "completed") return "completed"
+  if (result.status === "failed") return "failed"
+  if (result.status === "blocked") return "blocked"
+  const terminal = [...result.lifecycle].reverse().find(event =>
+    event.status === "completed" || event.status === "failed" || event.status === "blocked"
+  )
+  if (terminal?.status === "completed") return "completed"
+  if (terminal?.status === "failed") return "failed"
+  if (terminal?.status === "blocked") return "blocked"
+  return null
+}
+
+const isoSafe = (date: Date | string): string =>
+  typeof date === "string" ? date : date.toISOString()
+
+const isCoolingDown = (account: FleetRunSupervisorAccount, now: Date): boolean => {
+  if (account.cooldownUntil === null || account.cooldownUntil === undefined) return false
+  const until = Date.parse(isoSafe(account.cooldownUntil))
+  return !Number.isNaN(until) && until > now.getTime()
+}
+
+const activeAssignmentsForRun = (store: PylonOrchestrationStore, runRef: string): number =>
+  store.listTasks().filter(task => task.spec.fleetRunRef === runRef && liveTaskStatuses.has(task.status)).length
+
+const liveClaimsForRun = (store: PylonOrchestrationStore, runRef: string, now: Date): WorkClaim[] =>
+  store.listLiveWorkClaims(now).filter(claim => claim.runRef === runRef)
+
+const activeByAccount = (claims: readonly WorkClaim[]): Map<string, number> => {
+  const counts = new Map<string, number>()
+  for (const claim of claims) counts.set(claim.workerAccountRef, (counts.get(claim.workerAccountRef) ?? 0) + 1)
+  return counts
+}
+
+const pickAccount = (
+  accounts: readonly FleetRunSupervisorAccount[],
+  activeCounts: Map<string, number>,
+  now: Date,
+): FleetRunSupervisorAccount | null => {
+  const eligible = accounts
+    .filter(account => account.advertisedCapacity > 0)
+    .filter(account => !isCoolingDown(account, now))
+    .map(account => ({
+      account,
+      free: Math.max(0, account.advertisedCapacity - (activeCounts.get(account.accountRef) ?? 0)),
+    }))
+    .filter(entry => entry.free > 0)
+    .sort((a, b) => b.free - a.free || a.account.accountRef.localeCompare(b.account.accountRef))
+  return eligible[0]?.account ?? null
+}
+
+const taskIdFor = (runRef: string, claimRef: string): string =>
+  `${runRef}.task.${claimRef.replace(/[^a-zA-Z0-9_.-]/g, "_")}`
+
+const contextIdFor = (accountRef: string, taskId: string): string =>
+  `${accountRef}.ctx.${taskId}`.replace(/[^a-zA-Z0-9_.-]/g, "_")
+
+const claimRefFor = (runRef: string, workUnitRef: string, now: Date): string =>
+  `${runRef}.claim.${workUnitRef.replace(/[^a-zA-Z0-9_.-]/g, "_")}.${now.getTime()}`
+
+const emit = async (
+  sink: FleetRunSupervisorOptions["onLifecycle"],
+  event: FleetRunSupervisorObservedEvent,
+): Promise<void> => {
+  if (sink !== undefined) await sink(event)
+}
+
+export async function tickFleetRunSupervisor(
+  options: FleetRunSupervisorOptions,
+): Promise<FleetRunSupervisorTickResult> {
+  const clock = { ...defaultClock, ...options.clock }
+  const now = clock.now()
+  const store = options.store
+  const maxSpawnPerTick = Math.min(
+    Math.max(1, Math.trunc(options.maxSpawnPerTick ?? FLEET_RUN_SUPERVISOR_MAX_SPAWN_COUNT)),
+    FLEET_RUN_SUPERVISOR_MAX_SPAWN_COUNT,
+  )
+  const claimTtlMs = options.claimTtlMs ?? 30 * 60 * 1000
+
+  store.reconcileWorkClaims({ now })
+  const run = store.reconcileFleetRun(options.runRef, now)
+  if (run.state !== "running") {
+    return {
+      activeAssignments: activeAssignmentsForRun(store, run.runRef),
+      claimed: 0,
+      dispatched: 0,
+      freeSlots: 0,
+      run,
+    }
+  }
+
+  const liveClaims = liveClaimsForRun(store, run.runRef, now)
+  const accounts = await options.capacity.accounts({ run, now })
+  const activeCounts = activeByAccount(liveClaims)
+  const activeAssignments = activeAssignmentsForRun(store, run.runRef)
+  const targetFreeSlots = Math.max(0, run.targetConcurrency - activeAssignments)
+  const advertisedFreeSlots = accounts.reduce((total, account) => {
+    if (isCoolingDown(account, now)) return total
+    return total + Math.max(0, account.advertisedCapacity - (activeCounts.get(account.accountRef) ?? 0))
+  }, 0)
+  const freeSlots = Math.min(targetFreeSlots, advertisedFreeSlots, maxSpawnPerTick)
+
+  await emit(options.onLifecycle, {
+    kind: "tick",
+    runRef: run.runRef,
+    activeAssignments,
+    freeSlots,
+  })
+
+  if (freeSlots <= 0) {
+    return { activeAssignments, claimed: 0, dispatched: 0, freeSlots, run }
+  }
+
+  const plan = await options.planner.plan({ run, now })
+  let claimed = 0
+  let dispatched = 0
+
+  for (const workUnit of plan.claimable) {
+    if (dispatched >= freeSlots) break
+    const account = pickAccount(accounts, activeCounts, now)
+    if (account === null) break
+    const claim = store.tryClaimWorkUnit({
+      claimRef: claimRefFor(run.runRef, workUnit.workUnitRef, now),
+      workUnitRef: workUnit.workUnitRef,
+      runRef: run.runRef,
+      workerAccountRef: account.accountRef,
+      ttl: claimTtlMs,
+      now,
+    })
+    if (claim === null) continue
+    claimed += 1
+    activeCounts.set(account.accountRef, (activeCounts.get(account.accountRef) ?? 0) + 1)
+
+    const taskId = taskIdFor(run.runRef, claim.claimRef)
+    const contextId = contextIdFor(account.accountRef, taskId)
+    if (store.getDispatchContext(contextId) === null) {
+      store.createDispatchContext({
+        id: contextId,
+        assigneeHandle: account.accountRef,
+        runnerKind: run.workerKind === "claude" ? "claude_agent" : "codex",
+        lastHeartbeatAt: now,
+        maxConcurrentSlots: 1,
+        now,
+      })
+    }
+    store.createTask({
+      id: taskId,
+      spec: {
+        title: workUnit.title,
+        prompt: run.objective,
+        runnerKind: run.workerKind === "claude" ? "claude_agent" : "codex",
+        ...(workUnit.repo === undefined ? {} : { repo: workUnit.repo }),
+        issueRef: workUnit.number === undefined ? workUnit.workUnitRef : `#${workUnit.number}`,
+        fleetRunRef: run.runRef,
+      },
+      status: "ready",
+      now,
+    })
+    store.markDispatched(taskId, contextId, now)
+    store.updateWorkClaimState(claim.claimRef, "in_progress", now)
+
+    const result = await options.runner.dispatch({ accountRef: account.accountRef, claim, run, taskId, workUnit })
+    dispatched += 1
+
+    for (const event of result.lifecycle) {
+      await emit(options.onLifecycle, {
+        kind: "lifecycle",
+        runRef: run.runRef,
+        taskId,
+        claimRef: claim.claimRef,
+        accountRef: account.accountRef,
+        event,
+      })
+    }
+
+    const terminalStatus = terminalStatusForDispatch(result)
+    if (terminalStatus === null) {
+      await emit(options.onLifecycle, {
+        kind: "dispatch",
+        runRef: run.runRef,
+        taskId,
+        claimRef: claim.claimRef,
+        workUnitRef: workUnit.workUnitRef,
+        accountRef: account.accountRef,
+        assignmentRef: result.assignmentRef,
+        status: result.status,
+      })
+      continue
+    }
+
+    store.recordWorkerDone({
+      contextId,
+      taskId,
+      status: terminalStatus,
+      result: JSON.stringify({
+        assignmentRef: result.assignmentRef,
+        summary: result.summary ?? null,
+      }),
+      now,
+    })
+    store.updateWorkClaimState(
+      claim.claimRef,
+      terminalStatus === "completed" ? "closeout" : "released",
+      now,
+    )
+    await emit(options.onLifecycle, {
+      kind: "dispatch",
+      runRef: run.runRef,
+      taskId,
+      claimRef: claim.claimRef,
+      workUnitRef: workUnit.workUnitRef,
+      accountRef: account.accountRef,
+      assignmentRef: result.assignmentRef,
+      status: result.status,
+    })
+  }
+
+  const reconciled = store.reconcileFleetRun(run.runRef, clock.now())
+  if (reconciled.state === "completed") {
+    await emit(options.onLifecycle, { kind: "completed", runRef: run.runRef, reason: "drained" })
+  }
+  if (
+    reconciled.state === "running" &&
+    plan.claimable.length === 0 &&
+    activeAssignmentsForRun(store, run.runRef) === 0 &&
+    reconciled.refillPolicy.stopCondition === "backlog_empty"
+  ) {
+    const completed = store.updateFleetRunState(run.runRef, "completed", clock.now())
+    await emit(options.onLifecycle, { kind: "completed", runRef: run.runRef, reason: "backlog_empty" })
+    return {
+      activeAssignments: activeAssignmentsForRun(store, run.runRef),
+      claimed,
+      dispatched,
+      freeSlots,
+      run: completed,
+    }
+  }
+
+  return {
+    activeAssignments: activeAssignmentsForRun(store, run.runRef),
+    claimed,
+    dispatched,
+    freeSlots,
+    run: reconciled,
+  }
+}
+
+export function makeFleetRunSupervisor(
+  options: FleetRunSupervisorOptions,
+): Effect.Effect<FleetRunSupervisorHandle, FleetRunSupervisorError> {
+  return Effect.sync(() => {
+    const existing = activeSupervisors.get(options.pylonRef)
+    if (existing !== undefined && existing !== options.runRef) {
+      throw new FleetRunSupervisorError(`fleet run supervisor already active for pylon ${options.pylonRef}: ${existing}`)
+    }
+    activeSupervisors.set(options.pylonRef, options.runRef)
+    let stopped = false
+    return {
+      pylonRef: options.pylonRef,
+      runRef: options.runRef,
+      stop: () => Effect.sync(() => {
+        stopped = true
+        if (activeSupervisors.get(options.pylonRef) === options.runRef) activeSupervisors.delete(options.pylonRef)
+      }),
+      tick: () => Effect.tryPromise({
+        try: async () => {
+          if (stopped) throw new FleetRunSupervisorError(`fleet run supervisor stopped: ${options.runRef}`)
+          return await tickFleetRunSupervisor(options)
+        },
+        catch: (error: unknown) => error instanceof FleetRunSupervisorError
+          ? error
+          : new FleetRunSupervisorError("fleet run supervisor tick failed", error),
+      }),
+    }
+  })
+}
+
+export function startFleetRunSupervisor(
+  options: FleetRunSupervisorOptions,
+): Effect.Effect<FleetRunSupervisorHandle, FleetRunSupervisorError, Scope.Scope> {
+  return Effect.gen(function* () {
+    const handle = yield* makeFleetRunSupervisor(options)
+    const scope = yield* Effect.scope
+    yield* Scope.addFinalizer(scope, handle.stop())
+    yield* Effect.forkScoped(
+      Effect.forever(
+        Effect.gen(function* () {
+          yield* handle.tick()
+          yield* Effect.promise(() => ({ ...defaultClock, ...options.clock }).sleep(options.tickIntervalMs ?? 1000))
+        }),
+      ),
+    )
+    return handle
+  })
+}

--- a/clients/khala-code-desktop/tests/fleet-run-supervisor.test.ts
+++ b/clients/khala-code-desktop/tests/fleet-run-supervisor.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test"
 import { Database } from "bun:sqlite"
-import { Effect } from "effect"
+import { Effect, Exit, Scope } from "effect"
 
 import {
   createPylonOrchestrationStore,
@@ -10,6 +10,7 @@ import { fixtureCandidates, planFixtureWork, planWorkCandidates } from "../../..
 import {
   FLEET_RUN_SUPERVISOR_MAX_SPAWN_COUNT,
   makeFleetRunSupervisor,
+  startFleetRunSupervisor,
   tickFleetRunSupervisor,
   type FleetRunSupervisorAccount,
   type FleetRunSupervisorObservedEvent,
@@ -173,6 +174,107 @@ describe("FleetRunSupervisor", () => {
     expect(observed).toContainEqual({ kind: "completed", runRef: run.runRef, reason: "drained" })
   })
 
+  test("keeps refilling target 2 over 4 fixture units until all work drains", async () => {
+    const { store, run } = createStoreWithRun({ targetConcurrency: 2, workUnits: 4 })
+    const dispatched: string[] = []
+    const options = {
+      store,
+      pylonRef: "pylon.owner",
+      runRef: run.runRef,
+      planner: fixturePlannerWithClaims(store, 4),
+      runner: {
+        dispatch: async input => {
+          dispatched.push(input.workUnit.workUnitRef)
+          return {
+            assignmentRef: `assignment.${input.claim.claimRef}`,
+            lifecycle: [{ event: "assignment.closeout", status: "completed" }],
+            status: "completed" as const,
+          }
+        },
+      },
+      capacity: capacity([{ accountRef: "codex", advertisedCapacity: 2 }]),
+      clock: { now: () => fixedNow },
+    }
+
+    const first = await tickFleetRunSupervisor(options)
+    const second = await tickFleetRunSupervisor(options)
+    const third = await tickFleetRunSupervisor(options)
+
+    expect(first.dispatched).toBe(2)
+    expect(second.dispatched).toBe(2)
+    expect(third.dispatched).toBe(0)
+    expect(new Set(dispatched).size).toBe(4)
+    expect(store.listTasks("completed")).toHaveLength(4)
+    expect(store.getFleetRun(run.runRef)?.state).toBe("completed")
+    expect(store.getFleetRun(run.runRef)?.counters.workUnitsTotal).toBe(4)
+  })
+
+  test("closeout claims do not consume account capacity on the next tick", async () => {
+    const { store, run } = createStoreWithRun({ targetConcurrency: 1, workUnits: 2 })
+    const dispatched: string[] = []
+    const options = {
+      store,
+      pylonRef: "pylon.owner",
+      runRef: run.runRef,
+      planner: fixturePlannerWithClaims(store, 2),
+      runner: {
+        dispatch: async input => {
+          dispatched.push(input.workUnit.workUnitRef)
+          return {
+            assignmentRef: `assignment.${input.claim.claimRef}`,
+            lifecycle: [{ event: "assignment.closeout", status: "completed" }],
+            status: "completed" as const,
+          }
+        },
+      },
+      capacity: capacity([{ accountRef: "codex", advertisedCapacity: 1 }]),
+      clock: { now: () => fixedNow },
+    }
+
+    const first = await tickFleetRunSupervisor(options)
+    const second = await tickFleetRunSupervisor(options)
+
+    expect(first.dispatched).toBe(1)
+    expect(second.freeSlots).toBe(1)
+    expect(second.dispatched).toBe(1)
+    expect(dispatched).toHaveLength(2)
+    expect(store.listWorkClaims({ runRef: run.runRef, state: "closeout" })).toHaveLength(2)
+  })
+
+  test("throwing dispatch releases the claim, fails the unit, and later ticks continue", async () => {
+    const { store, run } = createStoreWithRun({ targetConcurrency: 1, workUnits: 2 })
+    let calls = 0
+    const options = {
+      store,
+      pylonRef: "pylon.owner",
+      runRef: run.runRef,
+      planner: fixturePlannerWithClaims(store, 2),
+      runner: {
+        dispatch: async input => {
+          calls += 1
+          if (calls === 1) throw new Error("dispatch exploded")
+          return {
+            assignmentRef: `assignment.${input.claim.claimRef}`,
+            lifecycle: [{ event: "assignment.closeout", status: "completed" }],
+            status: "completed" as const,
+          }
+        },
+      },
+      capacity: capacity([{ accountRef: "codex", advertisedCapacity: 1 }]),
+      clock: { now: () => fixedNow },
+    }
+
+    const first = await tickFleetRunSupervisor(options)
+    const second = await tickFleetRunSupervisor(options)
+
+    expect(first.dispatched).toBe(1)
+    expect(second.dispatched).toBe(1)
+    expect(calls).toBe(2)
+    expect(store.listWorkClaims({ runRef: run.runRef }).map(claim => claim.state)).toEqual(["released", "closeout"])
+    expect(store.listTasks("failed")).toHaveLength(1)
+    expect(store.listTasks("completed")).toHaveLength(1)
+  })
+
   test("refuses a second active supervisor for the same Pylon", async () => {
     const first = createStoreWithRun({ runRef: "fleet_run.one", targetConcurrency: 1 })
     const second = createStoreWithRun({ runRef: "fleet_run.two", targetConcurrency: 1 })
@@ -198,5 +300,87 @@ describe("FleetRunSupervisor", () => {
     }))).rejects.toThrow(/already active/)
 
     await Effect.runPromise(firstHandle.stop())
+  })
+
+  test("refuses a duplicate active supervisor for the same run", async () => {
+    const first = createStoreWithRun({ runRef: "fleet_run.same", targetConcurrency: 1 })
+
+    const firstHandle = await Effect.runPromise(makeFleetRunSupervisor({
+      store: first.store,
+      pylonRef: "pylon.owner.same",
+      runRef: first.run.runRef,
+      planner: fixturePlanner(1),
+      runner: acceptingRunner(),
+      capacity: capacity([{ accountRef: "codex", advertisedCapacity: 1 }]),
+      clock: { now: () => fixedNow },
+    }))
+
+    await expect(Effect.runPromise(makeFleetRunSupervisor({
+      store: first.store,
+      pylonRef: "pylon.owner.same",
+      runRef: first.run.runRef,
+      planner: fixturePlanner(1),
+      runner: acceptingRunner(),
+      capacity: capacity([{ accountRef: "codex", advertisedCapacity: 1 }]),
+      clock: { now: () => fixedNow },
+    }))).rejects.toThrow(/already active/)
+
+    await Effect.runPromise(firstHandle.stop())
+  })
+
+  test("start supervisor ticks until scope close and frees the registry", async () => {
+    const { store, run } = createStoreWithRun({ runRef: "fleet_run.scoped", targetConcurrency: 1, workUnits: 1 })
+    let tickCount = 0
+    let scopeClosed = false
+    const scope = Effect.runSync(Scope.make())
+
+    const handle = await Effect.runPromise(Effect.provideService(
+      startFleetRunSupervisor({
+        store,
+        pylonRef: "pylon.owner.scoped",
+        runRef: run.runRef,
+        planner: fixturePlannerWithClaims(store, 1),
+        runner: acceptingRunner(),
+        capacity: capacity([{ accountRef: "codex", advertisedCapacity: 1 }]),
+        tickIntervalMs: 1,
+        clock: {
+          now: () => fixedNow,
+          sleep: () => Promise.resolve(),
+        },
+        onLifecycle: event => {
+          if (event.kind === "tick" && !scopeClosed) tickCount += 1
+        },
+      }),
+      Scope.Scope,
+      scope,
+    ))
+
+    await new Promise<void>((resolve, reject) => {
+      const started = Date.now()
+      const poll = () => {
+        if (tickCount > 0) return resolve()
+        if (Date.now() - started > 1000) return reject(new Error("supervisor did not tick"))
+        setTimeout(poll, 1)
+      }
+      poll()
+    })
+    await Effect.runPromise(Scope.close(scope, Exit.void))
+    scopeClosed = true
+    const ticksAtClose = tickCount
+    await new Promise(resolve => setTimeout(resolve, 5))
+
+    expect(ticksAtClose).toBeGreaterThan(0)
+    expect(tickCount).toBe(ticksAtClose)
+    const replacementHandle = await Effect.runPromise(makeFleetRunSupervisor({
+      store,
+      pylonRef: "pylon.owner.scoped",
+      runRef: run.runRef,
+      planner: fixturePlanner(1),
+      runner: acceptingRunner(),
+      capacity: capacity([{ accountRef: "codex", advertisedCapacity: 1 }]),
+      clock: { now: () => fixedNow },
+    }))
+    expect(replacementHandle.pylonRef).toBe(handle.pylonRef)
+    await Effect.runPromise(replacementHandle.stop())
   })
 })

--- a/clients/khala-code-desktop/tests/fleet-run-supervisor.test.ts
+++ b/clients/khala-code-desktop/tests/fleet-run-supervisor.test.ts
@@ -14,6 +14,7 @@ import {
   tickFleetRunSupervisor,
   type FleetRunSupervisorAccount,
   type FleetRunSupervisorObservedEvent,
+  type FleetRunSupervisorDispatchInput,
   type FleetRunSupervisorRunner,
 } from "../src/bun/fleet-run-supervisor.js"
 
@@ -60,7 +61,7 @@ const capacity = (accounts: readonly FleetRunSupervisorAccount[]) => ({
 })
 
 const acceptingRunner = (dispatched: string[] = []): FleetRunSupervisorRunner => ({
-  dispatch: async input => {
+  dispatch: async (input: FleetRunSupervisorDispatchInput) => {
     dispatched.push(input.workUnit.workUnitRef)
     return {
       assignmentRef: `assignment.${input.claim.claimRef}`,
@@ -134,7 +135,7 @@ describe("FleetRunSupervisor", () => {
       runRef: run.runRef,
       planner: fixturePlannerWithClaims(store, 3),
       runner: {
-        dispatch: async input => ({
+        dispatch: async (input: FleetRunSupervisorDispatchInput) => ({
           assignmentRef: `assignment.${input.claim.claimRef}`,
           lifecycle: [
             { event: "assignment.accepted", status: "accepted" },
@@ -183,7 +184,7 @@ describe("FleetRunSupervisor", () => {
       runRef: run.runRef,
       planner: fixturePlannerWithClaims(store, 4),
       runner: {
-        dispatch: async input => {
+        dispatch: async (input: FleetRunSupervisorDispatchInput) => {
           dispatched.push(input.workUnit.workUnitRef)
           return {
             assignmentRef: `assignment.${input.claim.claimRef}`,
@@ -218,7 +219,7 @@ describe("FleetRunSupervisor", () => {
       runRef: run.runRef,
       planner: fixturePlannerWithClaims(store, 2),
       runner: {
-        dispatch: async input => {
+        dispatch: async (input: FleetRunSupervisorDispatchInput) => {
           dispatched.push(input.workUnit.workUnitRef)
           return {
             assignmentRef: `assignment.${input.claim.claimRef}`,
@@ -250,7 +251,7 @@ describe("FleetRunSupervisor", () => {
       runRef: run.runRef,
       planner: fixturePlannerWithClaims(store, 2),
       runner: {
-        dispatch: async input => {
+        dispatch: async (input: FleetRunSupervisorDispatchInput) => {
           calls += 1
           if (calls === 1) throw new Error("dispatch exploded")
           return {

--- a/clients/khala-code-desktop/tests/fleet-run-supervisor.test.ts
+++ b/clients/khala-code-desktop/tests/fleet-run-supervisor.test.ts
@@ -1,0 +1,202 @@
+import { describe, expect, test } from "bun:test"
+import { Database } from "bun:sqlite"
+import { Effect } from "effect"
+
+import {
+  createPylonOrchestrationStore,
+  type FleetRun,
+} from "../../../apps/pylon/src/orchestration/store.js"
+import { fixtureCandidates, planFixtureWork, planWorkCandidates } from "../../../apps/pylon/src/orchestration/work-planner.js"
+import {
+  FLEET_RUN_SUPERVISOR_MAX_SPAWN_COUNT,
+  makeFleetRunSupervisor,
+  tickFleetRunSupervisor,
+  type FleetRunSupervisorAccount,
+  type FleetRunSupervisorObservedEvent,
+  type FleetRunSupervisorRunner,
+} from "../src/bun/fleet-run-supervisor.js"
+
+const fixedNow = new Date("2026-07-01T12:00:00.000Z")
+
+function createStoreWithRun(input: {
+  readonly runRef?: string
+  readonly targetConcurrency: number
+  readonly workUnits?: number
+}) {
+  const store = createPylonOrchestrationStore(new Database(":memory:"))
+  const run = store.createFleetRun({
+    runRef: input.runRef ?? "fleet_run.test",
+    objective: "Run fixture fleet units.",
+    workSource: "fixture",
+    targetConcurrency: input.targetConcurrency,
+    workerKind: "codex",
+    state: "running",
+    startedAt: fixedNow,
+    now: fixedNow,
+    counters: { workUnitsTotal: input.workUnits ?? input.targetConcurrency },
+  })
+  return { store, run }
+}
+
+const fixturePlanner = (count: number) => ({
+  plan: async (input: { readonly run: FleetRun; readonly now: Date }) =>
+    planFixtureWork({ kind: "fixture", count }, { now: input.now }),
+})
+
+const fixturePlannerWithClaims = (
+  store: ReturnType<typeof createPylonOrchestrationStore>,
+  count: number,
+) => ({
+  plan: async (input: { readonly now: Date }) =>
+    planWorkCandidates("fixture", fixtureCandidates({ kind: "fixture", count }), {
+      now: input.now,
+      claimRegistry: store,
+    }),
+})
+
+const capacity = (accounts: readonly FleetRunSupervisorAccount[]) => ({
+  accounts: async () => accounts,
+})
+
+const acceptingRunner = (dispatched: string[] = []): FleetRunSupervisorRunner => ({
+  dispatch: async input => {
+    dispatched.push(input.workUnit.workUnitRef)
+    return {
+      assignmentRef: `assignment.${input.claim.claimRef}`,
+      lifecycle: [{ event: "assignment.accepted", status: "accepted" }],
+      status: "accepted",
+    }
+  },
+})
+
+describe("FleetRunSupervisor", () => {
+  test("refills arbitrary target concurrency across ticks while keeping MAX_SPAWN_COUNT per tick", async () => {
+    const { store, run } = createStoreWithRun({ targetConcurrency: 25, workUnits: 25 })
+    const dispatched: string[] = []
+
+    const options = {
+      store,
+      pylonRef: "pylon.owner",
+      runRef: run.runRef,
+      planner: fixturePlannerWithClaims(store, 25),
+      runner: acceptingRunner(dispatched),
+      capacity: capacity([
+        { accountRef: "codex", advertisedCapacity: 10 },
+        { accountRef: "codex-2", advertisedCapacity: 10 },
+        { accountRef: "codex-3", advertisedCapacity: 10 },
+      ]),
+      clock: { now: () => fixedNow },
+    }
+
+    const first = await tickFleetRunSupervisor(options)
+    const second = await tickFleetRunSupervisor(options)
+    const third = await tickFleetRunSupervisor(options)
+
+    expect(first.dispatched).toBe(FLEET_RUN_SUPERVISOR_MAX_SPAWN_COUNT)
+    expect(second.dispatched).toBe(FLEET_RUN_SUPERVISOR_MAX_SPAWN_COUNT)
+    expect(third.dispatched).toBe(5)
+    expect(store.listTasks("dispatched")).toHaveLength(25)
+    expect(new Set(dispatched).size).toBe(25)
+    expect(store.getFleetRun(run.runRef)?.counters.activeAssignments).toBe(25)
+  })
+
+  test("respects advertised account capacity and cooldowns", async () => {
+    const { store, run } = createStoreWithRun({ targetConcurrency: 6, workUnits: 6 })
+
+    const result = await tickFleetRunSupervisor({
+      store,
+      pylonRef: "pylon.owner",
+      runRef: run.runRef,
+      planner: fixturePlannerWithClaims(store, 6),
+      runner: acceptingRunner(),
+      capacity: capacity([
+        { accountRef: "codex", advertisedCapacity: 3, cooldownUntil: "2026-07-01T12:10:00.000Z" },
+        { accountRef: "codex-2", advertisedCapacity: 2 },
+      ]),
+      clock: { now: () => fixedNow },
+    })
+
+    expect(result.dispatched).toBe(2)
+    expect(store.listWorkClaims({ runRef: run.runRef }).map(claim => claim.workerAccountRef)).toEqual([
+      "codex-2",
+      "codex-2",
+    ])
+  })
+
+  test("streams terminal lifecycle into counters and drains cleanly when backlog is empty", async () => {
+    const { store, run } = createStoreWithRun({ targetConcurrency: 3, workUnits: 3 })
+    const observed: FleetRunSupervisorObservedEvent[] = []
+
+    await tickFleetRunSupervisor({
+      store,
+      pylonRef: "pylon.owner",
+      runRef: run.runRef,
+      planner: fixturePlannerWithClaims(store, 3),
+      runner: {
+        dispatch: async input => ({
+          assignmentRef: `assignment.${input.claim.claimRef}`,
+          lifecycle: [
+            { event: "assignment.accepted", status: "accepted" },
+            { event: "assignment.closeout", status: "completed" },
+          ],
+          status: "completed",
+          summary: "fixture completed",
+        }),
+      },
+      capacity: capacity([{ accountRef: "codex", advertisedCapacity: 3 }]),
+      clock: { now: () => fixedNow },
+      onLifecycle: event => {
+        observed.push(event)
+      },
+    })
+    const drained = await tickFleetRunSupervisor({
+      store,
+      pylonRef: "pylon.owner",
+      runRef: run.runRef,
+      planner: fixturePlannerWithClaims(store, 3),
+      runner: acceptingRunner(),
+      capacity: capacity([{ accountRef: "codex", advertisedCapacity: 3 }]),
+      clock: { now: () => fixedNow },
+      onLifecycle: event => {
+        observed.push(event)
+      },
+    })
+
+    expect(drained.run.state).toBe("completed")
+    expect(store.getFleetRun(run.runRef)?.counters).toMatchObject({
+      activeAssignments: 0,
+      completedAssignments: 3,
+      failedAssignments: 0,
+      blockedAssignments: 0,
+    })
+    expect(observed.filter(event => event.kind === "lifecycle")).toHaveLength(6)
+    expect(observed).toContainEqual({ kind: "completed", runRef: run.runRef, reason: "drained" })
+  })
+
+  test("refuses a second active supervisor for the same Pylon", async () => {
+    const first = createStoreWithRun({ runRef: "fleet_run.one", targetConcurrency: 1 })
+    const second = createStoreWithRun({ runRef: "fleet_run.two", targetConcurrency: 1 })
+
+    const firstHandle = await Effect.runPromise(makeFleetRunSupervisor({
+      store: first.store,
+      pylonRef: "pylon.owner",
+      runRef: first.run.runRef,
+      planner: fixturePlanner(1),
+      runner: acceptingRunner(),
+      capacity: capacity([{ accountRef: "codex", advertisedCapacity: 1 }]),
+      clock: { now: () => fixedNow },
+    }))
+
+    await expect(Effect.runPromise(makeFleetRunSupervisor({
+      store: second.store,
+      pylonRef: "pylon.owner",
+      runRef: second.run.runRef,
+      planner: fixturePlanner(1),
+      runner: acceptingRunner(),
+      capacity: capacity([{ accountRef: "codex", advertisedCapacity: 1 }]),
+      clock: { now: () => fixedNow },
+    }))).rejects.toThrow(/already active/)
+
+    await Effect.runPromise(firstHandle.stop())
+  })
+})


### PR DESCRIPTION
## Summary

- Adds a Khala Code Desktop Bun-host FleetRunSupervisor with an Effect scoped starter and deterministic tick API.
- Refills arbitrary target concurrency across ticks while keeping the per-tick spawn bound at 10, claims work through the Pylon claim registry, respects per-account capacity/cooldowns, and streams lifecycle/counter events.
- Adds fixture tests with a mocked Pylon runner for refill, capacity/cooldown handling, lifecycle counters, drain completion, and one-supervisor-per-Pylon refusal.
- Cleans exact-optional typing in the directly used Pylon orchestration store/planner path so the desktop package verify is green.

Closes #7829

## Verification

- `bun test tests/fleet-run-supervisor.test.ts` from `clients/khala-code-desktop`
- `bun run verify` from `clients/khala-code-desktop`

Note: the requested opaque verifier `command.public.pylon_khala.verify.d32c71ee8e1025e99460d008` was not resolvable to argv from local checkout metadata or the public issue body. The package-level verifier above is the relevant green verification for this change.
