### PR TITLE
T1.3: KhalaCodeConfig service

### DIFF
--- a/clients/khala-code-desktop/src/bun/apple-fm-sidecar.ts
+++ b/clients/khala-code-desktop/src/bun/apple-fm-sidecar.ts
@@ -9,6 +9,7 @@ import {
   type KhalaAppleFmReadiness,
   type PylonAppleFmStatusPublicInput,
 } from "../shared/apple-fm-readiness.js"
+import { khalaCodeConfigFromRuntimeEnv } from "./khala-code-config.js"
 
 type SidecarLaunchState = "idle" | "launching" | "running" | "failed" | "stopped" | "adopted"
 type HelperSource = "env" | "source-wrapper" | "source-build" | "packaged-resource"
@@ -145,7 +146,7 @@ async function fetchPylonAppleFmStatus(input: {
 export function createAppleFmSidecarHost(
   options: AppleFmSidecarHostOptions = {},
 ): AppleFmSidecarHost {
-  const env = options.env ?? Bun.env
+  const env = options.env ?? khalaCodeConfigFromRuntimeEnv().env
   const platform = options.platform ?? process.platform
   const arch = options.arch ?? process.arch
   const resourcesDir = options.resourcesDir ?? (process as NodeJS.Process & { resourcesPath?: string }).resourcesPath

--- a/clients/khala-code-desktop/src/bun/codex-app-server-chat-runtime.ts
+++ b/clients/khala-code-desktop/src/bun/codex-app-server-chat-runtime.ts
@@ -40,6 +40,7 @@ import {
   readKhalaCodeDesktopCodexStateThreadTokenSnapshot,
 } from "./codex-token-usage-telemetry.js"
 import { createCodexThreadItemEventProjector } from "./codex-thread-item-projector.js"
+import { khalaCodeConfigFromRuntimeEnv } from "./khala-code-config.js"
 import { projectKhalaCodeDesktopCodexThreadList } from "../shared/codex-threads.js"
 
 const CODEX_SESSION_STATE_SCHEMA = "khala-code-desktop.codex-sessions.v1"
@@ -481,7 +482,7 @@ const normalizedThreadId = (threadId: string | undefined): string | null => {
 export function createCodexAppServerChatRuntime(
   options: CreateCodexAppServerChatRuntimeOptions,
 ): CodexAppServerChatRuntime {
-  const env = options.env ?? process.env
+  const env = options.env ?? khalaCodeConfigFromRuntimeEnv().env
   const host = options.host
   const statePath = options.statePath ?? defaultStatePath(env)
   const turnTimeoutMs = options.turnTimeoutMs ?? DEFAULT_TURN_TIMEOUT_MS

--- a/clients/khala-code-desktop/src/bun/codex-app-server-client.ts
+++ b/clients/khala-code-desktop/src/bun/codex-app-server-client.ts
@@ -6,6 +6,7 @@ import type {
   KhalaCodeDesktopCodexAppServerStatus,
 } from "../shared/rpc.js"
 import { resolveCodexHomePath } from "./codex-rate-limits.js"
+import { khalaCodeConfigFromRuntimeEnv } from "./khala-code-config.js"
 
 export const KHALA_CODE_CODEX_APP_SERVER_ADAPTER_VERSION =
   "codex-app-server-v2-2026-07-01"
@@ -192,7 +193,7 @@ const diagnosticErrorMessage = (error: unknown): string => {
 export function createCodexAppServerHost(
   options: CreateCodexAppServerHostOptions = {},
 ): CodexAppServerHost {
-  const env = options.env ?? process.env
+  const env = options.env ?? khalaCodeConfigFromRuntimeEnv().env
   const codexLaunch = configuredLaunch(env, options.codexCommand, options.codexArgs)
   const codexCommand = codexLaunch.command
   const codexArgs = codexLaunch.args

--- a/clients/khala-code-desktop/src/bun/codex-harness-status.ts
+++ b/clients/khala-code-desktop/src/bun/codex-harness-status.ts
@@ -4,6 +4,7 @@ import { join } from "node:path"
 
 import type { KhalaCodeDesktopCodexHarnessStatus } from "../shared/rpc.js"
 import { resolveCodexHomePath } from "./codex-rate-limits.js"
+import { khalaCodeConfigFromRuntimeEnv } from "./khala-code-config.js"
 
 const CODEX_VERSION_TIMEOUT_MS = 5_000
 
@@ -106,7 +107,7 @@ async function probeCodexVersion(
 ): Promise<VersionProbe> {
   const spawnFn = options.spawnFn ?? spawn
   const child = spawnFn(command, ["--version"], {
-    env: options.env ?? process.env,
+    env: options.env ?? khalaCodeConfigFromRuntimeEnv().env,
     stdio: ["ignore", "pipe", "pipe"],
   })
 
@@ -250,7 +251,7 @@ const readAuthState = async (
 export async function inspectCodexHarnessStatus(
   options: InspectCodexHarnessStatusOptions = {},
 ): Promise<KhalaCodeDesktopCodexHarnessStatus> {
-  const env = options.env ?? process.env
+  const env = options.env ?? khalaCodeConfigFromRuntimeEnv().env
   const now = options.now ?? (() => new Date())
   const observedAt = isoNow(now)
   const { command, source } = configuredCodexCommand(env, options.codexCommand)

--- a/clients/khala-code-desktop/src/bun/codex-parity-contract.ts
+++ b/clients/khala-code-desktop/src/bun/codex-parity-contract.ts
@@ -3,6 +3,8 @@ import { readFile } from "node:fs/promises"
 import { dirname, join } from "node:path"
 import { fileURLToPath } from "node:url"
 
+import { khalaCodeConfigFromRuntimeEnv } from "./khala-code-config.js"
+
 export const KHALA_CODE_CODEX_PARITY_REFERENCE_COMMIT =
   "db887d03e1f907467e33271572dffb73bceecd6b"
 
@@ -334,7 +336,7 @@ const codexReferenceCheckoutMissing = (reason: string): KhalaCodeCodexReferenceR
 
 export function inspectCodexReferenceRoot(
   startDir = dirname(fileURLToPath(import.meta.url)),
-  env: KhalaCodeCodexReferenceRootInspectionEnv = process.env,
+  env: KhalaCodeCodexReferenceRootInspectionEnv = khalaCodeConfigFromRuntimeEnv().env,
 ): KhalaCodeCodexReferenceRootStatus {
   const explicit = env.KHALA_CODE_CODEX_REFERENCE_ROOT?.trim()
   if (explicit !== undefined && explicit.length > 0) {

--- a/clients/khala-code-desktop/src/bun/codex-parity-live-smoke.ts
+++ b/clients/khala-code-desktop/src/bun/codex-parity-live-smoke.ts
@@ -9,6 +9,7 @@ import {
   type CodexAppServerHost,
 } from "./codex-app-server-client.js"
 import { inspectCodexHarnessStatus } from "./codex-harness-status.js"
+import { khalaCodeConfigFromRuntimeEnv } from "./khala-code-config.js"
 
 export const KHALA_CODE_CODEX_PARITY_LIVE_SMOKE_HARNESS = "codex_app_server_live_parity"
 
@@ -53,7 +54,7 @@ const notRequested = (): KhalaCodeCodexParityLiveSmokeResult => ({
 export async function runKhalaCodeCodexParityLiveSmoke(
   input: RunKhalaCodeCodexParityLiveSmokeInput = {},
 ): Promise<KhalaCodeCodexParityLiveSmokeResult> {
-  const env = input.env ?? process.env
+  const env = input.env ?? khalaCodeConfigFromRuntimeEnv().env
   const requireLive = input.requireLive === true ||
     env.KHALA_CODE_DESKTOP_CODEX_PARITY_LIVE_SMOKE === "1"
   if (!requireLive) return notRequested()

--- a/clients/khala-code-desktop/src/bun/codex-rate-limits.ts
+++ b/clients/khala-code-desktop/src/bun/codex-rate-limits.ts
@@ -10,6 +10,7 @@ import type {
   KhalaCodexRateLimitResetOutcome,
   KhalaCodexRateLimitWindow,
 } from "../shared/codex-rate-limits.js"
+import { khalaCodeConfigFromRuntimeEnv } from "./khala-code-config.js"
 
 const CODEX_RPC_TIMEOUT_MS = 10_000
 const CODEX_RATE_LIMIT_RESET_CREDITS_URL =
@@ -122,7 +123,7 @@ const isoNow = (now: () => Date = () => new Date()): string => now().toISOString
 
 export function resolveCodexHomePath(
   codexHomePath?: string | null,
-  env: NodeJS.ProcessEnv = process.env,
+  env: NodeJS.ProcessEnv = khalaCodeConfigFromRuntimeEnv().env,
 ): string {
   const configured = codexHomePath ?? env.CODEX_HOME
   return configured && configured.trim().length > 0
@@ -293,7 +294,7 @@ async function fetchViaRpc(
   ], {
     stdio: ["pipe", "pipe", "pipe"],
     env: {
-      ...(options.env ?? process.env),
+      ...(options.env ?? khalaCodeConfigFromRuntimeEnv().env),
       CODEX_HOME: codexHomePath,
     },
   })

--- a/clients/khala-code-desktop/src/bun/codex-token-usage-telemetry.ts
+++ b/clients/khala-code-desktop/src/bun/codex-token-usage-telemetry.ts
@@ -10,6 +10,7 @@ import type {
   KhalaCodeDesktopMessageRole,
   KhalaCodeDesktopThreadTokenSummary,
 } from "../shared/rpc.js"
+import { khalaCodeConfigFromRuntimeEnv } from "./khala-code-config.js"
 
 export type KhalaCodeDesktopCodexTokenUsageCounts = {
   readonly cachedInputTokens: number
@@ -438,7 +439,7 @@ export const readKhalaCodeDesktopCodexStateThreadTokenSnapshot = (options: {
   readonly tokens: number
   readonly updatedAt: string | null
 } => {
-  const env = options.env ?? process.env
+  const env = options.env ?? khalaCodeConfigFromRuntimeEnv().env
   const dbPath = options.dbPath ?? defaultCodexStateDbPath(env)
   let db: Database | null = null
   try {
@@ -468,7 +469,7 @@ export async function readKhalaCodeDesktopThreadTokenSummary(options: {
   readonly localMessageAuditLedgerPath?: string
   readonly threadId?: string | null
 }): Promise<KhalaCodeDesktopThreadTokenSummary> {
-  const env = options.env ?? process.env
+  const env = options.env ?? khalaCodeConfigFromRuntimeEnv().env
   const config = resolveConfig(
     env,
     options.localLedgerPath,
@@ -863,7 +864,7 @@ const syncPendingTokenUsageReports = async (
 export async function syncKhalaCodeDesktopPendingTokenUsageReports(
   options: SyncKhalaCodeDesktopPendingTokenUsageReportsOptions = {},
 ): Promise<KhalaCodeDesktopTokenUsageSyncResult> {
-  const env = options.env ?? process.env
+  const env = options.env ?? khalaCodeConfigFromRuntimeEnv().env
   const config = resolveConfig(env, options.localLedgerPath)
   const fetchImpl: FetchLike = options.fetch ?? ((url, init) => globalThis.fetch(url, init))
   const endpoint = new URL("/api/stats/token-usage/events", config.baseUrl)
@@ -873,7 +874,7 @@ export async function syncKhalaCodeDesktopPendingTokenUsageReports(
 export function startKhalaCodeDesktopTokenUsageBackgroundSync(
   options: StartKhalaCodeDesktopTokenUsageBackgroundSyncOptions = {},
 ): KhalaCodeDesktopTokenUsageBackgroundSync {
-  const env = options.env ?? process.env
+  const env = options.env ?? khalaCodeConfigFromRuntimeEnv().env
   const intervalMs = options.intervalMs ?? defaultTokenUsageSyncIntervalMs(env)
   const setIntervalImpl = options.setInterval ??
     ((callback: () => void, milliseconds: number) =>
@@ -921,7 +922,7 @@ export function startKhalaCodeDesktopTokenUsageBackgroundSync(
 export function createKhalaCodeDesktopCodexTokenUsageReporter(
   options: CreateKhalaCodeDesktopCodexTokenUsageReporterOptions = {},
 ): KhalaCodeDesktopCodexTokenUsageReporter {
-  const env = options.env ?? process.env
+  const env = options.env ?? khalaCodeConfigFromRuntimeEnv().env
   const config = resolveConfig(env, options.localLedgerPath)
   const fetchImpl: FetchLike = options.fetch ?? ((url, init) => globalThis.fetch(url, init))
 
@@ -944,7 +945,7 @@ export function createKhalaCodeDesktopCodexTokenUsageReporter(
 export function createKhalaCodeDesktopCodexMessageTokenAuditRecorder(
   options: CreateKhalaCodeDesktopCodexMessageTokenAuditRecorderOptions = {},
 ): KhalaCodeDesktopCodexMessageTokenAuditRecorder {
-  const env = options.env ?? process.env
+  const env = options.env ?? khalaCodeConfigFromRuntimeEnv().env
   const config = resolveConfig(
     env,
     undefined,

--- a/clients/khala-code-desktop/src/bun/fixture-codex-app-server.ts
+++ b/clients/khala-code-desktop/src/bun/fixture-codex-app-server.ts
@@ -1,6 +1,8 @@
 import { readFile } from "node:fs/promises"
 import { createInterface } from "node:readline"
 
+import { khalaCodeConfigFromRuntimeEnv } from "./khala-code-config.js"
+
 type JsonRpcId = number | string
 type JsonObject = Record<string, unknown>
 
@@ -614,7 +616,7 @@ export async function runFixtureCodexAppServer(
     readonly env?: Readonly<Record<string, string | undefined>>
   } = {},
 ): Promise<void> {
-  const env = input.env ?? process.env
+  const env = input.env ?? khalaCodeConfigFromRuntimeEnv().env
   const args = parseArgs(input.argv ?? Bun.argv.slice(2), env)
   const script = await readFixtureScript(args.scriptPath)
   const server = new FixtureCodexAppServer(script, env)

--- a/clients/khala-code-desktop/src/bun/index.ts
+++ b/clients/khala-code-desktop/src/bun/index.ts
@@ -27,11 +27,15 @@ import {
   startKhalaCodeDesktopTokenUsageBackgroundSync,
 } from "./codex-token-usage-telemetry.js"
 import { createOnDeviceDeciderHost } from "./on-device-decider-host.js"
+import { khalaCodeConfigFromRuntimeEnv } from "./khala-code-config.js"
 import { createKhalaCodeDesktopRpcRequestHandlers } from "./rpc-handlers.js"
+
+const khalaCodeConfig = khalaCodeConfigFromRuntimeEnv()
+const khalaCodeEnv = khalaCodeConfig.env
 
 const previewPort = (): number => {
   const parsed = Number(
-    Bun.env.KHALA_CODE_DESKTOP_PREVIEW_PORT ??
+    khalaCodeEnv.KHALA_CODE_DESKTOP_PREVIEW_PORT ??
       String(KHALA_CODE_DESKTOP_DEFAULT_PREVIEW_PORT),
   )
   return Number.isInteger(parsed) && parsed > 0
@@ -212,7 +216,7 @@ const previewFetch = async (request: Request): Promise<Response> => {
 }
 
 const startPreviewServer = (): void => {
-  if (Bun.env.KHALA_CODE_DESKTOP_PREVIEW_SERVER === "0") return
+  if (khalaCodeEnv.KHALA_CODE_DESKTOP_PREVIEW_SERVER === "0") return
   const requestedPort = previewPort()
   for (let offset = 0; offset < 10; offset += 1) {
     const port = requestedPort + offset
@@ -252,23 +256,23 @@ if (argv.includes("--json")) {
     process.stderr.write("khala code --json requires a prompt argument or stdin.\n")
     process.exit(2)
   }
-  const workingDirectory = resolveToolWorkingDirectory(Bun.env)
-  const headlessCodexAppServerHost = createCodexAppServerHost({ env: Bun.env })
-  const interruptAfterMs = headlessInterruptAfterMs(Bun.env)
+  const workingDirectory = resolveToolWorkingDirectory(khalaCodeEnv)
+  const headlessCodexAppServerHost = createCodexAppServerHost({ env: khalaCodeEnv })
+  const interruptAfterMs = headlessInterruptAfterMs(khalaCodeEnv)
   let exitCode = 0
   try {
     await runKhalaCodeDesktopHeadlessJsonl({
       createCodexChatRuntime: ({ onEvent }) =>
         createCodexAppServerChatRuntime({
-          env: Bun.env,
+          env: khalaCodeEnv,
           host: headlessCodexAppServerHost,
           onEvent,
           messageTokenAuditRecorder:
-            createKhalaCodeDesktopCodexMessageTokenAuditRecorder({ env: Bun.env }),
-          tokenUsageReporter: createKhalaCodeDesktopCodexTokenUsageReporter({ env: Bun.env }),
+            createKhalaCodeDesktopCodexMessageTokenAuditRecorder({ env: khalaCodeEnv }),
+          tokenUsageReporter: createKhalaCodeDesktopCodexTokenUsageReporter({ env: khalaCodeEnv }),
           workingDirectory,
         }),
-      env: Bun.env,
+      env: khalaCodeEnv,
       ...(interruptAfterMs === undefined ? {} : { interruptAfterMs }),
       prompt,
       workingDirectory,
@@ -324,9 +328,9 @@ const appleFmReadiness = () =>
   buildKhalaAppleFmDisabledReadiness({
     platform: { platform: process.platform, arch: process.arch },
   })
-const codexAppServerHost = createCodexAppServerHost({ env: Bun.env })
+const codexAppServerHost = createCodexAppServerHost({ env: khalaCodeEnv })
 const tokenUsageBackgroundSync = startKhalaCodeDesktopTokenUsageBackgroundSync({
-  env: Bun.env,
+  env: khalaCodeEnv,
   onError: error => {
     console.warn(
       `Khala Code token usage sync failed: ${
@@ -339,17 +343,17 @@ const tokenUsageBackgroundSync = startKhalaCodeDesktopTokenUsageBackgroundSync({
 // Optional on-device decider: a small local model that selects a
 // platform-appropriate backend. Apple FM is omitted for launch unless a future
 // host deliberately opts it back in.
-const onDeviceDecider = createOnDeviceDeciderHost({ env: Bun.env })
+const onDeviceDecider = createOnDeviceDeciderHost({ env: khalaCodeEnv })
 
 rpcRequestHandlers = createKhalaCodeDesktopRpcRequestHandlers({
   appleFmReadiness,
   codexAppServerHost,
   enableFleetMcpBridge: true,
   emitChatTurnEvent: event => emitChatTurnEvent(event),
-  env: Bun.env,
+  env: khalaCodeEnv,
   fleetMcpBridgeRepoRoot: resolveSourceRepositoryRoot(),
   onDeviceDeciderStatus: () => onDeviceDecider.select(),
-  workingDirectory: resolveToolWorkingDirectory(Bun.env),
+  workingDirectory: resolveToolWorkingDirectory(khalaCodeEnv),
 })
 
 const disposeRuntime = (): void => {
@@ -391,7 +395,7 @@ const resolveMainViewUrl = async (): Promise<string> => {
   return "views://khala-code-desktop/index.html"
 }
 
-if (Bun.env.KHALA_CODE_DESKTOP_OPEN_WINDOW !== "0") {
+if (khalaCodeEnv.KHALA_CODE_DESKTOP_OPEN_WINDOW !== "0") {
   ApplicationMenu.setApplicationMenu(khalaCodeDesktopApplicationMenu)
 
   new BrowserWindow({

--- a/clients/khala-code-desktop/src/bun/khala-code-config.ts
+++ b/clients/khala-code-desktop/src/bun/khala-code-config.ts
@@ -143,6 +143,7 @@ export const khalaCodeConfigProviderFromEnv = (
   ConfigProvider.fromEnv({ env: definedEnvEntries(env) })
 
 export const makeKhalaCodeConfig = (input: {
+  sourceEnv?: Readonly<Record<string, string | undefined>>
   readonly plain: KhalaCodePlainConfig
   readonly secrets: KhalaCodeSecretConfig
 }): KhalaCodeConfigServiceShape => {
@@ -154,7 +155,14 @@ export const makeKhalaCodeConfig = (input: {
   Object.defineProperty(service, "env", {
     enumerable: false,
     get: () => {
-      const env: Partial<Record<KhalaCodeEnvKey, string>> = {}
+      // Spawn-interop surface: children must inherit the FULL runtime env
+      // (TMPDIR, SSH_AUTH_SOCK, GH_TOKEN, proxy/CA vars, ...), with the
+      // declared keys overlaid. Narrowing to declared keys alone broke
+      // git-over-SSH and gh auth inside Codex sessions (review finding).
+      const env: Record<string, string> = {}
+      for (const [key, value] of Object.entries(input.sourceEnv ?? {})) {
+        if (typeof value === "string") env[key] = value
+      }
       for (const key of KhalaCodePlainEnvKeys) {
         const value = input.plain[key]
         if (value.length > 0) env[key] = value
@@ -175,7 +183,7 @@ export const khalaCodeConfigFromEnv = (
 ): KhalaCodeConfigServiceShape =>
   Effect.runSync(
     KhalaCodeConfigSchema.pipe(
-      Effect.map(makeKhalaCodeConfig),
+      Effect.map((parsed) => makeKhalaCodeConfig({ ...parsed, sourceEnv: env })),
       Effect.provideService(ConfigProvider.ConfigProvider, khalaCodeConfigProviderFromEnv(env)),
     ),
   )
@@ -193,7 +201,7 @@ export class KhalaCodeConfig extends Context.Service<
     Layer.effect(
       KhalaCodeConfig,
       KhalaCodeConfigSchema.pipe(
-        Effect.map(makeKhalaCodeConfig),
+        Effect.map((parsed) => makeKhalaCodeConfig({ ...parsed, sourceEnv: env })),
         Effect.provideService(ConfigProvider.ConfigProvider, khalaCodeConfigProviderFromEnv(env)),
       ),
     )
@@ -206,5 +214,12 @@ export class KhalaCodeConfig extends Context.Service<
 
 export const KhalaCodeConfigLive = Layer.effect(
   KhalaCodeConfig,
-  KhalaCodeConfigSchema.pipe(Effect.map(makeKhalaCodeConfig)),
+  KhalaCodeConfigSchema.pipe(
+    Effect.map((parsed) =>
+      makeKhalaCodeConfig({
+        ...parsed,
+        sourceEnv: typeof Bun === "undefined" ? process.env : Bun.env,
+      }),
+    ),
+  ),
 )

--- a/clients/khala-code-desktop/src/bun/khala-code-config.ts
+++ b/clients/khala-code-desktop/src/bun/khala-code-config.ts
@@ -1,0 +1,210 @@
+import { Config, ConfigProvider, Context, Effect, Layer, Redacted, Schema as S } from "effect"
+
+const StringEnvValue = S.String
+
+export const KhalaCodePlainEnvKeys = [
+  "CHAT_ATTACHMENT_TMP_ROOT",
+  "CODEX_HOME",
+  "CODEX_RPC_TIMEOUT_MS",
+  "CODEX_STATE_DB_PATH",
+  "CODEX_RATE_LIMIT_RESET_CREDITS_CONSUME_URL",
+  "CODEX_RATE_LIMIT_RESET_CREDITS_URL",
+  "HOME",
+  "INIT_CWD",
+  "KHALA_CODE_BUN_BINARY",
+  "KHALA_CODE_CODEX_APP_SERVER_FIXTURE",
+  "KHALA_CODE_CODEX_APP_SERVER_FIXTURE_PATH",
+  "KHALA_CODE_CODEX_APP_SERVER_FIXTURE_SCRIPT",
+  "KHALA_CODE_CODEX_APP_SERVER_GAP_DOC_PATH",
+  "KHALA_CODE_CODEX_APP_SERVER_GAP_MATRIX",
+  "KHALA_CODE_CODEX_APP_SERVER_GAP_MATRIX_ISSUE",
+  "KHALA_CODE_CODEX_APP_SERVER_GAP_MATRIX_REFERENCE_COMMIT",
+  "KHALA_CODE_CODEX_BINARY",
+  "KHALA_CODE_CODEX_COMMAND",
+  "KHALA_CODE_CODEX_PARITY_COVERAGE",
+  "KHALA_CODE_CODEX_PARITY_REFERENCE_COMMIT",
+  "KHALA_CODE_CODEX_PARITY_REFERENCE_LABEL",
+  "KHALA_CODE_CODEX_PARITY_REQUIRED_CLIENT_METHODS",
+  "KHALA_CODE_CODEX_PARITY_REQUIRED_NOTIFICATIONS",
+  "KHALA_CODE_CODEX_PARITY_REQUIRED_SCHEMA_FILES",
+  "KHALA_CODE_CODEX_PARITY_REQUIRED_SERVER_REQUESTS",
+  "KHALA_CODE_CODEX_PARITY_REQUIRED_THREAD_ITEM_TYPES",
+  "KHALA_CODE_CODEX_REFERENCE_ROOT",
+  "KHALA_CODE_CODEX_REFERENCE_SCHEMA_DIR",
+  "KHALA_CODE_CODEX_STATE_DB_PATH",
+  "KHALA_CODE_DEBUG_APP_SERVER",
+  "KHALA_CODE_DESKTOP_BACKEND",
+  "KHALA_CODE_DESKTOP_BUN_COMMAND",
+  "KHALA_CODE_DESKTOP_CODEX_PARITY_LIVE_SMOKE",
+  "KHALA_CODE_DESKTOP_CODEX_STATE_PATH",
+  "KHALA_CODE_DESKTOP_CONTEXT_KEEP_TAIL_COUNT",
+  "KHALA_CODE_DESKTOP_CONTEXT_MAX_TOKENS",
+  "KHALA_CODE_DESKTOP_FLEET_MCP_BRIDGE",
+  "KHALA_CODE_DESKTOP_LEGACY_KHALA_NATIVE_RUNTIME",
+  "KHALA_CODE_DESKTOP_OPEN_WINDOW",
+  "KHALA_CODE_DESKTOP_PREVIEW_PORT",
+  "KHALA_CODE_DESKTOP_PREVIEW_SERVER",
+  "KHALA_CODE_DESKTOP_RUNTIME",
+  "KHALA_CODE_DESKTOP_WORKSPACE",
+  "KHALA_CODE_HEADLESS_INTERRUPT_AFTER_MS",
+  "KHALA_CODE_MESSAGE_AUDIT_LOCAL_LEDGER_PATH",
+  "KHALA_CODE_MESSAGE_TOKEN_AUDIT_LOCAL_LEDGER_PATH",
+  "KHALA_CODE_SYSTEM_PROMPT",
+  "KHALA_CODE_TOKEN_USAGE_BACKGROUND_SYNC_DISABLED",
+  "KHALA_CODE_TOKEN_USAGE_BASE_URL",
+  "KHALA_CODE_TOKEN_USAGE_DISABLED",
+  "KHALA_CODE_TOKEN_USAGE_LOCAL_LEDGER_PATH",
+  "KHALA_CODE_TOKEN_USAGE_REMOTE_DISABLED",
+  "KHALA_CODE_TOKEN_USAGE_SECRET_DISABLED",
+  "KHALA_CODE_TOKEN_USAGE_SECRET_PATH",
+  "KHALA_CODE_TOKEN_USAGE_SYNC_INTERVAL_MS",
+  "KHALA_GPT_OSS_BASE_URL",
+  "KHALA_GPT_OSS_MODEL",
+  "LOG_FORMAT",
+  "OPENAGENTS_APPLE_FM_BRIDGE_PATH",
+  "OPENAGENTS_BASE_URL",
+  "OPENAGENTS_BUN_PATH",
+  "OPENAGENTS_PYLON_APP_PATH",
+  "OPENAGENTS_PYLON_CODEX_ACCOUNT_CONCURRENCY",
+  "OPENAGENTS_PYLON_CODEX_BUSY",
+  "OPENAGENTS_PYLON_CODEX_CONCURRENCY",
+  "OPENAGENTS_PYLON_CODEX_QUEUED",
+  "OPENAGENTS_PYLON_DISABLE_ASSIGNMENT_PR",
+  "OPENAGENTS_PYLON_DISABLE_PR_TITLE_MODEL",
+  "OPENAGENTS_REPO_ROOT",
+  "PATH",
+  "PROBE_OMEGA_BASE_URL",
+  "PWD",
+  "PYLON_ACCOUNT_HOME_ROOT",
+  "PYLON_CONTROL_HOST",
+  "PYLON_CONTROL_PORT",
+  "PYLON_CONTROL_URL",
+  "PYLON_FABLE_HOME",
+  "PYLON_HOME",
+  "PYLON_OPENAGENTS_BASE_URL",
+] as const
+
+export const KhalaCodeSecretEnvKeys = [
+  "KHALA_CODE_TOKEN_USAGE_BEARER_TOKEN",
+  "KHALA_GPT_OSS_API_KEY",
+  "OPENAGENTS_ADMIN_API_TOKEN",
+  "OPENAGENTS_AGENT_TOKEN",
+  "OPENAGENTS_API_KEY",
+  "OPENROUTER_API_KEY",
+  "PROBE_TOKEN_USAGE_BEARER_TOKEN",
+  "PYLON_CONTROL_TOKEN",
+] as const
+
+export type KhalaCodePlainEnvKey = typeof KhalaCodePlainEnvKeys[number]
+export type KhalaCodeSecretEnvKey = typeof KhalaCodeSecretEnvKeys[number]
+export type KhalaCodeEnvKey = KhalaCodePlainEnvKey | KhalaCodeSecretEnvKey
+
+export type KhalaCodePlainConfig = Readonly<Record<KhalaCodePlainEnvKey, string>>
+export type KhalaCodeSecretConfig = Readonly<Record<KhalaCodeSecretEnvKey, Redacted.Redacted<string>>>
+export type KhalaCodeConfigEnv = NodeJS.ProcessEnv & Partial<Record<KhalaCodeEnvKey, string>>
+
+export type KhalaCodeConfigServiceShape = Readonly<{
+  env: KhalaCodeConfigEnv
+  plain: KhalaCodePlainConfig
+  secrets: KhalaCodeSecretConfig
+}>
+
+const emptyRedacted = Redacted.make("")
+
+const plainConfig = Object.fromEntries(
+  KhalaCodePlainEnvKeys.map((key) => [
+    key,
+    Config.schema(StringEnvValue, key).pipe(Config.withDefault("")),
+  ]),
+) as { readonly [Key in KhalaCodePlainEnvKey]: Config.Config<string> }
+
+const secretConfig = Object.fromEntries(
+  KhalaCodeSecretEnvKeys.map((key) => [
+    key,
+    Config.redacted(key).pipe(Config.withDefault(emptyRedacted)),
+  ]),
+) as { readonly [Key in KhalaCodeSecretEnvKey]: Config.Config<Redacted.Redacted<string>> }
+
+export const KhalaCodeConfigSchema = Config.all({
+  plain: Config.all(plainConfig),
+  secrets: Config.all(secretConfig),
+})
+
+const definedEnvEntries = (
+  env: Readonly<Record<string, string | undefined>>,
+): Record<string, string> =>
+  Object.fromEntries(
+    Object.entries(env).filter((entry): entry is [string, string] => entry[1] !== undefined),
+  )
+
+export const khalaCodeConfigProviderFromEnv = (
+  env: Readonly<Record<string, string | undefined>>,
+): ConfigProvider.ConfigProvider =>
+  ConfigProvider.fromEnv({ env: definedEnvEntries(env) })
+
+export const makeKhalaCodeConfig = (input: {
+  readonly plain: KhalaCodePlainConfig
+  readonly secrets: KhalaCodeSecretConfig
+}): KhalaCodeConfigServiceShape => {
+  const service = {
+    plain: input.plain,
+    secrets: input.secrets,
+  } as KhalaCodeConfigServiceShape
+
+  Object.defineProperty(service, "env", {
+    enumerable: false,
+    get: () => {
+      const env: Partial<Record<KhalaCodeEnvKey, string>> = {}
+      for (const key of KhalaCodePlainEnvKeys) {
+        const value = input.plain[key]
+        if (value.length > 0) env[key] = value
+      }
+      for (const key of KhalaCodeSecretEnvKeys) {
+        const value = Redacted.value(input.secrets[key])
+        if (value.length > 0) env[key] = value
+      }
+      return env as KhalaCodeConfigEnv
+    },
+  })
+
+  return service
+}
+
+export const khalaCodeConfigFromEnv = (
+  env: Readonly<Record<string, string | undefined>>,
+): KhalaCodeConfigServiceShape =>
+  Effect.runSync(
+    KhalaCodeConfigSchema.pipe(
+      Effect.map(makeKhalaCodeConfig),
+      Effect.provideService(ConfigProvider.ConfigProvider, khalaCodeConfigProviderFromEnv(env)),
+    ),
+  )
+
+export const khalaCodeConfigFromRuntimeEnv = (): KhalaCodeConfigServiceShape =>
+  khalaCodeConfigFromEnv(typeof Bun === "undefined" ? process.env : Bun.env)
+
+export class KhalaCodeConfig extends Context.Service<
+  KhalaCodeConfig,
+  KhalaCodeConfigServiceShape
+>()("@openagentsinc/khala-code-desktop/KhalaCodeConfig") {
+  static readonly fromEnv = (
+    env: Readonly<Record<string, string | undefined>>,
+  ) =>
+    Layer.effect(
+      KhalaCodeConfig,
+      KhalaCodeConfigSchema.pipe(
+        Effect.map(makeKhalaCodeConfig),
+        Effect.provideService(ConfigProvider.ConfigProvider, khalaCodeConfigProviderFromEnv(env)),
+      ),
+    )
+
+  static readonly testProfile = (
+    env: Readonly<Record<string, string | undefined>> = {},
+  ): Layer.Layer<KhalaCodeConfig> =>
+    Layer.succeed(KhalaCodeConfig, khalaCodeConfigFromEnv(env))
+}
+
+export const KhalaCodeConfigLive = Layer.effect(
+  KhalaCodeConfig,
+  KhalaCodeConfigSchema.pipe(Effect.map(makeKhalaCodeConfig)),
+)

--- a/clients/khala-code-desktop/src/bun/khala-codex-fleet-tools.ts
+++ b/clients/khala-code-desktop/src/bun/khala-codex-fleet-tools.ts
@@ -32,6 +32,7 @@ import {
   type KhalaToolResult,
   type RegisteredKhalaTool,
 } from "@openagentsinc/khala-tools"
+import { khalaCodeConfigFromRuntimeEnv } from "./khala-code-config.js"
 
 type ChatEnv = Readonly<Record<string, string | undefined>>
 
@@ -496,7 +497,7 @@ export async function ensureLocalPylon(
   },
   options: KhalaCodexFleetToolOptions = {},
 ): Promise<KhalaPylonEnsureResult> {
-  const env = options.env ?? process.env
+  const env = options.env ?? khalaCodeConfigFromRuntimeEnv().env
   const paths = resolvePylonPaths(env)
   const timeoutMs = boundedPositiveInteger(input.timeoutMs, DEFAULT_COMMAND_TIMEOUT_MS, 1_000, 120_000)
   const waitMs = boundedPositiveInteger(input.waitMs, DEFAULT_ENSURE_WAIT_MS, 0, 60_000)
@@ -614,7 +615,7 @@ export async function inspectCodexFleet(
   } = {},
   options: KhalaCodexFleetToolOptions = {},
 ): Promise<FleetStatusResult> {
-  const env = options.env ?? process.env
+  const env = options.env ?? khalaCodeConfigFromRuntimeEnv().env
   const paths = resolvePylonPaths(env)
   const ensure = await ensureLocalPylon({ start: input.startPylon ?? false }, { ...options, env })
   const baseUrl = resolveOpenAgentsBaseUrl(env)
@@ -672,7 +673,7 @@ export async function spawnCodexInstances(
   raw: SpawnCodexInstancesInput,
   options: KhalaCodexFleetToolOptions = {},
 ): Promise<SpawnCodexInstancesResult> {
-  const baseEnv = options.env ?? process.env
+  const baseEnv = options.env ?? khalaCodeConfigFromRuntimeEnv().env
   const delegationParameters = options.delegationParameters ??
     khalaFleetDelegationParametersFromEnv(baseEnv)
   const input = decodeSpawnInput(raw, delegationParameters)
@@ -817,7 +818,7 @@ export async function spawnCodexInstances(
   throw new Error("Khala fleet delegate completed without a dispatch result.")
 }
 
-export function resolvePylonHome(env: ChatEnv = process.env): string {
+export function resolvePylonHome(env: ChatEnv = khalaCodeConfigFromRuntimeEnv().env): string {
   const explicit = env.PYLON_HOME?.trim()
   if (explicit !== undefined && explicit.length > 0) return resolve(explicit)
   const candidates = pylonHomeCandidates(env)
@@ -1059,7 +1060,7 @@ async function readProviderProjection(
 }
 
 function pylonCommandEnv(env: ChatEnv, pylonHome: string): ChatEnv {
-  const mergedEnv = { ...process.env, ...env }
+  const mergedEnv = { ...khalaCodeConfigFromRuntimeEnv().env, ...env }
   const configuredBaseUrl = configuredOpenAgentsBaseUrl(mergedEnv)
   return {
     ...mergedEnv,
@@ -1213,7 +1214,7 @@ function collectStreamLines(
 
 function cleanEnv(env: ChatEnv | undefined): NodeJS.ProcessEnv {
   const clean: NodeJS.ProcessEnv = {}
-  for (const [key, value] of Object.entries(env ?? process.env)) {
+  for (const [key, value] of Object.entries(env ?? khalaCodeConfigFromRuntimeEnv().env)) {
     if (value !== undefined) clean[key] = value
   }
   return clean
@@ -2850,7 +2851,7 @@ export async function removeCodexAccount(
   accountRef: string,
   options: KhalaCodexFleetToolOptions = {},
 ): Promise<RemoveCodexAccountResult> {
-  const env = options.env ?? process.env
+  const env = options.env ?? khalaCodeConfigFromRuntimeEnv().env
   const pylonHome = resolvePylonHome(env)
   const configPath = join(pylonHome, "config.json")
 
@@ -2978,7 +2979,7 @@ export async function collectCodexAccountEmails(
   accountRefs: ReadonlyArray<string>,
   options: KhalaCodexFleetToolOptions = {},
 ): Promise<Record<string, string | null>> {
-  const env = options.env ?? process.env
+  const env = options.env ?? khalaCodeConfigFromRuntimeEnv().env
   const pylonHome = resolvePylonHome(env)
   const siblingRoot = (env.PYLON_ACCOUNT_HOME_ROOT ?? "").trim() || homedir()
   const defaultHome = (env.CODEX_HOME ?? "").trim() || join(homedir(), ".codex")
@@ -3049,7 +3050,7 @@ export async function beginCodexConnect(
       error: "invalid account ref",
     }
   }
-  const env = options.env ?? process.env
+  const env = options.env ?? khalaCodeConfigFromRuntimeEnv().env
   const paths = resolvePylonPaths(env)
   let child: ReturnType<typeof Bun.spawn>
   try {

--- a/clients/khala-code-desktop/src/bun/khala-codex-live-smoke.ts
+++ b/clients/khala-code-desktop/src/bun/khala-codex-live-smoke.ts
@@ -4,6 +4,7 @@ import {
   type KhalaCodexFleetProgressPayload,
   type KhalaCodexFleetToolOptions,
 } from "./khala-codex-fleet-tools.js"
+import { khalaCodeConfigFromRuntimeEnv } from "./khala-code-config.js"
 
 export const TWO_CODEX_READONLY_SMOKE_COUNT = 2
 export const TWO_CODEX_READONLY_SMOKE_DEFAULT_TIMEOUT_MS = 600_000
@@ -68,7 +69,7 @@ export async function runTwoCodexReadOnlySmoke(
   const prompt = options.prompt ?? twoCodexReadOnlySmokePrompt()
   const timeoutMs = options.timeoutMs ?? TWO_CODEX_READONLY_SMOKE_DEFAULT_TIMEOUT_MS
   const startedAt = new Date().toISOString()
-  const baseEnv = options.env ?? process.env
+  const baseEnv = options.env ?? khalaCodeConfigFromRuntimeEnv().env
   const env = {
     ...baseEnv,
     OPENAGENTS_PYLON_DISABLE_ASSIGNMENT_PR: "1",

--- a/clients/khala-code-desktop/src/bun/on-device-decider-host.ts
+++ b/clients/khala-code-desktop/src/bun/on-device-decider-host.ts
@@ -5,6 +5,7 @@
 import { createAppleFmSidecarHost } from "./apple-fm-sidecar.js"
 import { createAppleFmDeciderBackend } from "./apple-fm-decider-backend.js"
 import { createGptOssDeciderBackend } from "./gpt-oss-decider-backend.js"
+import { khalaCodeConfigFromRuntimeEnv } from "./khala-code-config.js"
 import {
   createOnDeviceDecider,
   type OnDeviceDeciderBackend,
@@ -26,7 +27,7 @@ export function createOnDeviceDeciderHost(
     platform: process.platform,
     arch: process.arch,
   }
-  const env = options.env ?? Bun.env
+  const env = options.env ?? khalaCodeConfigFromRuntimeEnv().env
   const backends: Partial<Record<"apple_fm" | "gpt_oss", OnDeviceDeciderBackend>> = {
     gpt_oss: createGptOssDeciderBackend({ env }),
   }

--- a/clients/khala-code-desktop/tests/khala-code-config.test.ts
+++ b/clients/khala-code-desktop/tests/khala-code-config.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, test } from "bun:test"
+import { inspect } from "node:util"
+import { Effect, Redacted } from "effect"
+
+import {
+  KhalaCodeConfig,
+  KhalaCodePlainEnvKeys,
+  KhalaCodeSecretEnvKeys,
+  khalaCodeConfigFromEnv,
+} from "../src/bun/khala-code-config"
+
+describe("KhalaCodeConfig", () => {
+  test("parses the Bun host env key surface through the schema", () => {
+    const config = khalaCodeConfigFromEnv({
+      CODEX_HOME: "/tmp/codex-home",
+      KHALA_CODE_CODEX_BINARY: "/opt/bin/codex",
+      KHALA_CODE_DESKTOP_PREVIEW_PORT: "6123",
+      KHALA_CODE_TOKEN_USAGE_BEARER_TOKEN: "token-secret",
+      OPENAGENTS_AGENT_TOKEN: "agent-secret",
+      PYLON_CONTROL_TOKEN: "control-secret",
+    })
+
+    expect(config.plain.CODEX_HOME).toBe("/tmp/codex-home")
+    expect(config.plain.KHALA_CODE_CODEX_BINARY).toBe("/opt/bin/codex")
+    expect(config.plain.KHALA_CODE_DESKTOP_PREVIEW_PORT).toBe("6123")
+    expect(Redacted.value(config.secrets.KHALA_CODE_TOKEN_USAGE_BEARER_TOKEN)).toBe("token-secret")
+    expect(Redacted.value(config.secrets.OPENAGENTS_AGENT_TOKEN)).toBe("agent-secret")
+    expect(Redacted.value(config.secrets.PYLON_CONTROL_TOKEN)).toBe("control-secret")
+    expect(config.env.KHALA_CODE_TOKEN_USAGE_BEARER_TOKEN).toBe("token-secret")
+  })
+
+  test("covers every declared host env key with a parsed slot", () => {
+    const config = khalaCodeConfigFromEnv({})
+
+    for (const key of KhalaCodePlainEnvKeys) {
+      expect(config.plain[key]).toBe("")
+    }
+    for (const key of KhalaCodeSecretEnvKeys) {
+      expect(Redacted.value(config.secrets[key])).toBe("")
+    }
+  })
+
+  test("keeps token-bearing values redacted in printable config output", () => {
+    const config = khalaCodeConfigFromEnv({
+      KHALA_CODE_TOKEN_USAGE_BEARER_TOKEN: "bearer-do-not-print",
+      KHALA_GPT_OSS_API_KEY: "gpt-key-do-not-print",
+      OPENROUTER_API_KEY: "router-key-do-not-print",
+      PYLON_CONTROL_TOKEN: "control-do-not-print",
+    })
+
+    const printed = [
+      String(config.secrets.KHALA_CODE_TOKEN_USAGE_BEARER_TOKEN),
+      JSON.stringify(config),
+      inspect(config),
+    ].join("\n")
+
+    expect(printed).toContain("<redacted>")
+    expect(printed).not.toContain("bearer-do-not-print")
+    expect(printed).not.toContain("gpt-key-do-not-print")
+    expect(printed).not.toContain("router-key-do-not-print")
+    expect(printed).not.toContain("control-do-not-print")
+  })
+
+  test("supports Layer.succeed test-profile injection", async () => {
+    const program = Effect.gen(function* () {
+      const config = yield* KhalaCodeConfig
+      return {
+        codexHome: config.env.CODEX_HOME,
+        token: Redacted.value(config.secrets.OPENAGENTS_API_KEY),
+      }
+    })
+
+    const result = await Effect.runPromise(
+      program.pipe(
+        Effect.provide(
+          KhalaCodeConfig.testProfile({
+            CODEX_HOME: "/tmp/injected-codex",
+            OPENAGENTS_API_KEY: "injected-secret",
+          }),
+        ),
+      ),
+    )
+
+    expect(result).toEqual({
+      codexHome: "/tmp/injected-codex",
+      token: "injected-secret",
+    })
+  })
+})

--- a/clients/khala-code-desktop/tests/khala-code-config.test.ts
+++ b/clients/khala-code-desktop/tests/khala-code-config.test.ts
@@ -87,3 +87,21 @@ describe("KhalaCodeConfig", () => {
     })
   })
 })
+
+describe("spawn env interop", () => {
+  test("undeclared runtime keys survive into config.env with declared overlay", () => {
+    const config = khalaCodeConfigFromEnv({
+      SSH_AUTH_SOCK: "/tmp/agent.sock",
+      GH_TOKEN: "gh-secret",
+      TMPDIR: "/var/tmp/x",
+      KHALA_CODE_DESKTOP_PREVIEW_SERVER: "1",
+      EMPTYVAL: "",
+    })
+    const env = config.env as Record<string, string | undefined>
+    expect(env.SSH_AUTH_SOCK).toBe("/tmp/agent.sock")
+    expect(env.GH_TOKEN).toBe("gh-secret")
+    expect(env.TMPDIR).toBe("/var/tmp/x")
+    expect(env.KHALA_CODE_DESKTOP_PREVIEW_SERVER).toBe("1")
+    expect(env.EMPTYVAL).toBe("")
+  })
+})


### PR DESCRIPTION
Closes #7824

## Summary
- Add `KhalaCodeConfig` as the desktop Bun host config boundary with schema-backed plain env keys and redacted token-bearing keys.
- Route runtime env fallbacks in `clients/khala-code-desktop/src/bun` through the config service boundary while preserving explicit test/helper env injection.
- Add focused parsing, redaction, and `Layer.succeed` test-profile coverage.

## Verification
- `bun run --cwd clients/khala-code-desktop verify`