### PR TITLE
T3.4: FleetRun RPC parity

### DIFF
--- a/apps/pylon/src/orchestration/store.ts
+++ b/apps/pylon/src/orchestration/store.ts
@@ -86,6 +86,9 @@ export const FleetRunStateSchema = S.Literals([
 ])
 export type FleetRunState = typeof FleetRunStateSchema.Type
 
+export const FleetRunControlVerbSchema = S.Literals(["pause", "resume", "drain", "stop"])
+export type FleetRunControlVerb = typeof FleetRunControlVerbSchema.Type
+
 export const FleetRunStopConditionSchema = S.Literals(["backlog_empty", "target_reached", "manual_stop"])
 export type FleetRunStopCondition = typeof FleetRunStopConditionSchema.Type
 
@@ -382,6 +385,34 @@ const assertWholeNonNegative = (field: string, value: number): void => {
 
 const assertNonEmpty = (kind: string, field: string, value: string): void => {
   if (!value.trim()) throw new Error(`${kind} ${field} is required`)
+}
+
+export const assertFleetRunControlTransition = (
+  state: FleetRunState,
+  verb: FleetRunControlVerb,
+): void => {
+  const allowed: Record<FleetRunControlVerb, readonly FleetRunState[]> = {
+    drain: ["running", "paused"],
+    pause: ["running"],
+    resume: ["paused"],
+    stop: ["draft", "running", "paused", "draining"],
+  }
+  if (!allowed[verb].includes(state)) {
+    throw new Error(`fleetRunControl cannot ${verb} a ${state} fleet run`)
+  }
+}
+
+const fleetRunControlState = (verb: FleetRunControlVerb): FleetRunState => {
+  switch (verb) {
+    case "pause":
+      return "paused"
+    case "resume":
+      return "running"
+    case "drain":
+      return "draining"
+    case "stop":
+      return "stopped"
+  }
 }
 
 const LIVE_WORK_CLAIM_STATES: readonly LiveWorkClaimState[] = ["claimed", "in_progress", "closeout"]
@@ -972,6 +1003,20 @@ export class PylonOrchestrationStore {
       startedAt: state === "running" && current.startedAt === null ? iso(now) : current.startedAt,
       updatedAt: iso(now),
     })
+  }
+
+  controlFleetRun(
+    runRef: string,
+    verb: FleetRunControlVerb,
+    now: Date = new Date(),
+  ): { previousState: FleetRunState; run: FleetRun } {
+    const current = this.getFleetRun(runRef)
+    if (current === null) throw new Error(`unknown fleet run: ${runRef}`)
+    assertFleetRunControlTransition(current.state, verb)
+    return {
+      previousState: current.state,
+      run: this.updateFleetRunState(runRef, fleetRunControlState(verb), now),
+    }
   }
 
   reconcileFleetRun(runRef: string, now: Date = new Date()): FleetRun {

--- a/clients/khala-code-desktop/src/bun/fleet-run-supervisor-rpc-adapter.ts
+++ b/clients/khala-code-desktop/src/bun/fleet-run-supervisor-rpc-adapter.ts
@@ -1,0 +1,379 @@
+import { spawn } from "node:child_process"
+import { randomUUID } from "node:crypto"
+import { mkdirSync } from "node:fs"
+import { Database } from "bun:sqlite"
+import { Effect, Exit, Scope } from "effect"
+import { join } from "node:path"
+
+import {
+  createPylonOrchestrationStore,
+  syncFleetRunsToOwnerLocalState,
+  type FleetRun,
+  type FleetRunControlVerb,
+  type FleetRunState,
+  type FleetRunStopCondition,
+  type FleetRunWorkSource,
+  type PylonOrchestrationStore,
+} from "../../../../apps/pylon/src/orchestration/store.js"
+import {
+  planFixtureWork,
+  planGithubBacklogWork,
+  planIssueListWork,
+  type FixtureWorkSource,
+  type GithubBacklogWorkSource,
+  type IssueListItem,
+  type IssueListWorkSource,
+  type WorkPlannerOutput,
+} from "../../../../apps/pylon/src/orchestration/work-planner.js"
+import type { KhalaCodeDesktopFleetRunSupervisorRpc } from "./rpc-handlers.js"
+import {
+  inspectCodexFleet,
+  resolvePylonHome,
+  spawnCodexInstances,
+  type KhalaCodexFleetToolOptions,
+} from "./khala-codex-fleet-tools.js"
+import {
+  startFleetRunSupervisor,
+  type FleetRunSupervisorCapacity,
+  type FleetRunSupervisorHandle,
+  type FleetRunSupervisorPlanner,
+  type FleetRunSupervisorRunner,
+} from "./fleet-run-supervisor.js"
+import type {
+  KhalaCodeDesktopFleetRunControlRequest,
+  KhalaCodeDesktopFleetRunListRequest,
+  KhalaCodeDesktopFleetRunProjection,
+  KhalaCodeDesktopFleetRunStartRequest,
+} from "../shared/rpc.js"
+
+type ChatEnv = Readonly<Record<string, string | undefined>>
+
+type ActiveSupervisor = {
+  readonly handle: FleetRunSupervisorHandle
+  readonly scope: Scope.Scope
+}
+
+type RpcIssueListItem = Exclude<
+  NonNullable<Extract<
+    KhalaCodeDesktopFleetRunStartRequest["workSource"],
+    { readonly kind: "issue_list" }
+  >["issues"]>[number],
+  number
+>
+
+export type KhalaCodeDesktopFleetRunSupervisorRpcAdapterOptions = {
+  readonly capacity?: FleetRunSupervisorCapacity
+  readonly env?: ChatEnv
+  readonly pylonRef?: string | null
+  readonly runner?: FleetRunSupervisorRunner
+  readonly store?: PylonOrchestrationStore
+  readonly tickIntervalMs?: number
+  readonly toolOptions?: KhalaCodexFleetToolOptions
+}
+
+const DEFAULT_VERIFY = "bun run --cwd clients/khala-code-desktop verify"
+
+const isIssueState = (value: unknown): value is NonNullable<IssueListItem["state"]> =>
+  value === "open" ||
+  value === "closed" ||
+  value === "merged" ||
+  value === "OPEN" ||
+  value === "CLOSED" ||
+  value === "MERGED"
+
+const normalizeIssueState = (value: unknown): IssueListItem["state"] | undefined => {
+  if (!isIssueState(value)) return undefined
+  const normalized = value.toLowerCase()
+  return normalized === "closed" || normalized === "merged" ? normalized : "open"
+}
+
+const normalizeIssueItem = (item: number | RpcIssueListItem | IssueListItem): number | IssueListItem => {
+  if (typeof item === "number") return item
+  const normalized: IssueListItem = {
+    number: item.number,
+    ...(item.kind === undefined ? {} : { kind: item.kind }),
+    ...(item.labels === undefined ? {} : { labels: [...item.labels] }),
+    ...(item.title === undefined ? {} : { title: item.title }),
+    ...(item.url === undefined ? {} : { url: item.url }),
+  }
+  const state = normalizeIssueState(item.state)
+  return state === undefined ? normalized : { ...normalized, state }
+}
+
+const normalizeRpcIssueItem = (
+  item: NonNullable<Extract<
+    KhalaCodeDesktopFleetRunStartRequest["workSource"],
+    { readonly kind: "issue_list" }
+  >["issues"]>[number],
+): number | IssueListItem => normalizeIssueItem(item as number | RpcIssueListItem)
+
+const normalizeWorkSource = (
+  source: KhalaCodeDesktopFleetRunStartRequest["workSource"],
+): IssueListWorkSource | FixtureWorkSource | GithubBacklogWorkSource => {
+  if (source.kind === "issue_list") {
+    if (source.repo === undefined || source.repo.trim().length === 0) {
+      throw new Error("fleetRunStart issue_list workSource requires repo")
+    }
+    return {
+      kind: "issue_list",
+      repo: source.repo,
+      issues: [...(source.issues ?? [])].map(issue => normalizeRpcIssueItem(issue as Parameters<typeof normalizeRpcIssueItem>[0])),
+    }
+  }
+  if (source.kind === "github_backlog") {
+    if (source.repo === undefined || source.repo.trim().length === 0) {
+      throw new Error("fleetRunStart github_backlog workSource requires repo")
+    }
+    return {
+      kind: "github_backlog",
+      repo: source.repo,
+      ...(source.limit === undefined ? {} : { limit: Math.max(1, Math.trunc(source.limit)) }),
+    }
+  }
+  return {
+    kind: "fixture",
+    ...(source.count === undefined ? {} : { count: Math.max(1, Math.trunc(source.count)) }),
+  }
+}
+
+const workSourceKind = (
+  source: IssueListWorkSource | FixtureWorkSource | GithubBacklogWorkSource,
+): FleetRunWorkSource => source.kind
+
+const runRefFor = (): string => `fleet_run.${randomUUID()}`
+
+const projectWorkSource = (
+  source: IssueListWorkSource | FixtureWorkSource | GithubBacklogWorkSource | undefined,
+  fallback: FleetRunWorkSource,
+): KhalaCodeDesktopFleetRunProjection["workSource"] => {
+  if (source === undefined) return { kind: fallback }
+  if (source.kind === "issue_list") {
+    return {
+      kind: "issue_list",
+      repo: source.repo,
+        issues: source.issues.map(issue => typeof issue === "number" ? issue : normalizeIssueItem(issue)),
+    }
+  }
+  if (source.kind === "github_backlog") {
+    return {
+      kind: "github_backlog",
+      repo: source.repo,
+      ...(source.limit === undefined ? {} : { limit: source.limit }),
+    }
+  }
+  return {
+    kind: "fixture",
+    ...(source.count === undefined ? {} : { count: source.count }),
+  }
+}
+
+const projectRun = (
+  run: FleetRun,
+  input: {
+    readonly pylonRef: string | null
+    readonly workSource?: IssueListWorkSource | FixtureWorkSource | GithubBacklogWorkSource
+  },
+): KhalaCodeDesktopFleetRunProjection => ({
+  counters: run.counters,
+  createdAt: run.createdAt,
+  dispatchKind: "supervised_dispatch",
+  objectiveProjected: false,
+  pylonRef: input.pylonRef,
+  refillPolicy: run.refillPolicy,
+  runRef: run.runRef,
+  startedAt: run.startedAt,
+  state: run.state,
+  targetConcurrency: run.targetConcurrency,
+  updatedAt: run.updatedAt,
+  workerKind: "codex",
+  workSource: projectWorkSource(input.workSource, run.workSource),
+})
+
+const ghJson = (args: readonly string[]): Promise<string> =>
+  new Promise((resolve, reject) => {
+    const child = spawn("gh", args, { stdio: ["ignore", "pipe", "pipe"] })
+    const stdout: Buffer[] = []
+    const stderr: Buffer[] = []
+    child.stdout.on("data", chunk => stdout.push(Buffer.from(chunk)))
+    child.stderr.on("data", chunk => stderr.push(Buffer.from(chunk)))
+    child.once("error", reject)
+    child.once("close", code => {
+      if (code === 0) return resolve(Buffer.concat(stdout).toString("utf8"))
+      reject(new Error(`gh ${args.join(" ")} failed: ${Buffer.concat(stderr).toString("utf8").trim()}`))
+    })
+  })
+
+const plannerFor = (
+  store: PylonOrchestrationStore,
+  sources: ReadonlyMap<string, IssueListWorkSource | FixtureWorkSource | GithubBacklogWorkSource>,
+): FleetRunSupervisorPlanner => ({
+  plan: async ({ run, now }): Promise<WorkPlannerOutput> => {
+    const source = sources.get(run.runRef)
+    if (source === undefined) return planFixtureWork({ kind: "fixture", count: 0 }, { now })
+    if (source.kind === "fixture") return planFixtureWork(source, { now })
+    if (source.kind === "issue_list") return planIssueListWork(source, { claimRegistry: store, now })
+    return planGithubBacklogWork(source, ghJson, { claimRegistry: store, now })
+  },
+})
+
+const capacityFor = (options: KhalaCodexFleetToolOptions | undefined): FleetRunSupervisorCapacity => ({
+  accounts: async () => {
+    const status = await inspectCodexFleet({ includeProcesses: false, startPylon: true }, options)
+    return status.accounts
+      .filter(account => account.provider === "codex")
+      .map(account => ({
+        accountRef: account.accountRef,
+        advertisedCapacity: Math.max(0, Math.trunc(
+          account.capacity?.available ??
+          account.capacity?.ready ??
+          (account.readiness === "ready" || account.readiness === "available" ? 1 : 0),
+        )),
+      }))
+  },
+})
+
+const runnerFor = (input: {
+  readonly pylonRef: string | null
+  readonly toolOptions?: KhalaCodexFleetToolOptions
+}): FleetRunSupervisorRunner => ({
+  dispatch: async dispatch => {
+    const fixture = dispatch.workUnit.kind === "fixture"
+    const result = await spawnCodexInstances({
+      accountRef: dispatch.accountRef,
+      claimRef: fixture ? undefined : dispatch.claim.claimRef,
+      count: 1,
+      fixture,
+      issue: dispatch.workUnit.number,
+      prompt: dispatch.run.objective,
+      pylonRef: input.pylonRef ?? undefined,
+      repo: dispatch.workUnit.repo,
+      verify: fixture ? undefined : DEFAULT_VERIFY,
+    }, input.toolOptions)
+    const slot = result.results[0]
+    return {
+      assignmentRef: slot?.assignmentRef ?? null,
+      lifecycle: [],
+      status: result.acceptedCount > 0 ? "accepted" : "failed",
+      summary: slot?.summary ?? null,
+    }
+  },
+})
+
+const defaultStore = (env: ChatEnv): PylonOrchestrationStore => {
+  const home = resolvePylonHome(env)
+  mkdirSync(home, { recursive: true })
+  return createPylonOrchestrationStore(new Database(join(home, "orchestration.sqlite")))
+}
+
+export function createKhalaCodeDesktopFleetRunSupervisorRpcAdapter(
+  options: KhalaCodeDesktopFleetRunSupervisorRpcAdapterOptions = {},
+): KhalaCodeDesktopFleetRunSupervisorRpc {
+  const env = options.env ?? {}
+  const store = options.store ?? defaultStore(env)
+  const pylonRef = options.pylonRef ?? null
+  const sources = new Map<string, IssueListWorkSource | FixtureWorkSource | GithubBacklogWorkSource>()
+  const active = new Map<string, ActiveSupervisor>()
+  const paths = { home: resolvePylonHome(env) }
+  const toolOptions = { ...options.toolOptions, env: { ...env, ...options.toolOptions?.env } }
+
+  const sync = async (): Promise<void> => {
+    await syncFleetRunsToOwnerLocalState(store, paths)
+  }
+
+  const projectionInput = (
+    runRef: string,
+  ): { readonly pylonRef: string | null; readonly workSource?: IssueListWorkSource | FixtureWorkSource | GithubBacklogWorkSource } => {
+    const workSource = sources.get(runRef)
+    return workSource === undefined ? { pylonRef } : { pylonRef, workSource }
+  }
+
+  const closeSupervisor = async (runRef: string): Promise<void> => {
+    const supervisor = active.get(runRef)
+    if (supervisor === undefined) return
+    await Effect.runPromise(Scope.close(supervisor.scope, Exit.void))
+    active.delete(runRef)
+  }
+
+  const startSupervisor = async (runRef: string): Promise<boolean> => {
+    if (active.has(runRef)) return false
+    const scope = Effect.runSync(Scope.make())
+    try {
+      const handle = await Effect.runPromise(Effect.provideService(
+        startFleetRunSupervisor({
+          capacity: options.capacity ?? capacityFor(toolOptions),
+          planner: plannerFor(store, sources),
+          pylonRef: pylonRef ?? "local-pylon",
+          runRef,
+          runner: options.runner ?? runnerFor({ pylonRef, toolOptions }),
+          store,
+          ...(options.tickIntervalMs === undefined ? {} : { tickIntervalMs: options.tickIntervalMs }),
+        }),
+        Scope.Scope,
+        scope,
+      ))
+      active.set(runRef, { handle, scope })
+      return true
+    } catch (error) {
+      await Effect.runPromise(Scope.close(scope, Exit.void))
+      throw error
+    }
+  }
+
+  return {
+    async control(request: KhalaCodeDesktopFleetRunControlRequest) {
+      const result = store.controlFleetRun(request.runRef, request.verb as FleetRunControlVerb)
+      if (request.verb === "resume") {
+        await startSupervisor(request.runRef)
+      } else if (request.verb === "pause" || request.verb === "stop") {
+        await closeSupervisor(request.runRef)
+      }
+      await sync()
+      return {
+        previousState: result.previousState as FleetRunState,
+        run: projectRun(result.run, projectionInput(result.run.runRef)),
+        supervisorActive: active.has(result.run.runRef),
+      }
+    },
+    async list(request?: KhalaCodeDesktopFleetRunListRequest) {
+      return store
+        .listFleetRuns(request?.state as FleetRunState | undefined)
+        .map(run => projectRun(run, projectionInput(run.runRef)))
+    },
+    async start(request: KhalaCodeDesktopFleetRunStartRequest) {
+      const workSource = normalizeWorkSource(request.workSource)
+      const refillPolicy = request.refillPolicy === undefined
+        ? undefined
+        : {
+            ...(request.refillPolicy.cooldownAware === undefined ? {} : { cooldownAware: request.refillPolicy.cooldownAware }),
+            ...(request.refillPolicy.maxPerAccount === undefined ? {} : { maxPerAccount: request.refillPolicy.maxPerAccount }),
+            ...(request.refillPolicy.stopCondition === undefined
+              ? {}
+              : { stopCondition: request.refillPolicy.stopCondition as FleetRunStopCondition }),
+          }
+      const run = store.createFleetRun({
+        runRef: request.runRef ?? runRefFor(),
+        objective: request.objective,
+        ...(refillPolicy === undefined ? {} : { refillPolicy }),
+        state: "running",
+        targetConcurrency: request.targetConcurrency,
+        workerKind: "codex",
+        workSource: workSourceKind(workSource),
+      })
+      sources.set(run.runRef, workSource)
+      const supervisorStarted = await startSupervisor(run.runRef)
+      if (request.tickImmediately === true) {
+        await Effect.runPromise(active.get(run.runRef)?.handle.tick() ?? Effect.void)
+      }
+      await sync()
+      const projected = projectRun(store.getFleetRun(run.runRef) ?? run, { pylonRef, workSource })
+      return { run: projected, supervisorStarted }
+    },
+    async status(request) {
+      const run = store.getFleetRun(request.runRef)
+      return {
+        run: run === null ? null : projectRun(run, projectionInput(run.runRef)),
+        supervisorActive: active.has(request.runRef),
+      }
+    },
+  }
+}

--- a/clients/khala-code-desktop/src/bun/index.ts
+++ b/clients/khala-code-desktop/src/bun/index.ts
@@ -28,6 +28,7 @@ import {
 } from "./codex-token-usage-telemetry.js"
 import { createOnDeviceDeciderHost } from "./on-device-decider-host.js"
 import { khalaCodeConfigFromRuntimeEnv } from "./khala-code-config.js"
+import { createKhalaCodeDesktopFleetRunSupervisorRpcAdapter } from "./fleet-run-supervisor-rpc-adapter.js"
 import { createKhalaCodeDesktopRpcRequestHandlers } from "./rpc-handlers.js"
 
 const khalaCodeConfig = khalaCodeConfigFromRuntimeEnv()
@@ -351,6 +352,7 @@ rpcRequestHandlers = createKhalaCodeDesktopRpcRequestHandlers({
   enableFleetMcpBridge: true,
   emitChatTurnEvent: event => emitChatTurnEvent(event),
   env: khalaCodeEnv,
+  fleetRunSupervisor: createKhalaCodeDesktopFleetRunSupervisorRpcAdapter({ env: khalaCodeEnv }),
   fleetMcpBridgeRepoRoot: resolveSourceRepositoryRoot(),
   onDeviceDeciderStatus: () => onDeviceDecider.select(),
   workingDirectory: resolveToolWorkingDirectory(khalaCodeEnv),

--- a/clients/khala-code-desktop/src/bun/rpc-handlers.ts
+++ b/clients/khala-code-desktop/src/bun/rpc-handlers.ts
@@ -264,21 +264,6 @@ const requireNonEmpty = (kind: string, field: string, value: string): void => {
   if (value.trim().length === 0) throw new Error(`${kind} requires ${field}`)
 }
 
-const assertFleetRunControlTransition = (
-  state: KhalaCodeDesktopFleetRunState,
-  verb: KhalaCodeDesktopFleetRunControlRequest["verb"],
-): void => {
-  const allowed: Record<KhalaCodeDesktopFleetRunControlRequest["verb"], readonly KhalaCodeDesktopFleetRunState[]> = {
-    drain: ["running", "paused"],
-    pause: ["running"],
-    resume: ["paused"],
-    stop: ["draft", "running", "paused", "draining"],
-  }
-  if (!allowed[verb].includes(state)) {
-    throw new Error(`fleetRunControl cannot ${verb} a ${state} fleet run`)
-  }
-}
-
 const normalizeMentionCandidate = (value: unknown): KhalaCodeDesktopCodexMentionCandidate | null => {
   if (!isRecord(value)) return null
   const path = stringValue(value.path)
@@ -1797,9 +1782,6 @@ export function createKhalaCodeDesktopRpcRequestHandlers(
     },
     async fleetRunControl(request): Promise<KhalaCodeDesktopFleetRunControlResult> {
       requireNonEmpty("fleetRunControl", "runRef", request.runRef)
-      const before = await requireFleetRunSupervisor().status({ runRef: request.runRef })
-      if (before.run === null) throw new Error(`unknown fleet run: ${request.runRef}`)
-      assertFleetRunControlTransition(before.run.state, request.verb)
       const result = await requireFleetRunSupervisor().control(request)
       return {
         ok: true,

--- a/clients/khala-code-desktop/src/bun/rpc-handlers.ts
+++ b/clients/khala-code-desktop/src/bun/rpc-handlers.ts
@@ -59,6 +59,16 @@ import {
   type KhalaCodeDesktopFleetPromotionRequest,
   type KhalaCodeDesktopFleetPromotionResult,
   type KhalaCodeDesktopFleetQueuePolicy,
+  type KhalaCodeDesktopFleetRunControlRequest,
+  type KhalaCodeDesktopFleetRunControlResult,
+  type KhalaCodeDesktopFleetRunListRequest,
+  type KhalaCodeDesktopFleetRunListResult,
+  type KhalaCodeDesktopFleetRunProjection,
+  type KhalaCodeDesktopFleetRunStartRequest,
+  type KhalaCodeDesktopFleetRunStartResult,
+  type KhalaCodeDesktopFleetRunState,
+  type KhalaCodeDesktopFleetRunStatusRequest,
+  type KhalaCodeDesktopFleetRunStatusResult,
   type KhalaCodeDesktopFleetSessionRole,
   type KhalaCodeDesktopFleetWorkerSession,
   type KhalaCodeDesktopFleetStatus,
@@ -101,6 +111,31 @@ import {
 type ChatEnv = Readonly<Record<string, string | undefined>>
 type MaybePromise<T> = T | Promise<T>
 
+export type KhalaCodeDesktopFleetRunSupervisorRpc = {
+  readonly control: (
+    request: KhalaCodeDesktopFleetRunControlRequest,
+  ) => MaybePromise<{
+    readonly previousState: KhalaCodeDesktopFleetRunState
+    readonly run: KhalaCodeDesktopFleetRunProjection
+    readonly supervisorActive: boolean
+  }>
+  readonly list: (
+    request?: KhalaCodeDesktopFleetRunListRequest,
+  ) => MaybePromise<readonly KhalaCodeDesktopFleetRunProjection[]>
+  readonly start: (
+    request: KhalaCodeDesktopFleetRunStartRequest,
+  ) => MaybePromise<{
+    readonly run: KhalaCodeDesktopFleetRunProjection
+    readonly supervisorStarted: boolean
+  }>
+  readonly status: (
+    request: KhalaCodeDesktopFleetRunStatusRequest,
+  ) => MaybePromise<{
+    readonly run: KhalaCodeDesktopFleetRunProjection | null
+    readonly supervisorActive: boolean
+  }>
+}
+
 export type KhalaCodeDesktopRpcHandlersInput = {
   readonly appleFmReadiness: () => MaybePromise<KhalaAppleFmReadiness>
   readonly codexAppServerHost?: CodexAppServerHost
@@ -112,6 +147,7 @@ export type KhalaCodeDesktopRpcHandlersInput = {
     readonly idempotencyKey: string
   }) => MaybePromise<KhalaCodexRateLimitResetOutcome>
   readonly codexFleetToolOptions?: KhalaCodexFleetToolOptions
+  readonly fleetRunSupervisor?: KhalaCodeDesktopFleetRunSupervisorRpc
   readonly fleetMcpBridgeRepoRoot?: string
   readonly env: ChatEnv
   readonly emitChatTurnEvent?: (event: KhalaCodeDesktopChatTurnEvent) => void
@@ -221,6 +257,25 @@ const materializeChatAttachments = async (
     ...request,
     attachments,
     turnId,
+  }
+}
+
+const requireNonEmpty = (kind: string, field: string, value: string): void => {
+  if (value.trim().length === 0) throw new Error(`${kind} requires ${field}`)
+}
+
+const assertFleetRunControlTransition = (
+  state: KhalaCodeDesktopFleetRunState,
+  verb: KhalaCodeDesktopFleetRunControlRequest["verb"],
+): void => {
+  const allowed: Record<KhalaCodeDesktopFleetRunControlRequest["verb"], readonly KhalaCodeDesktopFleetRunState[]> = {
+    drain: ["running", "paused"],
+    pause: ["running"],
+    resume: ["paused"],
+    stop: ["draft", "running", "paused", "draining"],
+  }
+  if (!allowed[verb].includes(state)) {
+    throw new Error(`fleetRunControl cannot ${verb} a ${state} fleet run`)
   }
 }
 
@@ -671,6 +726,12 @@ export function createKhalaCodeDesktopRpcRequestHandlers(
       throw new Error("Codex app-server chat runtime is not configured.")
     }
     return codexChatRuntime
+  }
+  const requireFleetRunSupervisor = (): KhalaCodeDesktopFleetRunSupervisorRpc => {
+    if (input.fleetRunSupervisor === undefined) {
+      throw new Error("Fleet run supervisor is not configured.")
+    }
+    return input.fleetRunSupervisor
   }
   const useLegacyKhalaNativeRuntime = (): boolean =>
     input.env.KHALA_CODE_DESKTOP_RUNTIME === "khala_native_runtime" ||
@@ -1709,6 +1770,48 @@ export function createKhalaCodeDesktopRpcRequestHandlers(
         env: input.env,
       })
       return promoteThreadResult(request, spawn)
+    },
+    async fleetRunStart(request): Promise<KhalaCodeDesktopFleetRunStartResult> {
+      requireNonEmpty("fleetRunStart", "objective", request.objective)
+      if (!Number.isInteger(request.targetConcurrency) || request.targetConcurrency < 1) {
+        throw new Error("fleetRunStart requires positive integer targetConcurrency")
+      }
+      const result = await requireFleetRunSupervisor().start(request)
+      return {
+        ok: true,
+        run: result.run,
+        supervisorStarted: result.supervisorStarted,
+      }
+    },
+    async fleetRunStatus(request): Promise<KhalaCodeDesktopFleetRunStatusResult> {
+      requireNonEmpty("fleetRunStatus", "runRef", request.runRef)
+      const result = await requireFleetRunSupervisor().status(request)
+      return {
+        ok: true,
+        run: result.run,
+        supervisorActive: result.supervisorActive,
+      }
+    },
+    async fleetRunControl(request): Promise<KhalaCodeDesktopFleetRunControlResult> {
+      requireNonEmpty("fleetRunControl", "runRef", request.runRef)
+      const before = await requireFleetRunSupervisor().status({ runRef: request.runRef })
+      if (before.run === null) throw new Error(`unknown fleet run: ${request.runRef}`)
+      assertFleetRunControlTransition(before.run.state, request.verb)
+      const result = await requireFleetRunSupervisor().control(request)
+      return {
+        ok: true,
+        previousState: result.previousState,
+        run: result.run,
+        supervisorActive: result.supervisorActive,
+        verb: request.verb,
+      }
+    },
+    async fleetRunList(request): Promise<KhalaCodeDesktopFleetRunListResult> {
+      const runs = await requireFleetRunSupervisor().list(request)
+      return {
+        ok: true,
+        runs: [...runs],
+      }
     },
     async codexHarnessStatus() {
       return codexHarnessStatus()

--- a/clients/khala-code-desktop/src/shared/rpc.ts
+++ b/clients/khala-code-desktop/src/shared/rpc.ts
@@ -1281,12 +1281,12 @@ const RpcFleetRunControlVerb = S.Literals(["pause", "resume", "drain", "stop"])
 const RpcFleetRunRefillPolicy = S.Struct({
   cooldownAware: S.Boolean,
   maxPerAccount: S.Number,
-  stopCondition: S.Literals(["backlog_empty", "manual_stop"]),
+  stopCondition: S.Literals(["backlog_empty", "target_reached", "manual_stop"]),
 })
 const RpcFleetRunRefillPolicyPatch = S.Struct({
   cooldownAware: S.optional(S.Boolean),
   maxPerAccount: S.optional(S.Number),
-  stopCondition: S.optional(S.Literals(["backlog_empty", "manual_stop"])),
+  stopCondition: S.optional(S.Literals(["backlog_empty", "target_reached", "manual_stop"])),
 })
 const RpcFleetRunCounters = S.Struct({
   activeAssignments: S.Number,

--- a/clients/khala-code-desktop/src/shared/rpc.ts
+++ b/clients/khala-code-desktop/src/shared/rpc.ts
@@ -174,6 +174,17 @@ export type KhalaCodeDesktopFleetDelegateRunMode = typeof RpcFleetDelegateRunReq
 export type KhalaCodeDesktopFleetDelegateRunRequest = typeof RpcFleetDelegateRunRequest.Type
 export type KhalaCodeDesktopFleetDelegateRunStep = typeof RpcFleetDelegateRunStep.Type
 export type KhalaCodeDesktopFleetDelegateRunResult = typeof RpcFleetDelegateRunResult.Type
+export type KhalaCodeDesktopFleetRunControlVerb = typeof RpcFleetRunControlVerb.Type
+export type KhalaCodeDesktopFleetRunState = typeof RpcFleetRunState.Type
+export type KhalaCodeDesktopFleetRunStartRequest = typeof RpcFleetRunStartRequest.Type
+export type KhalaCodeDesktopFleetRunStartResult = typeof RpcFleetRunStartResult.Type
+export type KhalaCodeDesktopFleetRunProjection = typeof RpcFleetRunProjection.Type
+export type KhalaCodeDesktopFleetRunStatusRequest = typeof RpcFleetRunStatusRequest.Type
+export type KhalaCodeDesktopFleetRunStatusResult = typeof RpcFleetRunStatusResult.Type
+export type KhalaCodeDesktopFleetRunControlRequest = typeof RpcFleetRunControlRequest.Type
+export type KhalaCodeDesktopFleetRunControlResult = typeof RpcFleetRunControlResult.Type
+export type KhalaCodeDesktopFleetRunListRequest = typeof RpcFleetRunListRequest.Type
+export type KhalaCodeDesktopFleetRunListResult = typeof RpcFleetRunListResult.Type
 export type KhalaCodeDesktopRemoveAccountResult = typeof RpcRemoveAccountResult.Type
 export type KhalaCodeDesktopConnectStart = typeof RpcConnectStart.Type
 
@@ -1263,6 +1274,96 @@ const RpcFleetDelegateRunResult = S.Struct({
   workerRuntime: RpcFleetWorkerRuntime,
 })
 
+const RpcFleetRunState = S.Literals(["draft", "running", "paused", "draining", "completed", "stopped"])
+const RpcFleetRunControlVerb = S.Literals(["pause", "resume", "drain", "stop"])
+const RpcFleetRunRefillPolicy = S.Struct({
+  cooldownAware: S.Boolean,
+  maxPerAccount: S.Number,
+  stopCondition: S.Literals(["backlog_empty", "manual_stop"]),
+})
+const RpcFleetRunRefillPolicyPatch = S.Struct({
+  cooldownAware: S.optional(S.Boolean),
+  maxPerAccount: S.optional(S.Number),
+  stopCondition: S.optional(S.Literals(["backlog_empty", "manual_stop"])),
+})
+const RpcFleetRunCounters = S.Struct({
+  activeAssignments: S.Number,
+  blockedAssignments: S.Number,
+  completedAssignments: S.Number,
+  failedAssignments: S.Number,
+  workUnitsTotal: S.Number,
+})
+const RpcFleetRunWorkSource = S.Struct({
+  kind: S.Literals(["github_backlog", "issue_list", "fixture"]),
+  repo: S.optional(S.String),
+  limit: S.optional(S.Number),
+  count: S.optional(S.Number),
+  issues: S.optional(S.Array(S.Union([
+    S.Number,
+    S.Struct({
+      kind: S.optional(S.Literals(["issue", "pr"])),
+      labels: S.optional(RpcStringArray),
+      number: S.Number,
+      state: S.optional(S.Literals(["open", "closed", "merged", "OPEN", "CLOSED", "MERGED"])),
+      title: S.optional(S.String),
+      url: S.optional(S.String),
+    }),
+  ]))),
+})
+const RpcFleetRunStartRequest = S.Struct({
+  objective: S.String,
+  runRef: S.optional(S.String),
+  targetConcurrency: S.Number,
+  workSource: RpcFleetRunWorkSource,
+  workerKind: S.optional(S.Literal("codex")),
+  refillPolicy: S.optional(RpcFleetRunRefillPolicyPatch),
+  tickImmediately: S.optional(S.Boolean),
+})
+const RpcFleetRunProjection = S.Struct({
+  counters: RpcFleetRunCounters,
+  createdAt: S.String,
+  dispatchKind: S.Literal("supervised_dispatch"),
+  objectiveProjected: S.Literal(false),
+  pylonRef: RpcStringNull,
+  refillPolicy: RpcFleetRunRefillPolicy,
+  runRef: S.String,
+  startedAt: RpcStringNull,
+  state: RpcFleetRunState,
+  targetConcurrency: S.Number,
+  updatedAt: S.String,
+  workerKind: S.Literal("codex"),
+  workSource: RpcFleetRunWorkSource,
+})
+const RpcFleetRunStartResult = S.Struct({
+  ok: S.Boolean,
+  run: RpcFleetRunProjection,
+  supervisorStarted: S.Boolean,
+})
+const RpcFleetRunStatusRequest = S.Struct({ runRef: S.String })
+const RpcFleetRunStatusResult = S.Struct({
+  ok: S.Boolean,
+  run: S.NullOr(RpcFleetRunProjection),
+  supervisorActive: S.Boolean,
+})
+const RpcFleetRunControlRequest = S.Struct({
+  runRef: S.String,
+  verb: RpcFleetRunControlVerb,
+})
+const RpcFleetRunControlResult = S.Struct({
+  ok: S.Boolean,
+  previousState: RpcFleetRunState,
+  run: RpcFleetRunProjection,
+  supervisorActive: S.Boolean,
+  verb: RpcFleetRunControlVerb,
+})
+const RpcFleetRunListRequest = S.Struct({
+  state: S.optional(RpcFleetRunState),
+})
+const RpcFleetRunListResult = S.Struct({
+  ok: S.Boolean,
+  runs: S.Array(RpcFleetRunProjection),
+})
+
 const RpcConnectStart = S.Struct({
   ok: S.Boolean,
   accountRef: S.String,
@@ -1320,6 +1421,10 @@ export const KhalaCodeDesktopRpcMethodSchemas = {
   codexFleetDelegateRun: { parameters: [param(RpcFleetDelegateRunRequest)], result: RpcFleetDelegateRunResult },
   codexFleetStatus: { parameters: noParams(), result: RpcFleetStatus },
   codexFleetPromoteThread: { parameters: [param(RpcFleetPromotionRequest)], result: RpcFleetPromotionResult },
+  fleetRunControl: { parameters: [param(RpcFleetRunControlRequest)], result: RpcFleetRunControlResult },
+  fleetRunList: { parameters: [optionalParam(RpcFleetRunListRequest)], result: RpcFleetRunListResult },
+  fleetRunStart: { parameters: [param(RpcFleetRunStartRequest)], result: RpcFleetRunStartResult },
+  fleetRunStatus: { parameters: [param(RpcFleetRunStatusRequest)], result: RpcFleetRunStatusResult },
   codexHarnessStatus: { parameters: noParams(), result: RpcCodexHarnessStatus },
   codexApprovalRespond: { parameters: [param(RpcApprovalRespondRequest)], result: RpcApprovalRespondResult },
   codexBackgroundTerminalsClean: { parameters: [param(RpcBackgroundTerminalsCleanRequest)], result: RpcCodexAppServerActionResult },
@@ -1457,6 +1562,10 @@ export type KhalaCodeDesktopRPCSchema = {
     codexFleetDelegateRun(request: KhalaCodeDesktopFleetDelegateRunRequest): Promise<KhalaCodeDesktopFleetDelegateRunResult>
     codexFleetStatus(): Promise<KhalaCodeDesktopFleetStatus>
     codexFleetPromoteThread(request: KhalaCodeDesktopFleetPromotionRequest): Promise<KhalaCodeDesktopFleetPromotionResult>
+    fleetRunControl(request: KhalaCodeDesktopFleetRunControlRequest): Promise<KhalaCodeDesktopFleetRunControlResult>
+    fleetRunList(request?: KhalaCodeDesktopFleetRunListRequest): Promise<KhalaCodeDesktopFleetRunListResult>
+    fleetRunStart(request: KhalaCodeDesktopFleetRunStartRequest): Promise<KhalaCodeDesktopFleetRunStartResult>
+    fleetRunStatus(request: KhalaCodeDesktopFleetRunStatusRequest): Promise<KhalaCodeDesktopFleetRunStatusResult>
     codexHarnessStatus(): Promise<KhalaCodeDesktopCodexHarnessStatus>
     codexApprovalRespond(request: KhalaCodeDesktopCodexApprovalRespondRequest): Promise<KhalaCodeDesktopCodexApprovalRespondResult>
     codexBackgroundTerminalsClean(request: KhalaCodeDesktopCodexBackgroundTerminalsCleanRequest): Promise<KhalaCodeDesktopCodexAppServerActionResult>

--- a/clients/khala-code-desktop/src/ui/main.ts
+++ b/clients/khala-code-desktop/src/ui/main.ts
@@ -172,6 +172,22 @@ const previewRpc = (): DesktopRpc => ({
       postPreviewRpc<
         Awaited<ReturnType<DesktopRpcRequests["codexFleetPromoteThread"]>>
       >("codexFleetPromoteThread", request),
+    fleetRunControl: request =>
+      postPreviewRpc<
+        Awaited<ReturnType<DesktopRpcRequests["fleetRunControl"]>>
+      >("fleetRunControl", request),
+    fleetRunList: request =>
+      postPreviewRpc<
+        Awaited<ReturnType<DesktopRpcRequests["fleetRunList"]>>
+      >("fleetRunList", request),
+    fleetRunStart: request =>
+      postPreviewRpc<
+        Awaited<ReturnType<DesktopRpcRequests["fleetRunStart"]>>
+      >("fleetRunStart", request),
+    fleetRunStatus: request =>
+      postPreviewRpc<
+        Awaited<ReturnType<DesktopRpcRequests["fleetRunStatus"]>>
+      >("fleetRunStatus", request),
     codexHarnessStatus: () =>
       postPreviewRpc<
         Awaited<ReturnType<DesktopRpcRequests["codexHarnessStatus"]>>

--- a/clients/khala-code-desktop/tests/fleet-run-supervisor-rpc-adapter.test.ts
+++ b/clients/khala-code-desktop/tests/fleet-run-supervisor-rpc-adapter.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, test } from "bun:test"
+import { Database } from "bun:sqlite"
+
+import { createPylonOrchestrationStore } from "../../../apps/pylon/src/orchestration/store"
+import { createKhalaCodeDesktopFleetRunSupervisorRpcAdapter } from "../src/bun/fleet-run-supervisor-rpc-adapter"
+import type { FleetRunSupervisorRunner } from "../src/bun/fleet-run-supervisor"
+
+const acceptingRunner: FleetRunSupervisorRunner = {
+  dispatch: async () => ({
+    assignmentRef: "assignment.test",
+    lifecycle: [],
+    status: "accepted",
+    summary: null,
+  }),
+}
+
+let fixtureOrdinal = 0
+
+const adapterFixture = () => {
+  fixtureOrdinal += 1
+  const store = createPylonOrchestrationStore(new Database(":memory:"))
+  const pylonRef = `pylon.test.${fixtureOrdinal}`
+  const adapter = createKhalaCodeDesktopFleetRunSupervisorRpcAdapter({
+    capacity: {
+      accounts: async () => [{ accountRef: "codex", advertisedCapacity: 0 }],
+    },
+    env: { PYLON_HOME: "/tmp/khala-code-fleet-run-rpc-adapter-test" },
+    pylonRef,
+    runner: acceptingRunner,
+    store,
+    tickIntervalMs: 60_000,
+  })
+  return { adapter, pylonRef, store }
+}
+
+describe("Khala Code fleet run supervisor RPC adapter", () => {
+  test("starts store-backed runs and retains normalized workSource projections", async () => {
+    const { adapter, pylonRef, store } = adapterFixture()
+
+    const result = await adapter.start({
+      objective: "Burn down public issues.",
+      runRef: "fleet_run.adapter.start",
+      targetConcurrency: 2,
+      workSource: {
+        kind: "issue_list",
+        repo: "OpenAgentsInc/openagents",
+        issues: [{
+          kind: "issue",
+          number: 7932,
+          state: "OPEN",
+          title: "Finish fleet run RPC",
+        }],
+      },
+    })
+
+    expect(result.supervisorStarted).toBe(true)
+    expect(store.getFleetRun("fleet_run.adapter.start")).toMatchObject({
+      objective: "Burn down public issues.",
+      state: "running",
+      workSource: "issue_list",
+    })
+    expect(result.run).toMatchObject({
+      objectiveProjected: false,
+      pylonRef,
+      workSource: {
+        kind: "issue_list",
+        repo: "OpenAgentsInc/openagents",
+        issues: [{ number: 7932, state: "open" }],
+      },
+    })
+    expect(result.run).not.toHaveProperty("objective")
+  })
+
+  test("accepts target_reached stop conditions in projections", async () => {
+    const { adapter } = adapterFixture()
+
+    const result = await adapter.start({
+      objective: "Run fixture target.",
+      runRef: "fleet_run.adapter.target",
+      targetConcurrency: 1,
+      refillPolicy: { stopCondition: "target_reached" },
+      workSource: { kind: "fixture", count: 1 },
+    })
+
+    expect(result.run.refillPolicy.stopCondition).toBe("target_reached")
+  })
+
+  test("rejects invalid control transitions in the store-backed authority", async () => {
+    const { adapter, store } = adapterFixture()
+    store.createFleetRun({
+      objective: "Already completed.",
+      runRef: "fleet_run.adapter.completed",
+      state: "completed",
+      targetConcurrency: 1,
+      workerKind: "codex",
+      workSource: "fixture",
+    })
+
+    await expect(adapter.control({ runRef: "fleet_run.adapter.completed", verb: "pause" }))
+      .rejects.toThrow("fleetRunControl cannot pause a completed fleet run")
+  })
+
+  test("rejects unknown control run refs", async () => {
+    const { adapter } = adapterFixture()
+
+    await expect(adapter.control({ runRef: "fleet_run.adapter.unknown", verb: "stop" }))
+      .rejects.toThrow("unknown fleet run: fleet_run.adapter.unknown")
+  })
+})

--- a/clients/khala-code-desktop/tests/rpc-handlers.test.ts
+++ b/clients/khala-code-desktop/tests/rpc-handlers.test.ts
@@ -18,6 +18,7 @@ import type {
   KhalaCodeDesktopCodexAppServerControlResult,
   KhalaCodeDesktopCodexAppServerStatus,
   KhalaCodeDesktopCodexHarnessStatus,
+  KhalaCodeDesktopFleetRunProjection,
 } from "../src/shared/rpc"
 
 const tempDirs: string[] = []
@@ -131,6 +132,39 @@ const stoppedAppServerStatus = (): KhalaCodeDesktopCodexAppServerStatus => ({
   transport: "stdio",
 })
 
+const fleetRunProjection = (
+  input: Partial<KhalaCodeDesktopFleetRunProjection> = {},
+): KhalaCodeDesktopFleetRunProjection => ({
+  counters: {
+    activeAssignments: 0,
+    blockedAssignments: 0,
+    completedAssignments: 0,
+    failedAssignments: 0,
+    workUnitsTotal: 25,
+  },
+  createdAt: "2026-07-01T12:00:00.000Z",
+  dispatchKind: "supervised_dispatch",
+  objectiveProjected: false,
+  pylonRef: "pylon.owner",
+  refillPolicy: {
+    cooldownAware: true,
+    maxPerAccount: 1,
+    stopCondition: "backlog_empty",
+  },
+  runRef: "fleet_run.test",
+  startedAt: "2026-07-01T12:00:00.000Z",
+  state: "running",
+  targetConcurrency: 25,
+  updatedAt: "2026-07-01T12:00:00.000Z",
+  workerKind: "codex",
+  workSource: {
+    kind: "issue_list",
+    repo: "OpenAgentsInc/openagents",
+    issues: [7832],
+  },
+  ...input,
+})
+
 function codexAppServerHost(
   request: CodexAppServerHost["request"],
 ): CodexAppServerHost {
@@ -210,6 +244,202 @@ function throwingCodexChatRuntime(
 }
 
 describe("Khala Code desktop RPC handlers", () => {
+  test("starts fleet runs through the supervisor RPC port", async () => {
+    const calls: unknown[] = []
+    const run = fleetRunProjection()
+    const handlers = createKhalaCodeDesktopRpcRequestHandlers({
+      appleFmReadiness: () => {
+        throw new Error("not used")
+      },
+      env: {},
+      fleetRunSupervisor: {
+        control: async () => {
+          throw new Error("not used")
+        },
+        list: async () => {
+          throw new Error("not used")
+        },
+        start: async request => {
+          calls.push(request)
+          return { run, supervisorStarted: true }
+        },
+        status: async () => {
+          throw new Error("not used")
+        },
+      },
+      onDeviceDeciderStatus: () => {
+        throw new Error("not used")
+      },
+      workingDirectory: process.cwd(),
+    })
+
+    await expect(handlers.fleetRunStart({
+      objective: "Burn down public issue backlog.",
+      targetConcurrency: 25,
+      workSource: {
+        kind: "issue_list",
+        repo: "OpenAgentsInc/openagents",
+        issues: [7832],
+      },
+    })).resolves.toEqual({
+      ok: true,
+      run,
+      supervisorStarted: true,
+    })
+    expect(calls).toHaveLength(1)
+  })
+
+  test("reads fleet run status through a public-safe projection", async () => {
+    const run = fleetRunProjection({
+      counters: {
+        activeAssignments: 3,
+        blockedAssignments: 1,
+        completedAssignments: 20,
+        failedAssignments: 1,
+        workUnitsTotal: 25,
+      },
+      state: "draining",
+    })
+    const handlers = createKhalaCodeDesktopRpcRequestHandlers({
+      appleFmReadiness: () => {
+        throw new Error("not used")
+      },
+      env: {},
+      fleetRunSupervisor: {
+        control: async () => {
+          throw new Error("not used")
+        },
+        list: async () => {
+          throw new Error("not used")
+        },
+        start: async () => {
+          throw new Error("not used")
+        },
+        status: async request => ({
+          run: request.runRef === run.runRef ? run : null,
+          supervisorActive: true,
+        }),
+      },
+      onDeviceDeciderStatus: () => {
+        throw new Error("not used")
+      },
+      workingDirectory: process.cwd(),
+    })
+
+    const result = await handlers.fleetRunStatus({ runRef: run.runRef })
+
+    expect(result).toEqual({ ok: true, run, supervisorActive: true })
+    expect(result.run).not.toHaveProperty("objective")
+  })
+
+  test("controls fleet run pause resume drain and stop transitions through the supervisor", async () => {
+    const calls: string[] = []
+    let current = fleetRunProjection({ state: "running" })
+    const handlers = createKhalaCodeDesktopRpcRequestHandlers({
+      appleFmReadiness: () => {
+        throw new Error("not used")
+      },
+      env: {},
+      fleetRunSupervisor: {
+        control: async request => {
+          calls.push(request.verb)
+          const previousState = current.state
+          const nextState = request.verb === "pause"
+            ? "paused"
+            : request.verb === "resume"
+              ? "running"
+              : request.verb === "drain"
+                ? "draining"
+                : "stopped"
+          current = fleetRunProjection({ state: nextState })
+          return { previousState, run: current, supervisorActive: nextState === "running" }
+        },
+        list: async () => {
+          throw new Error("not used")
+        },
+        start: async () => {
+          throw new Error("not used")
+        },
+        status: async () => ({ run: current, supervisorActive: current.state === "running" }),
+      },
+      onDeviceDeciderStatus: () => {
+        throw new Error("not used")
+      },
+      workingDirectory: process.cwd(),
+    })
+
+    await expect(handlers.fleetRunControl({ runRef: current.runRef, verb: "pause" }))
+      .resolves.toMatchObject({ previousState: "running", run: { state: "paused" }, verb: "pause" })
+    await expect(handlers.fleetRunControl({ runRef: current.runRef, verb: "resume" }))
+      .resolves.toMatchObject({ previousState: "paused", run: { state: "running" }, verb: "resume" })
+    await expect(handlers.fleetRunControl({ runRef: current.runRef, verb: "drain" }))
+      .resolves.toMatchObject({ previousState: "running", run: { state: "draining" }, verb: "drain" })
+    await expect(handlers.fleetRunControl({ runRef: current.runRef, verb: "stop" }))
+      .resolves.toMatchObject({ previousState: "draining", run: { state: "stopped" }, verb: "stop" })
+
+    expect(calls).toEqual(["pause", "resume", "drain", "stop"])
+  })
+
+  test("rejects invalid fleet run control transitions before mutation", async () => {
+    const run = fleetRunProjection({ state: "completed" })
+    let mutated = false
+    const handlers = createKhalaCodeDesktopRpcRequestHandlers({
+      appleFmReadiness: () => {
+        throw new Error("not used")
+      },
+      env: {},
+      fleetRunSupervisor: {
+        control: async () => {
+          mutated = true
+          return { previousState: "completed", run, supervisorActive: false }
+        },
+        list: async () => [run],
+        start: async () => ({ run, supervisorStarted: false }),
+        status: async () => ({ run, supervisorActive: false }),
+      },
+      onDeviceDeciderStatus: () => {
+        throw new Error("not used")
+      },
+      workingDirectory: process.cwd(),
+    })
+
+    await expect(handlers.fleetRunControl({ runRef: run.runRef, verb: "pause" }))
+      .rejects.toThrow("fleetRunControl cannot pause a completed fleet run")
+    expect(mutated).toBe(false)
+  })
+
+  test("lists fleet runs through the supervisor RPC port", async () => {
+    const running = fleetRunProjection({ runRef: "fleet_run.running", state: "running" })
+    const paused = fleetRunProjection({ runRef: "fleet_run.paused", state: "paused" })
+    const handlers = createKhalaCodeDesktopRpcRequestHandlers({
+      appleFmReadiness: () => {
+        throw new Error("not used")
+      },
+      env: {},
+      fleetRunSupervisor: {
+        control: async () => {
+          throw new Error("not used")
+        },
+        list: async request => [running, paused].filter(run => request?.state === undefined || run.state === request.state),
+        start: async () => {
+          throw new Error("not used")
+        },
+        status: async () => {
+          throw new Error("not used")
+        },
+      },
+      onDeviceDeciderStatus: () => {
+        throw new Error("not used")
+      },
+      workingDirectory: process.cwd(),
+    })
+
+    await expect(handlers.fleetRunList({ state: "paused" })).resolves.toEqual({
+      ok: true,
+      runs: [paused],
+    })
+  })
+
   test("answers native desktop status probes instead of falling through", async () => {
     const handlers = createKhalaCodeDesktopRpcRequestHandlers({
       appleFmReadiness: () => {

--- a/clients/khala-code-desktop/tests/rpc-handlers.test.ts
+++ b/clients/khala-code-desktop/tests/rpc-handlers.test.ts
@@ -380,7 +380,7 @@ describe("Khala Code desktop RPC handlers", () => {
     expect(calls).toEqual(["pause", "resume", "drain", "stop"])
   })
 
-  test("rejects invalid fleet run control transitions before mutation", async () => {
+  test("delegates fleet run control transition authority to the supervisor", async () => {
     const run = fleetRunProjection({ state: "completed" })
     let mutated = false
     const handlers = createKhalaCodeDesktopRpcRequestHandlers({
@@ -404,8 +404,58 @@ describe("Khala Code desktop RPC handlers", () => {
     })
 
     await expect(handlers.fleetRunControl({ runRef: run.runRef, verb: "pause" }))
-      .rejects.toThrow("fleetRunControl cannot pause a completed fleet run")
-    expect(mutated).toBe(false)
+      .resolves.toMatchObject({ previousState: "completed", run, verb: "pause" })
+    expect(mutated).toBe(true)
+  })
+
+  test("rejects fleet run RPCs when the supervisor is unconfigured", async () => {
+    const handlers = createKhalaCodeDesktopRpcRequestHandlers({
+      appleFmReadiness: () => {
+        throw new Error("not used")
+      },
+      env: {},
+      onDeviceDeciderStatus: () => {
+        throw new Error("not used")
+      },
+      workingDirectory: process.cwd(),
+    })
+
+    await expect(handlers.fleetRunStatus({ runRef: "fleet_run.missing" }))
+      .rejects.toThrow("Fleet run supervisor is not configured.")
+  })
+
+  test("rejects empty fleet run objectives and non-integer target concurrency", async () => {
+    const handlers = createKhalaCodeDesktopRpcRequestHandlers({
+      appleFmReadiness: () => {
+        throw new Error("not used")
+      },
+      env: {},
+      fleetRunSupervisor: {
+        control: async () => {
+          throw new Error("not used")
+        },
+        list: async () => [],
+        start: async () => {
+          throw new Error("not used")
+        },
+        status: async () => ({ run: null, supervisorActive: false }),
+      },
+      onDeviceDeciderStatus: () => {
+        throw new Error("not used")
+      },
+      workingDirectory: process.cwd(),
+    })
+
+    await expect(handlers.fleetRunStart({
+      objective: " ",
+      targetConcurrency: 1,
+      workSource: { kind: "fixture", count: 1 },
+    })).rejects.toThrow("fleetRunStart requires objective")
+    await expect(handlers.fleetRunStart({
+      objective: "Run fixture work.",
+      targetConcurrency: 1.5,
+      workSource: { kind: "fixture", count: 1 },
+    })).rejects.toThrow("fleetRunStart requires positive integer targetConcurrency")
   })
 
   test("lists fleet runs through the supervisor RPC port", async () => {


### PR DESCRIPTION
Closes #7832

## Summary
- Add schema-first FleetRun RPC methods for start, status, control, and list.
- Wire Bun RPC handlers through a FleetRunSupervisor RPC port with control transition guards.
- Add preview bridge parity and handler-table coverage/tests for all new methods.

## Verification
- bun run --cwd clients/khala-code-desktop verify