### PR TITLE
T3.3: Start fleet run form

### DIFF
--- a/clients/khala-code-desktop/src/ui/fleet-status.ts
+++ b/clients/khala-code-desktop/src/ui/fleet-status.ts
@@ -5,6 +5,8 @@ import type {
   KhalaCodeDesktopFleetAccount,
   KhalaCodeDesktopFleetDelegateRunRequest,
   KhalaCodeDesktopFleetDelegateRunResult,
+  KhalaCodeDesktopFleetRunStartRequest,
+  KhalaCodeDesktopFleetRunStartResult,
   KhalaCodeDesktopFleetStatus,
 } from "../shared/rpc"
 import { buildKhalaFleetBoardProjection } from "./fleet-board-projection"
@@ -28,6 +30,9 @@ export type FleetPanelOptions = Readonly<{
   delegateRun: (
     request: KhalaCodeDesktopFleetDelegateRunRequest,
   ) => Promise<KhalaCodeDesktopFleetDelegateRunResult>
+  fleetRunStart: (
+    request: KhalaCodeDesktopFleetRunStartRequest,
+  ) => Promise<KhalaCodeDesktopFleetRunStartResult>
   loadGymDemoProof: () =>
     | KhalaGymDelegationOptimizationRun
     | Promise<KhalaGymDelegationOptimizationRun>
@@ -43,6 +48,9 @@ export type FleetPanelOptions = Readonly<{
 type Handlers = Readonly<{
   onDelegateField: (field: keyof FleetDelegateFormState, value: string | boolean) => void
   onDelegateRun: () => void
+  onFleetRunField: (field: keyof FleetRunFormState, value: string) => void
+  onFleetRunPreview: () => void
+  onFleetRunStart: () => void
   onLoadGymDemoProof: () => void
   onOptimizationStart: () => void
   onRefresh: () => void
@@ -69,6 +77,13 @@ type FleetDelegateFormState = Readonly<{
   verify: string
 }>
 
+type FleetRunFormState = Readonly<{
+  objective: string
+  workSource: KhalaCodeDesktopFleetRunStartRequest["workSource"]["kind"]
+  targetConcurrency: string
+  workerKind: "codex" | "claude" | "auto"
+}>
+
 type DelegateRunView =
   | { readonly phase: "idle" }
   | { readonly phase: "loading" }
@@ -80,6 +95,24 @@ type OptimizationRunView =
   | { readonly phase: "loading" }
   | { readonly phase: "error"; readonly message: string }
   | { readonly phase: "ready"; readonly result: KhalaGymDelegationOptimizationRun }
+
+type FleetRunPreviewSlot = Readonly<{
+  accountRef: string
+  claimRef: string
+  slot: number
+  workerKind: FleetRunFormState["workerKind"]
+}>
+
+type FleetRunView =
+  | { readonly phase: "idle" }
+  | { readonly phase: "preview"; readonly slots: readonly FleetRunPreviewSlot[] }
+  | { readonly phase: "loading"; readonly slots: readonly FleetRunPreviewSlot[] }
+  | { readonly phase: "error"; readonly message: string; readonly slots?: readonly FleetRunPreviewSlot[] }
+  | {
+      readonly phase: "ready"
+      readonly result: KhalaCodeDesktopFleetRunStartResult
+      readonly slots: readonly FleetRunPreviewSlot[]
+    }
 
 type FleetView =
   | { readonly phase: "loading" }
@@ -305,6 +338,52 @@ const textInput = (
   return wrapper
 }
 
+const fleetRunTextInput = (
+  name: keyof FleetRunFormState,
+  label: string,
+  value: string,
+  handlers: Handlers,
+  options: Readonly<{
+    placeholder?: string
+    type?: "number" | "text"
+  }> = {},
+): HTMLElement => {
+  const wrapper = el("label", "khala-fleet-delegate-field")
+  wrapper.append(el("span", "khala-fleet-chip-label", label))
+  const input = el("input", "khala-fleet-delegate-input") as HTMLInputElement
+  input.name = String(name)
+  input.type = options.type ?? "text"
+  input.value = value
+  if (options.placeholder !== undefined) input.placeholder = options.placeholder
+  if (input.type === "number") input.min = "1"
+  input.addEventListener("input", () => handlers.onFleetRunField(name, input.value))
+  wrapper.append(input)
+  return wrapper
+}
+
+const fleetRunSelect = <T extends string>(
+  name: keyof FleetRunFormState,
+  label: string,
+  value: T,
+  options: readonly (readonly [T, string])[],
+  handlers: Handlers,
+): HTMLElement => {
+  const wrapper = el("label", "khala-fleet-delegate-field")
+  wrapper.append(el("span", "khala-fleet-chip-label", label))
+  const select = el("select", "khala-fleet-delegate-input") as HTMLSelectElement
+  select.name = String(name)
+  for (const [optionValue, optionLabel] of options) {
+    const option = el("option") as HTMLOptionElement
+    option.value = optionValue
+    option.textContent = optionLabel
+    option.selected = value === optionValue
+    select.append(option)
+  }
+  select.addEventListener("change", () => handlers.onFleetRunField(name, select.value))
+  wrapper.append(select)
+  return wrapper
+}
+
 const renderDelegateResult = (
   container: HTMLElement,
   run: DelegateRunView,
@@ -456,6 +535,130 @@ const renderDelegateRunner = (
 
   section.append(formEl)
   renderDelegateResult(section, run)
+  container.append(section)
+}
+
+const renderFleetRunResult = (
+  container: HTMLElement,
+  run: FleetRunView,
+): void => {
+  if (run.phase === "idle") return
+  const output = el("div", "khala-fleet-delegate-output")
+  if (run.phase === "error") {
+    output.dataset.state = "blocked"
+    output.append(
+      badge("missing", "Blocked"),
+      el("p", "khala-fleet-error", run.message),
+    )
+  } else if (run.phase === "loading") {
+    output.dataset.state = "loading"
+    output.append(
+      badge("online", "Starting"),
+      el("p", "khala-fleet-empty", "Starting supervised FleetRun…"),
+    )
+  } else if (run.phase === "ready") {
+    output.dataset.state = run.result.run.state
+    const chips = el("div", "khala-fleet-chips")
+    chips.append(
+      badge("online", titleize(run.result.run.state)),
+      detailChip("run", run.result.run.runRef),
+      detailChip("target", String(run.result.run.targetConcurrency)),
+      detailChip("source", run.result.run.workSource.kind),
+      detailChip("supervisor", run.result.supervisorStarted ? "started" : "not started"),
+    )
+    output.append(chips)
+  } else {
+    output.dataset.state = "preview"
+    output.append(
+      badge("ready", "Dry-run preview"),
+      el("p", "khala-fleet-empty", "Planned first wave before starting."),
+    )
+  }
+
+  const slots = "slots" in run ? run.slots : []
+  if (slots.length > 0) {
+    const list = el("div", "khala-fleet-run-preview")
+    for (const slot of slots) {
+      const row = el("article", "khala-fleet-run-preview-slot")
+      row.append(
+        detailChip(`slot ${slot.slot}`, slot.accountRef),
+        detailChip("claim", slot.claimRef),
+        detailChip("worker", slot.workerKind),
+      )
+      list.append(row)
+    }
+    output.append(list)
+  }
+  container.append(output)
+}
+
+const renderFleetRunStarter = (
+  container: HTMLElement,
+  form: FleetRunFormState,
+  run: FleetRunView,
+  handlers: Handlers,
+): void => {
+  const section = el("section", "khala-fleet-section khala-fleet-delegate khala-fleet-run-start")
+  section.append(sectionHeader("Start fleet run", "supervised FleetRun"))
+
+  const formEl = el("form", "khala-fleet-delegate-form") as HTMLFormElement
+  formEl.setAttribute("aria-label", "Start fleet run")
+  formEl.addEventListener("submit", event => {
+    event.preventDefault()
+    handlers.onFleetRunStart()
+  })
+
+  const objective = el("textarea", "khala-fleet-delegate-objective") as HTMLTextAreaElement
+  objective.name = "objective"
+  objective.value = form.objective
+  objective.rows = 2
+  objective.placeholder = "Fleet objective for sustained fan-out"
+  objective.setAttribute("aria-label", "Fleet run objective")
+  objective.addEventListener("input", () => handlers.onFleetRunField("objective", objective.value))
+  formEl.append(objective)
+
+  const controls = el("div", "khala-fleet-delegate-grid")
+  controls.append(
+    fleetRunSelect(
+      "workSource",
+      "source",
+      form.workSource,
+      [
+        ["github_backlog", "GitHub backlog"],
+        ["issue_list", "Issue list"],
+        ["fixture", "Fixture"],
+      ],
+      handlers,
+    ),
+    fleetRunTextInput("targetConcurrency", "target", form.targetConcurrency, handlers, {
+      placeholder: "25",
+      type: "number",
+    }),
+    fleetRunSelect(
+      "workerKind",
+      "worker",
+      form.workerKind,
+      [
+        ["codex", "Codex"],
+        ["claude", "Claude"],
+        ["auto", "Auto"],
+      ],
+      handlers,
+    ),
+  )
+  formEl.append(controls)
+
+  const footer = el("div", "khala-fleet-delegate-footer")
+  const preview = iconButton("Preview first wave", "Eye", "khala-fleet-refresh")
+  preview.addEventListener("click", handlers.onFleetRunPreview)
+  const start = iconButton(run.phase === "loading" ? "Starting" : "Start fleet run", "Play", "khala-fleet-run")
+  start.type = "submit"
+  start.disabled = run.phase === "loading"
+  footer.append(preview, start)
+  formEl.append(footer)
+
+  section.append(formEl)
+  renderFleetRunResult(section, run)
   container.append(section)
 }
 
@@ -863,6 +1066,8 @@ const render = (
   activeConnect: ConnectView | null,
   delegateForm: FleetDelegateFormState,
   delegateRun: DelegateRunView,
+  fleetRunForm: FleetRunFormState,
+  fleetRun: FleetRunView,
   optimizationRun: OptimizationRunView,
 ): void => {
   container.replaceChildren()
@@ -890,6 +1095,7 @@ const render = (
   // visible and live below it.
   if (activeConnect !== null) renderConnecting(body, activeConnect, handlers)
   renderDelegateRunner(body, delegateForm, delegateRun, handlers)
+  renderFleetRunStarter(body, fleetRunForm, fleetRun, handlers)
   renderOptimizationRunner(body, optimizationRun, handlers)
   if (view.phase === "loading") {
     body.append(el("p", "khala-fleet-empty", "Inspecting Codex fleet…"))
@@ -921,6 +1127,14 @@ export const mountFleetPanel = (
     verify: "",
   }
   let delegateRun: DelegateRunView = { phase: "idle" }
+  let fleetRunForm: FleetRunFormState = {
+    objective: "Run the public-safe fixture backlog through the Codex fleet.",
+    targetConcurrency: "2",
+    workerKind: "codex",
+    workSource: "fixture",
+  }
+  let fleetRun: FleetRunView = { phase: "idle" }
+  let fleetRunInFlight = false
   let optimizationInFlight = false
   let optimizationRun: OptimizationRunView = { phase: "idle" }
   let lastData: KhalaCodeDesktopFleetStatus | null = null
@@ -950,8 +1164,60 @@ export const mountFleetPanel = (
       activeConnect,
       delegateForm,
       delegateRun,
+      fleetRunForm,
+      fleetRun,
       optimizationRun,
     )
+
+  const fleetRunPreview = (): readonly FleetRunPreviewSlot[] | string => {
+    const targetConcurrency = Number.parseInt(fleetRunForm.targetConcurrency, 10)
+    if (!Number.isInteger(targetConcurrency) || targetConcurrency < 1) {
+      return "Fleet run target concurrency must be a positive integer."
+    }
+    if (lastData === null) return "Fleet status must load before previewing a run."
+    const accounts = lastData.accounts.filter(
+      account => accountReadinessState(account.readiness) === "ready",
+    )
+    if (accounts.length === 0) return "No ready worker accounts are available for the first wave."
+    const slots: FleetRunPreviewSlot[] = []
+    for (const account of accounts) {
+      const available = account.capacity?.available ?? 1
+      const slotCount = Math.max(0, available === null ? 1 : available)
+      for (let index = 0; index < slotCount && slots.length < targetConcurrency; index += 1) {
+        const slot = slots.length + 1
+        slots.push({
+          accountRef: account.accountRef,
+          claimRef: `claim.${fleetRunForm.workSource}.${String(slot).padStart(2, "0")}`,
+          slot,
+          workerKind: fleetRunForm.workerKind,
+        })
+      }
+      if (slots.length >= targetConcurrency) break
+    }
+    if (slots.length === 0) return "No available worker slots are available for the first wave."
+    return slots
+  }
+
+  const fleetRunRequest = (): KhalaCodeDesktopFleetRunStartRequest | string => {
+    const objective = fleetRunForm.objective.trim()
+    if (objective.length === 0) return "Fleet run requires an objective."
+    const targetConcurrency = Number.parseInt(fleetRunForm.targetConcurrency, 10)
+    if (!Number.isInteger(targetConcurrency) || targetConcurrency < 1) {
+      return "Fleet run target concurrency must be a positive integer."
+    }
+    if (fleetRunForm.workerKind !== "codex") {
+      return `${titleize(fleetRunForm.workerKind)} FleetRun starts are accepted by the form but only Codex is wired in this build.`
+    }
+    return {
+      objective,
+      targetConcurrency,
+      tickImmediately: false,
+      workerKind: "codex",
+      workSource: {
+        kind: fleetRunForm.workSource,
+      },
+    }
+  }
 
   const delegateRequest = (): KhalaCodeDesktopFleetDelegateRunRequest | string => {
     const objective = delegateForm.objective.trim()
@@ -1006,6 +1272,22 @@ export const mountFleetPanel = (
       if (field === "mode") paint()
     },
     onDelegateRun: () => onDelegateRun(),
+    onFleetRunField: (field, value) => {
+      fleetRunForm = {
+        ...fleetRunForm,
+        [field]: value,
+      } as FleetRunFormState
+      if (fleetRun.phase !== "loading") fleetRun = { phase: "idle" }
+      paint()
+    },
+    onFleetRunPreview: () => {
+      const preview = fleetRunPreview()
+      fleetRun = typeof preview === "string"
+        ? { phase: "error", message: preview }
+        : { phase: "preview", slots: preview }
+      paint()
+    },
+    onFleetRunStart: () => onFleetRunStart(),
     onLoadGymDemoProof: () => onLoadGymDemoProof(),
     onOptimizationStart: () => onOptimizationStart(),
     onRefresh: () => void refresh(),
@@ -1043,6 +1325,41 @@ export const mountFleetPanel = (
         paint()
       } finally {
         delegateInFlight = false
+      }
+    })()
+  }
+
+  const onFleetRunStart = (): void => {
+    if (fleetRunInFlight) return
+    const preview = fleetRunPreview()
+    if (typeof preview === "string") {
+      fleetRun = { phase: "error", message: preview }
+      paint()
+      return
+    }
+    const request = fleetRunRequest()
+    if (typeof request === "string") {
+      fleetRun = { phase: "error", message: request, slots: preview }
+      paint()
+      return
+    }
+    fleetRunInFlight = true
+    fleetRun = { phase: "loading", slots: preview }
+    paint()
+    void (async () => {
+      try {
+        const result = await options.fleetRunStart(request)
+        fleetRun = { phase: "ready", result, slots: preview }
+        await refresh()
+      } catch (error) {
+        fleetRun = {
+          phase: "error",
+          message: error instanceof Error ? error.message : String(error),
+          slots: preview,
+        }
+        paint()
+      } finally {
+        fleetRunInFlight = false
       }
     })()
   }
@@ -1099,6 +1416,8 @@ export const mountFleetPanel = (
           activeConnect,
           delegateForm,
           delegateRun,
+          fleetRunForm,
+          fleetRun,
           optimizationRun,
         )
         return
@@ -1161,6 +1480,8 @@ export const mountFleetPanel = (
           activeConnect,
           delegateForm,
           delegateRun,
+          fleetRunForm,
+          fleetRun,
           optimizationRun,
         )
       } else {

--- a/clients/khala-code-desktop/src/ui/main.ts
+++ b/clients/khala-code-desktop/src/ui/main.ts
@@ -2250,6 +2250,8 @@ const controls = {
   codexFleetStatus: () => rpc.request.codexFleetStatus(),
   codexFleetPromoteThread: (request: Parameters<DesktopRpcRequests["codexFleetPromoteThread"]>[0]) =>
     rpc.request.codexFleetPromoteThread(request),
+  fleetRunStart: (request: Parameters<DesktopRpcRequests["fleetRunStart"]>[0]) =>
+    rpc.request.fleetRunStart(request),
   codexHarnessStatus: () => rpc.request.codexHarnessStatus(),
   codexApprovalRespond: (request: Parameters<DesktopRpcRequests["codexApprovalRespond"]>[0]) =>
     rpc.request.codexApprovalRespond(request),
@@ -2524,6 +2526,7 @@ const fleetPanel =
     ? null
     : mountFleetPanel(fleetPanelEl, {
         delegateRun: request => controls.codexFleetDelegateRun(request),
+        fleetRunStart: request => controls.fleetRunStart(request),
         loadGymDemoProof: () => loadGymDemoOptimization(),
         startDelegationOptimization: async () => loadGymDemoOptimization(),
         fetch: () => controls.codexFleetStatus(),

--- a/clients/khala-code-desktop/tests/fleet-status.test.ts
+++ b/clients/khala-code-desktop/tests/fleet-status.test.ts
@@ -1,0 +1,196 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test"
+import { Window } from "happy-dom"
+
+import type {
+  KhalaCodeDesktopFleetRunStartRequest,
+  KhalaCodeDesktopFleetRunStartResult,
+  KhalaCodeDesktopFleetStatus,
+} from "../src/shared/rpc"
+import { mountFleetPanel } from "../src/ui/fleet-status"
+
+let previousDocument: typeof globalThis.document | undefined
+let previousWindow: typeof globalThis.window | undefined
+let previousMatchMedia: typeof globalThis.matchMedia | undefined
+
+const status = (): KhalaCodeDesktopFleetStatus => ({
+  ok: true,
+  observedAt: "2026-07-01T18:00:00.000Z",
+  pylon: {
+    message: "online",
+    pylonRef: "pylon.public.fleet",
+    status: "online",
+  },
+  availableCodexAssignments: 3,
+  maxCodexAssignments: 4,
+  tokenRate: {
+    activeAdjustedTokensPerMinute: null,
+    completedStatus: "not_measured",
+    completedTokenRows: null,
+    completedTokensPerMinute: null,
+    inFlightTokens: null,
+    inFlightTokensPerMinute: null,
+    source: "unavailable",
+    unavailableReason: null,
+  },
+  accounts: [
+    {
+      accountKey: null,
+      accountRef: "codex-a",
+      capacity: {
+        available: 2,
+        busy: 0,
+        queued: 0,
+        ready: 2,
+      },
+      email: "operator-a@example.com",
+      provider: "codex",
+      quotaState: "available",
+      readiness: "ready",
+    },
+    {
+      accountKey: null,
+      accountRef: "codex-b",
+      capacity: {
+        available: 1,
+        busy: 0,
+        queued: 0,
+        ready: 1,
+      },
+      email: "operator-b@example.com",
+      provider: "codex",
+      quotaState: "available",
+      readiness: "ready",
+    },
+  ],
+  activeAssignments: [],
+  processes: [],
+})
+
+const runStartResult = (
+  request: KhalaCodeDesktopFleetRunStartRequest,
+): KhalaCodeDesktopFleetRunStartResult => ({
+  ok: true,
+  run: {
+    counters: {
+      activeAssignments: 0,
+      blockedAssignments: 0,
+      completedAssignments: 0,
+      failedAssignments: 0,
+      workUnitsTotal: 0,
+    },
+    createdAt: "2026-07-01T18:00:00.000Z",
+    dispatchKind: "supervised_dispatch",
+    objectiveProjected: false,
+    pylonRef: "pylon.public.fleet",
+    refillPolicy: {
+      cooldownAware: true,
+      maxPerAccount: 1,
+      stopCondition: "backlog_empty",
+    },
+    runRef: "fleet.run.public.test",
+    startedAt: "2026-07-01T18:00:01.000Z",
+    state: "running",
+    targetConcurrency: request.targetConcurrency,
+    updatedAt: "2026-07-01T18:00:01.000Z",
+    workerKind: "codex",
+    workSource: request.workSource,
+  },
+  supervisorStarted: true,
+})
+
+const installDom = (): void => {
+  const window = new Window()
+  previousDocument = globalThis.document
+  previousWindow = globalThis.window
+  previousMatchMedia = globalThis.matchMedia
+  Object.defineProperty(globalThis, "window", { configurable: true, value: window })
+  Object.defineProperty(globalThis, "document", { configurable: true, value: window.document })
+  Object.defineProperty(globalThis, "matchMedia", {
+    configurable: true,
+    value: () => ({ matches: false }),
+  })
+}
+
+const restoreDom = (): void => {
+  Object.defineProperty(globalThis, "window", { configurable: true, value: previousWindow })
+  Object.defineProperty(globalThis, "document", { configurable: true, value: previousDocument })
+  Object.defineProperty(globalThis, "matchMedia", { configurable: true, value: previousMatchMedia })
+}
+
+const changeInput = (input: HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement, value: string): void => {
+  input.value = value
+  input.dispatchEvent(new window.Event(input.tagName === "SELECT" ? "change" : "input", { bubbles: true }))
+}
+
+describe("Fleet status panel", () => {
+  beforeEach(installDom)
+  afterEach(restoreDom)
+
+  test("previews the first FleetRun wave and starts through the mocked RPC", async () => {
+    const root = document.createElement("div")
+    const requests: KhalaCodeDesktopFleetRunStartRequest[] = []
+    const panel = mountFleetPanel(root, {
+      connectAccount: async () => ({
+        ok: false,
+        accountRef: "codex-test",
+        error: "disabled",
+        output: "",
+        userCode: null,
+        verificationUrl: null,
+      }),
+      delegateRun: async () => {
+        throw new Error("delegate runner should not be called")
+      },
+      fetch: async () => status(),
+      fleetRunStart: async request => {
+        requests.push(request)
+        return runStartResult(request)
+      },
+      loadGymDemoProof: () => {
+        throw new Error("gym proof should not be called")
+      },
+      openExternal: async () => false,
+      removeAccount: async () => ({ ok: true }),
+      startDelegationOptimization: async () => {
+        throw new Error("optimization should not be called")
+      },
+    })
+
+    await panel.refresh()
+
+    const form = root.querySelector<HTMLFormElement>('form[aria-label="Start fleet run"]')
+    expect(form).not.toBeNull()
+    changeInput(form!.elements.namedItem("objective") as HTMLTextAreaElement, "Burn down public fixture tasks.")
+    changeInput(form!.elements.namedItem("targetConcurrency") as HTMLInputElement, "3")
+    changeInput(form!.elements.namedItem("workSource") as HTMLSelectElement, "fixture")
+    changeInput(form!.elements.namedItem("workerKind") as HTMLSelectElement, "codex")
+
+    const previewButton = [...root.querySelectorAll<HTMLButtonElement>("button")]
+      .find(button => button.textContent?.includes("Preview first wave"))
+    expect(previewButton).not.toBeUndefined()
+    previewButton!.click()
+
+    expect(root.textContent).toContain("Planned first wave before starting.")
+    expect(root.textContent).toContain("claim.fixture.01")
+    expect(root.textContent).toContain("claim.fixture.02")
+    expect(root.textContent).toContain("claim.fixture.03")
+    expect(root.textContent).toContain("codex-a")
+    expect(root.textContent).toContain("codex-b")
+
+    form!.dispatchEvent(new window.Event("submit", { bubbles: true, cancelable: true }))
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(requests).toEqual([
+      {
+        objective: "Burn down public fixture tasks.",
+        targetConcurrency: 3,
+        tickImmediately: false,
+        workerKind: "codex",
+        workSource: { kind: "fixture" },
+      },
+    ])
+    expect(root.textContent).toContain("fleet.run.public.test")
+    expect(root.textContent).toContain("running")
+  })
+})

--- a/docs/fable/2026-07-01-fleet-fanout-coding-instructions.md
+++ b/docs/fable/2026-07-01-fleet-fanout-coding-instructions.md
@@ -160,11 +160,12 @@ Build:
    (pause/resume/drain/stop) so the single casual message works in default
    Codex mode. Keep approval mode `prompt`. `codex_spawn` stays as the
    bounded one-shot; the new verbs own sustained mode.
-4. **Fleet panel entry**: a "Start fleet run" form beside the existing
-   delegate runner: objective, work source, target concurrency, worker kind
-   (`codex | claude | auto` — wire `codex` now, accept the enum so Lane B of
-   the episode-245 doc lands without schema churn), dry-run preview showing
-   the planned first wave (accounts × slots × first claims) before starting.
+4. **Fleet panel entry**: **Done in PR "T3.3: Start fleet run form"**. The
+   Fleet panel renders a "Start fleet run" form beside the existing delegate
+   runner: objective, work source, target concurrency, worker kind
+   (`codex | claude | auto` accepted in the UI; `codex` wired to
+   `fleetRunStart`), and a public-safe dry-run preview showing the planned
+   first wave (accounts × slots × first claims) before starting.
 5. **RPC parity**: `fleetRunStart`, `fleetRunStatus`, `fleetRunControl`,
    `fleetRunList` methods; everything the UI can do, the bridge can do.
 

--- a/docs/fable/ROADMAP.md
+++ b/docs/fable/ROADMAP.md
@@ -91,7 +91,7 @@ run with refill.
 | --- | --- | --- | --- |
 | T3.1 | `FleetRunSupervisor` in the Bun host: Effect + `Scope`d tick loop (count active → claim → dispatch `khala.fleet.delegate` per free slot → stream lifecycle into counters); arbitrary N via refill across ticks; one supervisor per Pylon; built on `PylonService` when T7.3 lands (start on existing seams, do not wait) | T2.1, T2.2 | MED |
 | T3.2 | `khala_fleet` MCP verbs: `fleet_run_start`, `fleet_run_status`, `fleet_run_control` (pause/resume/drain/stop); approval mode stays `prompt`; `codex_spawn` remains the bounded one-shot | T3.1 | HIGH |
-| T3.3 | Fleet panel "Start fleet run" form: objective, work source, target concurrency, workerKind enum (`codex\|claude\|auto` accepted now, `codex` wired), dry-run preview of the first wave | T3.1 | HIGH |
+| T3.3 | **Done in PR "T3.3: Start fleet run form"**: Fleet panel "Start fleet run" form captures objective, work source, target concurrency, and workerKind enum (`codex\|claude\|auto` accepted; `codex` wired), renders a public-safe dry-run first-wave preview from current fleet status, and starts through `fleetRunStart` with form-state + mocked-RPC coverage | T3.1 | HIGH |
 | T3.4 | RPC parity: `fleetRunStart/Status/Control/List` methods + schemas (rides T1.1's contract) | T3.1, T1.1 | HIGH |
 | T3.5 | Fixture acceptance: target-25 fixture run reaches 25 simulated concurrent assignments via refill, drains cleanly, survives host restart; MCP verbs round-trip against scripted app-server fixture | T3.1–T3.4 | HIGH |
 


### PR DESCRIPTION
Closes #7831

## Summary
- Add a Fleet panel "Start fleet run" form beside the delegate runner with objective, work source, target concurrency, and worker kind controls.
- Render a public-safe dry-run first-wave preview from current fleet status before starting, and wire Codex starts through fleetRunStart from PR #7932.
- Update scoped Fable roadmap/instructions docs and add a happy-dom form-state + mocked-RPC test.

## Base note
PR #7932 is not merged into origin/main, so this branch is based on t3-4-fleet-run-rpc / origin/pr-7932.

## Verification
- bun test clients/khala-code-desktop/tests/fleet-status.test.ts
- bun run --cwd clients/khala-code-desktop typecheck
- command.public.pylon_khala.verify.d32c71ee8e1025e99460d008: bun run --cwd clients/khala-code-desktop test
