### PR TITLE
T7.5: Resilient token reporting

### DIFF
--- a/clients/khala-code-desktop/src/bun/codex-app-server-chat-runtime.ts
+++ b/clients/khala-code-desktop/src/bun/codex-app-server-chat-runtime.ts
@@ -1,6 +1,7 @@
-import { mkdir, readFile, writeFile } from "node:fs/promises"
+import { mkdir, readFile, rename, writeFile } from "node:fs/promises"
 import { homedir } from "node:os"
 import { dirname, join } from "node:path"
+import { Cause, Effect, Exit } from "effect"
 
 import type {
   KhalaCodeDesktopChatTurnAttachment,
@@ -35,6 +36,7 @@ import type {
   KhalaCodeDesktopCodexTokenUsageReporter,
 } from "./codex-token-usage-telemetry.js"
 import {
+  KhalaCodeDesktopTokenUsagePersistentFailure,
   khalaCodeDesktopCodexMessageTokenAuditMessage,
   khalaCodeDesktopCodexTokenUsageEventRefs,
   readKhalaCodeDesktopCodexStateThreadTokenSnapshot,
@@ -387,12 +389,18 @@ const parseState = (value: unknown): StoredCodexSessionState => {
   }
 }
 
+const quarantineStatePath = (statePath: string): string =>
+  `${statePath}.corrupt.${Date.now().toString(36)}`
+
 const readState = async (statePath: string): Promise<StoredCodexSessionState> => {
   try {
     return parseState(JSON.parse(await readFile(statePath, "utf8")))
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === "ENOENT") return emptyState()
-    throw error
+    await mkdir(dirname(statePath), { recursive: true })
+    await rename(statePath, quarantineStatePath(statePath)).catch(() => undefined)
+    await writeState(statePath, emptyState())
+    return emptyState()
   }
 }
 
@@ -932,6 +940,7 @@ export function createCodexAppServerChatRuntime(
     }).tokens
     const submittedAt = isoNow()
     const tokenUsageAuditEvents: KhalaCodeDesktopCodexMessageTokenAuditUsageEvent[] = []
+    const tokenUsageReportFailures: KhalaCodeDesktopTokenUsagePersistentFailure[] = []
     const pendingTokenUsageReports: Promise<void>[] = []
     let done = false
     let finish!: () => void
@@ -991,7 +1000,14 @@ export function createCodexAppServerChatRuntime(
         usage: delta,
       })
       if (tokenUsageReporter === null) return
-      const report = tokenUsageReporter(tokenUsageReport).catch(() => undefined)
+      const report = Effect.runPromiseExit(tokenUsageReporter(tokenUsageReport)).then(exit => {
+        if (Exit.isFailure(exit)) {
+          const failure = exit.cause.reasons.find(Cause.isFailReason)?.error
+          if (failure instanceof KhalaCodeDesktopTokenUsagePersistentFailure) {
+            tokenUsageReportFailures.push(failure)
+          }
+        }
+      })
       pendingTokenUsageReports.push(report)
     }
 
@@ -1116,9 +1132,11 @@ export function createCodexAppServerChatRuntime(
           reconciliation: {
             globalCountedTokens: countedCodexUsageTokens(capturedUsage),
             globalCounterRoute: "/api/stats/token-usage/events",
-            status: tokenUsageAuditEvents.length > 0
-              ? "global_count_event_recorded"
-              : "missing_token_usage_update",
+            status: tokenUsageReportFailures.length > 0
+              ? "global_count_event_failed"
+              : tokenUsageAuditEvents.length > 0
+                ? "global_count_event_recorded"
+                : "missing_token_usage_update",
             tokenAccountingRequired: true,
             tokenScope: "codex_turn_provider_reported",
             usageTruth: "exact",
@@ -1127,6 +1145,14 @@ export function createCodexAppServerChatRuntime(
           turnStatus,
           usage: capturedUsage,
           usageEvents: tokenUsageAuditEvents,
+          ...(tokenUsageReportFailures.length === 0 ? {} : {
+            tokenUsageFailureFlags: tokenUsageReportFailures.map(failure => ({
+              eventId: failure.eventId,
+              idempotencyKey: failure.idempotencyKey,
+              inboxFlagRef: failure.inboxFlagRef,
+              reason: failure.reason,
+            })),
+          }),
         })
       }
     }

--- a/clients/khala-code-desktop/src/bun/codex-token-usage-telemetry.ts
+++ b/clients/khala-code-desktop/src/bun/codex-token-usage-telemetry.ts
@@ -4,6 +4,7 @@ import { appendFile, mkdir, readFile, writeFile } from "node:fs/promises"
 import { homedir } from "node:os"
 import { dirname, join } from "node:path"
 import { Database } from "bun:sqlite"
+import { Effect, Schedule } from "effect"
 
 import type {
   KhalaCodeDesktopMessage,
@@ -41,7 +42,49 @@ export type KhalaCodeDesktopCodexTokenUsageEventRefs = {
 
 export type KhalaCodeDesktopCodexTokenUsageReporter = (
   report: KhalaCodeDesktopCodexTokenUsageReport,
-) => Promise<void>
+) => Effect.Effect<void, KhalaCodeDesktopTokenUsagePersistentFailure>
+
+export type KhalaCodeDesktopTokenUsageInboxFlag = {
+  readonly eventId: string | null
+  readonly idempotencyKey: string | null
+  readonly observedAt: string | null
+  readonly reason: string
+  readonly ref: string
+  readonly severity: "critical"
+  readonly status: "open"
+  readonly title: "Token usage reporting failed"
+}
+
+export class KhalaCodeDesktopTokenUsageReportFailure extends Error {
+  readonly _tag = "KhalaCodeDesktopTokenUsageReportFailure"
+  constructor(readonly input: {
+    readonly eventId: string | null
+    readonly idempotencyKey: string | null
+    readonly reason: string
+  }) {
+    super(input.reason)
+  }
+}
+
+export class KhalaCodeDesktopTokenUsagePersistentFailure extends Error {
+  readonly _tag = "KhalaCodeDesktopTokenUsagePersistentFailure"
+  readonly eventId: string | null
+  readonly idempotencyKey: string | null
+  readonly inboxFlagRef: string
+  readonly reason: string
+  constructor(input: {
+    readonly eventId: string | null
+    readonly idempotencyKey: string | null
+    readonly inboxFlagRef: string
+    readonly reason: string
+  }) {
+    super(input.reason)
+    this.eventId = input.eventId
+    this.idempotencyKey = input.idempotencyKey
+    this.inboxFlagRef = input.inboxFlagRef
+    this.reason = input.reason
+  }
+}
 
 export type KhalaCodeDesktopCodexMessageTokenAuditMessage = {
   readonly body: string
@@ -79,6 +122,7 @@ export type KhalaCodeDesktopCodexMessageTokenAuditRecord = {
     readonly globalCounterRoute: "/api/stats/token-usage/events"
     readonly status:
       | "global_count_backfilled_aggregate"
+      | "global_count_event_failed"
       | "global_count_event_recorded"
       | "missing_token_usage_update"
     readonly tokenAccountingRequired: true
@@ -89,6 +133,12 @@ export type KhalaCodeDesktopCodexMessageTokenAuditRecord = {
   readonly turnStatus: string
   readonly usage: KhalaCodeDesktopCodexTokenUsageCounts
   readonly usageEvents: readonly KhalaCodeDesktopCodexMessageTokenAuditUsageEvent[]
+  readonly tokenUsageFailureFlags?: readonly {
+    readonly eventId: string | null
+    readonly idempotencyKey: string | null
+    readonly inboxFlagRef: string
+    readonly reason: string
+  }[]
 }
 
 export type KhalaCodeDesktopCodexMessageTokenAuditRecorder = (
@@ -111,6 +161,8 @@ type TokenUsageTelemetryConfig = {
   readonly localMessageAuditLedgerPath: string
   readonly localLedgerPath: string
   readonly remoteDisabled: boolean
+  readonly retryBaseMs: number
+  readonly retryRecurs: number
 }
 
 export type KhalaCodeDesktopTokenUsageSyncResult = {
@@ -126,6 +178,8 @@ export type CreateKhalaCodeDesktopCodexTokenUsageReporterOptions = {
   readonly env?: Readonly<Record<string, string | undefined>>
   readonly fetch?: FetchLike
   readonly localLedgerPath?: string
+  readonly retryBaseMs?: number
+  readonly retryRecurs?: number
 }
 
 export type SyncKhalaCodeDesktopPendingTokenUsageReportsOptions = {
@@ -233,6 +287,14 @@ const defaultTokenUsageSyncIntervalMs = (
   return Number.isSafeInteger(parsed) && parsed >= 0 ? parsed : 2_000
 }
 
+const numberEnv = (
+  value: string | undefined,
+  fallback: number,
+): number => {
+  const parsed = Number.parseInt(value?.trim() ?? "", 10)
+  return Number.isSafeInteger(parsed) && parsed >= 0 ? parsed : fallback
+}
+
 const unquoteEnvValue = (value: string): string => {
   const trimmed = value.trim()
   if (trimmed.length >= 2) {
@@ -308,6 +370,8 @@ const resolveConfig = (
     localMessageAuditLedgerPath:
       localMessageAuditLedgerPath ?? defaultLocalMessageAuditLedgerPath(env),
     remoteDisabled,
+    retryBaseMs: numberEnv(env.KHALA_CODE_TOKEN_USAGE_RETRY_BASE_MS, 250),
+    retryRecurs: numberEnv(env.KHALA_CODE_TOKEN_USAGE_RETRY_RECURS, 2),
   }
 }
 
@@ -700,6 +764,9 @@ const appendJsonLine = async (path: string, value: unknown): Promise<void> => {
 const failureLedgerPath = (localLedgerPath: string): string =>
   join(dirname(localLedgerPath), "token-usage-report-failures.jsonl")
 
+const inboxFlagLedgerPath = (localLedgerPath: string): string =>
+  join(dirname(localLedgerPath), "token-usage-inbox-flags.jsonl")
+
 const successLedgerPath = (localLedgerPath: string): string =>
   join(dirname(localLedgerPath), "token-usage-report-successes.jsonl")
 
@@ -746,6 +813,70 @@ const tokenUsageEventForRemotePost = (event: JsonRecord): JsonRecord => {
     privacy: { leaderboardEligible: true, privacyOptOut: false },
     ...(tokenCounts === null ? {} : { tokenCounts }),
   }
+}
+
+const tokenUsageInboxFlagRef = (
+  eventId: string | null,
+  idempotencyKey: string | null,
+): string => {
+  const source = eventId ?? idempotencyKey ?? "unknown"
+  return `inbox.token_usage_reporting.${digest(source).slice(0, 16)}`
+}
+
+const appendTokenUsageInboxFlag = async (
+  localLedgerPath: string,
+  input: {
+    readonly eventId: string | null
+    readonly idempotencyKey: string | null
+    readonly observedAt: string | null
+    readonly reason: string
+  },
+): Promise<KhalaCodeDesktopTokenUsageInboxFlag> => {
+  const ref = tokenUsageInboxFlagRef(input.eventId, input.idempotencyKey)
+  const flag: KhalaCodeDesktopTokenUsageInboxFlag = {
+    eventId: input.eventId,
+    idempotencyKey: input.idempotencyKey,
+    observedAt: input.observedAt,
+    reason: input.reason,
+    ref,
+    severity: "critical",
+    status: "open",
+    title: "Token usage reporting failed",
+  }
+  await appendJsonLine(inboxFlagLedgerPath(localLedgerPath), {
+    schemaVersion: "khala-code-desktop.codex-token-usage.inbox-flag.v1",
+    flaggedAt: new Date().toISOString(),
+    flag,
+  })
+  return flag
+}
+
+export async function readKhalaCodeDesktopTokenUsageInboxFlags(options: {
+  readonly env?: Readonly<Record<string, string | undefined>>
+  readonly localLedgerPath?: string
+} = {}): Promise<readonly KhalaCodeDesktopTokenUsageInboxFlag[]> {
+  const env = options.env ?? khalaCodeConfigFromRuntimeEnv().env
+  const config = resolveConfig(env, options.localLedgerPath)
+  const rows = await readJsonLines(inboxFlagLedgerPath(config.localLedgerPath))
+  const byRef = new Map<string, KhalaCodeDesktopTokenUsageInboxFlag>()
+  for (const row of rows) {
+    const flag = objectField(row, "flag")
+    if (flag === null) continue
+    const ref = stringField(flag, "ref")
+    const reason = stringField(flag, "reason")
+    if (ref === null || reason === null) continue
+    byRef.set(ref, {
+      eventId: stringField(flag, "eventId"),
+      idempotencyKey: stringField(flag, "idempotencyKey"),
+      observedAt: stringField(flag, "observedAt"),
+      reason,
+      ref,
+      severity: "critical",
+      status: "open",
+      title: "Token usage reporting failed",
+    })
+  }
+  return [...byRef.values()]
 }
 
 const rewriteJsonLines = async (
@@ -923,23 +1054,69 @@ export function createKhalaCodeDesktopCodexTokenUsageReporter(
   options: CreateKhalaCodeDesktopCodexTokenUsageReporterOptions = {},
 ): KhalaCodeDesktopCodexTokenUsageReporter {
   const env = options.env ?? khalaCodeConfigFromRuntimeEnv().env
-  const config = resolveConfig(env, options.localLedgerPath)
+  const resolvedConfig = resolveConfig(env, options.localLedgerPath)
+  const config = {
+    ...resolvedConfig,
+    retryBaseMs: options.retryBaseMs ?? resolvedConfig.retryBaseMs,
+    retryRecurs: options.retryRecurs ?? resolvedConfig.retryRecurs,
+  }
   const fetchImpl: FetchLike = options.fetch ?? ((url, init) => globalThis.fetch(url, init))
 
-  return async report => {
+  return report => Effect.gen(function* () {
     const usage = normalizeUsage(report.usage)
     if (!hasUsage(usage)) return
     const normalizedReport = { ...report, usage }
     const event = khalaCodeDesktopCodexTokenUsageEvent(normalizedReport)
-    await appendJsonLine(config.localLedgerPath, {
+    yield* Effect.promise(() => appendJsonLine(config.localLedgerPath, {
       schemaVersion: "khala-code-desktop.codex-token-usage.local.v1",
       recordedAt: new Date().toISOString(),
       event,
-    })
+    }))
 
     const endpoint = new URL("/api/stats/token-usage/events", config.baseUrl)
-    await syncPendingTokenUsageReports(config, fetchImpl, endpoint)
-  }
+    const eventId = stringField(event, "eventId")
+    const idempotencyKey = stringField(event, "idempotencyKey")
+    const observedAt = stringField(event, "observedAt")
+    const syncEffect = Effect.tryPromise({
+      try: async () => {
+        const result = await syncPendingTokenUsageReports(config, fetchImpl, endpoint)
+        if (result.remoteConfigured && !result.ok) {
+          throw new KhalaCodeDesktopTokenUsageReportFailure({
+            eventId,
+            idempotencyKey,
+            reason: `token usage sync failed after ${result.failed}/${result.attempted} attempted remote post(s)`,
+          })
+        }
+      },
+      catch: error => error instanceof KhalaCodeDesktopTokenUsageReportFailure
+        ? error
+        : new KhalaCodeDesktopTokenUsageReportFailure({
+          eventId,
+          idempotencyKey,
+          reason: error instanceof Error ? error.message : String(error),
+        }),
+    }).pipe(
+      Effect.retry({
+        schedule: Schedule.exponential(config.retryBaseMs),
+        times: config.retryRecurs,
+      }),
+      Effect.catch(error => Effect.gen(function* () {
+        const flag = yield* Effect.promise(() => appendTokenUsageInboxFlag(config.localLedgerPath, {
+          eventId: error.input.eventId,
+          idempotencyKey: error.input.idempotencyKey,
+          observedAt,
+          reason: error.input.reason,
+        }))
+        return yield* Effect.fail(new KhalaCodeDesktopTokenUsagePersistentFailure({
+          eventId: error.input.eventId,
+          idempotencyKey: error.input.idempotencyKey,
+          inboxFlagRef: flag.ref,
+          reason: error.input.reason,
+        }))
+      })),
+    )
+    yield* syncEffect
+  })
 }
 
 export function createKhalaCodeDesktopCodexMessageTokenAuditRecorder(

--- a/clients/khala-code-desktop/src/bun/rpc-handlers.ts
+++ b/clients/khala-code-desktop/src/bun/rpc-handlers.ts
@@ -1,8 +1,9 @@
 import { randomUUID } from "node:crypto"
 import { Buffer } from "node:buffer"
-import { mkdir, writeFile } from "node:fs/promises"
+import { mkdir, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { basename, join } from "node:path"
+import { Effect } from "effect"
 
 import type { KhalaFleetDelegateStep } from "@openagentsinc/khala-tools"
 import type {
@@ -19,6 +20,7 @@ import {
   createKhalaCodeDesktopCodexMessageTokenAuditRecorder,
   createKhalaCodeDesktopCodexTokenUsageReporter,
   khalaCodeDesktopTokenUsageTelemetryStatus,
+  readKhalaCodeDesktopTokenUsageInboxFlags,
   readKhalaCodeDesktopThreadTokenSummary,
 } from "./codex-token-usage-telemetry.js"
 import {
@@ -181,11 +183,16 @@ const materializeChatAttachment = async (
     readonly sessionId: string
     readonly turnId: string
   },
-): Promise<KhalaCodeDesktopChatTurnAttachment> => {
+): Promise<{
+  readonly attachment: KhalaCodeDesktopChatTurnAttachment
+  readonly cleanupPath: string | null
+}> => {
   if (attachment.path !== undefined || attachment.dataBase64 === undefined) {
-    return attachment
+    return { attachment, cleanupPath: null }
   }
-  if (!attachment.mime.toLowerCase().startsWith("image/")) return attachment
+  if (!attachment.mime.toLowerCase().startsWith("image/")) {
+    return { attachment, cleanupPath: null }
+  }
   const directory = join(
     CHAT_ATTACHMENT_TMP_ROOT,
     safePathSegment(input.sessionId, "session"),
@@ -196,33 +203,60 @@ const materializeChatAttachment = async (
   const path = join(directory, filename)
   await writeFile(path, Buffer.from(attachment.dataBase64, "base64"))
   return {
-    id: attachment.id,
-    kind: "image",
-    mime: attachment.mime,
-    name: attachment.name,
-    path,
-    sizeBytes: attachment.sizeBytes,
+    attachment: {
+      id: attachment.id,
+      kind: "image",
+      mime: attachment.mime,
+      name: attachment.name,
+      path,
+      sizeBytes: attachment.sizeBytes,
+    },
+    cleanupPath: directory,
   }
 }
 
 const materializeChatAttachments = async (
   request: KhalaCodeDesktopChatTurnRequest,
-): Promise<KhalaCodeDesktopChatTurnRequest> => {
-  if (request.attachments === undefined || request.attachments.length === 0) return request
+): Promise<{
+  readonly cleanupPaths: readonly string[]
+  readonly request: KhalaCodeDesktopChatTurnRequest
+}> => {
+  if (request.attachments === undefined || request.attachments.length === 0) {
+    return { cleanupPaths: [], request }
+  }
   const turnId = request.turnId ?? randomUUID()
-  const attachments = await Promise.all(request.attachments.map((attachment, index) =>
+  const materialized = await Promise.all(request.attachments.map((attachment, index) =>
     materializeChatAttachment(attachment, {
       index,
       sessionId: request.sessionId,
       turnId,
     })
   ))
+  const cleanupPaths = [...new Set(materialized.flatMap(item =>
+    item.cleanupPath === null ? [] : [item.cleanupPath]
+  ))]
   return {
-    ...request,
-    attachments,
-    turnId,
+    cleanupPaths,
+    request: {
+      ...request,
+      attachments: materialized.map(item => item.attachment),
+      turnId,
+    },
   }
 }
+
+const withMaterializedChatAttachments = <A>(
+  request: KhalaCodeDesktopChatTurnRequest,
+  use: (request: KhalaCodeDesktopChatTurnRequest) => Promise<A>,
+): Promise<A> =>
+  Effect.runPromise(Effect.scoped(Effect.flatMap(Effect.acquireRelease(
+    Effect.promise(() => materializeChatAttachments(request)),
+    materialized => Effect.promise(async () => {
+      await Promise.all(materialized.cleanupPaths.map(path =>
+        rm(path, { force: true, recursive: true })
+      ))
+    }),
+  ), materialized => Effect.promise(() => use(materialized.request)))))
 
 const normalizeMentionCandidate = (value: unknown): KhalaCodeDesktopCodexMentionCandidate | null => {
   if (!isRecord(value)) return null
@@ -1962,20 +1996,24 @@ export function createKhalaCodeDesktopRpcRequestHandlers(
       }
     },
     async submitChatMessage(request) {
-      const materializedRequest = await materializeChatAttachments(request)
-      if (!useLegacyKhalaNativeRuntime()) {
-        const bridge = await maybeEnsureFleetMcpBridge()
-        return withFleetMcpBridgeNote(await labelCodexHarnessResponse(await requireCodexChatRuntime().startTurn({
-          ...materializedRequest,
-          cwd: input.workingDirectory,
-        })), bridge)
-      }
-      return labelLegacyRuntimeResponse(await legacyChatTurn({
-        env: input.env,
-        ...(input.emitChatTurnEvent === undefined ? {} : { onEvent: input.emitChatTurnEvent }),
-        request: materializedRequest,
-        workingDirectory: input.workingDirectory,
-      }))
+      return withMaterializedChatAttachments(
+        request,
+        async materializedRequest => {
+          if (!useLegacyKhalaNativeRuntime()) {
+            const bridge = await maybeEnsureFleetMcpBridge()
+            return withFleetMcpBridgeNote(await labelCodexHarnessResponse(await requireCodexChatRuntime().startTurn({
+              ...materializedRequest,
+              cwd: input.workingDirectory,
+            })), bridge)
+          }
+          return labelLegacyRuntimeResponse(await legacyChatTurn({
+            env: input.env,
+            ...(input.emitChatTurnEvent === undefined ? {} : { onEvent: input.emitChatTurnEvent }),
+            request: materializedRequest,
+            workingDirectory: input.workingDirectory,
+          }))
+        },
+      )
     },
     async consumeCodexRateLimitResetCredit(): Promise<KhalaCodeDesktopCodexRateLimitResetResult> {
       const observedAt = new Date().toISOString()
@@ -2006,6 +2044,15 @@ export function createKhalaCodeDesktopRpcRequestHandlers(
     },
     async tokenAccountingStatus() {
       const status = khalaCodeDesktopTokenUsageTelemetryStatus(input.env)
+      const flags = await readKhalaCodeDesktopTokenUsageInboxFlags({ env: input.env })
+      if (flags.length > 0) {
+        return runtimeStatus({
+          available: false,
+          capability: "token_accounting",
+          reason: `${flags.length} token usage reporting failure flag(s) need review; latest: ${flags[flags.length - 1]?.reason ?? "unknown failure"}`,
+          status: "error",
+        })
+      }
       return runtimeStatus({
         available: true,
         capability: "token_accounting",

--- a/clients/khala-code-desktop/src/ui/inbox.ts
+++ b/clients/khala-code-desktop/src/ui/inbox.ts
@@ -256,6 +256,19 @@ export const projectUnifiedInbox = (
     })
   }
 
+  if (source.tokenAccounting.status === "error" || source.tokenAccounting.status === "unavailable") {
+    items.push({
+      ref: "inbox.runtime.token_accounting.blocked",
+      kind: "run_blocked",
+      title: "Token accounting needs review",
+      summary: source.tokenAccounting.reason,
+      source: "runtime",
+      severity: "critical",
+      observedAt: source.tokenAccounting.observedAt,
+      actions: ["refresh"],
+    })
+  }
+
   const coverage = [
     {
       source: "Codex harness",
@@ -287,6 +300,11 @@ export const projectUnifiedInbox = (
       source: "fleet readiness",
       status: "connected" as const,
       summary: "Worker Codex account readiness, Pylon state, and assignment markers are projected locally.",
+    },
+    {
+      source: "token accounting",
+      status: source.tokenAccounting.available ? "connected" as const : "not_connected" as const,
+      summary: source.tokenAccounting.reason,
     },
   ]
 

--- a/clients/khala-code-desktop/tests/app-shell.test.ts
+++ b/clients/khala-code-desktop/tests/app-shell.test.ts
@@ -546,6 +546,71 @@ describe("khala code desktop app shell", () => {
     })
   })
 
+  test("projects persistent token usage reporting failures into the Unified Inbox", () => {
+    const observedAt = "2026-07-01T00:00:00.000Z"
+    const projection = projectUnifiedInbox({
+      fleet: {
+        ok: true,
+        observedAt,
+        pylon: {
+          status: "started",
+          pylonRef: "pylon.local",
+          message: "Pylon ready",
+        },
+        availableCodexAssignments: 0,
+        maxCodexAssignments: 0,
+        tokenRate: {
+          activeAdjustedTokensPerMinute: null,
+          completedStatus: "not_measured",
+          completedTokenRows: null,
+          completedTokensPerMinute: null,
+          inFlightTokens: null,
+          inFlightTokensPerMinute: null,
+          source: "unavailable",
+          unavailableReason: null,
+        },
+        accounts: [],
+        activeAssignments: [],
+        processes: [],
+      },
+      pylon: {
+        ok: true,
+        app: "Khala Code Desktop",
+        available: true,
+        capability: "pylon",
+        observedAt,
+        reason: "ready",
+        status: "ready",
+      },
+      coding: {
+        ok: true,
+        app: "Khala Code Desktop",
+        available: true,
+        capability: "coding",
+        observedAt,
+        reason: "ready",
+        status: "ready",
+      },
+      tokenAccounting: {
+        ok: true,
+        app: "Khala Code Desktop",
+        available: false,
+        capability: "token_accounting",
+        observedAt,
+        reason: "1 token usage reporting failure flag(s) need review; latest: token usage sync failed",
+        status: "error",
+      },
+    })
+
+    expect(projection.items).toContainEqual(expect.objectContaining({
+      ref: "inbox.runtime.token_accounting.blocked",
+      kind: "run_blocked",
+      title: "Token accounting needs review",
+      source: "runtime",
+      severity: "critical",
+    }))
+  })
+
   test("projects Codex ecosystem diagnostics into the Unified Inbox", () => {
     const observedAt = "2026-07-01T00:00:00.000Z"
     const ecosystem = projectKhalaCodeDesktopCodexEcosystem({

--- a/clients/khala-code-desktop/tests/codex-app-server-chat-runtime.test.ts
+++ b/clients/khala-code-desktop/tests/codex-app-server-chat-runtime.test.ts
@@ -1,8 +1,9 @@
-import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
+import { mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { Database } from "bun:sqlite"
 import { afterEach, describe, expect, test } from "bun:test"
+import { Effect } from "effect"
 
 import {
   createCodexAppServerChatRuntime,
@@ -208,6 +209,69 @@ describe("Codex app-server chat runtime", () => {
     expect(await readFile(fixture.statePath, "utf8")).toContain("thread-codex-1")
   })
 
+  test("quarantines corrupt session state and continues thread operations with fresh state", async () => {
+    const fixture = await stateFixture()
+    await writeFile(fixture.statePath, "{not-json", "utf8")
+    const records: RequestRecord[] = []
+    const host = createFakeHost({
+      records,
+      onRequest: (method, _params, subscribers) => {
+        if (method === "thread/start") {
+          return {
+            thread: { id: "thread-after-corrupt-state", status: "running" },
+            model: "gpt-5.1-codex",
+            modelProvider: "openai",
+            cwd: fixture.root,
+          }
+        }
+        if (method === "turn/start") {
+          queueMicrotask(() => {
+            emit(subscribers, {
+              method: "turn/completed",
+              params: {
+                threadId: "thread-after-corrupt-state",
+                turn: { id: "turn-after-corrupt-state", status: "completed" },
+              },
+            })
+          })
+          return { turn: { id: "turn-after-corrupt-state", status: "inProgress" } }
+        }
+        throw new Error(`unexpected request ${method}`)
+      },
+    })
+    const runtime = createCodexAppServerChatRuntime({
+      host,
+      statePath: fixture.statePath,
+      turnTimeoutMs: 1_000,
+      workingDirectory: fixture.root,
+    })
+
+    await expect(runtime.startTurn({
+      messages: [{ id: "user-corrupt-state", role: "user", body: "Recover state" }],
+      sessionId: "desktop-session-corrupt-state",
+      turnId: "desktop-turn-corrupt-state",
+    })).resolves.toMatchObject({
+      backend: {
+        threadId: "thread-after-corrupt-state",
+        turnId: "turn-after-corrupt-state",
+      },
+      ok: true,
+    })
+
+    const entries = await readdir(fixture.root)
+    expect(entries.some(entry => entry.startsWith("codex-sessions.json.corrupt."))).toBe(true)
+    const nextState = JSON.parse(await readFile(fixture.statePath, "utf8"))
+    expect(nextState).toMatchObject({
+      schema: "khala-code-desktop.codex-sessions.v1",
+      sessions: {
+        "desktop-session-corrupt-state": {
+          threadId: "thread-after-corrupt-state",
+        },
+      },
+    })
+    expect(records.map(record => record.method)).toEqual(["thread/start", "turn/start"])
+  })
+
   test("passes materialized image attachments as Codex local image input", async () => {
     const fixture = await stateFixture()
     const records: RequestRecord[] = []
@@ -364,9 +428,9 @@ describe("Codex app-server chat runtime", () => {
         messageAudits.push(record)
       },
       statePath: fixture.statePath,
-      tokenUsageReporter: async report => {
+      tokenUsageReporter: report => Effect.sync(() => {
         reports.push(report)
-      },
+      }),
       turnTimeoutMs: 1_000,
       workingDirectory: fixture.root,
     })
@@ -518,9 +582,9 @@ describe("Codex app-server chat runtime", () => {
         messageAudits.push(record)
       },
       statePath: fixture.statePath,
-      tokenUsageReporter: async report => {
+      tokenUsageReporter: report => Effect.sync(() => {
         reports.push(report)
-      },
+      }),
       turnTimeoutMs: 1_000,
       workingDirectory: fixture.root,
     })

--- a/clients/khala-code-desktop/tests/codex-token-usage-telemetry.test.ts
+++ b/clients/khala-code-desktop/tests/codex-token-usage-telemetry.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from "node:os"
 import { dirname, join } from "node:path"
 import { Database } from "bun:sqlite"
 import { afterEach, describe, expect, test } from "bun:test"
+import { Effect, Exit } from "effect"
 
 import {
   createKhalaCodeDesktopCodexMessageTokenAuditRecorder,
@@ -11,6 +12,7 @@ import {
   khalaCodeDesktopCodexTokenUsageEvent,
   khalaCodeDesktopCodexTokenUsageEventRefs,
   khalaCodeDesktopTokenUsageTelemetryStatus,
+  readKhalaCodeDesktopTokenUsageInboxFlags,
   readKhalaCodeDesktopThreadTokenSummary,
   startKhalaCodeDesktopTokenUsageBackgroundSync,
   syncKhalaCodeDesktopPendingTokenUsageReports,
@@ -110,7 +112,7 @@ describe("Codex token usage telemetry", () => {
       localLedgerPath: ledgerPath,
     })
 
-    await reporter(sampleReport())
+    await Effect.runPromise(reporter(sampleReport()))
 
     const lines = (await readFile(ledgerPath, "utf8")).trim().split("\n")
     expect(lines).toHaveLength(1)
@@ -136,6 +138,68 @@ describe("Codex token usage telemetry", () => {
       "utf8",
     )).trim().split("\n")
     expect(successLines).toHaveLength(1)
+  })
+
+  test("retries token usage reporting with an exponential Effect schedule before succeeding", async () => {
+    const ledgerPath = await tempLedgerPath()
+    let attempts = 0
+    const reporter = createKhalaCodeDesktopCodexTokenUsageReporter({
+      env: {
+        KHALA_CODE_TOKEN_USAGE_BASE_URL: "https://openagents.example",
+        KHALA_CODE_TOKEN_USAGE_BEARER_TOKEN: "test-token",
+      },
+      fetch: async () => {
+        attempts += 1
+        return attempts === 1
+          ? new Response(JSON.stringify({ error: "try again" }), { status: 503 })
+          : new Response(JSON.stringify({ inserted: true }), { status: 201 })
+      },
+      localLedgerPath: ledgerPath,
+      retryBaseMs: 0,
+      retryRecurs: 2,
+    })
+
+    await Effect.runPromise(reporter(sampleReport()))
+
+    expect(attempts).toBe(2)
+    const flags = await readKhalaCodeDesktopTokenUsageInboxFlags({ localLedgerPath: ledgerPath })
+    expect(flags).toHaveLength(0)
+    const successLines = (await readFile(
+      join(dirname(ledgerPath), "token-usage-report-successes.jsonl"),
+      "utf8",
+    )).trim().split("\n")
+    expect(successLines).toHaveLength(1)
+  })
+
+  test("writes a typed Inbox flag when token usage reporting persistently fails", async () => {
+    const ledgerPath = await tempLedgerPath()
+    let attempts = 0
+    const reporter = createKhalaCodeDesktopCodexTokenUsageReporter({
+      env: {
+        KHALA_CODE_TOKEN_USAGE_BASE_URL: "https://openagents.example",
+        KHALA_CODE_TOKEN_USAGE_BEARER_TOKEN: "test-token",
+      },
+      fetch: async () => {
+        attempts += 1
+        return new Response(JSON.stringify({ error: "still down" }), { status: 503 })
+      },
+      localLedgerPath: ledgerPath,
+      retryBaseMs: 0,
+      retryRecurs: 1,
+    })
+
+    const exit = await Effect.runPromiseExit(reporter(sampleReport()))
+
+    expect(Exit.isFailure(exit)).toBe(true)
+    expect(attempts).toBe(2)
+    const flags = await readKhalaCodeDesktopTokenUsageInboxFlags({ localLedgerPath: ledgerPath })
+    expect(flags).toHaveLength(1)
+    expect(flags[0]).toMatchObject({
+      ref: expect.stringContaining("inbox.token_usage_reporting."),
+      severity: "critical",
+      status: "open",
+      title: "Token usage reporting failed",
+    })
   })
 
   test("loads the owner Stats token from the local secret file when env is not exported", async () => {
@@ -209,7 +273,7 @@ describe("Codex token usage telemetry", () => {
       localLedgerPath,
     })
 
-    await reporter(sampleReport())
+    await Effect.runPromise(reporter(sampleReport()))
 
     expect(posts.map(post => (post.body as { eventId?: string }).eventId)).toEqual([
       String(oldEvent.eventId),

--- a/clients/khala-code-desktop/tests/khala-codex-fleet-tools.test.ts
+++ b/clients/khala-code-desktop/tests/khala-codex-fleet-tools.test.ts
@@ -19,6 +19,7 @@ import {
   type KhalaCodexFleetCommandInput,
   type KhalaCodexFleetCommandResult,
   type KhalaCodexFleetProgressPayload,
+  type KhalaFleetRunSnapshot,
 } from "../src/bun/khala-codex-fleet-tools"
 
 const tempDirs: string[] = []
@@ -189,17 +190,22 @@ function matrixBatchSpawnInFlight(
 async function waitForFleetRunSnapshot(
   manager: DefaultKhalaFleetRunSupervisorManager,
   runRef: string,
-  predicate: (snapshot: Awaited<ReturnType<DefaultKhalaFleetRunSupervisorManager["start"]>>) => boolean,
-): Promise<Awaited<ReturnType<DefaultKhalaFleetRunSupervisorManager["start"]>>> {
+  predicate: (snapshot: KhalaFleetRunSnapshot) => boolean,
+): Promise<KhalaFleetRunSnapshot> {
   for (let attempt = 0; attempt < 50; attempt += 1) {
-    const snapshot = await manager.status({ runRef })
-    if (Array.isArray(snapshot)) throw new Error("expected a single fleet run snapshot")
+    const snapshot = singleFleetRunSnapshot(await manager.status({ runRef }))
     if (predicate(snapshot)) return snapshot
     await Bun.sleep(10)
   }
-  const snapshot = await manager.status({ runRef })
-  if (Array.isArray(snapshot)) throw new Error("expected a single fleet run snapshot")
+  const snapshot = singleFleetRunSnapshot(await manager.status({ runRef }))
   throw new Error(`fleet run ${runRef} did not reach expected state; last state=${snapshot.run.state} active=${snapshot.active}`)
+}
+
+function singleFleetRunSnapshot(
+  snapshot: KhalaFleetRunSnapshot | readonly KhalaFleetRunSnapshot[],
+): KhalaFleetRunSnapshot {
+  if ("run" in snapshot) return snapshot
+  throw new Error("expected a single fleet run snapshot")
 }
 
 describe("Khala Code Codex fleet tools", () => {
@@ -513,11 +519,10 @@ describe("Khala Code Codex fleet tools", () => {
       targetConcurrency: 1,
       workSource: "fixture",
     })).rejects.toThrow("fleet run supervisor already active for pylon pylon.local.test")
-    const failedStart = await manager.status({ runRef: "fleet_run.test.failed_start" })
+    const failedStart = singleFleetRunSnapshot(await manager.status({ runRef: "fleet_run.test.failed_start" }))
 
     expect(active.active).toBe(true)
-    expect(Array.isArray(failedStart)).toBe(false)
-    expect(Array.isArray(failedStart) ? null : failedStart.run.state).toBe("stopped")
+    expect(failedStart.run.state).toBe("stopped")
 
     await manager.control({ runRef: "fleet_run.test.inflight", verb: "stop" })
     const afterStop = await manager.start({

--- a/clients/khala-code-desktop/tests/rpc-handlers.test.ts
+++ b/clients/khala-code-desktop/tests/rpc-handlers.test.ts
@@ -634,6 +634,7 @@ describe("Khala Code desktop RPC handlers", () => {
       ok: true,
     })
     expect(capturedAttachmentPath).toContain("attachment-image-1-composer.png")
+    await expect(readFile(capturedAttachmentPath ?? "", "utf8")).rejects.toThrow()
   })
 
   test("adds typed Codex auth blocker refs to failed Codex app-server chat turns", async () => {


### PR DESCRIPTION
Closes #7864

## Summary

- Converts Khala Code desktop Codex token usage reporting to an Effect-based reporter with `Schedule.exponential` retry and typed persistent-failure escalation.
- Records persistent token reporting failures as local Inbox flags and projects token-accounting runtime failures into the Unified Inbox.
- Scopes materialized chat attachment temp files so they are removed after submit completion/failure.
- Recovers corrupt Codex session-state JSON by quarantining the bad file and writing fresh state.
- Cleans up a desktop fleet-tools test type narrowing issue so package typecheck is green.

## Verification

- `bun run --cwd clients/khala-code-desktop verify`
- `bun run --cwd clients/khala-code-desktop test` (`command.public.pylon_khala.verify.d32c71ee8e1025e99460d008`)