### PR TITLE
T3.5: Fleet run fixture acceptance

### DIFF
--- a/apps/pylon/src/orchestration/store.ts
+++ b/apps/pylon/src/orchestration/store.ts
@@ -1571,7 +1571,10 @@ export class PylonOrchestrationStore {
       this.db
         .query(`
           UPDATE pylon_orchestration_dispatch_contexts
-             SET status = 'dispatched', current_task_id = $taskId, updated_at = $at
+             SET status = 'dispatched',
+                 current_task_id = $taskId,
+                 last_heartbeat_at = $at,
+                 updated_at = $at
            WHERE id = $contextId
         `)
         .run({ $contextId: contextId, $taskId: taskId, $at: at })

--- a/clients/khala-code-desktop/src/bun/fixture-codex-app-server.ts
+++ b/clients/khala-code-desktop/src/bun/fixture-codex-app-server.ts
@@ -57,6 +57,14 @@ type ActiveTurn = {
   turnId: string
 }
 
+type FixtureFleetRun = {
+  objective: string
+  runRef: string
+  state: "running"
+  targetConcurrency: number
+  workSource: string
+}
+
 type TemplateContext = Readonly<{
   approvalResponse?: unknown
   cwd: string
@@ -178,6 +186,7 @@ const applyTemplate = (
 
 class FixtureCodexAppServer {
   private readonly activeTurns = new Map<string, ActiveTurn>()
+  private readonly fleetRuns = new Map<string, FixtureFleetRun>()
   private readonly pendingServerResponses = new Map<JsonRpcId, (value: unknown) => void>()
   private readonly threads = new Map<string, ThreadRecord>()
   private nextThread = 0
@@ -230,6 +239,10 @@ class FixtureCodexAppServer {
       case "config/value/write":
       case "config/mcpServer/reload":
         return { ok: true, fixture: true }
+      case "mcpServerStatus/list":
+        return this.mcpServerStatusList()
+      case "mcpServer/tool/call":
+        return this.mcpServerToolCall(params)
       case "thread/start":
         return this.threadStart(params)
       case "thread/resume":
@@ -299,6 +312,87 @@ class FixtureCodexAppServer {
           network: { enabled: false },
         },
       }],
+    }
+  }
+
+  private mcpServerStatusList(): JsonObject {
+    return {
+      data: [{
+        name: "khala_fleet",
+        authStatus: "notRequired",
+        resources: [],
+        resourceTemplates: [],
+        tools: {
+          fleet_run_start: { name: "fleet_run_start" },
+          fleet_run_status: { name: "fleet_run_status" },
+        },
+      }],
+      nextCursor: null,
+    }
+  }
+
+  private mcpServerToolCall(params: unknown): JsonObject {
+    const server = stringField(params, "server")
+    if (server !== "khala_fleet") {
+      throw new Error(`Fixture MCP server not found: ${server ?? "(missing)"}.`)
+    }
+    const tool = stringField(params, "tool")
+    const args = objectField(params, "arguments") ?? {}
+    if (tool === "fleet_run_start") return this.fleetRunStart(args)
+    if (tool === "fleet_run_status") return this.fleetRunStatus(args)
+    throw new Error(`Fixture khala_fleet tool not found: ${tool ?? "(missing)"}.`)
+  }
+
+  private fleetRunStart(args: JsonObject): JsonObject {
+    const runRef = stringField(args, "run_ref") ?? `fleet_run.fixture.${this.fleetRuns.size + 1}`
+    const objective = stringField(args, "objective") ?? "Run fixture fleet units."
+    const targetConcurrency = numberField(args, "target_concurrency") ?? 1
+    const workSource = stringField(args, "work_source") ?? "fixture"
+    const run: FixtureFleetRun = {
+      objective,
+      runRef,
+      state: "running",
+      targetConcurrency,
+      workSource,
+    }
+    this.fleetRuns.set(runRef, run)
+    return this.fleetRunToolResult(run, "fleet_run_start")
+  }
+
+  private fleetRunStatus(args: JsonObject): JsonObject {
+    const runRef = stringField(args, "run_ref") ?? [...this.fleetRuns.keys()][0]
+    if (runRef === undefined) {
+      return {
+        content: [{ type: "text", text: "No fleet runs found." }],
+        isError: false,
+        structuredContent: { kind: "fleet_run_status", runs: [] },
+      }
+    }
+    const run = this.fleetRuns.get(runRef)
+    if (run === undefined) throw new Error(`unknown fixture FleetRun: ${runRef}`)
+    return this.fleetRunToolResult(run, "fleet_run_status")
+  }
+
+  private fleetRunToolResult(run: FixtureFleetRun, kind: "fleet_run_start" | "fleet_run_status"): JsonObject {
+    return {
+      content: [{
+        type: "text",
+        text: [
+          `FleetRun ${run.runRef}: ${run.state} (supervisor active)`,
+          `Objective: ${run.objective}`,
+          `Source: ${run.workSource}; concurrency=${run.targetConcurrency}`,
+        ].join("\n"),
+      }],
+      isError: false,
+      structuredContent: {
+        kind,
+        run: {
+          runRef: run.runRef,
+          state: run.state,
+          targetConcurrency: run.targetConcurrency,
+          workSource: run.workSource,
+        },
+      },
     }
   }
 

--- a/clients/khala-code-desktop/src/bun/fleet-run-supervisor.ts
+++ b/clients/khala-code-desktop/src/bun/fleet-run-supervisor.ts
@@ -41,8 +41,24 @@ export type FleetRunSupervisorDispatchResult = {
   readonly summary?: string | null
 }
 
+export type FleetRunSupervisorActiveAssignment = {
+  readonly accountRef: string
+  readonly claim: WorkClaim
+  readonly contextId: string
+  readonly taskId: string
+}
+
+export type FleetRunSupervisorReconcileResult = FleetRunSupervisorDispatchResult & {
+  readonly taskId: string
+}
+
 export type FleetRunSupervisorRunner = {
   readonly dispatch: (input: FleetRunSupervisorDispatchInput) => Promise<FleetRunSupervisorDispatchResult>
+  readonly reconcile?: (input: {
+    readonly activeAssignments: readonly FleetRunSupervisorActiveAssignment[]
+    readonly now: Date
+    readonly run: FleetRun
+  }) => Promise<readonly FleetRunSupervisorReconcileResult[]>
 }
 
 export type FleetRunSupervisorPlanner = {
@@ -177,6 +193,24 @@ const activeByAccount = (claims: readonly WorkClaim[]): Map<string, number> => {
   return counts
 }
 
+const collectActiveAssignments = (
+  store: PylonOrchestrationStore,
+  runRef: string,
+): FleetRunSupervisorActiveAssignment[] => {
+  const tasks = store.listTasks("dispatched").filter(task => task.spec.fleetRunRef === runRef)
+  const claims = new Map(store.listWorkClaims({ runRef }).map(claim => [taskIdFor(runRef, claim.claimRef), claim]))
+  return tasks.flatMap(task => {
+    const claim = claims.get(task.id)
+    if (claim === undefined || claim.state !== "in_progress") return []
+    return [{
+      accountRef: claim.workerAccountRef,
+      claim,
+      contextId: contextIdFor(claim.workerAccountRef, task.id),
+      taskId: task.id,
+    }]
+  })
+}
+
 const pickAccount = (
   accounts: readonly FleetRunSupervisorAccount[],
   activeCounts: Map<string, number>,
@@ -208,6 +242,52 @@ const emit = async (
   event: FleetRunSupervisorObservedEvent,
 ): Promise<void> => {
   if (sink !== undefined) await sink(event)
+}
+
+const recordTerminalAssignment = async (
+  options: FleetRunSupervisorOptions,
+  assignment: FleetRunSupervisorActiveAssignment,
+  result: FleetRunSupervisorDispatchResult,
+  now: Date,
+): Promise<boolean> => {
+  const terminalStatus = terminalStatusForDispatch(result)
+  if (terminalStatus === null) return false
+  for (const event of result.lifecycle) {
+    await emit(options.onLifecycle, {
+      kind: "lifecycle",
+      runRef: options.runRef,
+      taskId: assignment.taskId,
+      claimRef: assignment.claim.claimRef,
+      accountRef: assignment.accountRef,
+      event,
+    })
+  }
+  options.store.recordWorkerDone({
+    contextId: assignment.contextId,
+    taskId: assignment.taskId,
+    status: terminalStatus,
+    result: JSON.stringify({
+      assignmentRef: result.assignmentRef,
+      summary: result.summary ?? null,
+    }),
+    now,
+  })
+  options.store.updateWorkClaimState(
+    assignment.claim.claimRef,
+    terminalStatus === "completed" ? "closeout" : "released",
+    now,
+  )
+  await emit(options.onLifecycle, {
+    kind: "dispatch",
+    runRef: options.runRef,
+    taskId: assignment.taskId,
+    claimRef: assignment.claim.claimRef,
+    workUnitRef: assignment.claim.workUnitRef,
+    accountRef: assignment.accountRef,
+    assignmentRef: result.assignmentRef,
+    status: result.status,
+  })
+  return true
 }
 
 export async function tickFleetRunSupervisor(
@@ -243,6 +323,38 @@ export async function tickFleetRunSupervisor(
       dispatched: 0,
       freeSlots: 0,
       run,
+    }
+  }
+
+  const activeBeforeReconcile = collectActiveAssignments(store, run.runRef)
+  if (options.runner.reconcile !== undefined && activeBeforeReconcile.length > 0) {
+    const activeByTask = new Map(activeBeforeReconcile.map(assignment => [assignment.taskId, assignment]))
+    const reconciled = await options.runner.reconcile({ activeAssignments: activeBeforeReconcile, now, run })
+    for (const result of reconciled) {
+      const assignment = activeByTask.get(result.taskId)
+      if (assignment === undefined) continue
+      await recordTerminalAssignment(options, assignment, result, now)
+    }
+    run = store.reconcileFleetRun(options.runRef, now)
+    if (run.state !== "running" && run.counters.workUnitsTotal < expectedWorkUnitsTotal) {
+      run = store.upsertFleetRun({
+        ...run,
+        state: "running",
+        counters: {
+          ...run.counters,
+          workUnitsTotal: expectedWorkUnitsTotal,
+        },
+        updatedAt: now.toISOString(),
+      })
+    }
+    if (run.state !== "running") {
+      return {
+        activeAssignments: activeAssignmentsForRun(store, run.runRef),
+        claimed: 0,
+        dispatched: 0,
+        freeSlots: 0,
+        run,
+      }
     }
   }
 

--- a/clients/khala-code-desktop/tests/codex-fleet-mcp-bridge.test.ts
+++ b/clients/khala-code-desktop/tests/codex-fleet-mcp-bridge.test.ts
@@ -1,3 +1,7 @@
+import { mkdtemp, rm } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { fileURLToPath } from "node:url"
 import { describe, expect, test } from "bun:test"
 
 import {
@@ -16,7 +20,12 @@ import type {
   KhalaFleetRunStatusInput,
   KhalaFleetRunSupervisorManager,
 } from "../src/bun/khala-codex-fleet-tools"
+import { createCodexAppServerHost } from "../src/bun/codex-app-server-client"
 import { handleKhalaMcpRequest } from "@openagentsinc/khala-tools"
+
+const fixtureAppServerPath = fileURLToPath(
+  new URL("../src/bun/fixture-codex-app-server.ts", import.meta.url),
+)
 
 const fleetRunSnapshot = (input: {
   readonly active?: boolean
@@ -317,5 +326,66 @@ describe("Codex Fleet MCP bridge", () => {
       type: "text",
     })])
     expect(mock.calls.controls).toEqual([{ runRef: "fleet_run.mock", verb: "pause" }])
+  })
+
+  test("Fleet MCP run verbs round-trip through the scripted Codex app-server fixture", async () => {
+    const root = await mkdtemp(join(tmpdir(), "khala-fleet-mcp-app-server-"))
+    const host = createCodexAppServerHost({
+      env: {
+        CODEX_HOME: join(root, "codex-home"),
+        KHALA_CODE_BUN_BINARY: process.execPath,
+        KHALA_CODE_CODEX_APP_SERVER_FIXTURE: "1",
+        KHALA_CODE_CODEX_APP_SERVER_FIXTURE_PATH: fixtureAppServerPath,
+      } as NodeJS.ProcessEnv,
+      initializeTimeoutMs: 1_000,
+      requestTimeoutMs: 1_000,
+    })
+
+    try {
+      await expect(host.start()).resolves.toMatchObject({ ok: true })
+      await expect(ensureCodexFleetMcpBridge({
+        env: { KHALA_CODE_DESKTOP_BUN_COMMAND: process.execPath },
+        host,
+        repoRoot: process.cwd(),
+      })).resolves.toMatchObject({ ok: true })
+
+      const start = await host.request<{ content: Array<{ text: string; type: string }> }>(
+        "mcpServer/tool/call",
+        {
+          arguments: {
+            fixture_count: 5,
+            objective: "Burn down the fixture backlog.",
+            run_ref: "fleet_run.fixture_mcp",
+            target_concurrency: 2,
+            work_source: "fixture",
+          },
+          server: "khala_fleet",
+          threadId: "thread.fixture",
+          tool: "fleet_run_start",
+        },
+      )
+      expect(start.content).toEqual([expect.objectContaining({
+        text: expect.stringContaining("FleetRun fleet_run.fixture_mcp: running"),
+        type: "text",
+      })])
+
+      const status = await host.request<{ content: Array<{ text: string; type: string }> }>(
+        "mcpServer/tool/call",
+        {
+          arguments: { run_ref: "fleet_run.fixture_mcp" },
+          server: "khala_fleet",
+          threadId: "thread.fixture",
+          tool: "fleet_run_status",
+        },
+      )
+
+      expect(status.content).toEqual([expect.objectContaining({
+        text: expect.stringContaining("FleetRun fleet_run.fixture_mcp: running"),
+        type: "text",
+      })])
+    } finally {
+      host.dispose()
+      await rm(root, { force: true, recursive: true })
+    }
   })
 })

--- a/clients/khala-code-desktop/tests/fleet-run-supervisor.test.ts
+++ b/clients/khala-code-desktop/tests/fleet-run-supervisor.test.ts
@@ -1,3 +1,6 @@
+import { mkdtemp, rm } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
 import { describe, expect, test } from "bun:test"
 import { Database } from "bun:sqlite"
 import { Effect, Exit, Scope } from "effect"
@@ -13,6 +16,7 @@ import {
   startFleetRunSupervisor,
   tickFleetRunSupervisor,
   type FleetRunSupervisorAccount,
+  type FleetRunSupervisorActiveAssignment,
   type FleetRunSupervisorObservedEvent,
   type FleetRunSupervisorDispatchInput,
   type FleetRunSupervisorRunner,
@@ -71,7 +75,147 @@ const acceptingRunner = (dispatched: string[] = []): FleetRunSupervisorRunner =>
   },
 })
 
+function drainingRunner(input: {
+  readonly completeAfterPeak?: number
+  readonly completePerTick: number
+  readonly dispatched?: string[]
+  readonly onActive?: (assignments: readonly FleetRunSupervisorActiveAssignment[]) => void
+}): FleetRunSupervisorRunner {
+  let peakActive = 0
+  return {
+    dispatch: async (assignment: FleetRunSupervisorDispatchInput) => {
+      input.dispatched?.push(assignment.workUnit.workUnitRef)
+      return {
+        assignmentRef: `assignment.${assignment.claim.claimRef}`,
+        lifecycle: [{ event: "assignment.accepted", status: "accepted" }],
+        status: "accepted",
+      }
+    },
+    reconcile: async ({ activeAssignments }) => {
+      peakActive = Math.max(peakActive, activeAssignments.length)
+      input.onActive?.(activeAssignments)
+      if (peakActive < (input.completeAfterPeak ?? 1)) return []
+      return activeAssignments.slice(0, input.completePerTick).map(assignment => ({
+        assignmentRef: `assignment.${assignment.claim.claimRef}`,
+        lifecycle: [{ event: "assignment.closeout", status: "completed" }],
+        status: "completed" as const,
+        summary: "fixture assignment completed",
+        taskId: assignment.taskId,
+      }))
+    },
+  }
+}
+
 describe("FleetRunSupervisor", () => {
+  test("target-25 fixture acceptance reaches 25 simulated concurrent assignments and drains", async () => {
+    const { store, run } = createStoreWithRun({ runRef: "fleet_run.acceptance.target_25", targetConcurrency: 25, workUnits: 25 })
+    const dispatched: string[] = []
+    const activeCounts: number[] = []
+    let nowMs = fixedNow.getTime()
+    const options = {
+      store,
+      pylonRef: "pylon.owner.acceptance",
+      runRef: run.runRef,
+      planner: fixturePlannerWithClaims(store, 25),
+      runner: drainingRunner({
+        completeAfterPeak: 25,
+        completePerTick: 6,
+        dispatched,
+        onActive: assignments => activeCounts.push(assignments.length),
+      }),
+      capacity: capacity([
+        { accountRef: "codex", advertisedCapacity: 10 },
+        { accountRef: "codex-2", advertisedCapacity: 10 },
+        { accountRef: "codex-3", advertisedCapacity: 10 },
+      ]),
+      clock: { now: () => new Date(nowMs) },
+    }
+
+    for (let tick = 0; tick < 20; tick += 1) {
+      await tickFleetRunSupervisor(options)
+      nowMs += 1_000
+      if (store.getFleetRun(run.runRef)?.state === "completed") break
+    }
+
+    expect(activeCounts).toContain(25)
+    expect(new Set(dispatched).size).toBe(25)
+    expect(store.getFleetRun(run.runRef)?.state).toBe("completed")
+    expect(store.getFleetRun(run.runRef)?.counters).toMatchObject({
+      activeAssignments: 0,
+      completedAssignments: 25,
+      failedAssignments: 0,
+      blockedAssignments: 0,
+      workUnitsTotal: 25,
+    })
+    expect(store.listWorkClaims({ runRef: run.runRef, state: "closeout" })).toHaveLength(25)
+  })
+
+  test("fixture run survives host restart over the same sqlite file and continues refilling", async () => {
+    const root = await mkdtemp(join(tmpdir(), "khala-fleet-run-restart-"))
+    try {
+      const dbPath = join(root, "orchestration.sqlite")
+      const firstDb = new Database(dbPath)
+      const firstStore = createPylonOrchestrationStore(firstDb)
+      const run = firstStore.createFleetRun({
+        runRef: "fleet_run.acceptance.restart",
+        objective: "Run restart fixture fleet units.",
+        workSource: "fixture",
+        targetConcurrency: 10,
+        workerKind: "codex",
+        state: "running",
+        startedAt: fixedNow,
+        now: fixedNow,
+        counters: { workUnitsTotal: 15 },
+      })
+      const firstDispatched: string[] = []
+      await tickFleetRunSupervisor({
+        store: firstStore,
+        pylonRef: "pylon.owner.restart",
+        runRef: run.runRef,
+        planner: fixturePlannerWithClaims(firstStore, 15),
+        runner: acceptingRunner(firstDispatched),
+        capacity: capacity([{ accountRef: "codex", advertisedCapacity: 10 }]),
+        clock: { now: () => fixedNow },
+      })
+      expect(firstStore.listTasks("dispatched")).toHaveLength(10)
+      firstDb.close()
+
+      const secondDb = new Database(dbPath)
+      const secondStore = createPylonOrchestrationStore(secondDb)
+      const secondDispatched: string[] = []
+      const activeCounts: number[] = []
+      let nowMs = fixedNow.getTime() + 1_000
+      const options = {
+        store: secondStore,
+        pylonRef: "pylon.owner.restart",
+        runRef: run.runRef,
+        planner: fixturePlannerWithClaims(secondStore, 15),
+        runner: drainingRunner({
+          completePerTick: 5,
+          dispatched: secondDispatched,
+          onActive: assignments => activeCounts.push(assignments.length),
+        }),
+        capacity: capacity([{ accountRef: "codex", advertisedCapacity: 10 }]),
+        clock: { now: () => new Date(nowMs) },
+      }
+
+      for (let tick = 0; tick < 10; tick += 1) {
+        await tickFleetRunSupervisor(options)
+        nowMs += 1_000
+        if (secondStore.getFleetRun(run.runRef)?.state === "completed") break
+      }
+
+      expect(activeCounts[0]).toBe(10)
+      expect(new Set([...firstDispatched, ...secondDispatched]).size).toBe(15)
+      expect(secondStore.getFleetRun(run.runRef)?.state).toBe("completed")
+      expect(secondStore.getFleetRun(run.runRef)?.counters.completedAssignments).toBe(15)
+      expect(secondStore.listWorkClaims({ runRef: run.runRef, state: "released" })).toHaveLength(0)
+      secondDb.close()
+    } finally {
+      await rm(root, { force: true, recursive: true })
+    }
+  })
+
   test("refills arbitrary target concurrency across ticks while keeping MAX_SPAWN_COUNT per tick", async () => {
     const { store, run } = createStoreWithRun({ targetConcurrency: 25, workUnits: 25 })
     const dispatched: string[] = []


### PR DESCRIPTION
Closes #7833

## Summary
- Add FleetRun fixture acceptance coverage for target-25 refill-to-peak and clean drain.
- Add SQLite restart acceptance coverage that rehydrates a run from the same orchestration store and continues to closeout.
- Add a scripted khala_fleet MCP round-trip to the fixture Codex app-server for fleet_run_start then fleet_run_status.

## Engine fixes surfaced by the fixtures
- Mark dispatch contexts with a fresh heartbeat when a task is dispatched so claim reconciliation does not treat a newly dispatched or rehydrated worker as dead.
- Add a runner reconciliation hook so the supervisor can observe terminal active assignments after a host restart or between refill ticks, then reopen a run when known fixture backlog remains.

## Verification
- bun test clients/khala-code-desktop/tests/fleet-run-supervisor.test.ts clients/khala-code-desktop/tests/codex-fleet-mcp-bridge.test.ts
- bun run --cwd clients/khala-code-desktop typecheck
- bun run --cwd clients/khala-code-desktop test
