### PR TITLE
T8.1: ChatRuntime selector seam

### DIFF
--- a/clients/khala-code-desktop/src/bun/codex-thread-item-projector.ts
+++ b/clients/khala-code-desktop/src/bun/codex-thread-item-projector.ts
@@ -479,6 +479,7 @@ const projectionForItem = (
     role,
     body: boundedBody,
     codexItem,
+    harnessItem: codexItem,
   }
 }
 
@@ -501,49 +502,51 @@ const approvalMessage = (
     jsonSection("Permissions", params.permissions ?? params.additionalPermissions, context),
     jsonSection("Available decisions", params.availableDecisions, context),
   ].filter(Boolean).join("\n\n") || "Codex is waiting for approval.", context)
+  const codexItem: KhalaCodeDesktopCodexItemCard = {
+    itemId: item,
+    itemType: "approval",
+    status,
+    title,
+    ...(requestIdValue === undefined ? {} : {
+      approval: {
+        method: notification.method as KhalaCodeDesktopCodexApprovalMethod,
+        requestId: requestIdValue,
+        ...(arrayField(params, "availableDecisions").length === 0
+          ? {}
+          : { availableDecisions: arrayField(params, "availableDecisions") }),
+        ...(stringField(params, "command") === null ? {} : { command: stringField(params, "command")! }),
+        ...(stringField(params, "cwd") === null ? {} : { cwd: stringField(params, "cwd")! }),
+        ...(stringField(params, "grantRoot") === null ? {} : { grantRoot: stringField(params, "grantRoot")! }),
+        ...(objectField(params, "networkApprovalContext") === null
+          ? {}
+          : { networkApprovalContext: objectField(params, "networkApprovalContext")! }),
+        ...(objectField(params, "permissions") === null
+          ? {}
+          : { permissions: objectField(params, "permissions")! as KhalaCodeDesktopCodexPermissionProfile }),
+        ...(objectField(params, "additionalPermissions") === null
+          ? {}
+          : { additionalPermissions: objectField(params, "additionalPermissions")! }),
+        ...(stringArrayField(params, "proposedExecpolicyAmendment") === undefined
+          ? {}
+          : { proposedExecpolicyAmendment: stringArrayField(params, "proposedExecpolicyAmendment")! }),
+        ...(networkPolicyAmendments(params) === undefined
+          ? {}
+          : { proposedNetworkPolicyAmendments: networkPolicyAmendments(params)! }),
+        ...(stringField(params, "reason") === null ? {} : { reason: stringField(params, "reason")! }),
+      },
+    }),
+    ...cardContext({
+      ...(requestId === undefined ? {} : { requestId }),
+      threadId: threadIdFromParams(params),
+      turnId: turnIdFromParams(params),
+    }),
+  }
   return {
     id: `approval-${requestId ?? item}`,
     role: "tool",
     body,
-    codexItem: {
-      itemId: item,
-      itemType: "approval",
-      status,
-      title,
-      ...(requestIdValue === undefined ? {} : {
-        approval: {
-          method: notification.method as KhalaCodeDesktopCodexApprovalMethod,
-          requestId: requestIdValue,
-          ...(arrayField(params, "availableDecisions").length === 0
-            ? {}
-            : { availableDecisions: arrayField(params, "availableDecisions") }),
-          ...(stringField(params, "command") === null ? {} : { command: stringField(params, "command")! }),
-          ...(stringField(params, "cwd") === null ? {} : { cwd: stringField(params, "cwd")! }),
-          ...(stringField(params, "grantRoot") === null ? {} : { grantRoot: stringField(params, "grantRoot")! }),
-          ...(objectField(params, "networkApprovalContext") === null
-            ? {}
-            : { networkApprovalContext: objectField(params, "networkApprovalContext")! }),
-          ...(objectField(params, "permissions") === null
-            ? {}
-            : { permissions: objectField(params, "permissions")! as KhalaCodeDesktopCodexPermissionProfile }),
-          ...(objectField(params, "additionalPermissions") === null
-            ? {}
-            : { additionalPermissions: objectField(params, "additionalPermissions")! }),
-          ...(stringArrayField(params, "proposedExecpolicyAmendment") === undefined
-            ? {}
-            : { proposedExecpolicyAmendment: stringArrayField(params, "proposedExecpolicyAmendment")! }),
-          ...(networkPolicyAmendments(params) === undefined
-            ? {}
-            : { proposedNetworkPolicyAmendments: networkPolicyAmendments(params)! }),
-          ...(stringField(params, "reason") === null ? {} : { reason: stringField(params, "reason")! }),
-        },
-      }),
-      ...cardContext({
-        ...(requestId === undefined ? {} : { requestId }),
-        threadId: threadIdFromParams(params),
-        turnId: turnIdFromParams(params),
-      }),
-    },
+    codexItem,
+    harnessItem: codexItem,
   }
 }
 
@@ -608,7 +611,7 @@ export function createCodexThreadItemEventProjector(
         id: item.itemId,
         role: item.role,
         body: "",
-        ...(codexItem === undefined ? {} : { codexItem }),
+        ...(codexItem === undefined ? {} : { codexItem, harnessItem: codexItem }),
       }
       messages.set(item.itemId, {
         ...message,
@@ -696,20 +699,22 @@ export function createCodexThreadItemEventProjector(
     if (notification.method === "item/fileChange/patchUpdated") {
       const id = stringField(params, "itemId")
       if (id === null) return []
+      const codexItem: KhalaCodeDesktopCodexItemCard = {
+        itemId: id,
+        itemType: "fileChange",
+        status: "running",
+        title: fileChangesTitle(arrayField(params, "changes"), options),
+        ...cardContext({
+          threadId: threadIdFromParams(params),
+          turnId: turnIdFromParams(params),
+        }),
+      }
       return upsert({
         id,
         role: "tool",
         body: fileChangesBody(arrayField(params, "changes"), options),
-        codexItem: {
-          itemId: id,
-          itemType: "fileChange",
-          status: "running",
-          title: fileChangesTitle(arrayField(params, "changes"), options),
-          ...cardContext({
-            threadId: threadIdFromParams(params),
-            turnId: turnIdFromParams(params),
-          }),
-        },
+        codexItem,
+        harnessItem: codexItem,
       })
     }
 
@@ -745,6 +750,17 @@ export function createCodexThreadItemEventProjector(
       notification.method === "item/autoApprovalReview/completed"
     ) {
       const reviewId = stringField(params, "reviewId") ?? "auto-review"
+      const codexItem: KhalaCodeDesktopCodexItemCard = {
+        itemId: stringField(params, "targetItemId") ?? reviewId,
+        itemType: "approvalReview",
+        status: notification.method.endsWith("/completed") ? "completed" : "running",
+        title: "Approval review",
+        ...cardContext({
+          requestId: reviewId,
+          threadId: threadIdFromParams(params),
+          turnId: turnIdFromParams(params),
+        }),
+      }
       return upsert({
         id: `approval-review-${reviewId}`,
         role: "tool",
@@ -752,17 +768,8 @@ export function createCodexThreadItemEventProjector(
           jsonSection("Review", params.review, options).trim() || "Auto-approval review is running.",
           options,
         ),
-        codexItem: {
-          itemId: stringField(params, "targetItemId") ?? reviewId,
-          itemType: "approvalReview",
-          status: notification.method.endsWith("/completed") ? "completed" : "running",
-          title: "Approval review",
-          ...cardContext({
-            requestId: reviewId,
-            threadId: threadIdFromParams(params),
-            turnId: turnIdFromParams(params),
-          }),
-        },
+        codexItem,
+        harnessItem: codexItem,
       }, notification.method.endsWith("/completed"))
     }
 
@@ -775,6 +782,10 @@ export function createCodexThreadItemEventProjector(
         ...existing,
         body: existing.body.length === 0 ? "Approval resolved." : `${existing.body}\n\nApproval resolved.`,
         codexItem: {
+          ...existing.codexItem,
+          status: "completed",
+        },
+        harnessItem: {
           ...existing.codexItem,
           status: "completed",
         },

--- a/clients/khala-code-desktop/src/bun/headless.ts
+++ b/clients/khala-code-desktop/src/bun/headless.ts
@@ -12,15 +12,17 @@ import type {
 } from "../shared/rpc.js"
 import type { CodexAppServerChatRuntime } from "./codex-app-server-chat-runtime.js"
 
-export type KhalaCodeDesktopHeadlessCodexRuntime = Pick<
+export type KhalaCodeDesktopHeadlessChatRuntime = Pick<
   CodexAppServerChatRuntime,
   "interruptTurn" | "startThread" | "startTurn"
 >
 
+export type KhalaCodeDesktopHeadlessCodexRuntime = KhalaCodeDesktopHeadlessChatRuntime
+
 export type KhalaCodeDesktopHeadlessRunInput = {
   readonly createCodexChatRuntime: (input: {
     readonly onEvent: (event: KhalaCodeDesktopChatTurnEvent) => void
-  }) => KhalaCodeDesktopHeadlessCodexRuntime
+  }) => KhalaCodeDesktopHeadlessChatRuntime
   readonly env: Readonly<Record<string, string | undefined>>
   readonly interruptAfterMs?: number
   readonly prompt: string

--- a/clients/khala-code-desktop/src/bun/rpc-handlers.ts
+++ b/clients/khala-code-desktop/src/bun/rpc-handlers.ts
@@ -112,6 +112,24 @@ import {
 
 type ChatEnv = Readonly<Record<string, string | undefined>>
 type MaybePromise<T> = T | Promise<T>
+type ChatRuntime = CodexAppServerChatRuntime
+
+type ChatRuntimeSelection =
+  | {
+    readonly kind: "claude"
+    readonly runtime: ChatRuntime
+  }
+  | {
+    readonly kind: "codex"
+    readonly runtime: ChatRuntime
+  }
+  | {
+    readonly kind: "legacy"
+  }
+
+const claudeRuntimeUnsupportedMessage = "Claude app SDK chat runtime is not supported until T8.2."
+const legacyThreadLifecycleUnsupportedMessage =
+  "Legacy Khala native runtime does not support thread lifecycle RPCs."
 
 export type KhalaCodeDesktopFleetRunSupervisorRpc = {
   readonly control: (
@@ -747,15 +765,45 @@ export function createKhalaCodeDesktopRpcRequestHandlers(
     }
     return codexChatRuntime
   }
+  const unsupportedClaudeRuntime = (): ChatRuntime => {
+    const unsupported = async (): Promise<never> => {
+      throw new Error(claudeRuntimeUnsupportedMessage)
+    }
+    return {
+      archiveThread: unsupported,
+      compactThread: unsupported,
+      deleteThread: unsupported,
+      forkThread: unsupported,
+      interruptTurn: unsupported,
+      listThreads: unsupported,
+      readThread: unsupported,
+      renameThread: unsupported,
+      resumeThread: unsupported,
+      startThread: unsupported,
+      startTurn: unsupported,
+      steerTurn: unsupported,
+      threadIdForSession: async () => null,
+      unarchiveThread: unsupported,
+    }
+  }
   const requireFleetRunSupervisor = (): KhalaCodeDesktopFleetRunSupervisorRpc => {
     if (input.fleetRunSupervisor === undefined) {
       throw new Error("Fleet run supervisor is not configured.")
     }
     return input.fleetRunSupervisor
   }
-  const useLegacyKhalaNativeRuntime = (): boolean =>
-    input.env.KHALA_CODE_DESKTOP_RUNTIME === "khala_native_runtime" ||
-    input.env.KHALA_CODE_DESKTOP_LEGACY_KHALA_NATIVE_RUNTIME === "1"
+  const selectChatRuntime = (): ChatRuntimeSelection => {
+    if (input.env.KHALA_CODE_DESKTOP_RUNTIME === "claude_runtime") {
+      return { kind: "claude", runtime: unsupportedClaudeRuntime() }
+    }
+    if (
+      input.env.KHALA_CODE_DESKTOP_RUNTIME === "khala_native_runtime" ||
+      input.env.KHALA_CODE_DESKTOP_LEGACY_KHALA_NATIVE_RUNTIME === "1"
+    ) {
+      return { kind: "legacy" }
+    }
+    return { kind: "codex", runtime: requireCodexChatRuntime() }
+  }
   let fleetMcpBridgeReady = false
 
   const maybeEnsureFleetMcpBridge = async (): Promise<CodexFleetMcpBridgeEnsureResult | null> => {
@@ -841,6 +889,29 @@ export function createKhalaCodeDesktopRpcRequestHandlers(
     }
   }
 
+  const unsupportedClaudeChatResponse = (): KhalaCodeDesktopChatTurnResponse => ({
+    backend: {
+      blockerRefs: ["blocker.claude_app_sdk.unsupported_until_t8_2"],
+      kind: "claude_app_sdk",
+      model: "claude-app-sdk",
+      runtimeMode: "claude_runtime",
+      toolCatalogKind: "codex_harness_supplemental",
+      turnStatus: "unsupported",
+    },
+    messages: [{
+      id: `claude-runtime-unsupported-${Date.now().toString(36)}`,
+      role: "system",
+      body: claudeRuntimeUnsupportedMessage,
+    }],
+    ok: false,
+    toolNames: [],
+    usedTools: [],
+  })
+
+  const unsupportedLegacyThreadLifecycle = async (): Promise<never> => {
+    throw new Error(legacyThreadLifecycleUnsupportedMessage)
+  }
+
   const ecosystemNotifications: CodexAppServerNotification[] = []
   const ecosystemNotificationMethods = new Set([
     "app/list/updated",
@@ -877,7 +948,9 @@ export function createKhalaCodeDesktopRpcRequestHandlers(
   ): Promise<string | null> => {
     const explicit = request.threadId?.trim()
     if (explicit !== undefined && explicit.length > 0) return explicit
-    return await codexChatRuntime?.threadIdForSession(request.sessionId) ?? null
+    const selection = selectChatRuntime()
+    if (selection.kind === "legacy") return null
+    return await selection.runtime.threadIdForSession(request.sessionId) ?? null
   }
 
   const blockedSlashCommand = (
@@ -1974,49 +2047,83 @@ export function createKhalaCodeDesktopRpcRequestHandlers(
       })
     },
     async codexThreadArchive(request) {
-      return requireCodexChatRuntime().archiveThread(request)
+      const selection = selectChatRuntime()
+      if (selection.kind === "legacy") return unsupportedLegacyThreadLifecycle()
+      return selection.runtime.archiveThread(request)
     },
     async codexThreadCompact(request) {
-      return requireCodexChatRuntime().compactThread(request)
+      const selection = selectChatRuntime()
+      if (selection.kind === "legacy") return unsupportedLegacyThreadLifecycle()
+      return selection.runtime.compactThread(request)
     },
     async codexThreadDelete(request) {
-      return requireCodexChatRuntime().deleteThread(request)
+      const selection = selectChatRuntime()
+      if (selection.kind === "legacy") return unsupportedLegacyThreadLifecycle()
+      return selection.runtime.deleteThread(request)
     },
     async codexThreadFork(request) {
-      return requireCodexChatRuntime().forkThread(request)
+      const selection = selectChatRuntime()
+      if (selection.kind === "legacy") return unsupportedLegacyThreadLifecycle()
+      return selection.runtime.forkThread(request)
     },
     async codexThreadList(request) {
-      return requireCodexChatRuntime().listThreads(request)
+      const selection = selectChatRuntime()
+      if (selection.kind === "legacy") return unsupportedLegacyThreadLifecycle()
+      return selection.runtime.listThreads(request)
     },
     async codexThreadRead(request) {
-      return requireCodexChatRuntime().readThread(request)
+      const selection = selectChatRuntime()
+      if (selection.kind === "legacy") return unsupportedLegacyThreadLifecycle()
+      return selection.runtime.readThread(request)
     },
     async codexThreadRename(request) {
-      return requireCodexChatRuntime().renameThread(request)
+      const selection = selectChatRuntime()
+      if (selection.kind === "legacy") return unsupportedLegacyThreadLifecycle()
+      return selection.runtime.renameThread(request)
     },
     async codexThreadResume(request) {
-      return requireCodexChatRuntime().resumeThread(request)
+      const selection = selectChatRuntime()
+      if (selection.kind === "legacy") return unsupportedLegacyThreadLifecycle()
+      return selection.runtime.resumeThread(request)
     },
     async codexThreadStart(request = {}) {
-      return requireCodexChatRuntime().startThread({
+      const selection = selectChatRuntime()
+      if (selection.kind === "legacy") return unsupportedLegacyThreadLifecycle()
+      return selection.runtime.startThread({
         cwd: input.workingDirectory,
         ...request,
       })
     },
     async codexThreadUnarchive(request) {
-      return requireCodexChatRuntime().unarchiveThread(request)
+      const selection = selectChatRuntime()
+      if (selection.kind === "legacy") return unsupportedLegacyThreadLifecycle()
+      return selection.runtime.unarchiveThread(request)
     },
     async codexTurnInterrupt(request) {
-      return requireCodexChatRuntime().interruptTurn(request)
+      const selection = selectChatRuntime()
+      if (selection.kind === "legacy") return unsupportedLegacyThreadLifecycle()
+      return selection.runtime.interruptTurn(request)
     },
     async codexTurnStart(request) {
-      return requireCodexChatRuntime().startTurn({
+      const selection = selectChatRuntime()
+      if (selection.kind === "legacy") {
+        return labelLegacyRuntimeResponse(await legacyChatTurn({
+          env: input.env,
+          ...(input.emitChatTurnEvent === undefined ? {} : { onEvent: input.emitChatTurnEvent }),
+          request,
+          workingDirectory: request.cwd ?? input.workingDirectory,
+        }))
+      }
+      if (selection.kind === "claude") return unsupportedClaudeChatResponse()
+      return selection.runtime.startTurn({
         ...request,
         cwd: request.cwd ?? input.workingDirectory,
       })
     },
     async codexTurnSteer(request) {
-      return requireCodexChatRuntime().steerTurn(request)
+      const selection = selectChatRuntime()
+      if (selection.kind === "legacy") return unsupportedLegacyThreadLifecycle()
+      return selection.runtime.steerTurn(request)
     },
     async codingStatus() {
       const harness = await codexHarnessStatus()
@@ -2084,13 +2191,15 @@ export function createKhalaCodeDesktopRpcRequestHandlers(
       return withMaterializedChatAttachments(
         request,
         async materializedRequest => {
-          if (!useLegacyKhalaNativeRuntime()) {
+          const selection = selectChatRuntime()
+          if (selection.kind === "codex") {
             const bridge = await maybeEnsureFleetMcpBridge()
-            return withFleetMcpBridgeNote(await labelCodexHarnessResponse(await requireCodexChatRuntime().startTurn({
+            return withFleetMcpBridgeNote(await labelCodexHarnessResponse(await selection.runtime.startTurn({
               ...materializedRequest,
               cwd: input.workingDirectory,
             })), bridge)
           }
+          if (selection.kind === "claude") return unsupportedClaudeChatResponse()
           return labelLegacyRuntimeResponse(await legacyChatTurn({
             env: input.env,
             ...(input.emitChatTurnEvent === undefined ? {} : { onEvent: input.emitChatTurnEvent }),
@@ -2154,10 +2263,13 @@ export function createKhalaCodeDesktopRpcRequestHandlers(
       })
     },
     async toolCatalog() {
+      const selection = selectChatRuntime()
       return khalaCodeDesktopToolCatalog({
-        runtimeMode: useLegacyKhalaNativeRuntime()
+        runtimeMode: selection.kind === "legacy"
           ? "khala_native_runtime"
-          : "codex_harness",
+          : selection.kind === "claude"
+            ? "claude_runtime"
+            : "codex_harness",
       })
     },
   }

--- a/clients/khala-code-desktop/src/shared/rpc.ts
+++ b/clients/khala-code-desktop/src/shared/rpc.ts
@@ -193,7 +193,7 @@ const RpcStringArray = S.Array(S.String)
 const RpcJsonObject = S.Record(S.String, RpcJson)
 const RpcStringNull = S.NullOr(S.String)
 const RpcNumberNull = S.NullOr(S.Number)
-const RpcRuntimeMode = S.Literals(["codex_harness", "khala_native_runtime"])
+const RpcRuntimeMode = S.Literals(["claude_runtime", "codex_harness", "khala_native_runtime"])
 const RpcToolCatalogKind = S.Literals(["codex_harness_supplemental", "khala_native_legacy"])
 
 const RpcToolEvent = S.Struct({
@@ -252,6 +252,7 @@ const RpcCodexItemCard = S.Struct({
 
 export const KhalaCodeDesktopMessageSchema = S.Struct({
   codexItem: S.optional(RpcCodexItemCard),
+  harnessItem: S.optional(RpcCodexItemCard),
   id: S.String,
   role: S.Literals(["user", "assistant", "system", "tool"]),
   body: S.String,
@@ -321,7 +322,7 @@ const RpcBackendProjection = S.Struct({
   baseUrl: S.optional(S.String),
   blockerRefs: S.optional(RpcStringArray),
   credentialSource: S.optional(S.Literals(["env:OPENROUTER_API_KEY", "khala-provider-key"])),
-  kind: S.Literals(["codex_app_server", "hosted_openagents", "mock"]),
+  kind: S.Literals(["claude_app_sdk", "codex_app_server", "hosted_openagents", "mock"]),
   model: S.String,
   provider: S.optional(S.Literal("openrouter")),
   runtimeMode: S.optional(RpcRuntimeMode),

--- a/clients/khala-code-desktop/tests/rpc-handlers.test.ts
+++ b/clients/khala-code-desktop/tests/rpc-handlers.test.ts
@@ -792,6 +792,117 @@ describe("Khala Code desktop RPC handlers", () => {
     expect(legacyTurnStarted).toBe(false)
   })
 
+  test("routes explicit Codex turn starts through the selected Codex chat runtime", async () => {
+    let codexTurnStarted = false
+    const handlers = createKhalaCodeDesktopRpcRequestHandlers({
+      appleFmReadiness: () => {
+        throw new Error("not used")
+      },
+      codexChatRuntime: throwingCodexChatRuntime({
+        startTurn: async request => {
+          codexTurnStarted = true
+          expect(request.cwd).toBe("/workspace/project")
+          return {
+            backend: {
+              kind: "codex_app_server",
+              model: "gpt-5.1-codex",
+              threadId: request.threadId,
+              turnId: "turn-selected-codex",
+            },
+            messages: [{ id: "agent-selected-codex", role: "assistant", body: "selected codex" }],
+            ok: true,
+            toolNames: [],
+            usedTools: [],
+          }
+        },
+      }),
+      env: { KHALA_CODE_DESKTOP_RUNTIME: "codex_harness" },
+      onDeviceDeciderStatus: () => {
+        throw new Error("not used")
+      },
+      workingDirectory: "/workspace/project",
+    })
+
+    await expect(handlers.codexTurnStart({
+      messages: [{ id: "user-selected-codex", role: "user", body: "Run selected Codex" }],
+      sessionId: "desktop-session-selected-codex",
+      threadId: "thread-selected-codex",
+      turnId: "desktop-turn-selected-codex",
+    })).resolves.toMatchObject({
+      backend: {
+        kind: "codex_app_server",
+        threadId: "thread-selected-codex",
+      },
+      messages: [{ body: "selected codex" }],
+      ok: true,
+    })
+    expect(codexTurnStarted).toBe(true)
+  })
+
+  test("returns a typed unsupported response for the Claude runtime seam", async () => {
+    const handlers = createKhalaCodeDesktopRpcRequestHandlers({
+      appleFmReadiness: () => {
+        throw new Error("not used")
+      },
+      codexChatRuntime: throwingCodexChatRuntime(),
+      env: { KHALA_CODE_DESKTOP_RUNTIME: "claude_runtime" },
+      legacyChatTurn: async (): Promise<KhalaCodeDesktopChatTurnResponse> => {
+        throw new Error("legacy runtime should not handle Claude-selected turns")
+      },
+      onDeviceDeciderStatus: () => {
+        throw new Error("not used")
+      },
+      workingDirectory: process.cwd(),
+    })
+
+    await expect(handlers.submitChatMessage({
+      messages: [{ id: "user-claude", role: "user", body: "Use Claude" }],
+      sessionId: "desktop-session-claude",
+      turnId: "desktop-turn-claude",
+    })).resolves.toMatchObject({
+      backend: {
+        blockerRefs: ["blocker.claude_app_sdk.unsupported_until_t8_2"],
+        kind: "claude_app_sdk",
+        runtimeMode: "claude_runtime",
+        turnStatus: "unsupported",
+      },
+      messages: [{ body: "Claude app SDK chat runtime is not supported until T8.2." }],
+      ok: false,
+    })
+
+    await expect(handlers.codexTurnStart({
+      messages: [{ id: "user-claude-turn", role: "user", body: "Start Claude" }],
+      sessionId: "desktop-session-claude",
+      turnId: "desktop-turn-claude-2",
+    })).resolves.toMatchObject({
+      backend: {
+        kind: "claude_app_sdk",
+        runtimeMode: "claude_runtime",
+        turnStatus: "unsupported",
+      },
+      ok: false,
+    })
+  })
+
+  test("routes thread lifecycle RPCs through the selected Claude seam", async () => {
+    const handlers = createKhalaCodeDesktopRpcRequestHandlers({
+      appleFmReadiness: () => {
+        throw new Error("not used")
+      },
+      codexChatRuntime: throwingCodexChatRuntime(),
+      env: { KHALA_CODE_DESKTOP_RUNTIME: "claude_runtime" },
+      onDeviceDeciderStatus: () => {
+        throw new Error("not used")
+      },
+      workingDirectory: process.cwd(),
+    })
+
+    await expect(handlers.codexThreadStart({ sessionId: "desktop-session-claude" }))
+      .rejects.toThrow("Claude app SDK chat runtime is not supported until T8.2.")
+    await expect(handlers.codexThreadList({ sessionId: "desktop-session-claude" }))
+      .rejects.toThrow("Claude app SDK chat runtime is not supported until T8.2.")
+  })
+
   test("registers the Khala Fleet MCP bridge before default Codex chat turns", async () => {
     const requests: Array<{ method: string; params: unknown }> = []
     const host = {

--- a/clients/khala-code-desktop/tests/rpc-schema.test.ts
+++ b/clients/khala-code-desktop/tests/rpc-schema.test.ts
@@ -50,6 +50,55 @@ describe("Khala Code desktop schema-first RPC contract", () => {
     expect(result).toMatchObject({ ok: true })
   })
 
+  test("accepts neutral harnessItem while keeping codexItem back-compat", () => {
+    const harnessItem = {
+      itemId: "item-1",
+      itemType: "commandExecution",
+      status: "completed",
+      title: "Command",
+    }
+
+    const neutral = decodeKhalaCodeDesktopRpcResult("submitChatMessage", {
+      backend: {
+        kind: "claude_app_sdk",
+        model: "claude-app-sdk",
+        runtimeMode: "claude_runtime",
+      },
+      messages: [
+        {
+          body: "ran",
+          harnessItem,
+          id: "message-neutral",
+          role: "tool",
+        },
+      ],
+      ok: true,
+      toolNames: [],
+      usedTools: [],
+    }) as { readonly messages: readonly [{ readonly harnessItem?: typeof harnessItem }] }
+    expect(neutral.messages[0]).toMatchObject({ harnessItem })
+
+    const backCompat = decodeKhalaCodeDesktopRpcResult("submitChatMessage", {
+      backend: {
+        kind: "codex_app_server",
+        model: "gpt-5.1-codex",
+        runtimeMode: "codex_harness",
+      },
+      messages: [
+        {
+          body: "ran",
+          codexItem: harnessItem,
+          id: "message-codex",
+          role: "tool",
+        },
+      ],
+      ok: true,
+      toolNames: [],
+      usedTools: [],
+    }) as { readonly messages: readonly [{ readonly codexItem?: typeof harnessItem }] }
+    expect(backCompat.messages[0]).toMatchObject({ codexItem: harnessItem })
+  })
+
   test("rejects malformed request parameters before a handler runs", () => {
     expect(() =>
       decodeKhalaCodeDesktopRpcParameters("codexThreadRead", [{ includeTurns: true }]),


### PR DESCRIPTION
Closes #7865

## Summary
- extend Khala Code Desktop RPC schemas for `claude_runtime`, `claude_app_sdk`, and neutral `harnessItem` while keeping `codexItem` compatibility
- add a three-way chat runtime selector for Codex, legacy Khala native, and Claude seam routing
- route submit, turn start, and thread lifecycle RPCs through the selector, with Claude returning typed unsupported turn responses until T8.2
- widen the headless runtime pick to a neutral chat runtime alias

## Verification
- `git diff --check`
- `bun build clients/khala-code-desktop/src/bun/codex-thread-item-projector.ts --target bun --outdir /tmp/khala-code-projector-build`
- `bun build clients/khala-code-desktop/src/bun/headless.ts --target bun --outdir /tmp/khala-code-headless-build`
- `bun build clients/khala-code-desktop/src/shared/rpc.ts --target bun --outdir /tmp/khala-code-rpc-build`
- `bun run --cwd clients/khala-code-desktop verify` failed at typecheck because this bounded checkout does not resolve workspace packages such as `@openagentsinc/khala-tools`, `@openagentsinc/agent-runtime-schema`, `@openagentsinc/ui/*`, and `@openagentsinc/arbiter-effect`; `bun install` reported no changes and left those links unavailable.