### PR TITLE
T5.1: FleetRun header + controls

### DIFF
--- a/clients/khala-code-desktop/src/ui/fleet-status.ts
+++ b/clients/khala-code-desktop/src/ui/fleet-status.ts
@@ -5,6 +5,11 @@ import type {
   KhalaCodeDesktopFleetAccount,
   KhalaCodeDesktopFleetDelegateRunRequest,
   KhalaCodeDesktopFleetDelegateRunResult,
+  KhalaCodeDesktopFleetRunControlRequest,
+  KhalaCodeDesktopFleetRunControlResult,
+  KhalaCodeDesktopFleetRunListRequest,
+  KhalaCodeDesktopFleetRunListResult,
+  KhalaCodeDesktopFleetRunProjection,
   KhalaCodeDesktopFleetRunStartRequest,
   KhalaCodeDesktopFleetRunStartResult,
   KhalaCodeDesktopFleetStatus,
@@ -33,6 +38,12 @@ export type FleetPanelOptions = Readonly<{
   fleetRunStart: (
     request: KhalaCodeDesktopFleetRunStartRequest,
   ) => Promise<KhalaCodeDesktopFleetRunStartResult>
+  fleetRunControl: (
+    request: KhalaCodeDesktopFleetRunControlRequest,
+  ) => Promise<KhalaCodeDesktopFleetRunControlResult>
+  fleetRunList: (
+    request?: KhalaCodeDesktopFleetRunListRequest,
+  ) => Promise<KhalaCodeDesktopFleetRunListResult>
   loadGymDemoProof: () =>
     | KhalaGymDelegationOptimizationRun
     | Promise<KhalaGymDelegationOptimizationRun>
@@ -49,6 +60,7 @@ type Handlers = Readonly<{
   onDelegateField: (field: keyof FleetDelegateFormState, value: string | boolean) => void
   onDelegateRun: () => void
   onFleetRunField: (field: keyof FleetRunFormState, value: string) => void
+  onFleetRunControl: (verb: KhalaCodeDesktopFleetRunControlRequest["verb"]) => void
   onFleetRunPreview: () => void
   onFleetRunStart: () => void
   onLoadGymDemoProof: () => void
@@ -115,6 +127,13 @@ type FleetRunView =
       readonly result: KhalaCodeDesktopFleetRunStartResult
       readonly slots: readonly FleetRunPreviewSlot[]
     }
+
+type ActiveFleetRunView = Readonly<{
+  controlInFlight: KhalaCodeDesktopFleetRunControlRequest["verb"] | null
+  error: string | null
+  objective: string | null
+  run: KhalaCodeDesktopFleetRunProjection | null
+}>
 
 type FleetView =
   | { readonly phase: "loading" }
@@ -205,6 +224,62 @@ const formatElapsedMs = (elapsedMs: number | null): string | null => {
   const remainder = seconds % 60
   return minutes === 0 ? `${remainder}s` : `${minutes}m ${remainder}s`
 }
+
+const elapsedSince = (
+  startedAt: string | null,
+  updatedAt: string,
+  observedAt: string | null,
+): string => {
+  const start = Date.parse(startedAt ?? updatedAt)
+  const observed = Date.parse(observedAt ?? updatedAt)
+  const updated = Date.parse(updatedAt)
+  if (!Number.isFinite(start) || !Number.isFinite(observed) || !Number.isFinite(updated)) return "unknown"
+  const end = Math.max(observed, updated)
+  return formatElapsedMs(Math.max(0, end - start)) ?? "unknown"
+}
+
+const fleetRunStateBadge = (
+  state: KhalaCodeDesktopFleetRunProjection["state"],
+): "online" | "ready" | "missing" | "degraded" => {
+  if (state === "running") return "online"
+  if (state === "completed") return "ready"
+  if (state === "stopped") return "missing"
+  return "degraded"
+}
+
+const activeFleetRunSortScore = (
+  state: KhalaCodeDesktopFleetRunProjection["state"],
+): number => {
+  if (state === "running") return 0
+  if (state === "paused") return 1
+  if (state === "draining") return 2
+  if (state === "draft") return 3
+  return 4
+}
+
+const selectActiveFleetRun = (
+  runs: readonly KhalaCodeDesktopFleetRunProjection[],
+): KhalaCodeDesktopFleetRunProjection | null => {
+  const active = runs
+    .filter(run => run.state === "running" || run.state === "paused" || run.state === "draining")
+    .sort((left, right) => {
+      const score = activeFleetRunSortScore(left.state) - activeFleetRunSortScore(right.state)
+      if (score !== 0) return score
+      return Date.parse(right.updatedAt) - Date.parse(left.updatedAt)
+    })
+  return active[0] ?? null
+}
+
+const runBacklogRemaining = (
+  run: KhalaCodeDesktopFleetRunProjection,
+): number => Math.max(
+  0,
+  run.counters.workUnitsTotal
+    - run.counters.activeAssignments
+    - run.counters.completedAssignments
+    - run.counters.failedAssignments
+    - run.counters.blockedAssignments,
+)
 
 const accountCapacityLabel = (
   capacity: KhalaCodeDesktopFleetAccount["capacity"],
@@ -592,6 +667,75 @@ const renderFleetRunResult = (
     output.append(list)
   }
   container.append(output)
+}
+
+const renderFleetRunHeader = (
+  container: HTMLElement,
+  activeRun: ActiveFleetRunView,
+  observedAt: string | null,
+  handlers: Handlers,
+): void => {
+  const run = activeRun.run
+  if (run === null) return
+
+  const section = el("section", "khala-fleet-section khala-fleet-run-header")
+  section.dataset.state = run.state
+  section.append(sectionHeader("Active FleetRun", "orchestration store"))
+
+  const objective = activeRun.objective ?? (
+    run.objectiveProjected
+      ? "Objective projected by the orchestration store."
+      : "Objective is not projected by the public-safe run status."
+  )
+  const objectiveNode = el("p", "khala-fleet-run-objective", objective)
+
+  const chips = el("div", "khala-fleet-chips")
+  chips.append(
+    badge(fleetRunStateBadge(run.state), titleize(run.state)),
+    detailChip("run", run.runRef),
+    detailChip("target", String(run.targetConcurrency)),
+    detailChip("actual", String(run.counters.activeAssignments)),
+    detailChip("remaining", String(runBacklogRemaining(run))),
+    detailChip("claimed", String(run.counters.activeAssignments)),
+    detailChip("done", String(run.counters.completedAssignments)),
+    detailChip("elapsed", elapsedSince(run.startedAt, run.updatedAt, observedAt)),
+  )
+  if (run.counters.blockedAssignments > 0) {
+    chips.append(detailChip("blocked", String(run.counters.blockedAssignments)))
+  }
+  if (run.counters.failedAssignments > 0) {
+    chips.append(detailChip("failed", String(run.counters.failedAssignments)))
+  }
+
+  const controls = el("div", "khala-fleet-run-controls")
+  const controlSpecs: ReadonlyArray<readonly [
+    KhalaCodeDesktopFleetRunControlRequest["verb"],
+    IconName,
+  ]> = [
+    ["pause", "Pause"],
+    ["resume", "Play"],
+    ["drain", "Circle"],
+    ["stop", "Stop"],
+  ]
+  for (const [verb, icon] of controlSpecs) {
+    const label = titleize(verb)
+    const button = iconButton(
+      activeRun.controlInFlight === verb ? `${label}...` : label,
+      icon,
+      verb === "stop" ? "khala-fleet-run khala-fleet-run-danger" : "khala-fleet-run",
+    )
+    button.dataset.fleetRunControl = verb
+    button.disabled = activeRun.controlInFlight !== null
+    button.addEventListener("click", () => handlers.onFleetRunControl(verb))
+    controls.append(button)
+  }
+
+  section.append(objectiveNode, chips)
+  if (activeRun.error !== null) {
+    section.append(el("p", "khala-fleet-error", activeRun.error))
+  }
+  section.append(controls)
+  container.append(section)
 }
 
 const renderFleetRunStarter = (
@@ -1068,6 +1212,7 @@ const render = (
   activeConnect: ConnectView | null,
   delegateForm: FleetDelegateFormState,
   delegateRun: DelegateRunView,
+  activeRun: ActiveFleetRunView,
   fleetRunForm: FleetRunFormState,
   fleetRun: FleetRunView,
   optimizationRun: OptimizationRunView,
@@ -1097,6 +1242,7 @@ const render = (
   // visible and live below it.
   if (activeConnect !== null) renderConnecting(body, activeConnect, handlers)
   renderDelegateRunner(body, delegateForm, delegateRun, handlers)
+  renderFleetRunHeader(body, activeRun, view.phase === "ready" ? view.data.observedAt : null, handlers)
   renderFleetRunStarter(body, fleetRunForm, fleetRun, handlers)
   renderOptimizationRunner(body, optimizationRun, handlers)
   if (view.phase === "loading") {
@@ -1137,6 +1283,13 @@ export const mountFleetPanel = (
   }
   let fleetRun: FleetRunView = { phase: "idle" }
   let fleetRunInFlight = false
+  let activeRun: ActiveFleetRunView = {
+    controlInFlight: null,
+    error: null,
+    objective: null,
+    run: null,
+  }
+  const objectiveByRunRef = new Map<string, string>()
   let optimizationInFlight = false
   let optimizationRun: OptimizationRunView = { phase: "idle" }
   let lastData: KhalaCodeDesktopFleetStatus | null = null
@@ -1166,6 +1319,7 @@ export const mountFleetPanel = (
       activeConnect,
       delegateForm,
       delegateRun,
+      activeRun,
       fleetRunForm,
       fleetRun,
       optimizationRun,
@@ -1281,6 +1435,7 @@ export const mountFleetPanel = (
       if (fleetRun.phase !== "loading") fleetRun = { phase: "idle" }
       paint()
     },
+    onFleetRunControl: verb => onFleetRunControl(verb),
     onFleetRunPreview: () => {
       const preview = fleetRunPreview()
       fleetRun = typeof preview === "string"
@@ -1350,6 +1505,13 @@ export const mountFleetPanel = (
     void (async () => {
       try {
         const result = await options.fleetRunStart(request)
+        objectiveByRunRef.set(result.run.runRef, request.objective)
+        activeRun = {
+          controlInFlight: null,
+          error: null,
+          objective: request.objective,
+          run: result.run,
+        }
         fleetRun = { phase: "ready", result, slots: preview }
         await refresh()
       } catch (error) {
@@ -1361,6 +1523,34 @@ export const mountFleetPanel = (
         paint()
       } finally {
         fleetRunInFlight = false
+      }
+    })()
+  }
+
+  const onFleetRunControl = (
+    verb: KhalaCodeDesktopFleetRunControlRequest["verb"],
+  ): void => {
+    if (activeRun.run === null || activeRun.controlInFlight !== null) return
+    const runRef = activeRun.run.runRef
+    activeRun = { ...activeRun, controlInFlight: verb, error: null }
+    paint()
+    void (async () => {
+      try {
+        const result = await options.fleetRunControl({ runRef, verb })
+        activeRun = {
+          controlInFlight: null,
+          error: null,
+          objective: objectiveByRunRef.get(result.run.runRef) ?? activeRun.objective,
+          run: result.run,
+        }
+        await refresh()
+      } catch (error) {
+        activeRun = {
+          ...activeRun,
+          controlInFlight: null,
+          error: error instanceof Error ? error.message : String(error),
+        }
+        paint()
       }
     })()
   }
@@ -1417,6 +1607,7 @@ export const mountFleetPanel = (
           activeConnect,
           delegateForm,
           delegateRun,
+          activeRun,
           fleetRunForm,
           fleetRun,
           optimizationRun,
@@ -1468,8 +1659,22 @@ export const mountFleetPanel = (
       setRefreshBusy(true)
     }
     try {
-      const data = await options.fetch()
+      const [data, list] = await Promise.all([
+        options.fetch(),
+        options.fleetRunList(),
+      ])
       lastData = data
+      const selected = selectActiveFleetRun(list.runs)
+      activeRun = {
+        controlInFlight: activeRun.controlInFlight,
+        error: null,
+        objective: selected === null
+          ? null
+          : objectiveByRunRef.get(selected.runRef) ?? (
+              activeRun.run?.runRef === selected.runRef ? activeRun.objective : null
+            ),
+        run: selected,
+      }
       paint()
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error)
@@ -1481,11 +1686,17 @@ export const mountFleetPanel = (
           activeConnect,
           delegateForm,
           delegateRun,
+          activeRun,
           fleetRunForm,
           fleetRun,
           optimizationRun,
         )
       } else {
+        activeRun = {
+          ...activeRun,
+          controlInFlight: null,
+          error: message,
+        }
         setRefreshBusy(false)
       }
     } finally {

--- a/clients/khala-code-desktop/src/ui/main.ts
+++ b/clients/khala-code-desktop/src/ui/main.ts
@@ -2250,6 +2250,10 @@ const controls = {
   codexFleetStatus: () => rpc.request.codexFleetStatus(),
   codexFleetPromoteThread: (request: Parameters<DesktopRpcRequests["codexFleetPromoteThread"]>[0]) =>
     rpc.request.codexFleetPromoteThread(request),
+  fleetRunControl: (request: Parameters<DesktopRpcRequests["fleetRunControl"]>[0]) =>
+    rpc.request.fleetRunControl(request),
+  fleetRunList: (request?: Parameters<DesktopRpcRequests["fleetRunList"]>[0]) =>
+    rpc.request.fleetRunList(request),
   fleetRunStart: (request: Parameters<DesktopRpcRequests["fleetRunStart"]>[0]) =>
     rpc.request.fleetRunStart(request),
   codexHarnessStatus: () => rpc.request.codexHarnessStatus(),
@@ -2526,6 +2530,8 @@ const fleetPanel =
     ? null
     : mountFleetPanel(fleetPanelEl, {
         delegateRun: request => controls.codexFleetDelegateRun(request),
+        fleetRunControl: request => controls.fleetRunControl(request),
+        fleetRunList: request => controls.fleetRunList(request),
         fleetRunStart: request => controls.fleetRunStart(request),
         loadGymDemoProof: () => loadGymDemoOptimization(),
         startDelegationOptimization: async () => loadGymDemoOptimization(),

--- a/clients/khala-code-desktop/src/ui/styles.css
+++ b/clients/khala-code-desktop/src/ui/styles.css
@@ -2006,6 +2006,33 @@ button {
     linear-gradient(180deg, color-mix(in srgb, var(--oa-color-khala-energy-cyan) 4%, transparent), transparent 58%),
     var(--oa-color-component-surface);
 }
+.khala-fleet-run-header {
+  gap: 0.65rem;
+  padding: 0.85rem 0.95rem;
+  border: 1px solid color-mix(in srgb, var(--oa-color-khala-success) 24%, transparent);
+  border-radius: 0.55rem;
+  background:
+    linear-gradient(180deg, color-mix(in srgb, var(--oa-color-khala-success) 4%, transparent), transparent 58%),
+    var(--oa-color-component-surface);
+}
+.khala-fleet-run-header[data-state="paused"],
+.khala-fleet-run-header[data-state="draining"] {
+  border-color: color-mix(in srgb, var(--oa-color-khala-warning) 28%, transparent);
+}
+.khala-fleet-run-header[data-state="stopped"] {
+  border-color: color-mix(in srgb, var(--oa-color-khala-danger) 28%, transparent);
+}
+.khala-fleet-run-objective {
+  margin: 0;
+  color: color-mix(in srgb, var(--oa-color-component-text) 78%, transparent);
+  font-size: 0.82rem;
+  line-height: 1.45;
+}
+.khala-fleet-run-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+}
 .khala-fleet-delegate-form {
   display: grid;
   gap: 0.6rem;
@@ -2099,6 +2126,14 @@ button {
 .khala-fleet-run:disabled {
   cursor: default;
   opacity: 0.58;
+}
+.khala-fleet-run-danger {
+  border-color: color-mix(in srgb, var(--oa-color-khala-danger) 52%, transparent);
+  background: color-mix(in srgb, var(--oa-color-khala-danger) 12%, transparent);
+  color: var(--oa-color-component-text);
+}
+.khala-fleet-run-danger:hover {
+  background: color-mix(in srgb, var(--oa-color-khala-danger) 17%, transparent);
 }
 .khala-fleet-delegate-output {
   display: grid;

--- a/clients/khala-code-desktop/tests/fleet-status.test.ts
+++ b/clients/khala-code-desktop/tests/fleet-status.test.ts
@@ -2,6 +2,8 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test"
 import { Window } from "happy-dom"
 
 import type {
+  KhalaCodeDesktopFleetRunControlRequest,
+  KhalaCodeDesktopFleetRunProjection,
   KhalaCodeDesktopFleetRunStartRequest,
   KhalaCodeDesktopFleetRunStartResult,
   KhalaCodeDesktopFleetStatus,
@@ -66,17 +68,16 @@ const status = (): KhalaCodeDesktopFleetStatus => ({
   processes: [],
 })
 
-const runStartResult = (
-  request: KhalaCodeDesktopFleetRunStartRequest,
-): KhalaCodeDesktopFleetRunStartResult => ({
-  ok: true,
-  run: {
+const fleetRunProjection = (
+  input: Partial<KhalaCodeDesktopFleetRunProjection> = {},
+): KhalaCodeDesktopFleetRunProjection => ({
     counters: {
-      activeAssignments: 0,
+      activeAssignments: 2,
       blockedAssignments: 0,
-      completedAssignments: 0,
+      completedAssignments: 4,
       failedAssignments: 0,
-      workUnitsTotal: 0,
+      workUnitsTotal: 10,
+      ...input.counters,
     },
     createdAt: "2026-07-01T18:00:00.000Z",
     dispatchKind: "supervised_dispatch",
@@ -90,11 +91,21 @@ const runStartResult = (
     runRef: "fleet.run.public.test",
     startedAt: "2026-07-01T18:00:01.000Z",
     state: "running",
-    targetConcurrency: request.targetConcurrency,
-    updatedAt: "2026-07-01T18:00:01.000Z",
+    targetConcurrency: 3,
+    updatedAt: "2026-07-01T18:00:31.000Z",
     workerKind: "codex",
+    workSource: { kind: "fixture" },
+    ...input,
+})
+
+const runStartResult = (
+  request: KhalaCodeDesktopFleetRunStartRequest,
+): KhalaCodeDesktopFleetRunStartResult => ({
+  ok: true,
+  run: fleetRunProjection({
+    targetConcurrency: request.targetConcurrency,
     workSource: request.workSource,
-  },
+  }),
   supervisorStarted: true,
 })
 
@@ -122,6 +133,20 @@ const changeInput = (input: HTMLInputElement | HTMLTextAreaElement | HTMLSelectE
   input.dispatchEvent(new window.Event(input.tagName === "SELECT" ? "change" : "input", { bubbles: true }))
 }
 
+const clickButton = (root: HTMLElement, label: string): void => {
+  const button = [...root.querySelectorAll<HTMLButtonElement>("button")]
+    .find(item => item.textContent?.includes(label))
+  expect(button).not.toBeUndefined()
+  button!.click()
+}
+
+const flushPanelWork = async (): Promise<void> => {
+  await Promise.resolve()
+  await Promise.resolve()
+  await Promise.resolve()
+  await Promise.resolve()
+}
+
 describe("Fleet status panel", () => {
   beforeEach(installDom)
   afterEach(restoreDom)
@@ -129,6 +154,7 @@ describe("Fleet status panel", () => {
   test("previews the first FleetRun wave and starts through the mocked RPC", async () => {
     const root = document.createElement("div")
     const requests: KhalaCodeDesktopFleetRunStartRequest[] = []
+    let activeRun: KhalaCodeDesktopFleetRunProjection | null = null
     const panel = mountFleetPanel(root, {
       connectAccount: async () => ({
         ok: false,
@@ -142,9 +168,15 @@ describe("Fleet status panel", () => {
         throw new Error("delegate runner should not be called")
       },
       fetch: async () => status(),
+      fleetRunControl: async () => {
+        throw new Error("fleet run control should not be called")
+      },
+      fleetRunList: async () => ({ ok: true, runs: activeRun === null ? [] : [activeRun] }),
       fleetRunStart: async request => {
         requests.push(request)
-        return runStartResult(request)
+        const result = runStartResult(request)
+        activeRun = result.run
+        return result
       },
       loadGymDemoProof: () => {
         throw new Error("gym proof should not be called")
@@ -178,8 +210,7 @@ describe("Fleet status panel", () => {
     expect(root.textContent).toContain("codex-b")
 
     form!.dispatchEvent(new window.Event("submit", { bubbles: true, cancelable: true }))
-    await Promise.resolve()
-    await Promise.resolve()
+    await flushPanelWork()
 
     expect(requests).toEqual([
       {
@@ -190,6 +221,157 @@ describe("Fleet status panel", () => {
       },
     ])
     expect(root.textContent).toContain("fleet.run.public.test")
+    expect(root.textContent).toContain("Running")
+    expect(root.textContent).toContain("Burn down public fixture tasks.")
+    expect(root.textContent).toContain("target3")
+    expect(root.textContent).toContain("actual2")
+    expect(root.textContent).toContain("remaining4")
+    expect(root.textContent).toContain("claimed2")
+    expect(root.textContent).toContain("done4")
+    expect(root.textContent).toContain("elapsed30s")
+  })
+
+  test("renders the active FleetRun header from fleetRunList without fabricated objective text", async () => {
+    const root = document.createElement("div")
+    const activeRun = fleetRunProjection({
+      counters: {
+        activeAssignments: 1,
+        blockedAssignments: 1,
+        completedAssignments: 6,
+        failedAssignments: 1,
+        workUnitsTotal: 12,
+      },
+      state: "draining",
+      targetConcurrency: 5,
+      updatedAt: "2026-07-01T18:01:01.000Z",
+    })
+    const panel = mountFleetPanel(root, {
+      connectAccount: async () => ({
+        ok: false,
+        accountRef: "codex-test",
+        error: "disabled",
+        output: "",
+        userCode: null,
+        verificationUrl: null,
+      }),
+      delegateRun: async () => {
+        throw new Error("delegate runner should not be called")
+      },
+      fetch: async () => status(),
+      fleetRunControl: async () => {
+        throw new Error("fleet run control should not be called")
+      },
+      fleetRunList: async () => ({ ok: true, runs: [activeRun] }),
+      fleetRunStart: async request => runStartResult(request),
+      loadGymDemoProof: () => {
+        throw new Error("gym proof should not be called")
+      },
+      openExternal: async () => false,
+      removeAccount: async () => ({ ok: true }),
+      startDelegationOptimization: async () => {
+        throw new Error("optimization should not be called")
+      },
+    })
+
+    await panel.refresh()
+
+    expect(root.textContent).toContain("Active FleetRun")
+    expect(root.textContent).toContain("Draining")
+    expect(root.textContent).toContain("fleet.run.public.test")
+    expect(root.textContent).toContain("Objective is not projected by the public-safe run status.")
+    expect(root.textContent).toContain("target5")
+    expect(root.textContent).toContain("actual1")
+    expect(root.textContent).toContain("remaining3")
+    expect(root.textContent).toContain("claimed1")
+    expect(root.textContent).toContain("done6")
+    expect(root.textContent).toContain("blocked1")
+    expect(root.textContent).toContain("failed1")
+  })
+
+  test("wires every FleetRun control transition through mocked RPC and renders returned state", async () => {
+    const root = document.createElement("div")
+    let currentRun = fleetRunProjection({ state: "running" })
+    const controls: KhalaCodeDesktopFleetRunControlRequest[] = []
+    const panel = mountFleetPanel(root, {
+      connectAccount: async () => ({
+        ok: false,
+        accountRef: "codex-test",
+        error: "disabled",
+        output: "",
+        userCode: null,
+        verificationUrl: null,
+      }),
+      delegateRun: async () => {
+        throw new Error("delegate runner should not be called")
+      },
+      fetch: async () => status(),
+      fleetRunControl: async request => {
+        controls.push(request)
+        const nextState = request.verb === "pause"
+          ? "paused"
+          : request.verb === "resume"
+            ? "running"
+            : request.verb === "drain"
+              ? "draining"
+              : "stopped"
+        currentRun = fleetRunProjection({
+          counters: {
+            activeAssignments: request.verb === "stop" ? 0 : 1,
+            blockedAssignments: 0,
+            completedAssignments: 7,
+            failedAssignments: 0,
+            workUnitsTotal: 10,
+          },
+          state: nextState,
+          updatedAt: `2026-07-01T18:02:0${controls.length}.000Z`,
+        })
+        return {
+          ok: true,
+          previousState: request.verb === "resume" ? "paused" : "running",
+          run: currentRun,
+          supervisorActive: request.verb !== "stop",
+          verb: request.verb,
+        }
+      },
+      fleetRunList: async () => ({
+        ok: true,
+        runs: currentRun.state === "stopped" ? [] : [currentRun],
+      }),
+      fleetRunStart: async request => runStartResult(request),
+      loadGymDemoProof: () => {
+        throw new Error("gym proof should not be called")
+      },
+      openExternal: async () => false,
+      removeAccount: async () => ({ ok: true }),
+      startDelegationOptimization: async () => {
+        throw new Error("optimization should not be called")
+      },
+    })
+
+    await panel.refresh()
     expect(root.textContent).toContain("running")
+
+    clickButton(root, "Pause")
+    await flushPanelWork()
+    expect(root.textContent).toContain("Paused")
+
+    clickButton(root, "Resume")
+    await flushPanelWork()
+    expect(root.textContent).toContain("Running")
+
+    clickButton(root, "Drain")
+    await flushPanelWork()
+    expect(root.textContent).toContain("Draining")
+
+    clickButton(root, "Stop")
+    await flushPanelWork()
+    expect(root.textContent).not.toContain("Active FleetRun")
+
+    expect(controls).toEqual([
+      { runRef: "fleet.run.public.test", verb: "pause" },
+      { runRef: "fleet.run.public.test", verb: "resume" },
+      { runRef: "fleet.run.public.test", verb: "drain" },
+      { runRef: "fleet.run.public.test", verb: "stop" },
+    ])
   })
 })


### PR DESCRIPTION
Closes #7839

## Summary
- add an active FleetRun header in the Khala Code Desktop fleet panel
- render store-backed state, concurrency, backlog counters, and elapsed time
- wire Pause, Resume, Drain, and Stop controls through fleetRunControl

## Verification
- bun test clients/khala-code-desktop/tests/fleet-status.test.ts
- bun run --cwd clients/khala-code-desktop typecheck
- bun run --cwd clients/khala-code-desktop test

Required verification ref `command.public.pylon_khala.verify.d32c71ee8e1025e99460d008` resolves to `bun run --cwd clients/khala-code-desktop test` and passed.