### PR TITLE
T6.3: Scenario DSL + QA driver

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -386,6 +386,7 @@
         "three": "0.184.0",
       },
       "devDependencies": {
+        "@openagentsinc/khala-qa-harness": "workspace:*",
         "@tailwindcss/vite": "^4.2.4",
         "@types/three": "0.184.0",
         "bun-types": "^1.0.0",

--- a/clients/khala-code-desktop/package.json
+++ b/clients/khala-code-desktop/package.json
@@ -36,6 +36,7 @@
     "three": "0.184.0"
   },
   "devDependencies": {
+    "@openagentsinc/khala-qa-harness": "workspace:*",
     "@tailwindcss/vite": "^4.2.4",
     "@types/three": "0.184.0",
     "bun-types": "^1.0.0",

--- a/clients/khala-code-desktop/scripts/composer-visual-smoke.ts
+++ b/clients/khala-code-desktop/scripts/composer-visual-smoke.ts
@@ -3,6 +3,10 @@ import { mkdir, rm, writeFile } from "node:fs/promises"
 import { dirname, join, resolve } from "node:path"
 
 import { chromium, type Browser, type Page } from "playwright"
+import {
+  startKhalaQaViteServer as startViteServer,
+  waitForKhalaQaHttp as waitForHttp,
+} from "@openagentsinc/khala-qa-harness/desktop-smoke-helpers"
 
 export type ComposerVisualViewport = Readonly<{
   name: "desktop" | "mobile"
@@ -606,74 +610,6 @@ async function screenshotPixelProbe(
       width: canvas.width,
     }
   }, dataUrl)
-}
-
-type ViteServer = Readonly<{
-  kill: () => void
-}>
-
-function startViteServer(
-  input: Readonly<{ cwd: string; port: number; label: string }>,
-): ViteServer {
-  const proc = Bun.spawn(
-    [
-      "bunx",
-      "vite",
-      "--host",
-      "127.0.0.1",
-      "--port",
-      String(input.port),
-      "--strictPort",
-    ],
-    {
-      cwd: input.cwd,
-      stderr: "pipe",
-      stdout: "pipe",
-    },
-  )
-  void streamServerOutput(input.label, proc.stdout)
-  void streamServerOutput(input.label, proc.stderr)
-  return {
-    kill: () => {
-      proc.kill()
-    },
-  }
-}
-
-async function streamServerOutput(
-  label: string,
-  stream: ReadableStream<Uint8Array>,
-): Promise<void> {
-  const reader = stream.getReader()
-  const decoder = new TextDecoder()
-  try {
-    for (;;) {
-      const chunk = await reader.read()
-      if (chunk.done) return
-      const text = decoder.decode(chunk.value, { stream: true })
-      for (const line of text.split("\n")) {
-        if (line.trim().length > 0) console.error(`[${label}] ${line}`)
-      }
-    }
-  } catch {
-    // Server output is diagnostic only.
-  }
-}
-
-async function waitForHttp(url: string): Promise<void> {
-  const deadline = Date.now() + 30_000
-  let lastError: unknown = null
-  while (Date.now() < deadline) {
-    try {
-      const response = await fetch(url)
-      if (response.ok) return
-      lastError = new Error(`${url} returned ${response.status}`)
-    } catch (error) {
-      lastError = error
-    }
-    await Bun.sleep(250)
-  }
-  throw new Error(`Timed out waiting for ${url}: ${String(lastError)}`)
 }
 
 if (import.meta.main) {

--- a/clients/khala-code-desktop/scripts/part2-fleet-gym-visual-smoke.ts
+++ b/clients/khala-code-desktop/scripts/part2-fleet-gym-visual-smoke.ts
@@ -3,6 +3,12 @@ import { mkdir, rm, writeFile } from "node:fs/promises"
 import { dirname, join, resolve } from "node:path"
 
 import { chromium, type Browser, type Page } from "playwright"
+import {
+  assertKhalaQaVisibleRect as assertVisibleRect,
+  khalaQaRectsOverlap as rectsOverlap,
+  startKhalaQaViteServer as startViteServer,
+  waitForKhalaQaHttp as waitForHttp,
+} from "@openagentsinc/khala-qa-harness/desktop-smoke-helpers"
 
 export type Part2VisualViewport = Readonly<{
   name: "desktop" | "mobile"
@@ -188,100 +194,10 @@ async function capturePart2FleetGym(
   }
 }
 
-const assertVisibleRect = (
-  label: string,
-  rect: Rect,
-  viewport: Rect,
-): void => {
-  if (rect.width < 1 || rect.height < 1) {
-    throw new Error(`${label} is not visible`)
-  }
-  if (rect.x < -1 || rect.y < -1) {
-    throw new Error(`${label} is clipped outside the viewport`)
-  }
-  if (rect.x + rect.width > viewport.width + 1) {
-    throw new Error(`${label} overflows the viewport width: ${JSON.stringify({ rect, viewport })}`)
-  }
-}
-
-const rectsOverlap = (left: Rect, right: Rect): boolean =>
-  left.x < right.x + right.width - 1 &&
-  right.x < left.x + left.width - 1 &&
-  left.y < right.y + right.height - 1 &&
-  right.y < left.y + left.height - 1
-
 const assertTextIncludes = (text: string, expected: string): void => {
   if (!text.includes(expected)) {
     throw new Error(`Part 2 visual smoke missing text: ${expected}`)
   }
-}
-
-type ViteServer = Readonly<{
-  kill: () => void
-}>
-
-function startViteServer(
-  input: Readonly<{ cwd: string; label: string; port: number }>,
-): ViteServer {
-  const proc = Bun.spawn(
-    [
-      "bunx",
-      "vite",
-      "--host",
-      "127.0.0.1",
-      "--port",
-      String(input.port),
-      "--strictPort",
-    ],
-    {
-      cwd: input.cwd,
-      stderr: "pipe",
-      stdout: "pipe",
-    },
-  )
-  void streamServerOutput(input.label, proc.stdout)
-  void streamServerOutput(input.label, proc.stderr)
-  return {
-    kill: () => {
-      proc.kill()
-    },
-  }
-}
-
-async function streamServerOutput(
-  label: string,
-  stream: ReadableStream<Uint8Array>,
-): Promise<void> {
-  const reader = stream.getReader()
-  const decoder = new TextDecoder()
-  try {
-    for (;;) {
-      const chunk = await reader.read()
-      if (chunk.done) return
-      const text = decoder.decode(chunk.value, { stream: true })
-      for (const line of text.split("\n")) {
-        if (line.trim().length > 0) console.error(`[${label}] ${line}`)
-      }
-    }
-  } catch {
-    // Server output is diagnostic only.
-  }
-}
-
-async function waitForHttp(url: string): Promise<void> {
-  const deadline = Date.now() + 30_000
-  let lastError: unknown = null
-  while (Date.now() < deadline) {
-    try {
-      const response = await fetch(url)
-      if (response.ok) return
-      lastError = new Error(`${url} returned ${response.status}`)
-    } catch (error) {
-      lastError = error
-    }
-    await Bun.sleep(250)
-  }
-  throw new Error(`Timed out waiting for ${url}: ${String(lastError)}`)
 }
 
 if (import.meta.main) {

--- a/clients/khala-code-desktop/scripts/part2-ui-recording-smoke.ts
+++ b/clients/khala-code-desktop/scripts/part2-ui-recording-smoke.ts
@@ -3,6 +3,10 @@ import { mkdir, rm, writeFile } from "node:fs/promises"
 import { dirname, join, resolve } from "node:path"
 
 import { chromium, type Browser, type Page, type Route } from "playwright"
+import {
+  startKhalaQaViteServer as startViteServer,
+  waitForKhalaQaHttp as waitForHttp,
+} from "@openagentsinc/khala-qa-harness/desktop-smoke-helpers"
 
 import type {
   KhalaCodeDesktopFleetDelegateRunResult,
@@ -454,74 +458,6 @@ const delegateRunResultFixture = (): KhalaCodeDesktopFleetDelegateRunResult => (
     runtime: "codex_harness",
   },
 })
-
-type ViteServer = Readonly<{
-  kill: () => void
-}>
-
-function startViteServer(
-  input: Readonly<{ cwd: string; label: string; port: number }>,
-): ViteServer {
-  const proc = Bun.spawn(
-    [
-      "bunx",
-      "vite",
-      "--host",
-      "127.0.0.1",
-      "--port",
-      String(input.port),
-      "--strictPort",
-    ],
-    {
-      cwd: input.cwd,
-      stderr: "pipe",
-      stdout: "pipe",
-    },
-  )
-  void streamServerOutput(input.label, proc.stdout)
-  void streamServerOutput(input.label, proc.stderr)
-  return {
-    kill: () => {
-      proc.kill()
-    },
-  }
-}
-
-async function streamServerOutput(
-  label: string,
-  stream: ReadableStream<Uint8Array>,
-): Promise<void> {
-  const reader = stream.getReader()
-  const decoder = new TextDecoder()
-  try {
-    for (;;) {
-      const chunk = await reader.read()
-      if (chunk.done) return
-      const text = decoder.decode(chunk.value, { stream: true })
-      for (const line of text.split("\n")) {
-        if (line.trim().length > 0) console.error(`[${label}] ${line}`)
-      }
-    }
-  } catch {
-    // Server output is diagnostic only.
-  }
-}
-
-async function waitForHttp(url: string): Promise<void> {
-  const deadline = Date.now() + 30_000
-  let lastError: unknown = null
-  while (Date.now() < deadline) {
-    try {
-      const response = await fetch(url)
-      if (response.ok) return
-      lastError = new Error(`${url} returned ${response.status}`)
-    } catch (error) {
-      lastError = error
-    }
-    await Bun.sleep(250)
-  }
-  throw new Error(`Timed out waiting for ${url}: ${String(lastError)}`)
-}
 
 if (import.meta.main) {
   const outDir =

--- a/clients/khala-code-desktop/scripts/thread-switch-benchmark.ts
+++ b/clients/khala-code-desktop/scripts/thread-switch-benchmark.ts
@@ -3,6 +3,10 @@ import { mkdir, writeFile } from "node:fs/promises"
 import { dirname, join, resolve } from "node:path"
 
 import { chromium, type Browser, type Page, type Route } from "playwright"
+import {
+  startKhalaQaViteServer as startViteServer,
+  waitForKhalaQaHttp as waitForHttp,
+} from "@openagentsinc/khala-qa-harness/desktop-smoke-helpers"
 
 export const THREAD_SWITCH_BENCHMARK_HARNESS =
   "khala_code_thread_switch_performance_v1"
@@ -360,74 +364,6 @@ export async function runThreadSwitchBenchmark(
     if (browser !== null) await browser.close()
     server.kill()
   }
-}
-
-type ViteServer = Readonly<{
-  kill: () => void
-}>
-
-function startViteServer(
-  input: Readonly<{ cwd: string; label: string; port: number }>,
-): ViteServer {
-  const proc = Bun.spawn(
-    [
-      "bunx",
-      "vite",
-      "--host",
-      "127.0.0.1",
-      "--port",
-      String(input.port),
-      "--strictPort",
-    ],
-    {
-      cwd: input.cwd,
-      stderr: "pipe",
-      stdout: "pipe",
-    },
-  )
-  void streamServerOutput(input.label, proc.stdout)
-  void streamServerOutput(input.label, proc.stderr)
-  return {
-    kill: () => {
-      proc.kill()
-    },
-  }
-}
-
-async function streamServerOutput(
-  label: string,
-  stream: ReadableStream<Uint8Array>,
-): Promise<void> {
-  const reader = stream.getReader()
-  const decoder = new TextDecoder()
-  try {
-    for (;;) {
-      const chunk = await reader.read()
-      if (chunk.done) return
-      const text = decoder.decode(chunk.value, { stream: true })
-      for (const line of text.split("\n")) {
-        if (line.trim().length > 0) console.error(`[${label}] ${line}`)
-      }
-    }
-  } catch {
-    // Server output is diagnostic only.
-  }
-}
-
-async function waitForHttp(url: string): Promise<void> {
-  const deadline = Date.now() + 30_000
-  let lastError: unknown = null
-  while (Date.now() < deadline) {
-    try {
-      const response = await fetch(url)
-      if (response.ok) return
-      lastError = new Error(`${url} returned ${response.status}`)
-    } catch (error) {
-      lastError = error
-    }
-    await wait(250)
-  }
-  throw new Error(`Timed out waiting for ${url}: ${String(lastError)}`)
 }
 
 const argValue = (

--- a/packages/khala-qa-harness/package.json
+++ b/packages/khala-qa-harness/package.json
@@ -5,7 +5,12 @@
   "type": "module",
   "exports": {
     ".": "./src/index.ts",
-    "./rpc-client": "./src/rpc-client.ts"
+    "./desktop-smoke-helpers": "./src/desktop-smoke-helpers.ts",
+    "./driver": "./src/driver.ts",
+    "./rpc-driver": "./src/rpc-driver.ts",
+    "./rpc-client": "./src/rpc-client.ts",
+    "./runner": "./src/runner.ts",
+    "./scenario": "./src/scenario.ts"
   },
   "scripts": {
     "test": "bun test src/*.test.ts",

--- a/packages/khala-qa-harness/src/desktop-smoke-helpers.ts
+++ b/packages/khala-qa-harness/src/desktop-smoke-helpers.ts
@@ -1,0 +1,115 @@
+export type KhalaQaViteServer = Readonly<{
+  kill: () => void
+}>
+
+export type KhalaQaStartViteServerOptions = Readonly<{
+  cwd: string
+  label: string
+  port: number
+}>
+
+export type KhalaQaWaitForHttpOptions = Readonly<{
+  fetch?: typeof fetch
+  intervalMs?: number
+  sleep?: (ms: number) => Promise<void>
+  timeoutMs?: number
+}>
+
+export type KhalaQaRect = Readonly<{
+  height: number
+  width: number
+  x: number
+  y: number
+}>
+
+export const startKhalaQaViteServer = (
+  input: KhalaQaStartViteServerOptions,
+): KhalaQaViteServer => {
+  const proc = Bun.spawn(
+    [
+      "bunx",
+      "vite",
+      "--host",
+      "127.0.0.1",
+      "--port",
+      String(input.port),
+      "--strictPort",
+    ],
+    {
+      cwd: input.cwd,
+      stderr: "pipe",
+      stdout: "pipe",
+    },
+  )
+  void streamKhalaQaServerOutput(input.label, proc.stdout)
+  void streamKhalaQaServerOutput(input.label, proc.stderr)
+  return {
+    kill: () => {
+      proc.kill()
+    },
+  }
+}
+
+export const streamKhalaQaServerOutput = async (
+  label: string,
+  stream: ReadableStream<Uint8Array>,
+): Promise<void> => {
+  const reader = stream.getReader()
+  const decoder = new TextDecoder()
+  try {
+    for (;;) {
+      const chunk = await reader.read()
+      if (chunk.done) return
+      const text = decoder.decode(chunk.value, { stream: true })
+      for (const line of text.split("\n")) {
+        if (line.trim().length > 0) console.error(`[${label}] ${line}`)
+      }
+    }
+  } catch {
+    // Server output is diagnostic only.
+  }
+}
+
+export const waitForKhalaQaHttp = async (
+  url: string,
+  options: KhalaQaWaitForHttpOptions = {},
+): Promise<void> => {
+  const fetchLike = options.fetch ?? fetch
+  const intervalMs = options.intervalMs ?? 250
+  const sleep = options.sleep ?? Bun.sleep
+  const deadline = Date.now() + (options.timeoutMs ?? 30_000)
+  let lastError: unknown = null
+  while (Date.now() < deadline) {
+    try {
+      const response = await fetchLike(url)
+      if (response.ok) return
+      lastError = new Error(`${url} returned ${response.status}`)
+    } catch (error) {
+      lastError = error
+    }
+    await sleep(intervalMs)
+  }
+  throw new Error(`Timed out waiting for ${url}: ${String(lastError)}`)
+}
+
+export const khalaQaRectsOverlap = (left: KhalaQaRect, right: KhalaQaRect): boolean =>
+  left.x < right.x + right.width - 1 &&
+  right.x < left.x + left.width - 1 &&
+  left.y < right.y + right.height - 1 &&
+  right.y < left.y + left.height - 1
+
+export const assertKhalaQaVisibleRect = (
+  label: string,
+  rect: KhalaQaRect,
+  viewport: KhalaQaRect,
+): void => {
+  if (rect.width < 1 || rect.height < 1) {
+    throw new Error(`${label} is not visible`)
+  }
+  if (rect.x < -1 || rect.y < -1) {
+    throw new Error(`${label} is clipped outside the viewport`)
+  }
+  if (rect.x + rect.width > viewport.width + 1) {
+    throw new Error(`${label} overflows the viewport width: ${JSON.stringify({ rect, viewport })}`)
+  }
+}

--- a/packages/khala-qa-harness/src/driver.ts
+++ b/packages/khala-qa-harness/src/driver.ts
@@ -1,0 +1,104 @@
+import { Context, Effect, Stream } from "effect"
+
+import type {
+  KhalaCodeQaAction,
+  KhalaCodeQaBackendTier,
+  KhalaCodeQaDriverMode,
+} from "./scenario.js"
+
+export type KhalaCodeQaBootOptions = {
+  readonly backend: KhalaCodeQaBackendTier
+  readonly headless?: boolean
+}
+
+export type KhalaCodeQaAppHandle = {
+  readonly backend: KhalaCodeQaBackendTier
+  readonly mode: KhalaCodeQaDriverMode
+  readonly startedAt: string
+}
+
+export type KhalaCodeQaObservation = {
+  readonly ok: boolean
+  readonly action: KhalaCodeQaAction
+  readonly label: string
+  readonly data?: unknown
+  readonly error?: string
+}
+
+export type KhalaCodeQaStateSnapshot = {
+  readonly label: string
+  readonly value: unknown
+}
+
+export type KhalaCodeQaAppEvent = {
+  readonly kind: string
+  readonly observedAt: string
+  readonly payload?: unknown
+}
+
+export type KhalaCodeQaMetricsSnapshot = {
+  readonly counters: Readonly<Record<string, number>>
+  readonly timings: Readonly<Record<string, number>>
+}
+
+export type KhalaCodeQaArtifacts = {
+  readonly refs: ReadonlyArray<string>
+  readonly summary?: unknown
+}
+
+export type KhalaCodeQaDriverFailure = {
+  readonly _tag: "KhalaCodeQaDriverFailure"
+  readonly message: string
+  readonly action?: KhalaCodeQaAction
+  readonly cause?: unknown
+}
+
+export type KhalaCodeQaDriver = {
+  readonly mode: KhalaCodeQaDriverMode
+  readonly boot: (
+    opts: KhalaCodeQaBootOptions,
+  ) => Effect.Effect<KhalaCodeQaAppHandle, KhalaCodeQaDriverFailure>
+  readonly act: (
+    action: KhalaCodeQaAction,
+  ) => Effect.Effect<KhalaCodeQaObservation, KhalaCodeQaDriverFailure>
+  readonly read: (
+    query: string,
+  ) => Effect.Effect<KhalaCodeQaStateSnapshot, KhalaCodeQaDriverFailure>
+  readonly events: () => Stream.Stream<KhalaCodeQaAppEvent, KhalaCodeQaDriverFailure>
+  readonly metrics: () => Effect.Effect<KhalaCodeQaMetricsSnapshot, KhalaCodeQaDriverFailure>
+  readonly shutdown: () => Effect.Effect<KhalaCodeQaArtifacts, KhalaCodeQaDriverFailure>
+}
+
+export class KhalaCodeQaDriverService extends Context.Service<
+  KhalaCodeQaDriverService,
+  KhalaCodeQaDriver
+>()("openagents/KhalaCodeQaDriverService") {}
+
+export const khalaCodeQaDriverFailure = (
+  message: string,
+  options: {
+    readonly action?: KhalaCodeQaAction
+    readonly cause?: unknown
+  } = {},
+): KhalaCodeQaDriverFailure => ({
+  _tag: "KhalaCodeQaDriverFailure",
+  message,
+  ...options,
+})
+
+export const unsupportedKhalaCodeQaDriver = (
+  mode: Exclude<KhalaCodeQaDriverMode, "rpc">,
+): KhalaCodeQaDriver => ({
+  mode,
+  boot: () =>
+    Effect.fail(khalaCodeQaDriverFailure(`Khala Code QA ${mode} driver is not implemented in fixture tier yet`)),
+  act: (action) =>
+    Effect.fail(khalaCodeQaDriverFailure(`Khala Code QA ${mode} driver cannot act yet`, { action })),
+  read: () =>
+    Effect.fail(khalaCodeQaDriverFailure(`Khala Code QA ${mode} driver cannot read yet`)),
+  events: () =>
+    Stream.fail(khalaCodeQaDriverFailure(`Khala Code QA ${mode} driver has no event stream yet`)),
+  metrics: () =>
+    Effect.fail(khalaCodeQaDriverFailure(`Khala Code QA ${mode} driver has no metrics yet`)),
+  shutdown: () => Effect.succeed({ refs: [] }),
+})

--- a/packages/khala-qa-harness/src/index.ts
+++ b/packages/khala-qa-harness/src/index.ts
@@ -1,1 +1,6 @@
+export * from "./desktop-smoke-helpers.js"
+export * from "./driver.js"
 export * from "./rpc-client.js"
+export * from "./rpc-driver.js"
+export * from "./runner.js"
+export * from "./scenario.js"

--- a/packages/khala-qa-harness/src/rpc-driver.ts
+++ b/packages/khala-qa-harness/src/rpc-driver.ts
@@ -1,0 +1,173 @@
+import { Effect, Stream } from "effect"
+
+import {
+  KhalaCodeRpcClient,
+  KhalaCodeRpcMethodNames,
+  type KhalaCodeRpcCallOk,
+  type KhalaCodeRpcClientOptions,
+  type KhalaCodeRpcMethodName,
+} from "./rpc-client.js"
+import {
+  khalaCodeQaDriverFailure,
+  type KhalaCodeQaAppEvent,
+  type KhalaCodeQaAppHandle,
+  type KhalaCodeQaArtifacts,
+  type KhalaCodeQaBootOptions,
+  type KhalaCodeQaDriver,
+  type KhalaCodeQaDriverFailure,
+  type KhalaCodeQaMetricsSnapshot,
+  type KhalaCodeQaObservation,
+  type KhalaCodeQaStateSnapshot,
+} from "./driver.js"
+import type { KhalaCodeQaAction } from "./scenario.js"
+
+const isRpcMethodName = (method: string): method is KhalaCodeRpcMethodName =>
+  (KhalaCodeRpcMethodNames as ReadonlyArray<string>).includes(method)
+
+const errorMessage = (cause: unknown): string =>
+  cause instanceof Error ? cause.message : String(cause)
+
+export type KhalaCodeRpcQaDriverOptions = KhalaCodeRpcClientOptions & {
+  readonly now?: () => string
+}
+
+export class KhalaCodeRpcQaDriver implements KhalaCodeQaDriver {
+  readonly mode = "rpc" as const
+  readonly client: KhalaCodeRpcClient
+  readonly now: () => string
+  private handle: KhalaCodeQaAppHandle | undefined
+  private observations: KhalaCodeQaObservation[] = []
+  private rpcOracleByQuery = new Map<string, KhalaCodeRpcCallOk<KhalaCodeRpcMethodName>>()
+
+  constructor(options: KhalaCodeRpcQaDriverOptions = {}) {
+    this.client = new KhalaCodeRpcClient(options)
+    this.now = options.now ?? (() => new Date().toISOString())
+  }
+
+  boot(
+    opts: KhalaCodeQaBootOptions,
+  ): Effect.Effect<KhalaCodeQaAppHandle, KhalaCodeQaDriverFailure> {
+    return Effect.sync(() => {
+      this.handle = {
+        backend: opts.backend,
+        mode: "rpc",
+        startedAt: this.now(),
+      }
+      return this.handle
+    })
+  }
+
+  act(action: KhalaCodeQaAction): Effect.Effect<KhalaCodeQaObservation, KhalaCodeQaDriverFailure> {
+    if (action.kind === "boot") {
+      const bootOptions = {
+        backend: action.backend ?? this.handle?.backend ?? "fixture",
+        ...(action.headless === undefined ? {} : { headless: action.headless }),
+      }
+      return Effect.map(
+        this.boot(bootOptions),
+        (handle) => this.record({
+          action,
+          data: handle,
+          label: "boot",
+          ok: true,
+        }),
+      )
+    }
+
+    if (action.kind === "read") {
+      return Effect.map(this.read(action.query), (snapshot) =>
+        this.record({
+          action,
+          data: snapshot,
+          label: `read:${action.query}`,
+          ok: true,
+        }),
+      )
+    }
+
+    if (action.kind !== "rpc_call") {
+      return Effect.fail(
+        khalaCodeQaDriverFailure(`RPC QA driver does not support ${action.kind} actions`, { action }),
+      )
+    }
+    if (!isRpcMethodName(action.method)) {
+      return Effect.fail(
+        khalaCodeQaDriverFailure(`Unknown Khala Code RPC method: ${action.method}`, { action }),
+      )
+    }
+
+    const callWithOracle = this.client.callWithOracle.bind(this.client) as (
+      method: KhalaCodeRpcMethodName,
+      ...args: ReadonlyArray<unknown>
+    ) => Effect.Effect<KhalaCodeRpcCallOk<KhalaCodeRpcMethodName>, unknown>
+    return Effect.matchEffect(
+      callWithOracle(
+        action.method,
+        ...(action.args ?? []),
+      ),
+      {
+        onFailure: (cause) =>
+          Effect.succeed(
+            this.record({
+              action,
+              error: errorMessage(cause),
+              label: `rpc:${action.method}`,
+              ok: false,
+            }),
+          ),
+        onSuccess: (result) =>
+          Effect.sync(() => {
+            this.rpcOracleByQuery.set(`rpc:${action.method}`, result)
+            this.rpcOracleByQuery.set(action.method, result)
+            return this.record({
+              action,
+              data: result,
+              label: `rpc:${action.method}`,
+              ok: true,
+            })
+          }),
+      },
+    )
+  }
+
+  read(query: string): Effect.Effect<KhalaCodeQaStateSnapshot, KhalaCodeQaDriverFailure> {
+    const observed = this.rpcOracleByQuery.get(query)
+    if (observed !== undefined) {
+      return Effect.succeed({ label: query, value: observed.value })
+    }
+    return Effect.fail(khalaCodeQaDriverFailure(`RPC QA driver has no state snapshot for query: ${query}`))
+  }
+
+  events(): Stream.Stream<KhalaCodeQaAppEvent, KhalaCodeQaDriverFailure> {
+    return Stream.empty
+  }
+
+  metrics(): Effect.Effect<KhalaCodeQaMetricsSnapshot, KhalaCodeQaDriverFailure> {
+    return Effect.succeed({
+      counters: {
+        observations: this.observations.length,
+        rpcCalls: this.observations.filter((observation) => observation.action.kind === "rpc_call").length,
+      },
+      timings: {},
+    })
+  }
+
+  shutdown(): Effect.Effect<KhalaCodeQaArtifacts, KhalaCodeQaDriverFailure> {
+    return Effect.succeed({
+      refs: [],
+      summary: {
+        mode: "rpc",
+        observations: this.observations.length,
+      },
+    })
+  }
+
+  private record(observation: KhalaCodeQaObservation): KhalaCodeQaObservation {
+    this.observations.push(observation)
+    return observation
+  }
+}
+
+export const makeKhalaCodeRpcQaDriver = (
+  options?: KhalaCodeRpcQaDriverOptions,
+): KhalaCodeRpcQaDriver => new KhalaCodeRpcQaDriver(options)

--- a/packages/khala-qa-harness/src/runner.ts
+++ b/packages/khala-qa-harness/src/runner.ts
@@ -1,0 +1,227 @@
+import { Effect } from "effect"
+
+import type { KhalaCodeQaDriver, KhalaCodeQaObservation } from "./driver.js"
+import type {
+  KhalaCodeQaCommitment,
+  KhalaCodeQaOracleExpectation,
+  KhalaCodeQaScenario,
+  KhalaCodeQaVerdict,
+} from "./scenario.js"
+
+export type KhalaCodeQaOracleOutcome = {
+  readonly ok: boolean
+  readonly oracle: KhalaCodeQaOracleExpectation["oracle"]
+  readonly phaseName: string
+  readonly summary: string
+  readonly data?: unknown
+}
+
+export type KhalaCodeQaPhaseOutcome = {
+  readonly name: string
+  readonly observations: ReadonlyArray<KhalaCodeQaObservation>
+  readonly oracles: ReadonlyArray<KhalaCodeQaOracleOutcome>
+  readonly status: "pass" | "fail"
+}
+
+export type KhalaCodeQaCommitmentFinding = {
+  readonly id: string
+  readonly claim: string
+  readonly verdict: KhalaCodeQaVerdict
+  readonly evidenceSummary: string
+}
+
+export type KhalaCodeQaCommitmentReport = {
+  readonly verdict: KhalaCodeQaVerdict
+  readonly observed: boolean
+  readonly findings: ReadonlyArray<KhalaCodeQaCommitmentFinding>
+}
+
+export type KhalaCodeQaScenarioRunReport = {
+  readonly backend: KhalaCodeQaScenario["backend"]
+  readonly commitments: KhalaCodeQaCommitmentReport
+  readonly mode: KhalaCodeQaDriver["mode"]
+  readonly phaseOutcomes: ReadonlyArray<KhalaCodeQaPhaseOutcome>
+  readonly scenarioId: string
+  readonly status: "pass" | "fail"
+}
+
+const oracleEvidenceLabel = (phaseName: string, oracle: string): string =>
+  `${phaseName}:${oracle}`
+
+const runStatus = (phaseOutcomes: ReadonlyArray<KhalaCodeQaPhaseOutcome>): "pass" | "fail" =>
+  phaseOutcomes.every((phase) => phase.status === "pass") ? "pass" : "fail"
+
+const rollUp = (
+  findings: ReadonlyArray<KhalaCodeQaCommitmentFinding>,
+): KhalaCodeQaVerdict => {
+  if (findings.length === 0) return "INCONCLUSIVE"
+  if (findings.some((finding) => finding.verdict === "REFUTED")) return "REFUTED"
+  if (findings.some((finding) => finding.verdict === "INCONCLUSIVE")) return "INCONCLUSIVE"
+  return "CONFIRMED"
+}
+
+const verifyCommitments = (input: {
+  readonly commitments: ReadonlyArray<KhalaCodeQaCommitment>
+  readonly phaseOutcomes: ReadonlyArray<KhalaCodeQaPhaseOutcome>
+  readonly runStatus: "pass" | "fail"
+}): KhalaCodeQaCommitmentReport => {
+  const allOracles = input.phaseOutcomes.flatMap((phase) => phase.oracles)
+  const findings = input.commitments.map((commitment): KhalaCodeQaCommitmentFinding => {
+    if (commitment.evidence === "run-pass") {
+      return input.runStatus === "pass"
+        ? {
+            claim: commitment.claim,
+            evidenceSummary: "run completed with status=pass",
+            id: commitment.id,
+            verdict: "CONFIRMED",
+          }
+        : {
+            claim: commitment.claim,
+            evidenceSummary: "run completed with status=fail",
+            id: commitment.id,
+            verdict: "REFUTED",
+          }
+    }
+
+    const oracle = allOracles.find((outcome) =>
+      oracleEvidenceLabel(outcome.phaseName, outcome.oracle)
+        .toLowerCase()
+        .includes(commitment.match.toLowerCase()),
+    )
+    if (oracle === undefined) {
+      return {
+        claim: commitment.claim,
+        evidenceSummary: `no oracle outcome matched "${commitment.match}"`,
+        id: commitment.id,
+        verdict: "INCONCLUSIVE",
+      }
+    }
+    return oracle.ok
+      ? {
+          claim: commitment.claim,
+          evidenceSummary: `observed oracle ${oracleEvidenceLabel(oracle.phaseName, oracle.oracle)} = ok`,
+          id: commitment.id,
+          verdict: "CONFIRMED",
+        }
+      : {
+          claim: commitment.claim,
+          evidenceSummary: `observed oracle ${oracleEvidenceLabel(oracle.phaseName, oracle.oracle)} = failed`,
+          id: commitment.id,
+          verdict: "REFUTED",
+        }
+  })
+
+  return {
+    findings,
+    observed: findings.every((finding) => finding.verdict !== "INCONCLUSIVE"),
+    verdict: rollUp(findings),
+  }
+}
+
+const evaluateOracle = (
+  phaseName: string,
+  expectation: KhalaCodeQaOracleExpectation,
+  observations: ReadonlyArray<KhalaCodeQaObservation>,
+): KhalaCodeQaOracleOutcome => {
+  if (expectation.oracle === "schema") {
+    const schemaObservation = [...observations].reverse().find((observation) => {
+      if (observation.action.kind !== "rpc_call") return false
+      if (expectation.query === undefined) return true
+      return observation.action.method === expectation.query || `rpc:${observation.action.method}` === expectation.query
+    })
+    const data = schemaObservation?.data as
+      | { readonly oracle?: { readonly decoded?: boolean; readonly unknownFields?: ReadonlyArray<unknown> } }
+      | undefined
+    const decoded = data?.oracle?.decoded === true
+    const unknownFields = data?.oracle?.unknownFields ?? []
+    return {
+      data: data?.oracle,
+      ok: schemaObservation?.ok === true && decoded && unknownFields.length === 0,
+      oracle: "schema",
+      phaseName,
+      summary: schemaObservation === undefined
+        ? "no RPC observation available for schema oracle"
+        : decoded && unknownFields.length === 0
+          ? "RPC response decoded with no unknown fields"
+          : "RPC response failed schema oracle",
+    }
+  }
+
+  if (expectation.oracle === "crash") {
+    return {
+      ok: observations.every((observation) => observation.ok),
+      oracle: "crash",
+      phaseName,
+      summary: "phase actions completed without driver crash",
+    }
+  }
+
+  return {
+    ok: true,
+    oracle: expectation.oracle,
+    phaseName,
+    summary: `${expectation.oracle} oracle recorded for ${phaseName}`,
+  }
+}
+
+export const runKhalaCodeQaScenario = (input: {
+  readonly driver: KhalaCodeQaDriver
+  readonly scenario: KhalaCodeQaScenario
+}): Effect.Effect<KhalaCodeQaScenarioRunReport, never> =>
+  Effect.gen(function* () {
+    yield* input.driver.boot({ backend: input.scenario.backend, headless: true }).pipe(
+      Effect.catch(() =>
+        Effect.succeed({
+          backend: input.scenario.backend,
+          mode: input.driver.mode,
+          startedAt: new Date(0).toISOString(),
+        }),
+      ),
+    )
+
+    const phaseOutcomes: KhalaCodeQaPhaseOutcome[] = []
+    for (const phase of input.scenario.phases) {
+      const observations: KhalaCodeQaObservation[] = []
+      for (const action of phase.act) {
+        const observation = yield* input.driver.act(action).pipe(
+          Effect.catch((cause) =>
+            Effect.succeed({
+              action,
+              error: cause.message,
+              label: action.kind,
+              ok: false,
+            } satisfies KhalaCodeQaObservation),
+          ),
+        )
+        observations.push(observation)
+      }
+      const oracles = phase.expect.map((expectation) =>
+        evaluateOracle(phase.name, expectation, observations),
+      )
+      phaseOutcomes.push({
+        name: phase.name,
+        observations,
+        oracles,
+        status: observations.every((observation) => observation.ok) &&
+          oracles.every((oracle) => oracle.ok)
+          ? "pass"
+          : "fail",
+      })
+    }
+
+    const status = runStatus(phaseOutcomes)
+    const commitments = verifyCommitments({
+      commitments: input.scenario.commitments,
+      phaseOutcomes,
+      runStatus: status,
+    })
+    yield* input.driver.shutdown().pipe(Effect.catch(() => Effect.succeed({ refs: [] })))
+    return {
+      backend: input.scenario.backend,
+      commitments,
+      mode: input.driver.mode,
+      phaseOutcomes,
+      scenarioId: input.scenario.id,
+      status,
+    }
+  })

--- a/packages/khala-qa-harness/src/runner.ts
+++ b/packages/khala-qa-harness/src/runner.ts
@@ -13,6 +13,7 @@ export type KhalaCodeQaOracleOutcome = {
   readonly oracle: KhalaCodeQaOracleExpectation["oracle"]
   readonly phaseName: string
   readonly summary: string
+  readonly verdict: KhalaCodeQaVerdict
   readonly data?: unknown
 }
 
@@ -53,12 +54,23 @@ const runStatus = (phaseOutcomes: ReadonlyArray<KhalaCodeQaPhaseOutcome>): "pass
 
 const rollUp = (
   findings: ReadonlyArray<KhalaCodeQaCommitmentFinding>,
+  status: "pass" | "fail",
 ): KhalaCodeQaVerdict => {
   if (findings.length === 0) return "INCONCLUSIVE"
   if (findings.some((finding) => finding.verdict === "REFUTED")) return "REFUTED"
   if (findings.some((finding) => finding.verdict === "INCONCLUSIVE")) return "INCONCLUSIVE"
+  if (status === "fail") return "REFUTED"
   return "CONFIRMED"
 }
+
+const summarizeOracleLabels = (
+  oracles: ReadonlyArray<KhalaCodeQaOracleOutcome>,
+): string =>
+  oracles
+    .map((oracle) =>
+      `${oracleEvidenceLabel(oracle.phaseName, oracle.oracle)}=${oracle.verdict.toLowerCase()}`
+    )
+    .join(", ")
 
 const verifyCommitments = (input: {
   readonly commitments: ReadonlyArray<KhalaCodeQaCommitment>
@@ -83,12 +95,12 @@ const verifyCommitments = (input: {
           }
     }
 
-    const oracle = allOracles.find((outcome) =>
+    const matchingOracles = allOracles.filter((outcome) =>
       oracleEvidenceLabel(outcome.phaseName, outcome.oracle)
         .toLowerCase()
         .includes(commitment.match.toLowerCase()),
     )
-    if (oracle === undefined) {
+    if (matchingOracles.length === 0) {
       return {
         claim: commitment.claim,
         evidenceSummary: `no oracle outcome matched "${commitment.match}"`,
@@ -96,25 +108,35 @@ const verifyCommitments = (input: {
         verdict: "INCONCLUSIVE",
       }
     }
-    return oracle.ok
-      ? {
-          claim: commitment.claim,
-          evidenceSummary: `observed oracle ${oracleEvidenceLabel(oracle.phaseName, oracle.oracle)} = ok`,
-          id: commitment.id,
-          verdict: "CONFIRMED",
-        }
-      : {
-          claim: commitment.claim,
-          evidenceSummary: `observed oracle ${oracleEvidenceLabel(oracle.phaseName, oracle.oracle)} = failed`,
-          id: commitment.id,
-          verdict: "REFUTED",
-        }
+    const evidenceSummary = `observed oracles: ${summarizeOracleLabels(matchingOracles)}`
+    if (matchingOracles.some((oracle) => oracle.verdict === "REFUTED")) {
+      return {
+        claim: commitment.claim,
+        evidenceSummary,
+        id: commitment.id,
+        verdict: "REFUTED",
+      }
+    }
+    if (matchingOracles.some((oracle) => oracle.verdict === "INCONCLUSIVE")) {
+      return {
+        claim: commitment.claim,
+        evidenceSummary,
+        id: commitment.id,
+        verdict: "INCONCLUSIVE",
+      }
+    }
+    return {
+      claim: commitment.claim,
+      evidenceSummary,
+      id: commitment.id,
+      verdict: "CONFIRMED",
+    }
   })
 
   return {
     findings,
     observed: findings.every((finding) => finding.verdict !== "INCONCLUSIVE"),
-    verdict: rollUp(findings),
+    verdict: rollUp(findings, input.runStatus),
   }
 }
 
@@ -134,9 +156,10 @@ const evaluateOracle = (
       | undefined
     const decoded = data?.oracle?.decoded === true
     const unknownFields = data?.oracle?.unknownFields ?? []
+    const ok = schemaObservation?.ok === true && decoded && unknownFields.length === 0
     return {
       data: data?.oracle,
-      ok: schemaObservation?.ok === true && decoded && unknownFields.length === 0,
+      ok,
       oracle: "schema",
       phaseName,
       summary: schemaObservation === undefined
@@ -144,23 +167,28 @@ const evaluateOracle = (
         : decoded && unknownFields.length === 0
           ? "RPC response decoded with no unknown fields"
           : "RPC response failed schema oracle",
+      verdict: ok ? "CONFIRMED" : "REFUTED",
     }
   }
 
   if (expectation.oracle === "crash") {
+    const ok = observations.every((observation) => observation.ok)
     return {
-      ok: observations.every((observation) => observation.ok),
+      ok,
       oracle: "crash",
       phaseName,
       summary: "phase actions completed without driver crash",
+      verdict: ok ? "CONFIRMED" : "REFUTED",
     }
   }
 
   return {
-    ok: true,
+    data: { expectation },
+    ok: false,
     oracle: expectation.oracle,
     phaseName,
-    summary: `${expectation.oracle} oracle recorded for ${phaseName}`,
+    summary: `${expectation.oracle} oracle is not evaluated by this runner`,
+    verdict: "INCONCLUSIVE",
   }
 }
 
@@ -169,17 +197,33 @@ export const runKhalaCodeQaScenario = (input: {
   readonly scenario: KhalaCodeQaScenario
 }): Effect.Effect<KhalaCodeQaScenarioRunReport, never> =>
   Effect.gen(function* () {
-    yield* input.driver.boot({ backend: input.scenario.backend, headless: true }).pipe(
-      Effect.catch(() =>
-        Effect.succeed({
-          backend: input.scenario.backend,
-          mode: input.driver.mode,
-          startedAt: new Date(0).toISOString(),
-        }),
-      ),
+    const bootFailure = yield* input.driver.boot({ backend: input.scenario.backend, headless: true }).pipe(
+      Effect.match({
+        onFailure: (failure) => failure,
+        onSuccess: () => undefined,
+      }),
     )
 
     const phaseOutcomes: KhalaCodeQaPhaseOutcome[] = []
+    if (bootFailure !== undefined) {
+      phaseOutcomes.push({
+        name: "boot",
+        observations: [
+          {
+            action: {
+              backend: input.scenario.backend,
+              headless: true,
+              kind: "boot",
+            },
+            error: bootFailure.message,
+            label: "boot",
+            ok: false,
+          },
+        ],
+        oracles: [],
+        status: "fail",
+      })
+    }
     for (const phase of input.scenario.phases) {
       const observations: KhalaCodeQaObservation[] = []
       for (const action of phase.act) {

--- a/packages/khala-qa-harness/src/scenario-runner.test.ts
+++ b/packages/khala-qa-harness/src/scenario-runner.test.ts
@@ -1,0 +1,196 @@
+import { describe, expect, test } from "bun:test"
+import { Effect } from "effect"
+
+import {
+  assertKhalaQaVisibleRect,
+  decodeKhalaCodeQaScenario,
+  khalaQaRectsOverlap,
+  loadKhalaCodeQaScenario,
+  makeKhalaCodeRpcQaDriver,
+  runKhalaCodeQaScenario,
+  waitForKhalaQaHttp,
+  type KhalaCodeRpcFetch,
+} from "./index.js"
+
+const fixtureScenario = {
+  backend: "fixture",
+  commitments: [
+    {
+      claim: "appInfo decodes with the schema oracle",
+      evidence: "phase-oracle",
+      id: "schema.app_info",
+      match: "boot-rpc:schema",
+    },
+    {
+      claim: "the scenario completes without failed observations",
+      evidence: "run-pass",
+      id: "run.pass",
+    },
+  ],
+  id: "scenario.khala_code.fixture_rpc_app_info.v1",
+  modes: ["rpc"],
+  phases: [
+    {
+      act: [{ kind: "rpc_call", method: "appInfo" }],
+      expect: [
+        {
+          oracle: "schema",
+          query: "appInfo",
+        },
+        {
+          oracle: "crash",
+        },
+      ],
+      name: "boot-rpc",
+    },
+  ],
+}
+
+const jsonResponse = (payload: unknown, init?: ResponseInit): Response =>
+  new Response(JSON.stringify(payload), {
+    headers: { "content-type": "application/json" },
+    status: init?.status ?? 200,
+  })
+
+describe("Khala Code QA scenario DSL", () => {
+  test("loads typed fixture-tier scenarios", () => {
+    const scenario = loadKhalaCodeQaScenario(fixtureScenario)
+
+    expect(scenario.id).toBe("scenario.khala_code.fixture_rpc_app_info.v1")
+    expect(scenario.backend).toBe("fixture")
+    expect(scenario.phases[0]?.expect[0]?.oracle).toBe("schema")
+  })
+
+  test("rejects a phase without an oracle", () => {
+    const decoded = decodeKhalaCodeQaScenario({
+      ...fixtureScenario,
+      phases: [{ act: [{ kind: "rpc_call", method: "appInfo" }], expect: [], name: "bad" }],
+    })
+
+    expect("_tag" in decoded).toBe(true)
+    if ("_tag" in decoded) {
+      expect(decoded.message).toContain("has no oracle expectations")
+      expect(decoded.phaseName).toBe("bad")
+    }
+  })
+})
+
+describe("Khala Code QA RPC driver and runner", () => {
+  test("runs an RPC-mode scenario and confirms commitments from observed oracle outcomes", async () => {
+    const calls: Array<{ headers: Record<string, string>; url: string }> = []
+    const driver = makeKhalaCodeRpcQaDriver({
+      accessToken: "preview-token",
+      baseUrl: "http://fixture.local",
+      fetch: ((input, init) => {
+        calls.push({
+          headers: Object.fromEntries(new Headers(init?.headers)),
+          url: String(input),
+        })
+        return Promise.resolve(jsonResponse({
+          app: "Khala Code Desktop",
+          ok: true,
+          observedAt: "2026-07-01T00:00:00.000Z",
+        }))
+      }) as KhalaCodeRpcFetch,
+      now: () => "2026-07-01T00:00:00.000Z",
+    })
+
+    const report = await Effect.runPromise(
+      runKhalaCodeQaScenario({
+        driver,
+        scenario: loadKhalaCodeQaScenario(fixtureScenario),
+      }),
+    )
+
+    expect(calls).toEqual([
+      {
+        headers: {
+          "content-type": "application/json",
+          "x-khala-code-preview-token": "preview-token",
+        },
+        url: "http://fixture.local/rpc/appInfo",
+      },
+    ])
+    expect(report.status).toBe("pass")
+    expect(report.phaseOutcomes[0]?.oracles.map((oracle) => oracle.ok)).toEqual([true, true])
+    expect(report.commitments.verdict).toBe("CONFIRMED")
+    expect(report.commitments.observed).toBe(true)
+  })
+
+  test("refutes a run-pass commitment when the schema oracle fails", async () => {
+    const driver = makeKhalaCodeRpcQaDriver({
+      fetch: (() =>
+        Promise.resolve(jsonResponse({
+          app: "Khala Code Desktop",
+          ok: true,
+        }))) as KhalaCodeRpcFetch,
+    })
+
+    const report = await Effect.runPromise(
+      runKhalaCodeQaScenario({
+        driver,
+        scenario: loadKhalaCodeQaScenario(fixtureScenario),
+      }),
+    )
+
+    expect(report.status).toBe("fail")
+    expect(report.commitments.verdict).toBe("REFUTED")
+    expect(report.phaseOutcomes[0]?.oracles[0]?.ok).toBe(false)
+  })
+
+  test("keeps unobserved commitments inconclusive", async () => {
+    const scenario = loadKhalaCodeQaScenario({
+      ...fixtureScenario,
+      commitments: [
+        {
+          claim: "a later oracle was observed",
+          evidence: "phase-oracle",
+          id: "missing",
+          match: "missing-phase:schema",
+        },
+      ],
+    })
+    const driver = makeKhalaCodeRpcQaDriver({
+      fetch: (() =>
+        Promise.resolve(jsonResponse({
+          app: "Khala Code Desktop",
+          ok: true,
+          observedAt: "2026-07-01T00:00:00.000Z",
+        }))) as KhalaCodeRpcFetch,
+    })
+
+    const report = await Effect.runPromise(runKhalaCodeQaScenario({ driver, scenario }))
+
+    expect(report.status).toBe("pass")
+    expect(report.commitments.verdict).toBe("INCONCLUSIVE")
+  })
+})
+
+describe("desktop smoke helper extraction", () => {
+  test("waitForKhalaQaHttp uses injectable fetch and sleep", async () => {
+    let calls = 0
+    await waitForKhalaQaHttp("http://fixture.local", {
+      fetch: (() => {
+        calls += 1
+        return Promise.resolve(new Response("ok", { status: calls === 1 ? 503 : 200 }))
+      }) as unknown as typeof fetch,
+      intervalMs: 1,
+      sleep: () => Promise.resolve(),
+      timeoutMs: 100,
+    })
+
+    expect(calls).toBe(2)
+  })
+
+  test("probe helpers preserve the existing visible-rect and overlap behavior", () => {
+    const viewport = { height: 200, width: 200, x: 0, y: 0 }
+    assertKhalaQaVisibleRect("panel", { height: 50, width: 50, x: 10, y: 10 }, viewport)
+    expect(khalaQaRectsOverlap(
+      { height: 20, width: 20, x: 10, y: 10 },
+      { height: 20, width: 20, x: 15, y: 15 },
+    )).toBe(true)
+    expect(() =>
+      assertKhalaQaVisibleRect("panel", { height: 50, width: 50, x: 190, y: 10 }, viewport),
+    ).toThrow("overflows")
+  })
+})

--- a/packages/khala-qa-harness/src/scenario-runner.test.ts
+++ b/packages/khala-qa-harness/src/scenario-runner.test.ts
@@ -8,6 +8,7 @@ import {
   loadKhalaCodeQaScenario,
   makeKhalaCodeRpcQaDriver,
   runKhalaCodeQaScenario,
+  unsupportedKhalaCodeQaDriver,
   waitForKhalaQaHttp,
   type KhalaCodeRpcFetch,
 } from "./index.js"
@@ -71,6 +72,30 @@ describe("Khala Code QA scenario DSL", () => {
     if ("_tag" in decoded) {
       expect(decoded.message).toContain("has no oracle expectations")
       expect(decoded.phaseName).toBe("bad")
+    }
+  })
+
+  test("rejects a scenario without phases", () => {
+    const decoded = decodeKhalaCodeQaScenario({
+      ...fixtureScenario,
+      phases: [],
+    })
+
+    expect("_tag" in decoded).toBe(true)
+    if ("_tag" in decoded) {
+      expect(decoded.message).toContain("no phases")
+    }
+  })
+
+  test("rejects a scenario without modes", () => {
+    const decoded = decodeKhalaCodeQaScenario({
+      ...fixtureScenario,
+      modes: [],
+    })
+
+    expect("_tag" in decoded).toBe(true)
+    if ("_tag" in decoded) {
+      expect(decoded.message).toContain("no driver modes")
     }
   })
 })
@@ -163,6 +188,120 @@ describe("Khala Code QA RPC driver and runner", () => {
 
     expect(report.status).toBe("pass")
     expect(report.commitments.verdict).toBe("INCONCLUSIVE")
+  })
+
+  test("surfaces unevaluated perf budget oracles as inconclusive", async () => {
+    const scenario = loadKhalaCodeQaScenario({
+      ...fixtureScenario,
+      commitments: [
+        {
+          claim: "appInfo stays within the perf budget",
+          evidence: "phase-oracle",
+          id: "perf.app_info",
+          match: "boot-rpc:perf",
+        },
+      ],
+      phases: [
+        {
+          act: [{ kind: "rpc_call", method: "appInfo" }],
+          expect: [{ budget: 10, metric: "rpc.duration_ms", oracle: "perf" }],
+          name: "boot-rpc",
+        },
+      ],
+    })
+    const driver = makeKhalaCodeRpcQaDriver({
+      fetch: (() =>
+        Promise.resolve(jsonResponse({
+          app: "Khala Code Desktop",
+          ok: true,
+          observedAt: "2026-07-01T00:00:00.000Z",
+        }))) as KhalaCodeRpcFetch,
+    })
+
+    const report = await Effect.runPromise(runKhalaCodeQaScenario({ driver, scenario }))
+
+    expect(report.status).toBe("fail")
+    expect(report.phaseOutcomes[0]?.oracles[0]).toMatchObject({
+      ok: false,
+      oracle: "perf",
+      verdict: "INCONCLUSIVE",
+    })
+    expect(report.commitments.verdict).toBe("INCONCLUSIVE")
+    expect(report.commitments.observed).toBe(false)
+  })
+
+  test("refutes a commitment when any matching schema oracle fails", async () => {
+    let calls = 0
+    const scenario = loadKhalaCodeQaScenario({
+      ...fixtureScenario,
+      commitments: [
+        {
+          claim: "all schema observations pass",
+          evidence: "phase-oracle",
+          id: "schema.all",
+          match: "schema",
+        },
+      ],
+      phases: [
+        {
+          act: [{ kind: "rpc_call", method: "appInfo" }],
+          expect: [{ oracle: "schema", query: "appInfo" }],
+          name: "first-schema",
+        },
+        {
+          act: [{ kind: "rpc_call", method: "appInfo" }],
+          expect: [{ oracle: "schema", query: "appInfo" }],
+          name: "second-schema",
+        },
+      ],
+    })
+    const driver = makeKhalaCodeRpcQaDriver({
+      fetch: (() => {
+        calls += 1
+        return Promise.resolve(
+          calls === 1
+            ? jsonResponse({
+              app: "Khala Code Desktop",
+              ok: true,
+              observedAt: "2026-07-01T00:00:00.000Z",
+            })
+            : jsonResponse({
+              app: "Khala Code Desktop",
+              ok: true,
+            }),
+        )
+      }) as KhalaCodeRpcFetch,
+    })
+
+    const report = await Effect.runPromise(runKhalaCodeQaScenario({ driver, scenario }))
+
+    expect(report.status).toBe("fail")
+    expect(report.phaseOutcomes.map((phase) => phase.oracles[0]?.ok)).toEqual([true, false])
+    expect(report.commitments.findings[0]?.verdict).toBe("REFUTED")
+    expect(report.commitments.findings[0]?.evidenceSummary).toContain("second-schema:schema=refuted")
+    expect(report.commitments.verdict).toBe("REFUTED")
+  })
+
+  test("records boot failures as failed runs without synthesizing a handle", async () => {
+    const scenario = loadKhalaCodeQaScenario({
+      ...fixtureScenario,
+      modes: ["dom"],
+    })
+
+    const report = await Effect.runPromise(
+      runKhalaCodeQaScenario({
+        driver: unsupportedKhalaCodeQaDriver("dom"),
+        scenario,
+      }),
+    )
+
+    expect(report.status).toBe("fail")
+    expect(report.phaseOutcomes[0]).toMatchObject({
+      name: "boot",
+      status: "fail",
+    })
+    expect(report.phaseOutcomes[0]?.observations[0]?.error).toContain("driver is not implemented")
+    expect(report.commitments.verdict).toBe("REFUTED")
   })
 })
 

--- a/packages/khala-qa-harness/src/scenario.ts
+++ b/packages/khala-qa-harness/src/scenario.ts
@@ -193,6 +193,18 @@ const parseErrorMessage = (cause: unknown): string =>
 const validateScenario = (
   scenario: KhalaCodeQaScenario,
 ): KhalaCodeQaScenario | KhalaCodeQaScenarioLoadFailure => {
+  if (scenario.modes.length === 0) {
+    return {
+      _tag: "KhalaCodeQaScenarioLoadFailure",
+      message: "Scenario has no driver modes",
+    }
+  }
+  if (scenario.phases.length === 0) {
+    return {
+      _tag: "KhalaCodeQaScenarioLoadFailure",
+      message: "Scenario has no phases",
+    }
+  }
   for (const phase of scenario.phases) {
     if (phase.expect.length === 0) {
       return {

--- a/packages/khala-qa-harness/src/scenario.ts
+++ b/packages/khala-qa-harness/src/scenario.ts
@@ -1,0 +1,226 @@
+import { Schema as S } from "effect"
+
+export const KhalaCodeQaDriverMode = S.Literals(["rpc", "dom", "vision", "headless"])
+export type KhalaCodeQaDriverMode = "rpc" | "dom" | "vision" | "headless"
+
+export const KhalaCodeQaBackendTier = S.Literals(["fixture", "live_codex", "live_fleet"])
+export type KhalaCodeQaBackendTier = "fixture" | "live_codex" | "live_fleet"
+
+export const KhalaCodeQaVerdict = S.Literals(["CONFIRMED", "REFUTED", "INCONCLUSIVE"])
+export type KhalaCodeQaVerdict = "CONFIRMED" | "REFUTED" | "INCONCLUSIVE"
+
+export const KhalaCodeQaBootAction = S.Struct({
+  backend: S.optional(KhalaCodeQaBackendTier),
+  headless: S.optional(S.Boolean),
+  kind: S.Literal("boot"),
+})
+
+export const KhalaCodeQaRpcCallAction = S.Struct({
+  args: S.optional(S.Array(S.Unknown)),
+  kind: S.Literal("rpc_call"),
+  method: S.String,
+})
+
+export const KhalaCodeQaReadAction = S.Struct({
+  kind: S.Literal("read"),
+  query: S.String,
+})
+
+export const KhalaCodeQaUiAction = S.Struct({
+  kind: S.Literals([
+    "click",
+    "type",
+    "hotbar",
+    "slash_command",
+    "approve",
+    "thread_select",
+    "submit_composer",
+    "wait_for",
+  ]),
+  target: S.optional(S.String),
+  text: S.optional(S.String),
+  value: S.optional(S.String),
+})
+
+export const KhalaCodeQaAction = S.Union(
+  [
+    KhalaCodeQaBootAction,
+    KhalaCodeQaRpcCallAction,
+    KhalaCodeQaReadAction,
+    KhalaCodeQaUiAction,
+  ],
+)
+export type KhalaCodeQaAction =
+  | {
+      readonly backend?: KhalaCodeQaBackendTier
+      readonly headless?: boolean
+      readonly kind: "boot"
+    }
+  | {
+      readonly args?: ReadonlyArray<unknown>
+      readonly kind: "rpc_call"
+      readonly method: string
+    }
+  | {
+      readonly kind: "read"
+      readonly query: string
+    }
+  | {
+      readonly kind:
+        | "click"
+        | "type"
+        | "hotbar"
+        | "slash_command"
+        | "approve"
+        | "thread_select"
+        | "submit_composer"
+        | "wait_for"
+      readonly target?: string
+      readonly text?: string
+      readonly value?: string
+    }
+
+export const KhalaCodeQaOracleExpectation = S.Struct({
+  budget: S.optional(S.Number),
+  decode: S.optional(S.String),
+  id: S.optional(S.String),
+  left: S.optional(S.String),
+  match: S.optional(S.String),
+  metric: S.optional(S.String),
+  oracle: S.Literals([
+    "schema",
+    "consistency",
+    "invariant",
+    "public_safe",
+    "public_safe_dom",
+    "visual",
+    "perf",
+    "a11y",
+    "event",
+    "crash",
+  ]),
+  query: S.optional(S.String),
+  right: S.optional(S.String),
+  within_ms: S.optional(S.Number),
+})
+export type KhalaCodeQaOracleExpectation = {
+  readonly budget?: number
+  readonly decode?: string
+  readonly id?: string
+  readonly left?: string
+  readonly match?: string
+  readonly metric?: string
+  readonly oracle:
+    | "schema"
+    | "consistency"
+    | "invariant"
+    | "public_safe"
+    | "public_safe_dom"
+    | "visual"
+    | "perf"
+    | "a11y"
+    | "event"
+    | "crash"
+  readonly query?: string
+  readonly right?: string
+  readonly within_ms?: number
+}
+
+export const KhalaCodeQaCommitment = S.Union(
+  [
+    S.Struct({
+      claim: S.String,
+      evidence: S.Literal("phase-oracle"),
+      id: S.String,
+      match: S.String,
+    }),
+    S.Struct({
+      claim: S.String,
+      evidence: S.Literal("run-pass"),
+      id: S.String,
+    }),
+  ],
+)
+export type KhalaCodeQaCommitment =
+  | {
+      readonly claim: string
+      readonly evidence: "phase-oracle"
+      readonly id: string
+      readonly match: string
+    }
+  | {
+      readonly claim: string
+      readonly evidence: "run-pass"
+      readonly id: string
+    }
+
+export const KhalaCodeQaScenarioPhase = S.Struct({
+  act: S.Array(KhalaCodeQaAction),
+  expect: S.Array(KhalaCodeQaOracleExpectation),
+  name: S.String,
+})
+export type KhalaCodeQaScenarioPhase = {
+  readonly act: ReadonlyArray<KhalaCodeQaAction>
+  readonly expect: ReadonlyArray<KhalaCodeQaOracleExpectation>
+  readonly name: string
+}
+
+export const KhalaCodeQaScenario = S.Struct({
+  backend: KhalaCodeQaBackendTier,
+  commitments: S.Array(KhalaCodeQaCommitment),
+  id: S.String,
+  modes: S.Array(KhalaCodeQaDriverMode),
+  phases: S.Array(KhalaCodeQaScenarioPhase),
+})
+export type KhalaCodeQaScenario = {
+  readonly backend: KhalaCodeQaBackendTier
+  readonly commitments: ReadonlyArray<KhalaCodeQaCommitment>
+  readonly id: string
+  readonly modes: ReadonlyArray<KhalaCodeQaDriverMode>
+  readonly phases: ReadonlyArray<KhalaCodeQaScenarioPhase>
+}
+
+export type KhalaCodeQaScenarioLoadFailure = {
+  readonly _tag: "KhalaCodeQaScenarioLoadFailure"
+  readonly message: string
+  readonly phaseName?: string
+  readonly cause?: unknown
+}
+
+const parseErrorMessage = (cause: unknown): string =>
+  cause instanceof Error ? cause.message : String(cause)
+
+const validateScenario = (
+  scenario: KhalaCodeQaScenario,
+): KhalaCodeQaScenario | KhalaCodeQaScenarioLoadFailure => {
+  for (const phase of scenario.phases) {
+    if (phase.expect.length === 0) {
+      return {
+        _tag: "KhalaCodeQaScenarioLoadFailure",
+        message: `Scenario phase "${phase.name}" has no oracle expectations`,
+        phaseName: phase.name,
+      }
+    }
+  }
+  return scenario
+}
+
+export const decodeKhalaCodeQaScenario = (
+  input: unknown,
+): KhalaCodeQaScenario | KhalaCodeQaScenarioLoadFailure => {
+  try {
+    return validateScenario(S.decodeUnknownSync(KhalaCodeQaScenario)(input) as KhalaCodeQaScenario)
+  } catch (cause) {
+    return {
+      _tag: "KhalaCodeQaScenarioLoadFailure",
+      message: parseErrorMessage(cause),
+      cause,
+    }
+  }
+}
+
+export const loadKhalaCodeQaScenario = (input: unknown): KhalaCodeQaScenario => {
+  const decoded = decodeKhalaCodeQaScenario(input)
+  if ("_tag" in decoded) throw new Error(decoded.message)
+  return decoded
+}


### PR DESCRIPTION
Closes #7847

## Summary

- Adds the typed Khala Code QA scenario DSL with fixture/live backend tiers, four driver modes, per-phase oracle expectations, and loader rejection for phases without oracles.
- Adds the `KhalaCodeQaDriver` Effect service contract, RPC-mode driver backed by `KhalaCodeRpcClient` and the preview access header, and a scenario runner with typed per-phase oracle outcomes plus CONFIRMED/REFUTED/INCONCLUSIVE commitment verdicts.
- Extracts shared Vite/waitForHttp/visual probe helpers into `packages/khala-qa-harness` and wires the existing desktop smoke scripts to consume them.

## Verification

- `bun run --cwd packages/khala-qa-harness test` (required `command.public.pylon_khala.verify.aad6f4393892975803d98a3f`)
- `bun run --cwd packages/khala-qa-harness typecheck`
- `bun run --cwd clients/khala-code-desktop typecheck`