### PR TITLE
T8.2: Minimal Claude chat runtime

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -372,6 +372,7 @@
       "name": "@openagentsinc/khala-code-desktop",
       "version": "0.0.1",
       "dependencies": {
+        "@anthropic-ai/claude-agent-sdk": "^0.3.172",
         "@openagentsinc/agent-runtime-schema": "workspace:*",
         "@openagentsinc/arbiter-effect": "workspace:*",
         "@openagentsinc/composer-state": "workspace:*",

--- a/clients/khala-code-desktop/package.json
+++ b/clients/khala-code-desktop/package.json
@@ -22,6 +22,7 @@
     "dev:hmr": "concurrently \"vite --port 5173 --strictPort\" \"bun run dev\""
   },
   "dependencies": {
+    "@anthropic-ai/claude-agent-sdk": "^0.3.172",
     "@openagentsinc/agent-runtime-schema": "workspace:*",
     "@openagentsinc/arbiter-effect": "workspace:*",
     "@openagentsinc/composer-state": "workspace:*",

--- a/clients/khala-code-desktop/src/bun/claude-app-sdk-chat-runtime.ts
+++ b/clients/khala-code-desktop/src/bun/claude-app-sdk-chat-runtime.ts
@@ -1,4 +1,4 @@
-import { Effect, Stream } from "effect"
+import { Data, Effect, Stream } from "effect"
 
 import type {
   KhalaCodeDesktopChatTurnEvent,
@@ -40,6 +40,17 @@ type ClaudeSdkModule = {
   readonly query: ClaudeQueryFn
 }
 
+class ClaudeSdkRuntimeError extends Data.TaggedError("ClaudeSdkRuntimeError")<{
+  readonly cause: unknown
+  readonly message: string
+}> {}
+
+const claudeSdkRuntimeError = (error: unknown): ClaudeSdkRuntimeError =>
+  new ClaudeSdkRuntimeError({
+    cause: error,
+    message: error instanceof Error ? error.message : String(error),
+  })
+
 export type CreateClaudeAppSdkChatRuntimeOptions = {
   readonly env?: Readonly<Record<string, string | undefined>>
   readonly importer?: (specifier: string) => Promise<unknown>
@@ -50,6 +61,7 @@ export type CreateClaudeAppSdkChatRuntimeOptions = {
 }
 
 type ActiveClaudeTurn = {
+  readonly controller: AbortController
   readonly query: ClaudeQuery
   readonly sessionId: string
 }
@@ -95,7 +107,7 @@ export function createClaudeAppSdkChatRuntime(
   ): Promise<KhalaCodeDesktopCodexThreadResult> => {
     const desktopSessionId = request.sessionId ?? `claude-desktop-${Date.now().toString(36)}`
     const stored = await sessionStore.put(desktopSessionId, {
-      sessionId: crypto.randomUUID(),
+      sessionId: desktopSessionId,
     })
     return {
       ok: true,
@@ -129,8 +141,10 @@ export function createClaudeAppSdkChatRuntime(
     if (prompt.length === 0) {
       throw new Error("Claude app SDK chat runtime requires a non-empty prompt.")
     }
-    const stored = await sessionStore.get(request.sessionId)
-    const threadId = request.threadId ?? (request.startNewThread === true ? undefined : stored?.sessionId)
+    const stored = request.startNewThread === true ? null : await sessionStore.get(request.sessionId)
+    const threadId = request.threadId ?? stored?.sessionId
+    const freshSessionId = request.threadId ?? stored?.sessionId ?? request.sessionId
+    const shouldResume = threadId !== undefined && stored?.lastTurnId !== undefined
     const controller = new AbortController()
     const query = await loadQuery(options)
     const projector = createClaudeThreadItemProjector({
@@ -147,31 +161,38 @@ export function createClaudeAppSdkChatRuntime(
           cwd: request.cwd ?? options.workingDirectory,
           includePartialMessages: true,
           permissionMode: options.env?.KHALA_CODE_DESKTOP_CLAUDE_PERMISSION_MODE ?? "acceptEdits",
-          ...(threadId === undefined ? {} : { resume: threadId, sessionId: threadId }),
+          ...(shouldResume ? { resume: threadId } : { sessionId: freshSessionId }),
           env: {
             ...options.env,
             ...(options.env?.CLAUDE_CONFIG_DIR === undefined ? {} : { CLAUDE_CONFIG_DIR: options.env.CLAUDE_CONFIG_DIR }),
           },
         },
       }),
-      catch: error => error instanceof Error ? error : new Error(String(error)),
+      catch: claudeSdkRuntimeError,
     })
 
-    const queryHandle = await acquireQuery.pipe(Effect.runPromise)
-    activeTurns.set(desktopTurnId, { query: queryHandle, sessionId: request.sessionId })
     await runScoped(
       Effect.acquireRelease(
-        Effect.succeed(queryHandle),
+        acquireQuery.pipe(
+          Effect.tap(handle => Effect.sync(() => {
+            activeTurns.set(desktopTurnId, {
+              controller,
+              query: handle,
+              sessionId: request.sessionId,
+            })
+          })),
+        ),
         handle => Effect.promise(async () => {
           try {
             await handle.close?.()
           } finally {
             controller.abort()
+            activeTurns.delete(desktopTurnId)
           }
         }),
       ).pipe(
         Effect.flatMap(handle =>
-          Stream.fromAsyncIterable(handle, error => error).pipe(
+          Stream.fromAsyncIterable(handle, claudeSdkRuntimeError).pipe(
             Stream.runForEach(message =>
               Effect.sync(() => {
                 const sessionId = sdkSessionId(message)
@@ -182,7 +203,6 @@ export function createClaudeAppSdkChatRuntime(
             ),
           ),
         ),
-        Effect.ensuring(Effect.sync(() => activeTurns.delete(desktopTurnId))),
         Effect.scoped,
       ),
     )
@@ -226,7 +246,18 @@ export function createClaudeAppSdkChatRuntime(
     if (match === undefined) {
       return { ok: false, desktopSessionId: request.sessionId, desktopTurnId: request.turnId }
     }
-    await match[1].query.interrupt?.()
+    if (typeof match[1].query.interrupt !== "function") {
+      match[1].controller.abort()
+      await match[1].query.close?.()
+      return {
+        ok: false,
+        desktopSessionId: request.sessionId,
+        desktopTurnId: match[0],
+        error: "Claude Agent SDK query does not expose interrupt().",
+        threadId: await threadIdForSession(request.sessionId) ?? undefined,
+      }
+    }
+    await match[1].query.interrupt()
     return {
       ok: true,
       desktopSessionId: request.sessionId,

--- a/clients/khala-code-desktop/src/bun/claude-app-sdk-chat-runtime.ts
+++ b/clients/khala-code-desktop/src/bun/claude-app-sdk-chat-runtime.ts
@@ -1,0 +1,270 @@
+import { Effect, Stream } from "effect"
+
+import type {
+  KhalaCodeDesktopChatTurnEvent,
+  KhalaCodeDesktopChatTurnRequest,
+  KhalaCodeDesktopChatTurnResponse,
+  KhalaCodeDesktopCodexThreadCompactRequest,
+  KhalaCodeDesktopCodexThreadForkRequest,
+  KhalaCodeDesktopCodexThreadIdRequest,
+  KhalaCodeDesktopCodexThreadListRequest,
+  KhalaCodeDesktopCodexThreadListResult,
+  KhalaCodeDesktopCodexThreadMutationResult,
+  KhalaCodeDesktopCodexThreadReadRequest,
+  KhalaCodeDesktopCodexThreadRenameRequest,
+  KhalaCodeDesktopCodexThreadResult,
+  KhalaCodeDesktopCodexThreadResumeRequest,
+  KhalaCodeDesktopCodexThreadStartRequest,
+  KhalaCodeDesktopCodexTurnActionResult,
+  KhalaCodeDesktopCodexTurnInterruptRequest,
+  KhalaCodeDesktopCodexTurnSteerRequest,
+} from "../shared/rpc.js"
+import type { CodexAppServerChatRuntime } from "./codex-app-server-chat-runtime.js"
+import {
+  createClaudeSessionStore,
+  type ClaudeSessionStore,
+} from "./claude-session-store.js"
+import { createClaudeThreadItemProjector } from "./claude-thread-item-projector.js"
+
+type ClaudeQuery = AsyncIterable<unknown> & {
+  readonly close?: () => Promise<void> | void
+  readonly interrupt?: () => Promise<void> | void
+}
+
+type ClaudeQueryFn = (input: {
+  readonly prompt: string
+  readonly options: Record<string, unknown>
+}) => ClaudeQuery
+
+type ClaudeSdkModule = {
+  readonly query: ClaudeQueryFn
+}
+
+export type CreateClaudeAppSdkChatRuntimeOptions = {
+  readonly env?: Readonly<Record<string, string | undefined>>
+  readonly importer?: (specifier: string) => Promise<unknown>
+  readonly onEvent?: (event: KhalaCodeDesktopChatTurnEvent) => void
+  readonly query?: ClaudeQueryFn
+  readonly sessionStore?: ClaudeSessionStore
+  readonly workingDirectory: string
+}
+
+type ActiveClaudeTurn = {
+  readonly query: ClaudeQuery
+  readonly sessionId: string
+}
+
+const unsupported = async (): Promise<never> => {
+  throw new Error("Claude app SDK chat runtime does not support this thread operation until a later parity phase.")
+}
+
+const textFromRequest = (request: KhalaCodeDesktopChatTurnRequest): string =>
+  request.messages.map(message => message.body).filter(Boolean).join("\n\n").trim()
+
+const sdkSessionId = (value: unknown): string | null => {
+  if (typeof value !== "object" || value === null) return null
+  const candidate = (value as { readonly session_id?: unknown }).session_id
+  return typeof candidate === "string" && candidate.length > 0 ? candidate : null
+}
+
+const loadQuery = async (
+  options: CreateClaudeAppSdkChatRuntimeOptions,
+): Promise<ClaudeQueryFn> => {
+  if (options.query !== undefined) return options.query
+  const importer = options.importer ?? ((specifier: string) => import(specifier))
+  const mod = await importer("@anthropic-ai/claude-agent-sdk") as Partial<ClaudeSdkModule>
+  if (typeof mod.query !== "function") {
+    throw new Error("Claude Agent SDK did not expose query().")
+  }
+  return mod.query
+}
+
+const runScoped = async <A>(effect: Effect.Effect<A, unknown, never>): Promise<A> =>
+  Effect.runPromise(effect)
+
+export function createClaudeAppSdkChatRuntime(
+  options: CreateClaudeAppSdkChatRuntimeOptions,
+): CodexAppServerChatRuntime {
+  const sessionStore = options.sessionStore ?? createClaudeSessionStore({
+    ...(options.env === undefined ? {} : { env: options.env }),
+  })
+  const activeTurns = new Map<string, ActiveClaudeTurn>()
+
+  const startThread = async (
+    request: KhalaCodeDesktopCodexThreadStartRequest = {},
+  ): Promise<KhalaCodeDesktopCodexThreadResult> => {
+    const desktopSessionId = request.sessionId ?? `claude-desktop-${Date.now().toString(36)}`
+    const stored = await sessionStore.put(desktopSessionId, {
+      sessionId: crypto.randomUUID(),
+    })
+    return {
+      ok: true,
+      desktopSessionId,
+      thread: { id: stored.sessionId, title: "Claude session" },
+      threadId: stored.sessionId,
+    }
+  }
+
+  const resumeThread = async (
+    request: KhalaCodeDesktopCodexThreadResumeRequest,
+  ): Promise<KhalaCodeDesktopCodexThreadResult> => {
+    const desktopSessionId = request.sessionId ?? request.threadId
+    await sessionStore.put(desktopSessionId, { sessionId: request.threadId })
+    return {
+      ok: true,
+      desktopSessionId,
+      thread: { id: request.threadId, title: "Claude session" },
+      threadId: request.threadId,
+    }
+  }
+
+  const threadIdForSession = async (desktopSessionId: string): Promise<string | null> =>
+    (await sessionStore.get(desktopSessionId))?.sessionId ?? null
+
+  const startTurn = async (
+    request: KhalaCodeDesktopChatTurnRequest & { readonly cwd?: string },
+  ): Promise<KhalaCodeDesktopChatTurnResponse> => {
+    const desktopTurnId = request.turnId ?? `claude-turn-${Date.now().toString(36)}`
+    const prompt = textFromRequest(request)
+    if (prompt.length === 0) {
+      throw new Error("Claude app SDK chat runtime requires a non-empty prompt.")
+    }
+    const stored = await sessionStore.get(request.sessionId)
+    const threadId = request.threadId ?? (request.startNewThread === true ? undefined : stored?.sessionId)
+    const controller = new AbortController()
+    const query = await loadQuery(options)
+    const projector = createClaudeThreadItemProjector({
+      desktopSessionId: request.sessionId,
+      turnId: desktopTurnId,
+    })
+    let resolvedThreadId = threadId ?? null
+
+    const acquireQuery = Effect.tryPromise({
+      try: async () => query({
+        prompt,
+        options: {
+          abortController: controller,
+          cwd: request.cwd ?? options.workingDirectory,
+          includePartialMessages: true,
+          permissionMode: options.env?.KHALA_CODE_DESKTOP_CLAUDE_PERMISSION_MODE ?? "acceptEdits",
+          ...(threadId === undefined ? {} : { resume: threadId, sessionId: threadId }),
+          env: {
+            ...options.env,
+            ...(options.env?.CLAUDE_CONFIG_DIR === undefined ? {} : { CLAUDE_CONFIG_DIR: options.env.CLAUDE_CONFIG_DIR }),
+          },
+        },
+      }),
+      catch: error => error instanceof Error ? error : new Error(String(error)),
+    })
+
+    const queryHandle = await acquireQuery.pipe(Effect.runPromise)
+    activeTurns.set(desktopTurnId, { query: queryHandle, sessionId: request.sessionId })
+    await runScoped(
+      Effect.acquireRelease(
+        Effect.succeed(queryHandle),
+        handle => Effect.promise(async () => {
+          try {
+            await handle.close?.()
+          } finally {
+            controller.abort()
+          }
+        }),
+      ).pipe(
+        Effect.flatMap(handle =>
+          Stream.fromAsyncIterable(handle, error => error).pipe(
+            Stream.runForEach(message =>
+              Effect.sync(() => {
+                const sessionId = sdkSessionId(message)
+                if (sessionId !== null) resolvedThreadId = sessionId
+                const projected = projector.project(message)
+                for (const event of projected.events) options.onEvent?.(event)
+              }),
+            ),
+          ),
+        ),
+        Effect.ensuring(Effect.sync(() => activeTurns.delete(desktopTurnId))),
+        Effect.scoped,
+      ),
+    )
+    const finalThreadId = resolvedThreadId ?? threadId ?? request.sessionId
+    await sessionStore.put(request.sessionId, {
+      sessionId: finalThreadId,
+      lastTurnId: desktopTurnId,
+    })
+    const messages = projector.messages()
+    return {
+      backend: {
+        kind: "claude_app_sdk",
+        model: "claude-app-sdk",
+        runtimeMode: "claude_runtime",
+        threadId: finalThreadId,
+        toolCatalogKind: "codex_harness_supplemental",
+        turnId: desktopTurnId,
+        turnStatus: projector.status(),
+      },
+      messages: messages.length === 0
+        ? [{
+          body: `Claude completed the turn with status: ${projector.status()}.`,
+          id: `${desktopTurnId}-claude-status`,
+          role: "system",
+        }]
+        : messages,
+      ok: projector.status() !== "failed",
+      toolNames: projector.toolNames(),
+      ...(projector.usage() === undefined ? {} : { usage: projector.usage() }),
+      usedTools: projector.toolNames(),
+    }
+  }
+
+  const interruptTurn = async (
+    request: KhalaCodeDesktopCodexTurnInterruptRequest,
+  ): Promise<KhalaCodeDesktopCodexTurnActionResult> => {
+    const entries = [...activeTurns.entries()]
+    const match = request.turnId === undefined
+      ? entries.find(([, turn]) => turn.sessionId === request.sessionId)
+      : entries.find(([turnId, turn]) => turnId === request.turnId && turn.sessionId === request.sessionId)
+    if (match === undefined) {
+      return { ok: false, desktopSessionId: request.sessionId, desktopTurnId: request.turnId }
+    }
+    await match[1].query.interrupt?.()
+    return {
+      ok: true,
+      desktopSessionId: request.sessionId,
+      desktopTurnId: match[0],
+      threadId: await threadIdForSession(request.sessionId) ?? undefined,
+    }
+  }
+
+  const mutationUnsupported = async <A extends KhalaCodeDesktopCodexThreadMutationResult["action"]>(
+    action: A,
+    request: KhalaCodeDesktopCodexThreadIdRequest,
+  ): Promise<KhalaCodeDesktopCodexThreadMutationResult> => ({
+    action,
+    ok: false,
+    threadId: request.threadId,
+  })
+  const actionUnsupported = async (
+    request: KhalaCodeDesktopCodexThreadCompactRequest | KhalaCodeDesktopCodexTurnSteerRequest,
+  ): Promise<KhalaCodeDesktopCodexTurnActionResult> => ({
+    ok: false,
+    desktopSessionId: request.sessionId ?? "",
+    ...(!("threadId" in request) || request.threadId === undefined ? {} : { threadId: request.threadId }),
+  })
+
+  return {
+    archiveThread: request => mutationUnsupported("archive", request),
+    compactThread: actionUnsupported,
+    deleteThread: request => mutationUnsupported("delete", request),
+    forkThread: async (request: KhalaCodeDesktopCodexThreadForkRequest) => mutationUnsupported("fork", request),
+    interruptTurn,
+    listThreads: async (_request?: KhalaCodeDesktopCodexThreadListRequest): Promise<KhalaCodeDesktopCodexThreadListResult> => unsupported(),
+    readThread: async (_request: KhalaCodeDesktopCodexThreadReadRequest) => unsupported(),
+    renameThread: async (request: KhalaCodeDesktopCodexThreadRenameRequest) => mutationUnsupported("rename", request),
+    resumeThread,
+    startThread,
+    startTurn,
+    steerTurn: actionUnsupported,
+    threadIdForSession,
+    unarchiveThread: request => mutationUnsupported("unarchive", request),
+  }
+}

--- a/clients/khala-code-desktop/src/bun/claude-app-sdk-gap-matrix.ts
+++ b/clients/khala-code-desktop/src/bun/claude-app-sdk-gap-matrix.ts
@@ -1,0 +1,46 @@
+export type ClaudeAppSdkGapMatrixRow = {
+  readonly id: string
+  readonly phase: "phase_1" | "phase_2" | "phase_3"
+  readonly status: "covered" | "deferred"
+  readonly note: string
+}
+
+export const CLAUDE_APP_SDK_GAP_MATRIX: readonly ClaudeAppSdkGapMatrixRow[] = [
+  {
+    id: "claude.phase1.chat_stream",
+    phase: "phase_1",
+    status: "covered",
+    note: "query() streams assistant text, reasoning blocks, tool_use/tool_result events, result status, and exact usage into neutral chat turn events.",
+  },
+  {
+    id: "claude.phase1.interrupt",
+    phase: "phase_1",
+    status: "covered",
+    note: "Desktop stop maps to Query.interrupt(); scoped teardown still calls close() and aborts the owned AbortController.",
+  },
+  {
+    id: "claude.phase1.session_resume",
+    phase: "phase_1",
+    status: "covered",
+    note: "Desktop session ids persist to ~/.khala-code/claude-sessions.json v1, with KHALA_CODE_DESKTOP_CLAUDE_STATE_PATH override.",
+  },
+  {
+    id: "claude.phase2.approvals",
+    phase: "phase_2",
+    status: "deferred",
+    note: "Claude-native canUseTool approvals are intentionally deferred to T8.3.",
+  },
+  {
+    id: "claude.phase2.telemetry_ingest",
+    phase: "phase_2",
+    status: "deferred",
+    note: "Phase 1 returns exact SDK result usage locally; ingest route selection remains a T8.3 decision.",
+  },
+  {
+    id: "claude.phase3.sidebar_catalog",
+    phase: "phase_3",
+    status: "deferred",
+    note: "SDK listSessions()/getSessionMessages() backing for the sidebar is deferred to T8.4.",
+  },
+]
+

--- a/clients/khala-code-desktop/src/bun/claude-harness-status.ts
+++ b/clients/khala-code-desktop/src/bun/claude-harness-status.ts
@@ -1,0 +1,50 @@
+import {
+  probeClaudeAgentReadiness,
+  type ClaudeAgentReadiness,
+  type ClaudeAgentProbeOptions,
+} from "../../../../apps/pylon/src/claude-agent.js"
+
+export type KhalaCodeDesktopClaudeHarnessStatus = {
+  readonly available: boolean
+  readonly blockerRefs: readonly string[]
+  readonly capability: "claude_harness"
+  readonly credentialSourceRef: string | null
+  readonly observedAt: string
+  readonly reason: string
+  readonly status: ClaudeAgentReadiness["state"]
+}
+
+export type InspectClaudeHarnessStatusOptions = ClaudeAgentProbeOptions & {
+  readonly now?: () => Date
+}
+
+const reasonFor = (readiness: ClaudeAgentReadiness): string => {
+  switch (readiness.state) {
+    case "ready":
+      return "ready"
+    case "sdk_missing":
+      return "Claude Agent SDK is not installed."
+    case "credentials_missing":
+      return "Claude credentials are missing."
+    case "platform_unsupported":
+      return "Claude Agent SDK is not supported on this platform."
+    case "disabled_by_config":
+      return "Claude harness is disabled by config."
+  }
+}
+
+export async function inspectClaudeHarnessStatus(
+  options: InspectClaudeHarnessStatusOptions = {},
+): Promise<KhalaCodeDesktopClaudeHarnessStatus> {
+  const readiness = await probeClaudeAgentReadiness(options)
+  const available = readiness.state === "ready"
+  return {
+    available,
+    blockerRefs: readiness.blockerRefs,
+    capability: "claude_harness",
+    credentialSourceRef: readiness.credentialSourceRef,
+    observedAt: (options.now ?? (() => new Date()))().toISOString(),
+    reason: reasonFor(readiness),
+    status: readiness.state,
+  }
+}

--- a/clients/khala-code-desktop/src/bun/claude-session-store.ts
+++ b/clients/khala-code-desktop/src/bun/claude-session-store.ts
@@ -1,0 +1,95 @@
+import { mkdir, readFile, writeFile } from "node:fs/promises"
+import { homedir } from "node:os"
+import { dirname, join } from "node:path"
+
+import { Schema as S } from "effect"
+
+const CLAUDE_SESSION_STORE_SCHEMA = "khala-code-desktop.claude-sessions.v1"
+
+const SessionEntry = S.Struct({
+  sessionId: S.String,
+  lastTurnId: S.optional(S.String),
+  updatedAt: S.String,
+})
+
+const SessionStoreFile = S.Struct({
+  schema: S.Literal(CLAUDE_SESSION_STORE_SCHEMA),
+  sessions: S.Record(S.String, SessionEntry),
+})
+
+export type ClaudeDesktopSessionEntry = typeof SessionEntry.Type
+type ClaudeSessionStoreFile = typeof SessionStoreFile.Type
+
+export type ClaudeSessionStore = Readonly<{
+  get: (desktopSessionId: string) => Promise<ClaudeDesktopSessionEntry | null>
+  put: (desktopSessionId: string, entry: {
+    readonly sessionId: string
+    readonly lastTurnId?: string
+  }) => Promise<ClaudeDesktopSessionEntry>
+  path: string
+}>
+
+export type CreateClaudeSessionStoreOptions = {
+  readonly env?: Readonly<Record<string, string | undefined>>
+  readonly now?: () => Date
+  readonly path?: string
+}
+
+const emptyStore = (): ClaudeSessionStoreFile => ({
+  schema: CLAUDE_SESSION_STORE_SCHEMA,
+  sessions: {},
+})
+
+export function resolveClaudeSessionStorePath(
+  env: Readonly<Record<string, string | undefined>> = Bun.env,
+): string {
+  const override = env.KHALA_CODE_DESKTOP_CLAUDE_STATE_PATH?.trim()
+  if (override !== undefined && override.length > 0) return override
+  const home = env.HOME?.trim() || homedir()
+  return join(home, ".khala-code", "claude-sessions.json")
+}
+
+async function readStore(path: string): Promise<ClaudeSessionStoreFile> {
+  try {
+    const raw = await readFile(path, "utf8")
+    const decoded = S.decodeUnknownSync(SessionStoreFile)(JSON.parse(raw))
+    return { schema: decoded.schema, sessions: { ...decoded.sessions } }
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code
+    if (code === "ENOENT") return emptyStore()
+    return emptyStore()
+  }
+}
+
+async function writeStore(path: string, store: ClaudeSessionStoreFile): Promise<void> {
+  await mkdir(dirname(path), { recursive: true })
+  await writeFile(path, `${JSON.stringify(store, null, 2)}\n`, "utf8")
+}
+
+export function createClaudeSessionStore(
+  options: CreateClaudeSessionStoreOptions = {},
+): ClaudeSessionStore {
+  const path = options.path ?? resolveClaudeSessionStorePath(options.env)
+  const now = options.now ?? (() => new Date())
+
+  return {
+    path,
+    async get(desktopSessionId) {
+      const store = await readStore(path)
+      return store.sessions[desktopSessionId] ?? null
+    },
+    async put(desktopSessionId, entry) {
+      const store = await readStore(path)
+      const updated: ClaudeDesktopSessionEntry = {
+        sessionId: entry.sessionId,
+        ...(entry.lastTurnId === undefined ? {} : { lastTurnId: entry.lastTurnId }),
+        updatedAt: now().toISOString(),
+      }
+      await writeStore(path, {
+        schema: store.schema,
+        sessions: { ...store.sessions, [desktopSessionId]: updated },
+      })
+      return updated
+    },
+  }
+}

--- a/clients/khala-code-desktop/src/bun/claude-thread-item-projector.ts
+++ b/clients/khala-code-desktop/src/bun/claude-thread-item-projector.ts
@@ -100,6 +100,9 @@ const numberField = (value: Record<string, unknown> | null | undefined, field: s
   return typeof candidate === "number" && Number.isFinite(candidate) ? candidate : 0
 }
 
+const isObject = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value)
+
 const contentText = (block: Record<string, unknown>): string => {
   const text = block.text
   if (typeof text === "string") return text
@@ -115,8 +118,7 @@ const messageId = (
   index: number,
 ): string => `${stringField(message, "uuid") ?? turnId}-${prefix}-${index}`
 
-const usageFromClaude = (message: Record<string, unknown>): KhalaCodeDesktopUsage | undefined => {
-  const usage = objectField(message, "usage") ?? objectField(message, "modelUsage")
+const usageFromUsageObject = (usage: Record<string, unknown> | null): KhalaCodeDesktopUsage | undefined => {
   if (usage === null) return undefined
   const input = numberField(usage, "input_tokens") + numberField(usage, "cache_creation_input_tokens")
   const cachedInput = numberField(usage, "cache_read_input_tokens")
@@ -124,6 +126,45 @@ const usageFromClaude = (message: Record<string, unknown>): KhalaCodeDesktopUsag
   const reasoningOutput = numberField(usage, "reasoning_output_tokens")
   if (input + cachedInput + output + reasoningOutput === 0) return undefined
   return { input, cachedInput, output, reasoningOutput }
+}
+
+const usageFromClaude = (message: Record<string, unknown>): KhalaCodeDesktopUsage | undefined =>
+  usageFromUsageObject(objectField(message, "usage") ?? objectField(message, "modelUsage"))
+
+const usageObjectsFrom = (value: Record<string, unknown> | null): readonly Record<string, unknown>[] => {
+  if (value === null) return []
+  if (
+    numberField(value, "input_tokens") +
+    numberField(value, "cache_creation_input_tokens") +
+    numberField(value, "cache_read_input_tokens") +
+    numberField(value, "output_tokens") +
+    numberField(value, "reasoning_output_tokens") > 0
+  ) return [value]
+  return Object.values(value).filter(isObject)
+}
+
+const addUsage = (
+  left: KhalaCodeDesktopUsage | undefined,
+  right: KhalaCodeDesktopUsage | undefined,
+): KhalaCodeDesktopUsage | undefined => {
+  if (left === undefined) return right
+  if (right === undefined) return left
+  return {
+    cachedInput: left.cachedInput + right.cachedInput,
+    input: left.input + right.input,
+    output: left.output + right.output,
+    reasoningOutput: left.reasoningOutput + right.reasoningOutput,
+  }
+}
+
+const usageFromClaudeResult = (message: Record<string, unknown>): KhalaCodeDesktopUsage | undefined => {
+  const direct =
+    usageFromClaude(message) ??
+    usageFromClaude(objectField(message, "message") ?? {})
+  const modelUsage = usageObjectsFrom(objectField(message, "modelUsage"))
+    .map(usageFromUsageObject)
+    .reduce(addUsage, undefined)
+  return addUsage(direct, modelUsage)
 }
 
 export function createClaudeThreadItemProjector(input: {
@@ -135,6 +176,8 @@ export function createClaudeThreadItemProjector(input: {
   let status = "running"
   let usage: KhalaCodeDesktopUsage | undefined
   let assistantCount = 0
+  const streamBlockIds = new Map<number, string>()
+  const streamBlockKinds = new Map<number, string>()
 
   const appendMessage = (message: KhalaCodeDesktopMessage): void => {
     const existing = messages.findIndex(candidate => candidate.id === message.id)
@@ -182,7 +225,7 @@ export function createClaudeThreadItemProjector(input: {
           event: {
             eventId: `${toolUseId}-started`,
             invocationId: toolUseId,
-            kind: "tool.started",
+            kind: "tool_started",
             payload: block,
             sessionId: input.desktopSessionId,
           },
@@ -207,7 +250,7 @@ export function createClaudeThreadItemProjector(input: {
           event: {
             eventId: `${toolUseId}-completed`,
             invocationId: toolUseId,
-            kind: "tool.completed",
+            kind: "tool_completed",
             payload: block,
             sessionId: input.desktopSessionId,
           },
@@ -219,16 +262,100 @@ export function createClaudeThreadItemProjector(input: {
     return { events, messages, status, toolNames: [...toolNames], usage }
   }
 
+  const projectStreamEvent = (raw: Record<string, unknown>): ClaudeProjectedMessage => {
+    const event = objectField(raw, "event") ?? raw
+    const eventType = stringField(event, "type") ?? stringField(raw, "event_type") ?? ""
+    const indexValue = event.index ?? raw.index
+    const index = typeof indexValue === "number" && Number.isInteger(indexValue) ? indexValue : 0
+    const events: KhalaCodeDesktopChatTurnEvent[] = []
+
+    if (eventType === "content_block_start") {
+      const block = objectField(event, "content_block") ?? objectField(raw, "content_block") ?? {}
+      const blockType = stringField(block, "type") ?? "text"
+      if (blockType !== "text" && blockType !== "thinking") {
+        return { events, messages, status, toolNames: [...toolNames], usage }
+      }
+      const id = `${input.turnId}-claude-stream-${index}`
+      streamBlockIds.set(index, id)
+      streamBlockKinds.set(index, blockType)
+      const message: KhalaCodeDesktopMessage = {
+        body: "",
+        id,
+        role: "assistant",
+        ...(blockType === "thinking" ? {
+          harnessItem: {
+            itemId: id,
+            itemType: "reasoning",
+            status: "running",
+            title: "Claude reasoning",
+          },
+        } : {}),
+      }
+      appendMessage(message)
+      events.push({ message, turnId: input.turnId, type: "message_start" })
+      return { events, messages, status, toolNames: [...toolNames], usage }
+    }
+
+    if (eventType === "content_block_delta") {
+      const delta = objectField(event, "delta") ?? objectField(raw, "delta") ?? event
+      const text = stringField(delta, "text") ?? ""
+      if (text.length === 0) return { events, messages, status, toolNames: [...toolNames], usage }
+      const id = streamBlockIds.get(index) ?? `${input.turnId}-claude-stream-${index}`
+      const blockType = streamBlockKinds.get(index) ?? "text"
+      if (!streamBlockIds.has(index)) {
+        streamBlockIds.set(index, id)
+        streamBlockKinds.set(index, blockType)
+        const message: KhalaCodeDesktopMessage = {
+          body: "",
+          id,
+          role: "assistant",
+          ...(blockType === "thinking" ? {
+            harnessItem: {
+              itemId: id,
+              itemType: "reasoning",
+              status: "running",
+              title: "Claude reasoning",
+            },
+          } : {}),
+        }
+        appendMessage(message)
+        events.push({ message, turnId: input.turnId, type: "message_start" })
+      }
+      const existing = messages.find(message => message.id === id)
+      appendMessage({
+        ...(existing ?? { id, role: "assistant" as const }),
+        body: `${existing?.body ?? ""}${text}`,
+      })
+      events.push({ delta: text, messageId: id, turnId: input.turnId, type: "message_delta" })
+      return { events, messages, status, toolNames: [...toolNames], usage }
+    }
+
+    if (eventType === "content_block_stop") {
+      const id = streamBlockIds.get(index)
+      if (id !== undefined) events.push({ messageId: id, turnId: input.turnId, type: "message_done" })
+      return { events, messages, status, toolNames: [...toolNames], usage }
+    }
+
+    return { events, messages, status, toolNames: [...toolNames], usage }
+  }
+
   return {
     messages: () => messages,
     project(message) {
-      const decoded = S.decodeUnknownSync(ClaudeSdkMessageSchema as never)(message) as Record<string, unknown>
+      if (!isObject(message)) return { events: [], messages, status, toolNames: [...toolNames], usage }
+      if (message.type === "stream_event") return projectStreamEvent(message)
+      let decoded: Record<string, unknown>
+      try {
+        decoded = S.decodeUnknownSync(ClaudeSdkMessageSchema as never)(message) as Record<string, unknown>
+      } catch {
+        return { events: [], messages, status, toolNames: [...toolNames], usage }
+      }
       if (decoded.type === "assistant") return projectAssistant(decoded as Parameters<typeof projectAssistant>[0])
       if (decoded.type === "user") return projectUser(decoded as Parameters<typeof projectUser>[0])
       if (decoded.type === "result") {
         const subtype = typeof decoded.subtype === "string" ? decoded.subtype : ""
-        status = subtype.startsWith("error") ? "failed" : "completed"
-        usage = usageFromClaude(decoded as Record<string, unknown>)
+        status = subtype.startsWith("error") ? "failed" : subtype === "interrupted" ? "interrupted" : "completed"
+        usage = usageFromClaudeResult(message)
         return { events: [], messages, status, toolNames: [...toolNames], usage }
       }
       if (decoded.type === "system" && decoded.subtype === "session_state_changed") {

--- a/clients/khala-code-desktop/src/bun/claude-thread-item-projector.ts
+++ b/clients/khala-code-desktop/src/bun/claude-thread-item-projector.ts
@@ -1,0 +1,243 @@
+import { Schema as S } from "effect"
+
+import type {
+  KhalaCodeDesktopChatTurnEvent,
+  KhalaCodeDesktopMessage,
+  KhalaCodeDesktopUsage,
+} from "../shared/rpc.js"
+
+const ClaudeContentBlock = S.Record(S.String, S.Unknown)
+const UnknownRecord = S.Record(S.String, S.Unknown)
+
+const ClaudeSystemMessage = S.Struct({
+  type: S.Literal("system"),
+  subtype: S.optional(S.String),
+  uuid: S.optional(S.String),
+  session_id: S.optional(S.String),
+})
+
+const ClaudeAssistantMessage = S.Struct({
+  type: S.Literal("assistant"),
+  uuid: S.optional(S.String),
+  session_id: S.optional(S.String),
+  message: S.Struct({
+    content: S.Array(ClaudeContentBlock),
+  }),
+})
+
+const ClaudeUserMessage = S.Struct({
+  type: S.Literal("user"),
+  uuid: S.optional(S.String),
+  session_id: S.optional(S.String),
+  message: S.Struct({
+    content: S.Union([S.String, S.Array(ClaudeContentBlock)]),
+  }),
+})
+
+const ClaudeResultMessage = S.Struct({
+  type: S.Literal("result"),
+  subtype: S.optional(S.String),
+  uuid: S.optional(S.String),
+  session_id: S.optional(S.String),
+  usage: S.optional(UnknownRecord),
+  modelUsage: S.optional(UnknownRecord),
+})
+
+const ClaudeStreamEventMessage = S.Struct({
+  type: S.Literal("stream_event"),
+  uuid: S.optional(S.String),
+  session_id: S.optional(S.String),
+})
+
+const ClaudeSessionStateChangedMessage = S.Struct({
+  type: S.Literal("system"),
+  subtype: S.Literal("session_state_changed"),
+  uuid: S.optional(S.String),
+  session_id: S.optional(S.String),
+  state: S.optional(S.String),
+})
+
+export const ClaudeSdkMessageSchema = S.Union([
+  ClaudeAssistantMessage,
+  ClaudeUserMessage,
+  ClaudeResultMessage,
+  ClaudeStreamEventMessage,
+  ClaudeSessionStateChangedMessage,
+  ClaudeSystemMessage,
+])
+export type ClaudeSdkMessage = typeof ClaudeSdkMessageSchema.Type
+
+export type ClaudeProjectedMessage = {
+  readonly events: readonly KhalaCodeDesktopChatTurnEvent[]
+  readonly messages: readonly KhalaCodeDesktopMessage[]
+  readonly status: string
+  readonly toolNames: readonly string[]
+  readonly usage?: KhalaCodeDesktopUsage | undefined
+}
+
+export type ClaudeThreadItemProjector = Readonly<{
+  messages: () => readonly KhalaCodeDesktopMessage[]
+  project: (message: unknown) => ClaudeProjectedMessage
+  status: () => string
+  toolNames: () => readonly string[]
+  usage: () => KhalaCodeDesktopUsage | undefined
+}>
+
+const stringField = (value: Record<string, unknown>, field: string): string | null => {
+  const candidate = value[field]
+  return typeof candidate === "string" && candidate.length > 0 ? candidate : null
+}
+
+const objectField = (value: Record<string, unknown>, field: string): Record<string, unknown> | null => {
+  const candidate = value[field]
+  return typeof candidate === "object" && candidate !== null && !Array.isArray(candidate)
+    ? candidate as Record<string, unknown>
+    : null
+}
+
+const numberField = (value: Record<string, unknown> | null | undefined, field: string): number => {
+  const candidate = value?.[field]
+  return typeof candidate === "number" && Number.isFinite(candidate) ? candidate : 0
+}
+
+const contentText = (block: Record<string, unknown>): string => {
+  const text = block.text
+  if (typeof text === "string") return text
+  const partial = objectField(block, "delta")
+  const deltaText = partial === null ? null : stringField(partial, "text")
+  return deltaText ?? ""
+}
+
+const messageId = (
+  turnId: string,
+  prefix: string,
+  message: Record<string, unknown>,
+  index: number,
+): string => `${stringField(message, "uuid") ?? turnId}-${prefix}-${index}`
+
+const usageFromClaude = (message: Record<string, unknown>): KhalaCodeDesktopUsage | undefined => {
+  const usage = objectField(message, "usage") ?? objectField(message, "modelUsage")
+  if (usage === null) return undefined
+  const input = numberField(usage, "input_tokens") + numberField(usage, "cache_creation_input_tokens")
+  const cachedInput = numberField(usage, "cache_read_input_tokens")
+  const output = numberField(usage, "output_tokens")
+  const reasoningOutput = numberField(usage, "reasoning_output_tokens")
+  if (input + cachedInput + output + reasoningOutput === 0) return undefined
+  return { input, cachedInput, output, reasoningOutput }
+}
+
+export function createClaudeThreadItemProjector(input: {
+  readonly desktopSessionId: string
+  readonly turnId: string
+}): ClaudeThreadItemProjector {
+  const messages: KhalaCodeDesktopMessage[] = []
+  const toolNames = new Set<string>()
+  let status = "running"
+  let usage: KhalaCodeDesktopUsage | undefined
+  let assistantCount = 0
+
+  const appendMessage = (message: KhalaCodeDesktopMessage): void => {
+    const existing = messages.findIndex(candidate => candidate.id === message.id)
+    if (existing === -1) messages.push(message)
+    else messages[existing] = message
+  }
+
+  const projectAssistant = (decoded: {
+    readonly message: { readonly content: readonly Record<string, unknown>[] }
+    readonly uuid?: string
+  }): ClaudeProjectedMessage => {
+    const events: KhalaCodeDesktopChatTurnEvent[] = []
+    const raw = decoded as Record<string, unknown>
+    const content = decoded.message.content as readonly Record<string, unknown>[]
+    for (const [index, block] of content.entries()) {
+      const blockType = stringField(block, "type") ?? "text"
+      if (blockType === "text" || blockType === "thinking") {
+        const body = contentText(block)
+        if (body.length === 0) continue
+        const id = messageId(input.turnId, blockType, raw, assistantCount++)
+        const message: KhalaCodeDesktopMessage = {
+          body,
+          id,
+          role: "assistant",
+          ...(blockType === "thinking" ? {
+            harnessItem: {
+              itemId: id,
+              itemType: "reasoning",
+              status: "completed",
+              title: "Claude reasoning",
+            },
+          } : {}),
+        }
+        appendMessage(message)
+        events.push({ message: { ...message, body: "" }, turnId: input.turnId, type: "message_start" })
+        events.push({ delta: body, messageId: id, turnId: input.turnId, type: "message_delta" })
+        events.push({ messageId: id, turnId: input.turnId, type: "message_done" })
+        continue
+      }
+      if (blockType === "tool_use") {
+        const toolName = stringField(block, "name") ?? "claude_tool"
+        const toolUseId = stringField(block, "id") ?? `${input.turnId}-claude-tool-${index}`
+        toolNames.add(toolName)
+        events.push({
+          event: {
+            eventId: `${toolUseId}-started`,
+            invocationId: toolUseId,
+            kind: "tool.started",
+            payload: block,
+            sessionId: input.desktopSessionId,
+          },
+          turnId: input.turnId,
+          type: "tool_event",
+        })
+      }
+    }
+    return { events, messages, status, toolNames: [...toolNames], usage }
+  }
+
+  const projectUser = (decoded: {
+    readonly message: { readonly content: string | readonly Record<string, unknown>[] }
+  }): ClaudeProjectedMessage => {
+    const events: KhalaCodeDesktopChatTurnEvent[] = []
+    const content = decoded.message.content
+    if (Array.isArray(content)) {
+      for (const [index, block] of content.entries()) {
+        if (stringField(block, "type") !== "tool_result") continue
+        const toolUseId = stringField(block, "tool_use_id") ?? `${input.turnId}-claude-tool-result-${index}`
+        events.push({
+          event: {
+            eventId: `${toolUseId}-completed`,
+            invocationId: toolUseId,
+            kind: "tool.completed",
+            payload: block,
+            sessionId: input.desktopSessionId,
+          },
+          turnId: input.turnId,
+          type: "tool_event",
+        })
+      }
+    }
+    return { events, messages, status, toolNames: [...toolNames], usage }
+  }
+
+  return {
+    messages: () => messages,
+    project(message) {
+      const decoded = S.decodeUnknownSync(ClaudeSdkMessageSchema as never)(message) as Record<string, unknown>
+      if (decoded.type === "assistant") return projectAssistant(decoded as Parameters<typeof projectAssistant>[0])
+      if (decoded.type === "user") return projectUser(decoded as Parameters<typeof projectUser>[0])
+      if (decoded.type === "result") {
+        const subtype = typeof decoded.subtype === "string" ? decoded.subtype : ""
+        status = subtype.startsWith("error") ? "failed" : "completed"
+        usage = usageFromClaude(decoded as Record<string, unknown>)
+        return { events: [], messages, status, toolNames: [...toolNames], usage }
+      }
+      if (decoded.type === "system" && decoded.subtype === "session_state_changed") {
+        status = typeof decoded.state === "string" ? decoded.state : status
+      }
+      return { events: [], messages, status, toolNames: [...toolNames], usage }
+    },
+    status: () => status,
+    toolNames: () => [...toolNames],
+    usage: () => usage,
+  }
+}

--- a/clients/khala-code-desktop/src/bun/headless.ts
+++ b/clients/khala-code-desktop/src/bun/headless.ts
@@ -20,7 +20,10 @@ export type KhalaCodeDesktopHeadlessChatRuntime = Pick<
 export type KhalaCodeDesktopHeadlessCodexRuntime = KhalaCodeDesktopHeadlessChatRuntime
 
 export type KhalaCodeDesktopHeadlessRunInput = {
-  readonly createCodexChatRuntime: (input: {
+  readonly createChatRuntime?: (input: {
+    readonly onEvent: (event: KhalaCodeDesktopChatTurnEvent) => void
+  }) => KhalaCodeDesktopHeadlessChatRuntime
+  readonly createCodexChatRuntime?: (input: {
     readonly onEvent: (event: KhalaCodeDesktopChatTurnEvent) => void
   }) => KhalaCodeDesktopHeadlessChatRuntime
   readonly env: Readonly<Record<string, string | undefined>>
@@ -55,13 +58,15 @@ export async function runKhalaCodeDesktopHeadlessJsonl(
       emitJsonl(threadEvent)
     }
   }
-  const codexChatRuntime = input.createCodexChatRuntime({ onEvent })
+  const createRuntime = input.createChatRuntime ?? input.createCodexChatRuntime
+  if (createRuntime === undefined) throw new Error("Headless chat runtime factory is not configured.")
+  const chatRuntime = createRuntime({ onEvent })
 
   let threadId: string | undefined
   let interruptTimer: ReturnType<typeof setTimeout> | undefined
 
   try {
-    const thread = await codexChatRuntime.startThread({
+    const thread = await chatRuntime.startThread({
       sessionId,
       ...(input.workingDirectory === undefined ? {} : { cwd: input.workingDirectory }),
     })
@@ -71,11 +76,11 @@ export async function runKhalaCodeDesktopHeadlessJsonl(
 
     if (input.interruptAfterMs !== undefined && input.interruptAfterMs >= 0) {
       interruptTimer = setTimeout(() => {
-        void codexChatRuntime.interruptTurn({ sessionId, turnId }).catch(() => undefined)
+        void chatRuntime.interruptTurn({ sessionId, turnId }).catch(() => undefined)
       }, input.interruptAfterMs)
     }
 
-    const response = await codexChatRuntime.startTurn({
+    const response = await chatRuntime.startTurn({
       messages: [{ body: input.prompt, id: "headless-user-1", role: "user" }],
       sessionId,
       ...(threadId === undefined ? {} : { threadId }),

--- a/clients/khala-code-desktop/src/bun/index.ts
+++ b/clients/khala-code-desktop/src/bun/index.ts
@@ -21,6 +21,7 @@ import {
   runKhalaCodeDesktopHeadlessJsonl,
 } from "./headless.js"
 import { createCodexAppServerChatRuntime } from "./codex-app-server-chat-runtime.js"
+import { createClaudeAppSdkChatRuntime } from "./claude-app-sdk-chat-runtime.js"
 import { createCodexAppServerHost } from "./codex-app-server-client.js"
 import {
   createKhalaCodeDesktopCodexMessageTokenAuditRecorder,
@@ -419,16 +420,22 @@ if (argv.includes("--json")) {
   let exitCode = 0
   try {
     await runKhalaCodeDesktopHeadlessJsonl({
-      createCodexChatRuntime: ({ onEvent }) =>
-        createCodexAppServerChatRuntime({
-          env: khalaCodeEnv,
-          host: headlessCodexAppServerHost,
-          onEvent,
-          messageTokenAuditRecorder:
-            createKhalaCodeDesktopCodexMessageTokenAuditRecorder({ env: khalaCodeEnv }),
-          tokenUsageReporter: createKhalaCodeDesktopCodexTokenUsageReporter({ env: khalaCodeEnv }),
-          workingDirectory,
-        }),
+      createChatRuntime: ({ onEvent }) =>
+        khalaCodeEnv.KHALA_CODE_DESKTOP_RUNTIME === "claude_runtime"
+          ? createClaudeAppSdkChatRuntime({
+            env: khalaCodeEnv,
+            onEvent,
+            workingDirectory,
+          })
+          : createCodexAppServerChatRuntime({
+            env: khalaCodeEnv,
+            host: headlessCodexAppServerHost,
+            onEvent,
+            messageTokenAuditRecorder:
+              createKhalaCodeDesktopCodexMessageTokenAuditRecorder({ env: khalaCodeEnv }),
+            tokenUsageReporter: createKhalaCodeDesktopCodexTokenUsageReporter({ env: khalaCodeEnv }),
+            workingDirectory,
+          }),
       env: khalaCodeEnv,
       ...(interruptAfterMs === undefined ? {} : { interruptAfterMs }),
       prompt,

--- a/clients/khala-code-desktop/src/bun/rpc-handlers.ts
+++ b/clients/khala-code-desktop/src/bun/rpc-handlers.ts
@@ -768,11 +768,19 @@ export function createKhalaCodeDesktopRpcRequestHandlers(
     }
     return codexChatRuntime
   }
-  const requireClaudeChatRuntime = (): ChatRuntime => input.claudeChatRuntime ?? createClaudeAppSdkChatRuntime({
-    env: input.env,
-    ...(input.emitChatTurnEvent === undefined ? {} : { onEvent: input.emitChatTurnEvent }),
-    workingDirectory: input.workingDirectory,
-  })
+  // Memoized: interrupt must see the SAME runtime instance (and its
+  // activeTurns map) that started the turn — a fresh instance per RPC call
+  // makes stop a no-op in claude_runtime mode.
+  let lazyClaudeChatRuntime: ChatRuntime | undefined
+  const requireClaudeChatRuntime = (): ChatRuntime => {
+    if (input.claudeChatRuntime !== undefined) return input.claudeChatRuntime
+    lazyClaudeChatRuntime ??= createClaudeAppSdkChatRuntime({
+      env: input.env,
+      ...(input.emitChatTurnEvent === undefined ? {} : { onEvent: input.emitChatTurnEvent }),
+      workingDirectory: input.workingDirectory,
+    })
+    return lazyClaudeChatRuntime
+  }
   const requireFleetRunSupervisor = (): KhalaCodeDesktopFleetRunSupervisorRpc => {
     if (input.fleetRunSupervisor === undefined) {
       throw new Error("Fleet run supervisor is not configured.")

--- a/clients/khala-code-desktop/src/bun/rpc-handlers.ts
+++ b/clients/khala-code-desktop/src/bun/rpc-handlers.ts
@@ -611,6 +611,7 @@ const delegateRunStepSummary = (
     case "verify_closeout":
       return `Closeout verification ${status}.`
   }
+  return `Delegate run step ${status}.`
 }
 
 const projectDelegateRunStep = (
@@ -767,7 +768,7 @@ export function createKhalaCodeDesktopRpcRequestHandlers(
     }
     return codexChatRuntime
   }
-  const claudeChatRuntime = input.claudeChatRuntime ?? createClaudeAppSdkChatRuntime({
+  const requireClaudeChatRuntime = (): ChatRuntime => input.claudeChatRuntime ?? createClaudeAppSdkChatRuntime({
     env: input.env,
     ...(input.emitChatTurnEvent === undefined ? {} : { onEvent: input.emitChatTurnEvent }),
     workingDirectory: input.workingDirectory,
@@ -780,7 +781,7 @@ export function createKhalaCodeDesktopRpcRequestHandlers(
   }
   const selectChatRuntime = (): ChatRuntimeSelection => {
     if (input.env.KHALA_CODE_DESKTOP_RUNTIME === "claude_runtime") {
-      return { kind: "claude", runtime: claudeChatRuntime }
+      return { kind: "claude", runtime: requireClaudeChatRuntime() }
     }
     if (
       input.env.KHALA_CODE_DESKTOP_RUNTIME === "khala_native_runtime" ||
@@ -2094,7 +2095,7 @@ export function createKhalaCodeDesktopRpcRequestHandlers(
       return selection.runtime.steerTurn(request)
     },
     async codingStatus() {
-      if (selectChatRuntime().kind === "claude") {
+      if (input.env.KHALA_CODE_DESKTOP_RUNTIME === "claude_runtime") {
         const harness = await claudeHarnessStatus()
         return runtimeStatus({
           available: harness.available,

--- a/clients/khala-code-desktop/src/bun/rpc-handlers.ts
+++ b/clients/khala-code-desktop/src/bun/rpc-handlers.ts
@@ -91,6 +91,8 @@ import {
   parseKhalaCodeDesktopSlashCommand,
 } from "../shared/codex-slash-commands.js"
 import { inspectCodexHarnessStatus } from "./codex-harness-status.js"
+import { createClaudeAppSdkChatRuntime } from "./claude-app-sdk-chat-runtime.js"
+import { inspectClaudeHarnessStatus } from "./claude-harness-status.js"
 import {
   consumeKhalaCodexRateLimitResetCredit,
   fetchKhalaCodexRateLimitStatus,
@@ -127,7 +129,6 @@ type ChatRuntimeSelection =
     readonly kind: "legacy"
   }
 
-const claudeRuntimeUnsupportedMessage = "Claude app SDK chat runtime is not supported until T8.2."
 const legacyThreadLifecycleUnsupportedMessage =
   "Legacy Khala native runtime does not support thread lifecycle RPCs."
 
@@ -160,6 +161,7 @@ export type KhalaCodeDesktopRpcHandlersInput = {
   readonly appleFmReadiness: () => MaybePromise<KhalaAppleFmReadiness>
   readonly codexAppServerHost?: CodexAppServerHost
   readonly codexChatRuntime?: CodexAppServerChatRuntime
+  readonly claudeChatRuntime?: CodexAppServerChatRuntime
   readonly enableFleetMcpBridge?: boolean
   readonly codexRateLimitStatus?: () => MaybePromise<KhalaCodexRateLimitProviderStatus>
   readonly codexHarnessStatus?: () => MaybePromise<KhalaCodeDesktopCodexHarnessStatus>
@@ -765,27 +767,11 @@ export function createKhalaCodeDesktopRpcRequestHandlers(
     }
     return codexChatRuntime
   }
-  const unsupportedClaudeRuntime = (): ChatRuntime => {
-    const unsupported = async (): Promise<never> => {
-      throw new Error(claudeRuntimeUnsupportedMessage)
-    }
-    return {
-      archiveThread: unsupported,
-      compactThread: unsupported,
-      deleteThread: unsupported,
-      forkThread: unsupported,
-      interruptTurn: unsupported,
-      listThreads: unsupported,
-      readThread: unsupported,
-      renameThread: unsupported,
-      resumeThread: unsupported,
-      startThread: unsupported,
-      startTurn: unsupported,
-      steerTurn: unsupported,
-      threadIdForSession: async () => null,
-      unarchiveThread: unsupported,
-    }
-  }
+  const claudeChatRuntime = input.claudeChatRuntime ?? createClaudeAppSdkChatRuntime({
+    env: input.env,
+    ...(input.emitChatTurnEvent === undefined ? {} : { onEvent: input.emitChatTurnEvent }),
+    workingDirectory: input.workingDirectory,
+  })
   const requireFleetRunSupervisor = (): KhalaCodeDesktopFleetRunSupervisorRpc => {
     if (input.fleetRunSupervisor === undefined) {
       throw new Error("Fleet run supervisor is not configured.")
@@ -794,7 +780,7 @@ export function createKhalaCodeDesktopRpcRequestHandlers(
   }
   const selectChatRuntime = (): ChatRuntimeSelection => {
     if (input.env.KHALA_CODE_DESKTOP_RUNTIME === "claude_runtime") {
-      return { kind: "claude", runtime: unsupportedClaudeRuntime() }
+      return { kind: "claude", runtime: claudeChatRuntime }
     }
     if (
       input.env.KHALA_CODE_DESKTOP_RUNTIME === "khala_native_runtime" ||
@@ -889,25 +875,6 @@ export function createKhalaCodeDesktopRpcRequestHandlers(
     }
   }
 
-  const unsupportedClaudeChatResponse = (): KhalaCodeDesktopChatTurnResponse => ({
-    backend: {
-      blockerRefs: ["blocker.claude_app_sdk.unsupported_until_t8_2"],
-      kind: "claude_app_sdk",
-      model: "claude-app-sdk",
-      runtimeMode: "claude_runtime",
-      toolCatalogKind: "codex_harness_supplemental",
-      turnStatus: "unsupported",
-    },
-    messages: [{
-      id: `claude-runtime-unsupported-${Date.now().toString(36)}`,
-      role: "system",
-      body: claudeRuntimeUnsupportedMessage,
-    }],
-    ok: false,
-    toolNames: [],
-    usedTools: [],
-  })
-
   const unsupportedLegacyThreadLifecycle = async (): Promise<never> => {
     throw new Error(legacyThreadLifecycleUnsupportedMessage)
   }
@@ -932,6 +899,8 @@ export function createKhalaCodeDesktopRpcRequestHandlers(
   const codexHarnessStatus = async (): Promise<KhalaCodeDesktopCodexHarnessStatus> =>
     input.codexHarnessStatus?.() ??
     inspectCodexHarnessStatus({ env: input.env as NodeJS.ProcessEnv })
+  const claudeHarnessStatus = async () =>
+    inspectClaudeHarnessStatus({ env: input.env })
 
   const codexAccountsStatus = async (): Promise<KhalaCodeDesktopCodexAccountsStatus> => {
     const harness = await codexHarnessStatus()
@@ -2114,7 +2083,6 @@ export function createKhalaCodeDesktopRpcRequestHandlers(
           workingDirectory: request.cwd ?? input.workingDirectory,
         }))
       }
-      if (selection.kind === "claude") return unsupportedClaudeChatResponse()
       return selection.runtime.startTurn({
         ...request,
         cwd: request.cwd ?? input.workingDirectory,
@@ -2126,6 +2094,15 @@ export function createKhalaCodeDesktopRpcRequestHandlers(
       return selection.runtime.steerTurn(request)
     },
     async codingStatus() {
+      if (selectChatRuntime().kind === "claude") {
+        const harness = await claudeHarnessStatus()
+        return runtimeStatus({
+          available: harness.available,
+          capability: "coding",
+          reason: harness.reason,
+          status: harness.available ? "ready" : "unavailable",
+        })
+      }
       const harness = await codexHarnessStatus()
       if (!harness.available) {
         return runtimeStatus({
@@ -2199,7 +2176,12 @@ export function createKhalaCodeDesktopRpcRequestHandlers(
               cwd: input.workingDirectory,
             })), bridge)
           }
-          if (selection.kind === "claude") return unsupportedClaudeChatResponse()
+          if (selection.kind === "claude") {
+            return selection.runtime.startTurn({
+              ...materializedRequest,
+              cwd: input.workingDirectory,
+            })
+          }
           return labelLegacyRuntimeResponse(await legacyChatTurn({
             env: input.env,
             ...(input.emitChatTurnEvent === undefined ? {} : { onEvent: input.emitChatTurnEvent }),

--- a/clients/khala-code-desktop/tests/claude-app-sdk-chat-runtime.test.ts
+++ b/clients/khala-code-desktop/tests/claude-app-sdk-chat-runtime.test.ts
@@ -1,0 +1,212 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { mkdtemp, readFile, rm } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+import { createClaudeAppSdkChatRuntime } from "../src/bun/claude-app-sdk-chat-runtime"
+import { createClaudeSessionStore } from "../src/bun/claude-session-store"
+import { createClaudeThreadItemProjector } from "../src/bun/claude-thread-item-projector"
+import type { KhalaCodeDesktopChatTurnEvent } from "../src/shared/rpc"
+
+const tempDirs: string[] = []
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map(dir => rm(dir, { force: true, recursive: true })))
+})
+
+async function tempPath(name: string): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "khala-code-claude-"))
+  tempDirs.push(dir)
+  return join(dir, name)
+}
+
+async function* messages(items: readonly unknown[]): AsyncGenerator<unknown> {
+  for (const item of items) yield item
+}
+
+describe("Claude Agent SDK chat runtime", () => {
+  test("projects SDK text reasoning tools and usage into neutral turn events", () => {
+    const projector = createClaudeThreadItemProjector({
+      desktopSessionId: "desktop-session-1",
+      turnId: "desktop-turn-1",
+    })
+
+    const first = projector.project({
+      type: "assistant",
+      uuid: "assistant-message-1",
+      session_id: "claude-session-1",
+      message: {
+        content: [
+          { type: "thinking", text: "checking constraints" },
+          { type: "text", text: "Hello from Claude" },
+          { type: "tool_use", id: "tool-use-1", name: "Bash", input: { command: "pwd" } },
+        ],
+      },
+    })
+    const second = projector.project({
+      type: "user",
+      uuid: "tool-result-message-1",
+      session_id: "claude-session-1",
+      message: {
+        content: [{ type: "tool_result", tool_use_id: "tool-use-1", content: "ok" }],
+      },
+    })
+    const done = projector.project({
+      type: "result",
+      subtype: "success",
+      uuid: "result-1",
+      session_id: "claude-session-1",
+      usage: {
+        input_tokens: 7,
+        cache_read_input_tokens: 2,
+        output_tokens: 11,
+        reasoning_output_tokens: 3,
+      },
+    })
+
+    expect(first.events.map(event => event.type)).toEqual([
+      "message_start",
+      "message_delta",
+      "message_done",
+      "message_start",
+      "message_delta",
+      "message_done",
+      "tool_event",
+    ])
+    expect(second.events[0]).toMatchObject({
+      event: { invocationId: "tool-use-1", kind: "tool.completed" },
+      type: "tool_event",
+    })
+    expect(projector.messages().map(message => message.body)).toEqual([
+      "checking constraints",
+      "Hello from Claude",
+    ])
+    expect(done.usage).toEqual({
+      cachedInput: 2,
+      input: 7,
+      output: 11,
+      reasoningOutput: 3,
+    })
+    expect(projector.toolNames()).toEqual(["Bash"])
+  })
+
+  test("persists desktop session mapping in the v1 Claude session store", async () => {
+    const statePath = await tempPath("claude-sessions.json")
+    const store = createClaudeSessionStore({
+      now: () => new Date("2026-07-01T12:00:00.000Z"),
+      path: statePath,
+    })
+
+    await store.put("desktop-session-1", {
+      sessionId: "claude-session-1",
+      lastTurnId: "turn-1",
+    })
+
+    expect(await store.get("desktop-session-1")).toEqual({
+      sessionId: "claude-session-1",
+      lastTurnId: "turn-1",
+      updatedAt: "2026-07-01T12:00:00.000Z",
+    })
+    expect(JSON.parse(await readFile(statePath, "utf8"))).toMatchObject({
+      schema: "khala-code-desktop.claude-sessions.v1",
+      sessions: {
+        "desktop-session-1": { sessionId: "claude-session-1" },
+      },
+    })
+  })
+
+  test("streams a mocked SDK query and resumes by persisted Claude session id", async () => {
+    const statePath = await tempPath("claude-runtime-state.json")
+    const events: KhalaCodeDesktopChatTurnEvent[] = []
+    const queryCalls: unknown[] = []
+    const runtime = createClaudeAppSdkChatRuntime({
+      onEvent: event => events.push(event),
+      query: input => {
+        queryCalls.push(input)
+        return messages([
+          {
+            type: "assistant",
+            uuid: "assistant-1",
+            session_id: "claude-session-1",
+            message: { content: [{ type: "text", text: "First turn" }] },
+          },
+          { type: "result", subtype: "success", session_id: "claude-session-1" },
+        ])
+      },
+      sessionStore: createClaudeSessionStore({ path: statePath }),
+      workingDirectory: "/repo",
+    })
+
+    const first = await runtime.startTurn({
+      messages: [{ body: "hello", id: "user-1", role: "user" }],
+      sessionId: "desktop-session-1",
+      turnId: "turn-1",
+    })
+    const second = await runtime.startTurn({
+      messages: [{ body: "again", id: "user-2", role: "user" }],
+      sessionId: "desktop-session-1",
+      turnId: "turn-2",
+    })
+
+    expect(first.backend).toMatchObject({
+      kind: "claude_app_sdk",
+      runtimeMode: "claude_runtime",
+      threadId: "claude-session-1",
+    })
+    expect(second.backend.threadId).toBe("claude-session-1")
+    expect((queryCalls[1] as { options: Record<string, unknown> }).options).toMatchObject({
+      resume: "claude-session-1",
+      sessionId: "claude-session-1",
+    })
+    expect(events.map(event => event.type)).toContain("message_delta")
+  })
+
+  test("interrupts the active SDK query handle", async () => {
+    let interrupted = false
+    let release!: () => void
+    const released = new Promise<void>(resolve => {
+      release = resolve
+    })
+    let queryStarted!: () => void
+    const started = new Promise<void>(resolve => {
+      queryStarted = resolve
+    })
+    const runtime = createClaudeAppSdkChatRuntime({
+      query: () => {
+        queryStarted()
+        return {
+          async *[Symbol.asyncIterator]() {
+            await released
+            yield { type: "result", subtype: "success", session_id: "claude-session-interrupt" }
+          },
+          interrupt: async () => {
+            interrupted = true
+            release()
+          },
+          close: async () => undefined,
+        }
+      },
+      workingDirectory: "/repo",
+    })
+
+    const turn = runtime.startTurn({
+      messages: [{ body: "wait", id: "user-1", role: "user" }],
+      sessionId: "desktop-session-interrupt",
+      turnId: "turn-interrupt",
+    })
+    await started
+    await new Promise(resolve => setTimeout(resolve, 0))
+    const interruptedResult = await runtime.interruptTurn({
+      sessionId: "desktop-session-interrupt",
+      turnId: "turn-interrupt",
+    })
+    await turn
+
+    expect(interrupted).toBe(true)
+    expect(interruptedResult).toMatchObject({
+      ok: true,
+      desktopTurnId: "turn-interrupt",
+    })
+  })
+
+})

--- a/clients/khala-code-desktop/tests/claude-app-sdk-chat-runtime.test.ts
+++ b/clients/khala-code-desktop/tests/claude-app-sdk-chat-runtime.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os"
 import { join } from "node:path"
 
 import { createClaudeAppSdkChatRuntime } from "../src/bun/claude-app-sdk-chat-runtime"
+import { CLAUDE_APP_SDK_GAP_MATRIX } from "../src/bun/claude-app-sdk-gap-matrix"
 import { createClaudeSessionStore } from "../src/bun/claude-session-store"
 import { createClaudeThreadItemProjector } from "../src/bun/claude-thread-item-projector"
 import type { KhalaCodeDesktopChatTurnEvent } from "../src/shared/rpc"
@@ -74,7 +75,7 @@ describe("Claude Agent SDK chat runtime", () => {
       "tool_event",
     ])
     expect(second.events[0]).toMatchObject({
-      event: { invocationId: "tool-use-1", kind: "tool.completed" },
+      event: { invocationId: "tool-use-1", kind: "tool_completed" },
       type: "tool_event",
     })
     expect(projector.messages().map(message => message.body)).toEqual([
@@ -88,6 +89,87 @@ describe("Claude Agent SDK chat runtime", () => {
       reasoningOutput: 3,
     })
     expect(projector.toolNames()).toEqual(["Bash"])
+  })
+
+  test("skips unmodeled SDK messages and renders stream_event deltas", () => {
+    const projector = createClaudeThreadItemProjector({
+      desktopSessionId: "desktop-session-stream",
+      turnId: "desktop-turn-stream",
+    })
+
+    expect(projector.project({ type: "rate_limit_event", uuid: "rate-limit-1" }).events).toEqual([])
+    projector.project({
+      event: {
+        content_block: { type: "text" },
+        index: 0,
+        type: "content_block_start",
+      },
+      session_id: "claude-session-stream",
+      type: "stream_event",
+      uuid: "stream-start",
+    })
+    const delta = projector.project({
+      event: {
+        delta: { text: "partial text", type: "text_delta" },
+        index: 0,
+        type: "content_block_delta",
+      },
+      session_id: "claude-session-stream",
+      type: "stream_event",
+      uuid: "stream-delta",
+    })
+    const done = projector.project({
+      event: {
+        index: 0,
+        type: "content_block_stop",
+      },
+      session_id: "claude-session-stream",
+      type: "stream_event",
+      uuid: "stream-stop",
+    })
+
+    expect(delta.events).toContainEqual({
+      delta: "partial text",
+      messageId: "desktop-turn-stream-claude-stream-0",
+      turnId: "desktop-turn-stream",
+      type: "message_delta",
+    })
+    expect(done.events).toContainEqual({
+      messageId: "desktop-turn-stream-claude-stream-0",
+      turnId: "desktop-turn-stream",
+      type: "message_done",
+    })
+    expect(projector.messages()).toMatchObject([{ body: "partial text" }])
+  })
+
+  test("captures SDK modelUsage from interrupted results", () => {
+    const projector = createClaudeThreadItemProjector({
+      desktopSessionId: "desktop-session-usage",
+      turnId: "desktop-turn-usage",
+    })
+
+    const result = projector.project({
+      modelUsage: {
+        "claude-opus-4": {
+          cache_read_input_tokens: 5,
+          input_tokens: 10,
+          output_tokens: 7,
+          reasoning_output_tokens: 2,
+        },
+      },
+      session_id: "claude-session-usage",
+      subtype: "interrupted",
+      type: "result",
+      uuid: "result-usage",
+    })
+
+    expect(result.status).toBe("interrupted")
+    expect(result.usage).toEqual({
+      cachedInput: 5,
+      input: 10,
+      output: 7,
+      reasoningOutput: 2,
+    })
   })
 
   test("persists desktop session mapping in the v1 Claude session store", async () => {
@@ -115,7 +197,7 @@ describe("Claude Agent SDK chat runtime", () => {
     })
   })
 
-  test("streams a mocked SDK query and resumes by persisted Claude session id", async () => {
+  test("starts fresh sessions with sessionId and resumes later turns with resume alone", async () => {
     const statePath = await tempPath("claude-runtime-state.json")
     const events: KhalaCodeDesktopChatTurnEvent[] = []
     const queryCalls: unknown[] = []
@@ -156,12 +238,40 @@ describe("Claude Agent SDK chat runtime", () => {
     expect(second.backend.threadId).toBe("claude-session-1")
     expect((queryCalls[1] as { options: Record<string, unknown> }).options).toMatchObject({
       resume: "claude-session-1",
-      sessionId: "claude-session-1",
     })
+    expect((queryCalls[1] as { options: Record<string, unknown> }).options).not.toHaveProperty("sessionId")
     expect(events.map(event => event.type)).toContain("message_delta")
   })
 
+  test("startThread then startTurn sends only the fresh sessionId", async () => {
+    const statePath = await tempPath("claude-start-thread-state.json")
+    const queryCalls: unknown[] = []
+    const runtime = createClaudeAppSdkChatRuntime({
+      query: input => {
+        queryCalls.push(input)
+        return messages([
+          { type: "result", subtype: "success", session_id: "desktop-session-started" },
+        ])
+      },
+      sessionStore: createClaudeSessionStore({ path: statePath }),
+      workingDirectory: "/repo",
+    })
+
+    await runtime.startThread({ sessionId: "desktop-session-started" })
+    await runtime.startTurn({
+      messages: [{ body: "hello", id: "user-started", role: "user" }],
+      sessionId: "desktop-session-started",
+      turnId: "turn-started",
+    })
+
+    expect((queryCalls[0] as { options: Record<string, unknown> }).options).toMatchObject({
+      sessionId: "desktop-session-started",
+    })
+    expect((queryCalls[0] as { options: Record<string, unknown> }).options).not.toHaveProperty("resume")
+  })
+
   test("interrupts the active SDK query handle", async () => {
+    const statePath = await tempPath("claude-interrupt-state.json")
     let interrupted = false
     let release!: () => void
     const released = new Promise<void>(resolve => {
@@ -186,6 +296,7 @@ describe("Claude Agent SDK chat runtime", () => {
           close: async () => undefined,
         }
       },
+      sessionStore: createClaudeSessionStore({ path: statePath }),
       workingDirectory: "/repo",
     })
 
@@ -209,4 +320,63 @@ describe("Claude Agent SDK chat runtime", () => {
     })
   })
 
+  test("does not report interrupt success when the SDK handle has no interrupt method", async () => {
+    const statePath = await tempPath("claude-no-interrupt-state.json")
+    let release!: () => void
+    const released = new Promise<void>(resolve => {
+      release = resolve
+    })
+    let queryStarted!: () => void
+    const started = new Promise<void>(resolve => {
+      queryStarted = resolve
+    })
+    const runtime = createClaudeAppSdkChatRuntime({
+      query: () => {
+        queryStarted()
+        return {
+          async *[Symbol.asyncIterator]() {
+            await released
+            yield { type: "result", subtype: "success", session_id: "claude-session-no-interrupt" }
+          },
+          close: async () => {
+            release()
+          },
+        }
+      },
+      sessionStore: createClaudeSessionStore({ path: statePath }),
+      workingDirectory: "/repo",
+    })
+
+    const turn = runtime.startTurn({
+      messages: [{ body: "wait", id: "user-no-interrupt", role: "user" }],
+      sessionId: "desktop-session-no-interrupt",
+      turnId: "turn-no-interrupt",
+    })
+    await started
+    await new Promise(resolve => setTimeout(resolve, 0))
+    const interruptedResult = await runtime.interruptTurn({
+      sessionId: "desktop-session-no-interrupt",
+      turnId: "turn-no-interrupt",
+    })
+    await turn
+
+    expect(interruptedResult).toMatchObject({
+      ok: false,
+      desktopTurnId: "turn-no-interrupt",
+      error: "Claude Agent SDK query does not expose interrupt().",
+    })
+  })
+
+  test("imports the Claude SDK gap matrix into the checked runtime surface", () => {
+    expect(CLAUDE_APP_SDK_GAP_MATRIX.map(row => row.id)).toEqual([
+      "claude.phase1.chat_stream",
+      "claude.phase1.interrupt",
+      "claude.phase1.session_resume",
+      "claude.phase2.approvals",
+      "claude.phase2.telemetry_ingest",
+      "claude.phase3.sidebar_catalog",
+    ])
+    expect(CLAUDE_APP_SDK_GAP_MATRIX.filter(row => row.status === "covered").map(row => row.phase))
+      .toEqual(["phase_1", "phase_1", "phase_1"])
+  })
 })

--- a/clients/khala-code-desktop/tests/rpc-handlers.test.ts
+++ b/clients/khala-code-desktop/tests/rpc-handlers.test.ts
@@ -839,11 +839,29 @@ describe("Khala Code desktop RPC handlers", () => {
     expect(codexTurnStarted).toBe(true)
   })
 
-  test("returns a typed unsupported response for the Claude runtime seam", async () => {
+  test("routes chat turns through the Claude runtime seam", async () => {
+    const claudeRuntime = throwingCodexChatRuntime({
+      startTurn: async request => ({
+        backend: {
+          kind: "claude_app_sdk",
+          model: "claude-app-sdk",
+          runtimeMode: "claude_runtime",
+          threadId: request.threadId ?? "claude-session-selected",
+          toolCatalogKind: "codex_harness_supplemental",
+          turnId: request.turnId ?? "claude-turn-selected",
+          turnStatus: "completed",
+        },
+        messages: [{ id: "claude-message-selected", role: "assistant", body: "selected claude" }],
+        ok: true,
+        toolNames: [],
+        usedTools: [],
+      }),
+    })
     const handlers = createKhalaCodeDesktopRpcRequestHandlers({
       appleFmReadiness: () => {
         throw new Error("not used")
       },
+      claudeChatRuntime: claudeRuntime,
       codexChatRuntime: throwingCodexChatRuntime(),
       env: { KHALA_CODE_DESKTOP_RUNTIME: "claude_runtime" },
       legacyChatTurn: async (): Promise<KhalaCodeDesktopChatTurnResponse> => {
@@ -861,13 +879,12 @@ describe("Khala Code desktop RPC handlers", () => {
       turnId: "desktop-turn-claude",
     })).resolves.toMatchObject({
       backend: {
-        blockerRefs: ["blocker.claude_app_sdk.unsupported_until_t8_2"],
         kind: "claude_app_sdk",
         runtimeMode: "claude_runtime",
-        turnStatus: "unsupported",
+        turnStatus: "completed",
       },
-      messages: [{ body: "Claude app SDK chat runtime is not supported until T8.2." }],
-      ok: false,
+      messages: [{ body: "selected claude" }],
+      ok: true,
     })
 
     await expect(handlers.codexTurnStart({
@@ -878,17 +895,35 @@ describe("Khala Code desktop RPC handlers", () => {
       backend: {
         kind: "claude_app_sdk",
         runtimeMode: "claude_runtime",
-        turnStatus: "unsupported",
+        turnStatus: "completed",
       },
-      ok: false,
+      ok: true,
     })
   })
 
   test("routes thread lifecycle RPCs through the selected Claude seam", async () => {
+    let started = false
+    let listed = false
+    const claudeRuntime = throwingCodexChatRuntime({
+      startThread: async request => {
+        started = true
+        return {
+          ok: true,
+          desktopSessionId: request.sessionId,
+          thread: { id: "claude-thread-selected" },
+          threadId: "claude-thread-selected",
+        }
+      },
+      listThreads: async () => {
+        listed = true
+        return { ok: true, threads: [] }
+      },
+    })
     const handlers = createKhalaCodeDesktopRpcRequestHandlers({
       appleFmReadiness: () => {
         throw new Error("not used")
       },
+      claudeChatRuntime: claudeRuntime,
       codexChatRuntime: throwingCodexChatRuntime(),
       env: { KHALA_CODE_DESKTOP_RUNTIME: "claude_runtime" },
       onDeviceDeciderStatus: () => {
@@ -898,9 +933,11 @@ describe("Khala Code desktop RPC handlers", () => {
     })
 
     await expect(handlers.codexThreadStart({ sessionId: "desktop-session-claude" }))
-      .rejects.toThrow("Claude app SDK chat runtime is not supported until T8.2.")
+      .resolves.toMatchObject({ ok: true, threadId: "claude-thread-selected" })
     await expect(handlers.codexThreadList({ sessionId: "desktop-session-claude" }))
-      .rejects.toThrow("Claude app SDK chat runtime is not supported until T8.2.")
+      .resolves.toMatchObject({ ok: true, threads: [] })
+    expect(started).toBe(true)
+    expect(listed).toBe(true)
   })
 
   test("registers the Khala Fleet MCP bridge before default Codex chat turns", async () => {

--- a/clients/khala-code-desktop/tests/rpc-handlers.test.ts
+++ b/clients/khala-code-desktop/tests/rpc-handlers.test.ts
@@ -909,14 +909,14 @@ describe("Khala Code desktop RPC handlers", () => {
         started = true
         return {
           ok: true,
-          desktopSessionId: request.sessionId,
+          desktopSessionId: request?.sessionId ?? "desktop-session-claude",
           thread: { id: "claude-thread-selected" },
           threadId: "claude-thread-selected",
         }
       },
       listThreads: async () => {
         listed = true
-        return { ok: true, threads: [] }
+        return { data: [], ok: true, threads: [] }
       },
     })
     const handlers = createKhalaCodeDesktopRpcRequestHandlers({

--- a/clients/khala-code-desktop/tsconfig.typecheck.json
+++ b/clients/khala-code-desktop/tsconfig.typecheck.json
@@ -2,6 +2,15 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "paths": {
+      "@openagentsinc/agent-runtime-schema": ["../../packages/agent-runtime-schema/src/index.ts"],
+      "@openagentsinc/arbiter-effect": ["../../packages/arbiter-effect/src/index.ts"],
+      "@openagentsinc/arbiter-effect/*": ["../../packages/arbiter-effect/src/*"],
+      "@openagentsinc/composer-state": ["../../packages/composer-state/src/index.ts"],
+      "@openagentsinc/khala-qa-harness": ["../../packages/khala-qa-harness/src/index.ts"],
+      "@openagentsinc/khala-qa-harness/*": ["../../packages/khala-qa-harness/src/*"],
+      "@openagentsinc/khala-tools": ["../../packages/khala-tools/src/index.ts"],
+      "@openagentsinc/ui": ["../../packages/ui/src/index.ts"],
+      "@openagentsinc/ui/*": ["../../packages/ui/src/*"],
       "electrobun/bun": ["./src/types/electrobun-bun.d.ts"]
     }
   }


### PR DESCRIPTION
Closes #7866

## Summary
- Adds a minimal Claude Agent SDK chat runtime for Khala Code Desktop, including Effect Stream wrapping around query(), scoped close/abort teardown, interrupt, and persisted desktop-session to Claude-session mapping.
- Adds Claude SDK message projection into neutral chat turn events for assistant text, reasoning, tool use/results, result status, and usage.
- Wires Claude runtime selection through RPC handlers and headless mode, plus Claude harness status wrapping the existing Pylon probes.
- Adds a Phase 1 Claude gap matrix and mocked SDK fixture tests.

## Verification
- PASS: bun test clients/khala-code-desktop/tests/claude-app-sdk-chat-runtime.test.ts
- FAIL: bun run --cwd clients/khala-code-desktop verify (required ref command.public.pylon_khala.verify.c2cf893c3b48c76502ade240) stops in existing typecheck/module-resolution failures before tests/build, including missing workspace package resolution for @openagentsinc/khala-tools and pre-existing cross-package type errors in apps/openagents.com Worker gym/probe files. Filtered output for the new Claude files shows no Claude type errors, only Effect warnings about untagged Error in the new runtime.