### PR TITLE
T5.2: Worker cards + lifecycle streaming

### DIFF
--- a/apps/pylon/src/orchestration/store.ts
+++ b/apps/pylon/src/orchestration/store.ts
@@ -1156,6 +1156,22 @@ export class PylonOrchestrationStore {
     return this.updateWorkClaimState(claimRef, "released", now)
   }
 
+  updateWorkClaimAssignmentRef(claimRef: string, assignmentRef: string | null, now: Date = new Date()): WorkClaim {
+    const current = this.getWorkClaim(claimRef)
+    if (current === null) throw new Error(`unknown work claim: ${claimRef}`)
+    this.db
+      .query(`
+        UPDATE pylon_orchestration_work_claims
+           SET assignment_ref = $assignmentRef,
+               updated_at = $updatedAt
+         WHERE claim_ref = $claimRef
+      `)
+      .run({ $claimRef: claimRef, $assignmentRef: assignmentRef, $updatedAt: iso(now) })
+    const updated = this.getWorkClaim(claimRef)
+    if (updated === null) throw new Error(`failed to update work claim assignment: ${claimRef}`)
+    return updated
+  }
+
   refreshLiveWorkClaim(workUnitRef: string, now: Date = new Date()): WorkClaim | null {
     const current = this.getLiveWorkClaim(workUnitRef, now)
     if (current === null) return null

--- a/clients/khala-code-desktop/src/bun/fleet-run-supervisor-rpc-adapter.ts
+++ b/clients/khala-code-desktop/src/bun/fleet-run-supervisor-rpc-adapter.ts
@@ -1,9 +1,10 @@
 import { spawn } from "node:child_process"
 import { randomUUID } from "node:crypto"
 import { mkdirSync } from "node:fs"
+import { appendFile, mkdir } from "node:fs/promises"
 import { Database } from "bun:sqlite"
 import { Effect, Exit, Scope } from "effect"
-import { join } from "node:path"
+import { dirname, join } from "node:path"
 
 import {
   createPylonOrchestrationStore,
@@ -36,6 +37,8 @@ import {
   startFleetRunSupervisor,
   type FleetRunSupervisorCapacity,
   type FleetRunSupervisorHandle,
+  type FleetRunSupervisorLifecycleEvent,
+  type FleetRunSupervisorObservedEvent,
   type FleetRunSupervisorPlanner,
   type FleetRunSupervisorRunner,
 } from "./fleet-run-supervisor.js"
@@ -44,6 +47,8 @@ import type {
   KhalaCodeDesktopFleetRunListRequest,
   KhalaCodeDesktopFleetRunProjection,
   KhalaCodeDesktopFleetRunStartRequest,
+  KhalaCodeDesktopFleetWorkerControlRequest,
+  KhalaCodeDesktopFleetWorkerControlResult,
 } from "../shared/rpc.js"
 
 type ChatEnv = Readonly<Record<string, string | undefined>>
@@ -64,6 +69,7 @@ type RpcIssueListItem = Exclude<
 export type KhalaCodeDesktopFleetRunSupervisorRpcAdapterOptions = {
   readonly capacity?: FleetRunSupervisorCapacity
   readonly env?: ChatEnv
+  readonly onLifecycleNdjson?: (line: string) => void | Promise<void>
   readonly pylonRef?: string | null
   readonly runner?: FleetRunSupervisorRunner
   readonly store?: PylonOrchestrationStore
@@ -265,6 +271,22 @@ const defaultStore = (env: ChatEnv): PylonOrchestrationStore => {
   return createPylonOrchestrationStore(new Database(join(home, "orchestration.sqlite")))
 }
 
+const manualInboxLedgerPath = (home: string): string =>
+  join(home, "fleet-worker-inbox.jsonl")
+
+const inboxRefFor = (request: KhalaCodeDesktopFleetWorkerControlRequest, observedAt: string): string =>
+  `inbox.assignment.${request.workerRefHash}.${request.verb}.${observedAt.replace(/[^0-9TZ]/g, "")}`
+
+const lifecycleEventLine = (event: FleetRunSupervisorLifecycleEvent): string =>
+  `${JSON.stringify({
+    schema: "openagents.pylon.assignment_run_lifecycle_event.v0.1",
+    event: event.event,
+    observedAt: new Date().toISOString(),
+    ...(event.assignmentRef === undefined || event.assignmentRef === null ? {} : { assignmentRef: event.assignmentRef }),
+    ...(event.phase === undefined || event.phase === null ? {} : { phase: event.phase }),
+    ...(event.status === undefined || event.status === null ? {} : { status: event.status }),
+  })}\n`
+
 export function createKhalaCodeDesktopFleetRunSupervisorRpcAdapter(
   options: KhalaCodeDesktopFleetRunSupervisorRpcAdapterOptions = {},
 ): KhalaCodeDesktopFleetRunSupervisorRpc {
@@ -278,6 +300,11 @@ export function createKhalaCodeDesktopFleetRunSupervisorRpcAdapter(
 
   const sync = async (): Promise<void> => {
     await syncFleetRunsToOwnerLocalState(store, paths)
+  }
+
+  const publishLifecycle = async (event: FleetRunSupervisorObservedEvent): Promise<void> => {
+    if (event.kind !== "lifecycle") return
+    await options.onLifecycleNdjson?.(lifecycleEventLine(event.event))
   }
 
   const projectionInput = (
@@ -306,6 +333,7 @@ export function createKhalaCodeDesktopFleetRunSupervisorRpcAdapter(
           runRef,
           runner: options.runner ?? runnerFor({ pylonRef, toolOptions }),
           store,
+          onLifecycle: publishLifecycle,
           ...(options.tickIntervalMs === undefined ? {} : { tickIntervalMs: options.tickIntervalMs }),
         }),
         Scope.Scope,
@@ -316,6 +344,114 @@ export function createKhalaCodeDesktopFleetRunSupervisorRpcAdapter(
     } catch (error) {
       await Effect.runPromise(Scope.close(scope, Exit.void))
       throw error
+    }
+  }
+
+  const claimForWorkerControl = (
+    request: KhalaCodeDesktopFleetWorkerControlRequest,
+  ) => {
+    const claims = store.listWorkClaims({
+      ...(request.runRef === null ? {} : { runRef: request.runRef }),
+    })
+    if (request.assignmentRef !== null) {
+      return claims.find(claim => claim.assignmentRef === request.assignmentRef) ?? null
+    }
+    if (request.issueRef !== null) {
+      return claims.find(claim => claim.workUnitRef.includes(request.issueRef ?? "")) ?? null
+    }
+    return null
+  }
+
+  const appendManualFlag = async (
+    request: KhalaCodeDesktopFleetWorkerControlRequest,
+  ): Promise<string> => {
+    const observedAt = new Date().toISOString()
+    const ref = inboxRefFor(request, observedAt)
+    const row = {
+      schemaVersion: "khala-code-desktop.fleet-worker-inbox.v1",
+      ref,
+      assignmentRef: request.assignmentRef,
+      issueRef: request.issueRef,
+      note: request.note ?? null,
+      observedAt,
+      runRef: request.runRef,
+      verb: request.verb,
+      workerRefHash: request.workerRefHash,
+    }
+    const path = manualInboxLedgerPath(paths.home)
+    await mkdir(dirname(path), { recursive: true })
+    await appendFile(path, `${JSON.stringify(row)}\n`, "utf8")
+    return ref
+  }
+
+  const closeClaimTask = (
+    claimRef: string,
+    status: "blocked" | "failed",
+    summary: string,
+  ): void => {
+    const task = store.listTasks("dispatched").find(candidate =>
+      candidate.id.includes(claimRef.replace(/[^a-zA-Z0-9_.-]/g, "_"))
+    )
+    if (task === undefined) return
+    const context = store.listDispatchContexts("dispatched").find(candidate =>
+      candidate.currentTaskId === task.id
+    )
+    if (context === undefined) return
+    store.recordWorkerDone({
+      contextId: context.id,
+      taskId: task.id,
+      status,
+      result: JSON.stringify({ assignmentRef: null, summary }),
+      maxFailures: Number.MAX_SAFE_INTEGER,
+    })
+  }
+
+  const workerControl = async (
+    request: KhalaCodeDesktopFleetWorkerControlRequest,
+  ): Promise<KhalaCodeDesktopFleetWorkerControlResult> => {
+    const claim = claimForWorkerControl(request)
+    if (request.verb === "flag") {
+      return {
+        accepted: true,
+        assignmentRef: request.assignmentRef,
+        inboxItemRef: await appendManualFlag(request),
+        ok: true,
+        runRef: request.runRef,
+        verb: request.verb,
+        workerRefHash: request.workerRefHash,
+      }
+    }
+    if (claim === null) {
+      throw new Error(`fleetWorkerControl could not find active claim for ${request.assignmentRef ?? request.issueRef ?? request.workerRefHash}`)
+    }
+    if (request.verb === "interrupt") {
+      if (request.runRef !== null) await closeSupervisor(request.runRef)
+      closeClaimTask(claim.claimRef, "blocked", "manual interrupt requested from fleet worker card")
+      store.releaseWorkClaim(claim.claimRef)
+    } else {
+      closeClaimTask(claim.claimRef, "failed", "manual retry requested from fleet worker card")
+      store.releaseLiveWorkClaim(claim.workUnitRef)
+      const runRef = request.runRef ?? claim.runRef
+      const run = store.updateFleetRunState(runRef, "running")
+      store.upsertFleetRun({
+        ...run,
+        counters: {
+          ...run.counters,
+          workUnitsTotal: run.counters.workUnitsTotal + 1,
+        },
+      })
+      await startSupervisor(runRef)
+      await Effect.runPromise(active.get(runRef)?.handle.tick() ?? Effect.void)
+    }
+    await sync()
+    return {
+      accepted: true,
+      assignmentRef: request.assignmentRef,
+      inboxItemRef: null,
+      ok: true,
+      runRef: request.runRef ?? claim.runRef,
+      verb: request.verb,
+      workerRefHash: request.workerRefHash,
     }
   }
 
@@ -375,5 +511,6 @@ export function createKhalaCodeDesktopFleetRunSupervisorRpcAdapter(
         supervisorActive: active.has(request.runRef),
       }
     },
+    workerControl,
   }
 }

--- a/clients/khala-code-desktop/src/bun/fleet-run-supervisor.ts
+++ b/clients/khala-code-desktop/src/bun/fleet-run-supervisor.ts
@@ -262,6 +262,9 @@ const recordTerminalAssignment = async (
       event,
     })
   }
+  if (result.assignmentRef !== null) {
+    options.store.updateWorkClaimAssignmentRef(assignment.claim.claimRef, result.assignmentRef, now)
+  }
   options.store.recordWorkerDone({
     contextId: assignment.contextId,
     taskId: assignment.taskId,
@@ -470,6 +473,9 @@ export async function tickFleetRunSupervisor(
         accountRef: account.accountRef,
         event,
       })
+    }
+    if (result.assignmentRef !== null) {
+      store.updateWorkClaimAssignmentRef(claim.claimRef, result.assignmentRef, now)
     }
 
     const terminalStatus = terminalStatusForDispatch(result)

--- a/clients/khala-code-desktop/src/bun/index.ts
+++ b/clients/khala-code-desktop/src/bun/index.ts
@@ -11,6 +11,7 @@ import {
   khalaCodeDesktopRpcHandlerFailure,
   khalaCodeDesktopRpcMethodSchema,
   type KhalaCodeDesktopChatTurnEvent,
+  type KhalaCodeDesktopFleetLifecycleEvent,
   type KhalaCodeDesktopRpcMethodName,
   type KhalaCodeDesktopRPCSchema,
 } from "../shared/rpc.js"
@@ -242,6 +243,7 @@ const previewEventsResponse = (request: Request): Response => {
 }
 
 let emitChatTurnEvent = (_event: KhalaCodeDesktopChatTurnEvent): void => {}
+let emitFleetLifecycleEvent = (_event: KhalaCodeDesktopFleetLifecycleEvent): void => {}
 let rpcRequestHandlers: KhalaCodeDesktopRPCSchema["requests"]
 
 const previewRpcResponse = async (
@@ -508,7 +510,13 @@ rpcRequestHandlers = createKhalaCodeDesktopRpcRequestHandlers({
   enableFleetMcpBridge: true,
   emitChatTurnEvent: event => emitChatTurnEvent(event),
   env: khalaCodeEnv,
-  fleetRunSupervisor: createKhalaCodeDesktopFleetRunSupervisorRpcAdapter({ env: khalaCodeEnv }),
+  fleetRunSupervisor: createKhalaCodeDesktopFleetRunSupervisorRpcAdapter({
+    env: khalaCodeEnv,
+    onLifecycleNdjson: line => emitFleetLifecycleEvent({
+      line,
+      observedAt: new Date().toISOString(),
+    }),
+  }),
   fleetMcpBridgeRepoRoot: resolveSourceRepositoryRoot(),
   onDeviceDeciderStatus: () => onDeviceDecider.select(),
   workingDirectory: resolveToolWorkingDirectory(khalaCodeEnv),
@@ -547,6 +555,19 @@ emitChatTurnEvent = event => {
     event,
     observedAt: new Date().toISOString(),
     type: "chatTurnEvent",
+  })
+}
+
+emitFleetLifecycleEvent = event => {
+  try {
+    rpc.send.fleetLifecycleEvent(event)
+  } catch {
+    // Headless preview runs have no native window transport; SSE remains active.
+  }
+  publishPreviewBridgeEvent({
+    detail: event,
+    observedAt: event.observedAt,
+    type: "fleetLifecycleEvent",
   })
 }
 

--- a/clients/khala-code-desktop/src/bun/preview-rpc-policy.ts
+++ b/clients/khala-code-desktop/src/bun/preview-rpc-policy.ts
@@ -39,6 +39,7 @@ export const mutatingPreviewRpcMethods = new Set<KhalaCodeDesktopRpcMethodName>(
   "consumeCodexRateLimitResetCredit",
   "fleetRunControl",
   "fleetRunStart",
+  "fleetWorkerControl",
   "openExternalUrl",
   "removeCodexAccount",
   "slashCommandDispatch",

--- a/clients/khala-code-desktop/src/bun/rpc-handlers.ts
+++ b/clients/khala-code-desktop/src/bun/rpc-handlers.ts
@@ -73,6 +73,7 @@ import {
   type KhalaCodeDesktopFleetRunStatusResult,
   type KhalaCodeDesktopFleetSessionRole,
   type KhalaCodeDesktopFleetWorkerSession,
+  type KhalaCodeDesktopFleetWorkerControlRequest,
   type KhalaCodeDesktopFleetWorkerControlResult,
   type KhalaCodeDesktopFleetStatus,
   type KhalaCodeDesktopRPCSchema,
@@ -155,6 +156,9 @@ export type KhalaCodeDesktopFleetRunSupervisorRpc = {
     readonly run: KhalaCodeDesktopFleetRunProjection | null
     readonly supervisorActive: boolean
   }>
+  readonly workerControl?: (
+    request: KhalaCodeDesktopFleetWorkerControlRequest,
+  ) => MaybePromise<KhalaCodeDesktopFleetWorkerControlResult>
 }
 
 export type KhalaCodeDesktopRpcHandlersInput = {
@@ -1911,18 +1915,11 @@ export function createKhalaCodeDesktopRpcRequestHandlers(
       if (request.verb !== "flag") {
         requireNonEmpty("fleetWorkerControl", "assignmentRef", request.assignmentRef ?? "")
       }
-      const inboxItemRef = request.verb === "flag"
-        ? `inbox.assignment.${request.workerRefHash}.manual_flag`
-        : null
-      return {
-        accepted: true,
-        assignmentRef: request.assignmentRef,
-        inboxItemRef,
-        ok: true,
-        runRef: request.runRef,
-        verb: request.verb,
-        workerRefHash: request.workerRefHash,
+      const supervisor = requireFleetRunSupervisor()
+      if (supervisor.workerControl === undefined) {
+        throw new Error("fleetWorkerControl requires fleet-run supervisor worker control")
       }
+      return supervisor.workerControl(request)
     },
     async codexHarnessStatus() {
       return codexHarnessStatus()

--- a/clients/khala-code-desktop/src/bun/rpc-handlers.ts
+++ b/clients/khala-code-desktop/src/bun/rpc-handlers.ts
@@ -73,6 +73,7 @@ import {
   type KhalaCodeDesktopFleetRunStatusResult,
   type KhalaCodeDesktopFleetSessionRole,
   type KhalaCodeDesktopFleetWorkerSession,
+  type KhalaCodeDesktopFleetWorkerControlResult,
   type KhalaCodeDesktopFleetStatus,
   type KhalaCodeDesktopRPCSchema,
   type KhalaCodeDesktopRuntimeStatus,
@@ -1903,6 +1904,24 @@ export function createKhalaCodeDesktopRpcRequestHandlers(
       return {
         ok: true,
         runs: [...runs],
+      }
+    },
+    async fleetWorkerControl(request): Promise<KhalaCodeDesktopFleetWorkerControlResult> {
+      requireNonEmpty("fleetWorkerControl", "workerRefHash", request.workerRefHash)
+      if (request.verb !== "flag") {
+        requireNonEmpty("fleetWorkerControl", "assignmentRef", request.assignmentRef ?? "")
+      }
+      const inboxItemRef = request.verb === "flag"
+        ? `inbox.assignment.${request.workerRefHash}.manual_flag`
+        : null
+      return {
+        accepted: true,
+        assignmentRef: request.assignmentRef,
+        inboxItemRef,
+        ok: true,
+        runRef: request.runRef,
+        verb: request.verb,
+        workerRefHash: request.workerRefHash,
       }
     },
     async codexHarnessStatus() {

--- a/clients/khala-code-desktop/src/shared/rpc.ts
+++ b/clients/khala-code-desktop/src/shared/rpc.ts
@@ -87,6 +87,10 @@ export type KhalaCodeDesktopMessage =
 
 export type KhalaCodeDesktopChatTurnEvent =
   typeof KhalaCodeDesktopChatTurnEventSchema.Type
+export type KhalaCodeDesktopFleetLifecycleEvent = Readonly<{
+  line: string
+  observedAt: string
+}>
 
 export type KhalaCodeDesktopUsage = typeof RpcUsage.Type
 export type KhalaCodeDesktopChatTurnAttachment = typeof RpcChatAttachment.Type
@@ -1646,5 +1650,6 @@ export type KhalaCodeDesktopRPCSchema = {
   }
   messages: {
     chatTurnEvent(event: KhalaCodeDesktopChatTurnEvent): void
+    fleetLifecycleEvent(event: KhalaCodeDesktopFleetLifecycleEvent): void
   }
 }

--- a/clients/khala-code-desktop/src/shared/rpc.ts
+++ b/clients/khala-code-desktop/src/shared/rpc.ts
@@ -185,6 +185,8 @@ export type KhalaCodeDesktopFleetRunControlRequest = typeof RpcFleetRunControlRe
 export type KhalaCodeDesktopFleetRunControlResult = typeof RpcFleetRunControlResult.Type
 export type KhalaCodeDesktopFleetRunListRequest = typeof RpcFleetRunListRequest.Type
 export type KhalaCodeDesktopFleetRunListResult = typeof RpcFleetRunListResult.Type
+export type KhalaCodeDesktopFleetWorkerControlRequest = typeof RpcFleetWorkerControlRequest.Type
+export type KhalaCodeDesktopFleetWorkerControlResult = typeof RpcFleetWorkerControlResult.Type
 export type KhalaCodeDesktopRemoveAccountResult = typeof RpcRemoveAccountResult.Type
 export type KhalaCodeDesktopConnectStart = typeof RpcConnectStart.Type
 
@@ -1366,6 +1368,24 @@ const RpcFleetRunListResult = S.Struct({
   ok: S.Boolean,
   runs: S.Array(RpcFleetRunProjection),
 })
+const RpcFleetWorkerControlVerb = S.Literals(["interrupt", "retry", "flag"])
+const RpcFleetWorkerControlRequest = S.Struct({
+  assignmentRef: RpcStringNull,
+  issueRef: RpcStringNull,
+  note: S.optional(S.String),
+  runRef: RpcStringNull,
+  verb: RpcFleetWorkerControlVerb,
+  workerRefHash: S.String,
+})
+const RpcFleetWorkerControlResult = S.Struct({
+  accepted: S.Boolean,
+  assignmentRef: RpcStringNull,
+  inboxItemRef: RpcStringNull,
+  ok: S.Boolean,
+  runRef: RpcStringNull,
+  verb: RpcFleetWorkerControlVerb,
+  workerRefHash: S.String,
+})
 
 const RpcConnectStart = S.Struct({
   ok: S.Boolean,
@@ -1428,6 +1448,7 @@ export const KhalaCodeDesktopRpcMethodSchemas = {
   fleetRunList: { parameters: [optionalParam(RpcFleetRunListRequest)], result: RpcFleetRunListResult },
   fleetRunStart: { parameters: [param(RpcFleetRunStartRequest)], result: RpcFleetRunStartResult },
   fleetRunStatus: { parameters: [param(RpcFleetRunStatusRequest)], result: RpcFleetRunStatusResult },
+  fleetWorkerControl: { parameters: [param(RpcFleetWorkerControlRequest)], result: RpcFleetWorkerControlResult },
   codexHarnessStatus: { parameters: noParams(), result: RpcCodexHarnessStatus },
   codexApprovalRespond: { parameters: [param(RpcApprovalRespondRequest)], result: RpcApprovalRespondResult },
   codexBackgroundTerminalsClean: { parameters: [param(RpcBackgroundTerminalsCleanRequest)], result: RpcCodexAppServerActionResult },
@@ -1569,6 +1590,7 @@ export type KhalaCodeDesktopRPCSchema = {
     fleetRunList(request?: KhalaCodeDesktopFleetRunListRequest): Promise<KhalaCodeDesktopFleetRunListResult>
     fleetRunStart(request: KhalaCodeDesktopFleetRunStartRequest): Promise<KhalaCodeDesktopFleetRunStartResult>
     fleetRunStatus(request: KhalaCodeDesktopFleetRunStatusRequest): Promise<KhalaCodeDesktopFleetRunStatusResult>
+    fleetWorkerControl(request: KhalaCodeDesktopFleetWorkerControlRequest): Promise<KhalaCodeDesktopFleetWorkerControlResult>
     codexHarnessStatus(): Promise<KhalaCodeDesktopCodexHarnessStatus>
     codexApprovalRespond(request: KhalaCodeDesktopCodexApprovalRespondRequest): Promise<KhalaCodeDesktopCodexApprovalRespondResult>
     codexBackgroundTerminalsClean(request: KhalaCodeDesktopCodexBackgroundTerminalsCleanRequest): Promise<KhalaCodeDesktopCodexAppServerActionResult>

--- a/clients/khala-code-desktop/src/ui/fleet-status.ts
+++ b/clients/khala-code-desktop/src/ui/fleet-status.ts
@@ -13,9 +13,18 @@ import type {
   KhalaCodeDesktopFleetRunStartRequest,
   KhalaCodeDesktopFleetRunStartResult,
   KhalaCodeDesktopFleetStatus,
+  KhalaCodeDesktopFleetWorkerControlRequest,
+  KhalaCodeDesktopFleetWorkerControlResult,
 } from "../shared/rpc"
 import { buildKhalaFleetBoardProjection } from "./fleet-board-projection"
 import { renderKhalaFleetBoardHtml } from "./fleet-board-renderer"
+import {
+  buildKhalaFleetWorkerCards,
+  consumeKhalaFleetWorkerLifecycleNdjson,
+  createKhalaFleetWorkerCardThrottler,
+  type KhalaFleetWorkerLifecycleFrame,
+  type KhalaFleetWorkerCard,
+} from "./fleet-worker-cards"
 import {
   defaultKhalaFleetDelegationActiveParameters,
   type KhalaGymDelegationOptimizationRun,
@@ -41,6 +50,9 @@ export type FleetPanelOptions = Readonly<{
   fleetRunControl: (
     request: KhalaCodeDesktopFleetRunControlRequest,
   ) => Promise<KhalaCodeDesktopFleetRunControlResult>
+  fleetWorkerControl: (
+    request: KhalaCodeDesktopFleetWorkerControlRequest,
+  ) => Promise<KhalaCodeDesktopFleetWorkerControlResult>
   fleetRunList: (
     request?: KhalaCodeDesktopFleetRunListRequest,
   ) => Promise<KhalaCodeDesktopFleetRunListResult>
@@ -54,6 +66,8 @@ export type FleetPanelOptions = Readonly<{
   ) => Promise<{ readonly ok: boolean; readonly error?: string }>
   connectAccount: (accountRef: string) => Promise<KhalaCodeDesktopConnectStart>
   openExternal: (url: string) => Promise<boolean>
+  lifecycleNdjson?: () => AsyncIterable<string | Uint8Array>
+  lifecycleUpdateThrottleMs?: number
 }>
 
 type Handlers = Readonly<{
@@ -61,6 +75,10 @@ type Handlers = Readonly<{
   onDelegateRun: () => void
   onFleetRunField: (field: keyof FleetRunFormState, value: string) => void
   onFleetRunControl: (verb: KhalaCodeDesktopFleetRunControlRequest["verb"]) => void
+  onFleetWorkerControl: (
+    card: KhalaFleetWorkerCard,
+    verb: KhalaCodeDesktopFleetWorkerControlRequest["verb"],
+  ) => void
   onFleetRunPreview: () => void
   onFleetRunStart: () => void
   onLoadGymDemoProof: () => void
@@ -331,14 +349,66 @@ const fleetInFlightLabel = (
   return `${tokenRate.inFlightTokens} token(s)${rate}`
 }
 
-const assignmentTokenRateLabel = (
-  tokenRate: KhalaCodeDesktopFleetStatus["activeAssignments"][number]["tokenRate"],
-): string => {
-  if (tokenRate.status === "pending") return "pending exact rows"
-  if (tokenRate.status === "not_measured") return "not measured"
-  const tokens = tokenRate.tokens === null ? "unknown" : `${tokenRate.tokens}`
-  const rate = tokenRate.tokensPerMinute === null ? "" : `, ${tokenRate.tokensPerMinute}/min`
-  return `${tokens} ${tokenRate.status}${rate}`
+const workerStateBadge = (
+  state: KhalaFleetWorkerCard["neutralState"],
+): "ready" | "online" | "missing" | "degraded" => {
+  if (state === "done") return "ready"
+  if (state === "working" || state === "queued") return "online"
+  if (state === "failed" || state === "offline") return "missing"
+  return "degraded"
+}
+
+const renderWorkerCard = (
+  card: KhalaFleetWorkerCard,
+  activeRun: ActiveFleetRunView,
+  handlers: Handlers,
+): HTMLElement => {
+  const row = el("article", "khala-fleet-worker-card")
+  row.dataset.state = card.neutralState
+  row.dataset.workerRefHash = card.workerRefHash
+
+  const top = el("div", "khala-fleet-worker-card-top")
+  top.append(
+    badge(workerStateBadge(card.neutralState), titleize(card.neutralState)),
+    detailChip("worker", card.workerRefHash),
+  )
+  row.append(top)
+
+  const chips = el("div", "khala-fleet-chips")
+  chips.append(detailChip("work", card.claimedWorkUnit))
+  appendChip(chips, "assignment", card.assignmentRefHash)
+  appendChip(chips, "issue", card.issueRefHash)
+  appendChip(chips, "elapsed", formatElapsedMs(card.elapsedMs))
+  appendChip(chips, "tokens", card.tokenLabel)
+  appendChip(chips, "closeout", card.closeoutStatus)
+  if (card.blockerRefs.length > 0) {
+    chips.append(detailChip("blockers", card.blockerRefs.slice(0, 3).join(", ")))
+  }
+  row.append(chips)
+
+  const lifecycle = el("p", "khala-fleet-worker-lifecycle")
+  lifecycle.dataset.hasFrame = card.lifecycle === null ? "false" : "true"
+  lifecycle.textContent = card.lifecycle?.line ?? "No lifecycle frame received yet."
+  row.append(lifecycle)
+
+  const controls = el("div", "khala-fleet-worker-controls")
+  const actionSpecs: ReadonlyArray<readonly [
+    KhalaCodeDesktopFleetWorkerControlRequest["verb"],
+    IconName,
+  ]> = [
+    ["interrupt", "Stop"],
+    ["retry", "Reload"],
+    ["flag", "Flag"],
+  ]
+  for (const [verb, icon] of actionSpecs) {
+    const button = iconButton(titleize(verb), icon, verb === "interrupt" ? "khala-fleet-run khala-fleet-run-danger" : "khala-fleet-run")
+    button.dataset.fleetWorkerControl = verb
+    button.disabled = activeRun.run === null || (card.assignmentRef === null && verb !== "flag")
+    button.addEventListener("click", () => handlers.onFleetWorkerControl(card, verb))
+    controls.append(button)
+  }
+  row.append(controls)
+  return row
 }
 
 const appendChip = (
@@ -1009,6 +1079,8 @@ const renderReady = (
   container: HTMLElement,
   data: KhalaCodeDesktopFleetStatus,
   handlers: Handlers,
+  activeRun: ActiveFleetRunView,
+  lifecycleFrames: readonly KhalaFleetWorkerLifecycleFrame[],
 ): void => {
   const readyAccounts = data.accounts.filter(
     account => accountReadinessState(account.readiness) === "ready",
@@ -1089,34 +1161,17 @@ const renderReady = (
 
   // Active assignments
   const activeSection = el("section", "khala-fleet-section")
+  const workerCards = buildKhalaFleetWorkerCards(data, lifecycleFrames)
   activeSection.append(
-    sectionHeader("Active assignments", `${data.activeAssignments.length} active`),
+    sectionHeader("Worker cards", `${workerCards.length} active`),
   )
-  if (data.activeAssignments.length === 0) {
+  if (workerCards.length === 0) {
     activeSection.append(
       el("p", "khala-fleet-empty", "No active Codex assignments right now."),
     )
   } else {
-    const list = el("div", "khala-fleet-assignment-list")
-    for (const marker of data.activeAssignments) {
-      const row = el("article", "khala-fleet-assignment")
-      const chips = el("div", "khala-fleet-chips")
-      if (marker.issueRef !== null) chips.append(detailChip("issue", marker.issueRef))
-      if (marker.assignmentRef !== null) {
-        chips.append(detailChip("assignment", marker.assignmentRef))
-      }
-      appendChip(chips, "closeout", marker.closeoutStatus ?? marker.workerSession?.closeoutStatus ?? null)
-      appendChip(chips, "review", marker.workerSession?.reviewState ?? null)
-      appendChip(chips, "approval", marker.workerSession?.approvalState ?? null)
-      appendChip(chips, "transcript", marker.workerSession?.transcriptRef ?? null)
-      if ((marker.blockerRefs ?? marker.workerSession?.blockerRefs ?? []).length > 0) {
-        chips.append(detailChip("blockers", (marker.blockerRefs ?? marker.workerSession?.blockerRefs ?? []).slice(0, 3).join(", ")))
-      }
-      appendChip(chips, "elapsed", formatElapsedMs(marker.elapsedMs))
-      appendChip(chips, "tokens", assignmentTokenRateLabel(marker.tokenRate))
-      row.append(chips)
-      list.append(row)
-    }
+    const list = el("div", "khala-fleet-worker-card-list")
+    for (const card of workerCards) list.append(renderWorkerCard(card, activeRun, handlers))
     activeSection.append(list)
   }
   container.append(activeSection)
@@ -1213,6 +1268,7 @@ const render = (
   delegateForm: FleetDelegateFormState,
   delegateRun: DelegateRunView,
   activeRun: ActiveFleetRunView,
+  lifecycleFrames: readonly KhalaFleetWorkerLifecycleFrame[],
   fleetRunForm: FleetRunFormState,
   fleetRun: FleetRunView,
   optimizationRun: OptimizationRunView,
@@ -1252,7 +1308,7 @@ const render = (
       el("p", "khala-fleet-error", `Could not load fleet status: ${view.message}`),
     )
   } else {
-    renderReady(body, view.data, handlers)
+    renderReady(body, view.data, handlers, activeRun, lifecycleFrames)
   }
   container.append(body)
 }
@@ -1293,6 +1349,8 @@ export const mountFleetPanel = (
   let optimizationInFlight = false
   let optimizationRun: OptimizationRunView = { phase: "idle" }
   let lastData: KhalaCodeDesktopFleetStatus | null = null
+  let lifecycleFrames: readonly KhalaFleetWorkerLifecycleFrame[] = []
+  let lifecycleStarted = false
   let connectPoll = 0
   let activeConnect: ConnectView | null = null
   let visible = false
@@ -1320,6 +1378,7 @@ export const mountFleetPanel = (
       delegateForm,
       delegateRun,
       activeRun,
+      lifecycleFrames,
       fleetRunForm,
       fleetRun,
       optimizationRun,
@@ -1410,6 +1469,23 @@ export const mountFleetPanel = (
     return request
   }
 
+  const lifecycleThrottler = createKhalaFleetWorkerCardThrottler({
+    intervalMs: options.lifecycleUpdateThrottleMs ?? 200,
+    onUpdate: update => {
+      lifecycleFrames = update.frames
+      paint()
+    },
+  })
+
+  const startLifecycleStream = (): void => {
+    if (lifecycleStarted || options.lifecycleNdjson === undefined) return
+    lifecycleStarted = true
+    void consumeKhalaFleetWorkerLifecycleNdjson(
+      options.lifecycleNdjson(),
+      frame => lifecycleThrottler.push(frame),
+    )
+  }
+
   const handlers: Handlers = {
     onDelegateField: (field, value) => {
       if (field === "noRun") {
@@ -1436,6 +1512,7 @@ export const mountFleetPanel = (
       paint()
     },
     onFleetRunControl: verb => onFleetRunControl(verb),
+    onFleetWorkerControl: (card, verb) => onFleetWorkerControl(card, verb),
     onFleetRunPreview: () => {
       const preview = fleetRunPreview()
       fleetRun = typeof preview === "string"
@@ -1555,6 +1632,27 @@ export const mountFleetPanel = (
     })()
   }
 
+  const onFleetWorkerControl = (
+    card: KhalaFleetWorkerCard,
+    verb: KhalaCodeDesktopFleetWorkerControlRequest["verb"],
+  ): void => {
+    void (async () => {
+      try {
+        await options.fleetWorkerControl({
+          assignmentRef: card.assignmentRef,
+          issueRef: card.issueRef,
+          runRef: activeRun.run?.runRef ?? null,
+          verb,
+          workerRefHash: card.workerRefHash,
+        })
+        await refresh()
+      } catch {
+        // The card control is best-effort UI plumbing; the next refresh keeps
+        // the visible state authoritative from Fleet status.
+      }
+    })()
+  }
+
   const onLoadGymDemoProof = (): void => {
     if (optimizationInFlight) return
     void (async () => {
@@ -1608,6 +1706,7 @@ export const mountFleetPanel = (
           delegateForm,
           delegateRun,
           activeRun,
+          lifecycleFrames,
           fleetRunForm,
           fleetRun,
           optimizationRun,
@@ -1687,6 +1786,7 @@ export const mountFleetPanel = (
           delegateForm,
           delegateRun,
           activeRun,
+          lifecycleFrames,
           fleetRunForm,
           fleetRun,
           optimizationRun,
@@ -1708,6 +1808,7 @@ export const mountFleetPanel = (
     visible = next
     window.clearInterval(pollTimer)
     if (!next) return
+    startLifecycleStream()
     void refresh()
     // Live updates: poll while the panel is visible (skipping in-flight loads).
     // The list stays live even during an active connect.

--- a/clients/khala-code-desktop/src/ui/fleet-worker-cards.ts
+++ b/clients/khala-code-desktop/src/ui/fleet-worker-cards.ts
@@ -1,0 +1,290 @@
+import { Effect, Stream } from "effect"
+import {
+  decodePylonLifecycleWireEventJson,
+  type PylonLifecycleWireEvent,
+} from "@openagentsinc/agent-runtime-schema"
+
+import type {
+  KhalaCodeDesktopFleetAssignment,
+  KhalaCodeDesktopFleetStatus,
+  KhalaCodeDesktopFleetWorkerControlRequest,
+} from "../shared/rpc"
+
+export type KhalaFleetWorkerNeutralState =
+  | "idle"
+  | "queued"
+  | "working"
+  | "waiting"
+  | "blocked"
+  | "done"
+  | "failed"
+  | "offline"
+
+export type KhalaFleetWorkerLifecycleFrame = Readonly<{
+  assignmentRef: string | null
+  elapsedMs: number | null
+  event: string
+  line: string
+  observedAt: string
+  tokenCountKind: "exact" | "estimated" | null
+  tokensSoFar: number | null
+}>
+
+export type KhalaFleetWorkerCard = Readonly<{
+  assignmentRef: string | null
+  assignmentRefHash: string | null
+  blockerRefs: readonly string[]
+  claimedWorkUnit: string
+  closeoutStatus: string | null
+  elapsedMs: number | null
+  issueRef: string | null
+  issueRefHash: string | null
+  lifecycle: KhalaFleetWorkerLifecycleFrame | null
+  neutralState: KhalaFleetWorkerNeutralState
+  tokenLabel: string
+  workerRefHash: string
+}>
+
+export type KhalaFleetWorkerCardActionHandlers = Readonly<{
+  onWorkerControl: (
+    request: KhalaCodeDesktopFleetWorkerControlRequest,
+  ) => void
+}>
+
+const hashRef = (value: string): string => {
+  let hash = 0x811c9dc5
+  for (let index = 0; index < value.length; index += 1) {
+    hash ^= value.charCodeAt(index)
+    hash = Math.imul(hash, 0x01000193)
+  }
+  return (hash >>> 0).toString(16).padStart(8, "0")
+}
+
+export const khalaFleetWorkerRefHash = (
+  value: string | null | undefined,
+  fallback: string,
+): string => `ref.${hashRef(value ?? fallback)}`
+
+const eventName = (event: PylonLifecycleWireEvent): string =>
+  event.schema === "openagents.pylon.assignment_run_lifecycle_event.v0.1"
+    ? event.event
+    : event.assignmentEvent ?? event.state
+
+const eventAssignmentRef = (event: PylonLifecycleWireEvent): string | null =>
+  event.assignmentRef ?? null
+
+const eventElapsedMs = (event: PylonLifecycleWireEvent): number | null =>
+  event.schema === "openagents.pylon.assignment_run_lifecycle_event.v0.1"
+    ? event.elapsedMs ?? null
+    : null
+
+const eventTokensSoFar = (event: PylonLifecycleWireEvent): number | null =>
+  event.schema === "openagents.pylon.assignment_run_lifecycle_event.v0.1"
+    ? event.tokensSoFar ?? null
+    : null
+
+const eventTokenCountKind = (
+  event: PylonLifecycleWireEvent,
+): "exact" | "estimated" | null =>
+  event.schema === "openagents.pylon.assignment_run_lifecycle_event.v0.1"
+    ? event.tokenCountKind ?? null
+    : null
+
+const lifecycleLine = (event: PylonLifecycleWireEvent): string => {
+  const parts = [eventName(event)]
+  if (event.schema === "openagents.pylon.assignment_run_lifecycle_event.v0.1") {
+    if (event.phase !== undefined) parts.push(`phase=${event.phase}`)
+    if (event.status !== undefined) parts.push(`status=${event.status}`)
+    if (event.tokensSoFar !== undefined) parts.push(`tokens=${event.tokensSoFar}`)
+  } else if (event.status !== undefined) {
+    parts.push(`status=${event.status}`)
+  }
+  return parts.join(" ")
+}
+
+export const khalaFleetWorkerLifecycleFrameFromWireEvent = (
+  event: PylonLifecycleWireEvent,
+): KhalaFleetWorkerLifecycleFrame => ({
+  assignmentRef: eventAssignmentRef(event),
+  elapsedMs: eventElapsedMs(event),
+  event: eventName(event),
+  line: lifecycleLine(event),
+  observedAt: event.observedAt,
+  tokenCountKind: eventTokenCountKind(event),
+  tokensSoFar: eventTokensSoFar(event),
+})
+
+export const parseKhalaFleetWorkerLifecycleNdjsonLine = (
+  line: string,
+): KhalaFleetWorkerLifecycleFrame | null => {
+  const trimmed = line.trim()
+  if (!trimmed.startsWith("{") || !trimmed.endsWith("}")) return null
+  try {
+    return khalaFleetWorkerLifecycleFrameFromWireEvent(
+      decodePylonLifecycleWireEventJson(trimmed),
+    )
+  } catch {
+    return null
+  }
+}
+
+export const khalaFleetWorkerLifecycleFramesFromNdjson = (
+  ndjson: string,
+): Promise<readonly KhalaFleetWorkerLifecycleFrame[]> => {
+  const frames: KhalaFleetWorkerLifecycleFrame[] = []
+  return Effect.runPromise(Effect.gen(function* () {
+    yield* Stream.fromIterable([new TextEncoder().encode(ndjson)]).pipe(
+      Stream.decodeText(),
+      Stream.splitLines,
+      Stream.runForEach(line =>
+        Effect.sync(() => {
+          const frame = parseKhalaFleetWorkerLifecycleNdjsonLine(line)
+          if (frame !== null) frames.push(frame)
+        }),
+      ),
+    )
+    return frames
+  }))
+}
+
+const bytesFromLifecycleChunks = async function* (
+  source: AsyncIterable<string | Uint8Array>,
+): AsyncIterable<Uint8Array> {
+  const encoder = new TextEncoder()
+  for await (const chunk of source) {
+    yield typeof chunk === "string" ? encoder.encode(chunk) : chunk
+  }
+}
+
+export const consumeKhalaFleetWorkerLifecycleNdjson = (
+  source: AsyncIterable<string | Uint8Array>,
+  onFrame: (frame: KhalaFleetWorkerLifecycleFrame) => void | Promise<void>,
+): Promise<void> =>
+  Effect.runPromise(
+    Stream.fromAsyncIterable(bytesFromLifecycleChunks(source), error => new Error(String(error))).pipe(
+      Stream.decodeText(),
+      Stream.splitLines,
+      Stream.runForEach(line =>
+        Effect.promise(async () => {
+          const frame = parseKhalaFleetWorkerLifecycleNdjsonLine(line)
+          if (frame !== null) await onFrame(frame)
+        }),
+      ),
+      Effect.catch(() => Effect.void),
+    ),
+  )
+
+export type KhalaFleetWorkerCardUpdate = Readonly<{
+  frame: KhalaFleetWorkerLifecycleFrame
+  frames: readonly KhalaFleetWorkerLifecycleFrame[]
+}>
+
+export type KhalaFleetWorkerCardThrottler = Readonly<{
+  flush: () => void
+  push: (frame: KhalaFleetWorkerLifecycleFrame) => void
+}>
+
+export const createKhalaFleetWorkerCardThrottler = (input: {
+  readonly intervalMs: number
+  readonly onUpdate: (update: KhalaFleetWorkerCardUpdate) => void
+  readonly setTimeout?: (callback: () => void, ms: number) => number
+  readonly clearTimeout?: (handle: number) => void
+}): KhalaFleetWorkerCardThrottler => {
+  const setTimer = input.setTimeout ?? ((callback, ms) => window.setTimeout(callback, ms))
+  const clearTimer = input.clearTimeout ?? (handle => window.clearTimeout(handle))
+  const frames: KhalaFleetWorkerLifecycleFrame[] = []
+  let pending: KhalaFleetWorkerLifecycleFrame | null = null
+  let timer: number | null = null
+
+  const flush = (): void => {
+    if (timer !== null) {
+      clearTimer(timer)
+      timer = null
+    }
+    if (pending === null) return
+    const frame = pending
+    pending = null
+    frames.push(frame)
+    input.onUpdate({ frame, frames: [...frames] })
+  }
+
+  return {
+    flush,
+    push: frame => {
+      pending = frame
+      if (timer !== null) return
+      timer = setTimer(flush, Math.max(0, input.intervalMs))
+    },
+  }
+}
+
+const neutralStateForAssignment = (
+  assignment: KhalaCodeDesktopFleetAssignment,
+): KhalaFleetWorkerNeutralState => {
+  const blockers = assignment.blockerRefs ?? assignment.workerSession?.blockerRefs ?? []
+  if (blockers.length > 0) return "blocked"
+  const closeout = assignment.closeoutStatus ?? assignment.workerSession?.closeoutStatus
+  if (closeout === "accepted" || closeout === "completed") return "done"
+  if (closeout === "failed" || closeout === "rejected") return "failed"
+  if (assignment.workerSession?.approvalState === "approval_required") return "waiting"
+  return "working"
+}
+
+const tokenLabel = (
+  assignment: KhalaCodeDesktopFleetAssignment,
+  frame: KhalaFleetWorkerLifecycleFrame | null,
+): string => {
+  if (assignment.tokenRate.status === "exact") {
+    const tokens = assignment.tokenRate.tokens === null ? "unknown" : String(assignment.tokenRate.tokens)
+    return `${tokens} exact`
+  }
+  if (assignment.tokenRate.status === "pending") return "pending exact rows"
+  if (assignment.tokenRate.status === "not_measured") {
+    if (frame?.tokensSoFar !== null && frame?.tokensSoFar !== undefined) {
+      const kind = frame.tokenCountKind ?? "pending"
+      return `${frame.tokensSoFar} ${kind}`
+    }
+    return "not measured"
+  }
+  const tokens = assignment.tokenRate.tokens === null ? "unknown" : String(assignment.tokenRate.tokens)
+  return `${tokens} ${assignment.tokenRate.status}`
+}
+
+export const buildKhalaFleetWorkerCards = (
+  status: KhalaCodeDesktopFleetStatus,
+  frames: readonly KhalaFleetWorkerLifecycleFrame[] = [],
+): readonly KhalaFleetWorkerCard[] => {
+  const latestByAssignment = new Map<string, KhalaFleetWorkerLifecycleFrame>()
+  for (const frame of frames) {
+    if (frame.assignmentRef !== null) latestByAssignment.set(frame.assignmentRef, frame)
+  }
+  return status.activeAssignments.map((assignment, index) => {
+    const assignmentRefHash = assignment.assignmentRef === null
+      ? null
+      : khalaFleetWorkerRefHash(assignment.assignmentRef, `assignment-${index}`)
+    const issueRefHash = assignment.issueRef === null
+      ? null
+      : khalaFleetWorkerRefHash(assignment.issueRef, `issue-${index}`)
+    const workerRefHash = khalaFleetWorkerRefHash(
+      assignment.assignmentRef ?? assignment.issueRef,
+      `worker-${index}`,
+    )
+    const lifecycle = assignment.assignmentRef === null
+      ? null
+      : latestByAssignment.get(assignment.assignmentRef) ?? null
+    return {
+      assignmentRef: assignment.assignmentRef,
+      assignmentRefHash,
+      blockerRefs: assignment.blockerRefs ?? assignment.workerSession?.blockerRefs ?? [],
+      claimedWorkUnit: issueRefHash ?? assignmentRefHash ?? workerRefHash,
+      closeoutStatus: assignment.closeoutStatus ?? assignment.workerSession?.closeoutStatus ?? null,
+      elapsedMs: lifecycle?.elapsedMs ?? assignment.elapsedMs,
+      issueRef: assignment.issueRef,
+      issueRefHash,
+      lifecycle,
+      neutralState: neutralStateForAssignment(assignment),
+      tokenLabel: tokenLabel(assignment, lifecycle),
+      workerRefHash,
+    }
+  })
+}

--- a/clients/khala-code-desktop/src/ui/fleet-worker-cards.ts
+++ b/clients/khala-code-desktop/src/ui/fleet-worker-cards.ts
@@ -192,26 +192,33 @@ export const createKhalaFleetWorkerCardThrottler = (input: {
 }): KhalaFleetWorkerCardThrottler => {
   const setTimer = input.setTimeout ?? ((callback, ms) => window.setTimeout(callback, ms))
   const clearTimer = input.clearTimeout ?? (handle => window.clearTimeout(handle))
-  const frames: KhalaFleetWorkerLifecycleFrame[] = []
-  let pending: KhalaFleetWorkerLifecycleFrame | null = null
+  const framesByAssignment = new Map<string, KhalaFleetWorkerLifecycleFrame>()
+  const pendingByAssignment = new Map<string, KhalaFleetWorkerLifecycleFrame>()
   let timer: number | null = null
+  const assignmentKey = (frame: KhalaFleetWorkerLifecycleFrame): string =>
+    frame.assignmentRef ?? `__unassigned__:${frame.observedAt}:${frame.event}`
 
   const flush = (): void => {
     if (timer !== null) {
       clearTimer(timer)
       timer = null
     }
-    if (pending === null) return
-    const frame = pending
-    pending = null
-    frames.push(frame)
-    input.onUpdate({ frame, frames: [...frames] })
+    if (pendingByAssignment.size === 0) return
+    const pending = [...pendingByAssignment.values()]
+    pendingByAssignment.clear()
+    for (const frame of pending) {
+      framesByAssignment.set(assignmentKey(frame), frame)
+    }
+    const frames = [...framesByAssignment.values()]
+    for (const frame of pending) {
+      input.onUpdate({ frame, frames })
+    }
   }
 
   return {
     flush,
     push: frame => {
-      pending = frame
+      pendingByAssignment.set(assignmentKey(frame), frame)
       if (timer !== null) return
       timer = setTimer(flush, Math.max(0, input.intervalMs))
     },

--- a/clients/khala-code-desktop/src/ui/main.ts
+++ b/clients/khala-code-desktop/src/ui/main.ts
@@ -188,6 +188,10 @@ const previewRpc = (): DesktopRpc => ({
       postPreviewRpc<
         Awaited<ReturnType<DesktopRpcRequests["fleetRunStatus"]>>
       >("fleetRunStatus", request),
+    fleetWorkerControl: request =>
+      postPreviewRpc<
+        Awaited<ReturnType<DesktopRpcRequests["fleetWorkerControl"]>>
+      >("fleetWorkerControl", request),
     codexHarnessStatus: () =>
       postPreviewRpc<
         Awaited<ReturnType<DesktopRpcRequests["codexHarnessStatus"]>>
@@ -2256,6 +2260,8 @@ const controls = {
     rpc.request.fleetRunList(request),
   fleetRunStart: (request: Parameters<DesktopRpcRequests["fleetRunStart"]>[0]) =>
     rpc.request.fleetRunStart(request),
+  fleetWorkerControl: (request: Parameters<DesktopRpcRequests["fleetWorkerControl"]>[0]) =>
+    rpc.request.fleetWorkerControl(request),
   codexHarnessStatus: () => rpc.request.codexHarnessStatus(),
   codexApprovalRespond: (request: Parameters<DesktopRpcRequests["codexApprovalRespond"]>[0]) =>
     rpc.request.codexApprovalRespond(request),
@@ -2533,6 +2539,7 @@ const fleetPanel =
         fleetRunControl: request => controls.fleetRunControl(request),
         fleetRunList: request => controls.fleetRunList(request),
         fleetRunStart: request => controls.fleetRunStart(request),
+        fleetWorkerControl: request => controls.fleetWorkerControl(request),
         loadGymDemoProof: () => loadGymDemoOptimization(),
         startDelegationOptimization: async () => loadGymDemoOptimization(),
         fetch: () => controls.codexFleetStatus(),

--- a/clients/khala-code-desktop/src/ui/main.ts
+++ b/clients/khala-code-desktop/src/ui/main.ts
@@ -49,6 +49,7 @@ import {
   type KhalaCodeDesktopRpcMethodName,
   type KhalaCodeDesktopChatTurnAttachment,
   type KhalaCodeDesktopChatTurnEvent,
+  type KhalaCodeDesktopFleetLifecycleEvent,
   type KhalaCodeDesktopChatTurnRequest,
   type KhalaCodeDesktopMessage,
   type KhalaCodeDesktopMessageRole,
@@ -403,8 +404,63 @@ const previewRpc = (): DesktopRpc => ({
   },
   send: {
     chatTurnEvent: () => undefined,
+    fleetLifecycleEvent: () => undefined,
   },
 })
+
+const createAsyncLineQueue = (): {
+  readonly iterable: () => AsyncIterable<string>
+  readonly push: (line: string) => void
+} => {
+  const values: string[] = []
+  const waiters: Array<(value: IteratorResult<string>) => void> = []
+  const push = (line: string): void => {
+    const waiter = waiters.shift()
+    if (waiter === undefined) {
+      values.push(line)
+      return
+    }
+    waiter({ done: false, value: line })
+  }
+  return {
+    iterable: async function* () {
+      while (true) {
+        if (values.length > 0) {
+          yield values.shift()!
+          continue
+        }
+        yield await new Promise<string>(resolve => {
+          waiters.push(result => {
+            if (!result.done) resolve(result.value)
+          })
+        })
+      }
+    },
+    push,
+  }
+}
+
+const fleetLifecycleLines = createAsyncLineQueue()
+const applyFleetLifecycleEvent = (event: KhalaCodeDesktopFleetLifecycleEvent): void => {
+  fleetLifecycleLines.push(event.line)
+}
+
+const startPreviewFleetLifecycleEvents = (): void => {
+  if (!isKhalaPreviewWindow) return
+  const eventSource = new EventSource("/rpc/events")
+  eventSource.addEventListener("fleetLifecycleEvent", event => {
+    try {
+      const payload = JSON.parse((event as MessageEvent<string>).data) as {
+        readonly detail?: { readonly line?: unknown }
+      }
+      if (typeof payload.detail?.line === "string") {
+        fleetLifecycleLines.push(payload.detail.line)
+      }
+    } catch {
+      // Ignore malformed preview diagnostics; lifecycle decoding is lossy-safe.
+    }
+  })
+}
 
 const nativeRpc = Electroview.defineRPC<KhalaCodeDesktopRPCSchema>({
   maxRequestTime: KHALA_CODE_DESKTOP_RPC_MAX_REQUEST_TIME_MS,
@@ -413,6 +469,9 @@ const nativeRpc = Electroview.defineRPC<KhalaCodeDesktopRPCSchema>({
     messages: {
       chatTurnEvent(event) {
         applyChatTurnEvent(event)
+      },
+      fleetLifecycleEvent(event) {
+        applyFleetLifecycleEvent(event)
       },
     },
   },
@@ -429,6 +488,7 @@ const isKhalaPreviewWindow =
 // Electrobun internal ports also run on localhost, but they only accept socket
 // RPC and will log noisy fallthroughs for /rpc/* requests.
 const rpc = isKhalaPreviewWindow ? previewRpc() : nativeRpc
+startPreviewFleetLifecycleEvents()
 if (!isKhalaPreviewWindow) {
   new Electroview({ rpc: nativeRpc })
 }
@@ -2540,6 +2600,7 @@ const fleetPanel =
         fleetRunList: request => controls.fleetRunList(request),
         fleetRunStart: request => controls.fleetRunStart(request),
         fleetWorkerControl: request => controls.fleetWorkerControl(request),
+        lifecycleNdjson: fleetLifecycleLines.iterable,
         loadGymDemoProof: () => loadGymDemoOptimization(),
         startDelegationOptimization: async () => loadGymDemoOptimization(),
         fetch: () => controls.codexFleetStatus(),

--- a/clients/khala-code-desktop/src/ui/styles.css
+++ b/clients/khala-code-desktop/src/ui/styles.css
@@ -1876,7 +1876,8 @@ button {
   color: var(--oa-color-khala-danger-strong);
 }
 .khala-fleet-account-list,
-.khala-fleet-assignment-list {
+.khala-fleet-assignment-list,
+.khala-fleet-worker-card-list {
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
@@ -1995,6 +1996,36 @@ button {
   border-radius: 0.5rem;
   border: 1px solid var(--oa-color-component-border);
   background: var(--oa-color-component-surface);
+}
+.khala-fleet-worker-card {
+  display: grid;
+  gap: 0.6rem;
+  padding: 0.7rem;
+  border-radius: 0.5rem;
+  border: 1px solid var(--oa-color-component-border);
+  background: var(--oa-color-component-surface);
+}
+.khala-fleet-worker-card-top,
+.khala-fleet-worker-controls {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.45rem;
+}
+.khala-fleet-worker-lifecycle {
+  margin: 0;
+  min-height: 2rem;
+  padding: 0.45rem 0.55rem;
+  border-radius: 0.4rem;
+  border: 1px solid color-mix(in srgb, var(--oa-color-component-border) 80%, transparent);
+  color: color-mix(in srgb, var(--oa-color-component-text) 84%, transparent);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+  font-size: 0.72rem;
+  line-height: 1.45;
+  overflow-wrap: anywhere;
+}
+.khala-fleet-worker-lifecycle[data-has-frame="false"] {
+  color: color-mix(in srgb, var(--oa-color-component-text) 52%, transparent);
 }
 
 .khala-fleet-delegate {

--- a/clients/khala-code-desktop/tests/app-shell.test.ts
+++ b/clients/khala-code-desktop/tests/app-shell.test.ts
@@ -758,6 +758,7 @@ describe("khala code desktop app shell", () => {
     expect(css).toContain(".khala-fleet-parameter-readout")
     expect(main).toContain("loadGymDemoOptimization")
     expect(main).toContain("startDelegationOptimization")
+    expect(main).toContain("lifecycleNdjson: fleetLifecycleLines.iterable")
     expect(`${rpc}\n${handlers}\n${fleetPanel}\n${main}`).toContain("codexFleetDelegateRun")
     expect(`${rpc}\n${handlers}\n${fleetPanel}\n${main}`).not.toMatch(
       /raw[_-]?(prompt|trace).*Projected:\s*true|localPathsProjected:\s*true|providerPayloadProjected:\s*true/i,

--- a/clients/khala-code-desktop/tests/app-shell.test.ts
+++ b/clients/khala-code-desktop/tests/app-shell.test.ts
@@ -719,7 +719,7 @@ describe("khala code desktop app shell", () => {
     expect(fleetPanel).toContain("isDisplayOnlyDefaultAccountRef")
     expect(fleetPanel).toContain("accountCapacityLabel")
     expect(fleetPanel).toContain("fleetTokenRateLabel")
-    expect(fleetPanel).toContain("assignmentTokenRateLabel")
+    expect(fleetPanel).toContain("buildKhalaFleetWorkerCards")
     expect(fleetPanel).toContain("renderDelegateRunner")
     expect(fleetPanel).toContain("renderOptimizationRunner")
     expect(fleetPanel).toContain("defaultKhalaFleetDelegationActiveParameters")

--- a/clients/khala-code-desktop/tests/fleet-run-supervisor-rpc-adapter.test.ts
+++ b/clients/khala-code-desktop/tests/fleet-run-supervisor-rpc-adapter.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, test } from "bun:test"
 import { Database } from "bun:sqlite"
+import { mkdtemp, readFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
 
 import { createPylonOrchestrationStore } from "../../../apps/pylon/src/orchestration/store"
 import { createKhalaCodeDesktopFleetRunSupervisorRpcAdapter } from "../src/bun/fleet-run-supervisor-rpc-adapter"
@@ -16,17 +19,21 @@ const acceptingRunner: FleetRunSupervisorRunner = {
 
 let fixtureOrdinal = 0
 
-const adapterFixture = () => {
+const adapterFixture = (input: {
+  readonly advertisedCapacity?: number
+  readonly env?: Record<string, string>
+  readonly runner?: FleetRunSupervisorRunner
+} = {}) => {
   fixtureOrdinal += 1
   const store = createPylonOrchestrationStore(new Database(":memory:"))
   const pylonRef = `pylon.test.${fixtureOrdinal}`
   const adapter = createKhalaCodeDesktopFleetRunSupervisorRpcAdapter({
     capacity: {
-      accounts: async () => [{ accountRef: "codex", advertisedCapacity: 0 }],
+      accounts: async () => [{ accountRef: "codex", advertisedCapacity: input.advertisedCapacity ?? 0 }],
     },
-    env: { PYLON_HOME: "/tmp/khala-code-fleet-run-rpc-adapter-test" },
+    env: input.env ?? { PYLON_HOME: "/tmp/khala-code-fleet-run-rpc-adapter-test" },
     pylonRef,
-    runner: acceptingRunner,
+    runner: input.runner ?? acceptingRunner,
     store,
     tickIntervalMs: 60_000,
   })
@@ -105,5 +112,147 @@ describe("Khala Code fleet run supervisor RPC adapter", () => {
 
     await expect(adapter.control({ runRef: "fleet_run.adapter.unknown", verb: "stop" }))
       .rejects.toThrow("unknown fleet run: fleet_run.adapter.unknown")
+  })
+
+  test("worker retry releases the active claim and re-enqueues the work unit", async () => {
+    let sequence = 0
+    const { adapter, store } = adapterFixture({
+      advertisedCapacity: 1,
+      runner: {
+        dispatch: async () => {
+          sequence += 1
+          return {
+            assignmentRef: `assignment.retry.${sequence}`,
+            lifecycle: [],
+            status: "accepted",
+            summary: null,
+          }
+        },
+      },
+    })
+
+    await adapter.start({
+      objective: "Retry active work.",
+      runRef: "fleet_run.adapter.retry",
+      targetConcurrency: 1,
+      tickImmediately: true,
+      workSource: { kind: "fixture", count: 1 },
+    })
+    const first = store.listWorkClaims({ runRef: "fleet_run.adapter.retry" })[0]
+    expect(first).toMatchObject({ assignmentRef: "assignment.retry.1", state: "in_progress" })
+
+    expect(adapter.workerControl).toBeDefined()
+    const result = await adapter.workerControl!({
+      assignmentRef: "assignment.retry.1",
+      issueRef: null,
+      runRef: "fleet_run.adapter.retry",
+      verb: "retry",
+      workerRefHash: "ref.retry",
+    })
+
+    expect(result).toMatchObject({ accepted: true, verb: "retry" })
+    const claims = store.listWorkClaims({ runRef: "fleet_run.adapter.retry" })
+    expect(claims.find(claim => claim.assignmentRef === "assignment.retry.1")?.state).toBe("released")
+    expect(claims.find(claim => claim.assignmentRef === "assignment.retry.2")?.state).toBe("in_progress")
+  })
+
+  test("worker interrupt stops the active supervisor and releases the active claim", async () => {
+    const { adapter, store } = adapterFixture({ advertisedCapacity: 1 })
+    await adapter.start({
+      objective: "Interrupt active work.",
+      runRef: "fleet_run.adapter.interrupt",
+      targetConcurrency: 1,
+      tickImmediately: true,
+      workSource: { kind: "fixture", count: 1 },
+    })
+
+    expect(adapter.workerControl).toBeDefined()
+    const result = await adapter.workerControl!({
+      assignmentRef: "assignment.test",
+      issueRef: null,
+      runRef: "fleet_run.adapter.interrupt",
+      verb: "interrupt",
+      workerRefHash: "ref.interrupt",
+    })
+
+    expect(result).toMatchObject({ accepted: true, verb: "interrupt" })
+    expect((await adapter.status({ runRef: "fleet_run.adapter.interrupt" })).supervisorActive).toBe(false)
+    expect(store.listWorkClaims({ runRef: "fleet_run.adapter.interrupt" })[0]?.state).toBe("released")
+  })
+
+  test("worker flag appends a persisted inbox row", async () => {
+    const home = await mkdtemp(join(tmpdir(), "khala-code-fleet-worker-flag-"))
+    const { adapter } = adapterFixture({ env: { PYLON_HOME: home } })
+
+    expect(adapter.workerControl).toBeDefined()
+    const result = await adapter.workerControl!({
+      assignmentRef: "assignment.flag",
+      issueRef: "#7946",
+      note: "Needs operator review.",
+      runRef: "fleet_run.adapter.flag",
+      verb: "flag",
+      workerRefHash: "ref.flag",
+    })
+
+    expect(result.inboxItemRef).toStartWith("inbox.assignment.ref.flag.flag.")
+    const ledger = await readFile(join(home, "fleet-worker-inbox.jsonl"), "utf8")
+    expect(JSON.parse(ledger.trim())).toMatchObject({
+      assignmentRef: "assignment.flag",
+      note: "Needs operator review.",
+      ref: result.inboxItemRef,
+      verb: "flag",
+    })
+  })
+
+  test("publishes supervisor lifecycle events as panel NDJSON", async () => {
+    const lines: string[] = []
+    const { adapter } = (() => {
+      fixtureOrdinal += 1
+      const store = createPylonOrchestrationStore(new Database(":memory:"))
+      return {
+        adapter: createKhalaCodeDesktopFleetRunSupervisorRpcAdapter({
+          capacity: {
+            accounts: async () => [{ accountRef: "codex", advertisedCapacity: 1 }],
+          },
+          env: { PYLON_HOME: "/tmp/khala-code-fleet-run-rpc-adapter-test" },
+          onLifecycleNdjson: line => {
+            lines.push(line)
+          },
+          pylonRef: `pylon.test.${fixtureOrdinal}`,
+          runner: {
+            dispatch: async () => ({
+              assignmentRef: "assignment.lifecycle",
+              lifecycle: [{
+                assignmentRef: "assignment.lifecycle",
+                event: "assignment_run.runtime_progress",
+                phase: "runtime_active",
+                status: "running",
+              }],
+              status: "accepted",
+              summary: null,
+            }),
+          },
+          store,
+          tickIntervalMs: 60_000,
+        }),
+      }
+    })()
+
+    await adapter.start({
+      objective: "Stream lifecycle.",
+      runRef: "fleet_run.adapter.lifecycle",
+      targetConcurrency: 1,
+      tickImmediately: true,
+      workSource: { kind: "fixture", count: 1 },
+    })
+
+    expect(lines).toHaveLength(1)
+    expect(JSON.parse(lines[0]!)).toMatchObject({
+      assignmentRef: "assignment.lifecycle",
+      event: "assignment_run.runtime_progress",
+      phase: "runtime_active",
+      schema: "openagents.pylon.assignment_run_lifecycle_event.v0.1",
+      status: "running",
+    })
   })
 })

--- a/clients/khala-code-desktop/tests/fleet-status.test.ts
+++ b/clients/khala-code-desktop/tests/fleet-status.test.ts
@@ -178,6 +178,9 @@ describe("Fleet status panel", () => {
         activeRun = result.run
         return result
       },
+      fleetWorkerControl: async () => {
+        throw new Error("fleet worker control should not be called")
+      },
       loadGymDemoProof: () => {
         throw new Error("gym proof should not be called")
       },
@@ -263,6 +266,9 @@ describe("Fleet status panel", () => {
       },
       fleetRunList: async () => ({ ok: true, runs: [activeRun] }),
       fleetRunStart: async request => runStartResult(request),
+      fleetWorkerControl: async () => {
+        throw new Error("fleet worker control should not be called")
+      },
       loadGymDemoProof: () => {
         throw new Error("gym proof should not be called")
       },
@@ -338,6 +344,9 @@ describe("Fleet status panel", () => {
         runs: currentRun.state === "stopped" ? [] : [currentRun],
       }),
       fleetRunStart: async request => runStartResult(request),
+      fleetWorkerControl: async () => {
+        throw new Error("fleet worker control should not be called")
+      },
       loadGymDemoProof: () => {
         throw new Error("gym proof should not be called")
       },

--- a/clients/khala-code-desktop/tests/fleet-worker-cards.test.ts
+++ b/clients/khala-code-desktop/tests/fleet-worker-cards.test.ts
@@ -110,10 +110,13 @@ describe("Khala Fleet worker cards", () => {
 
   test("throttles worker card updates and flushes the latest frame", () => {
     const callbacks: Array<() => void> = []
-    const updates: string[] = []
+    const updates: Array<{ readonly event: string; readonly frames: readonly string[] }> = []
     const throttler = createKhalaFleetWorkerCardThrottler({
       intervalMs: 200,
-      onUpdate: update => updates.push(update.frame.event),
+      onUpdate: update => updates.push({
+        event: update.frame.event,
+        frames: update.frames.map(frame => `${frame.assignmentRef}:${frame.event}`),
+      }),
       setTimeout: callback => {
         callbacks.push(callback)
         return callbacks.length
@@ -139,10 +142,41 @@ describe("Khala Fleet worker cards", () => {
       tokenCountKind: null,
       tokensSoFar: null,
     })
+    throttler.push({
+      assignmentRef: "assignment.public.worker-card-b",
+      elapsedMs: null,
+      event: "assignment_run.completed",
+      line: "assignment_run.completed",
+      observedAt: "2026-07-01T00:00:02.000Z",
+      tokenCountKind: null,
+      tokensSoFar: null,
+    })
 
     expect(updates).toEqual([])
     callbacks[0]?.()
-    expect(updates).toEqual(["assignment_run.runtime_progress"])
+    expect(updates.map(update => update.event)).toEqual([
+      "assignment_run.runtime_progress",
+      "assignment_run.completed",
+    ])
+    expect(updates.at(-1)?.frames).toEqual([
+      "assignment.public.worker-card:assignment_run.runtime_progress",
+      "assignment.public.worker-card-b:assignment_run.completed",
+    ])
+
+    throttler.push({
+      assignmentRef: "assignment.public.worker-card",
+      elapsedMs: null,
+      event: "assignment_run.completed",
+      line: "assignment_run.completed",
+      observedAt: "2026-07-01T00:00:03.000Z",
+      tokenCountKind: null,
+      tokensSoFar: null,
+    })
+    callbacks[1]?.()
+    expect(updates.at(-1)?.frames).toEqual([
+      "assignment.public.worker-card:assignment_run.completed",
+      "assignment.public.worker-card-b:assignment_run.completed",
+    ])
   })
 
   test("renders worker controls through mocked RPC without exposing raw refs in the card", async () => {

--- a/clients/khala-code-desktop/tests/fleet-worker-cards.test.ts
+++ b/clients/khala-code-desktop/tests/fleet-worker-cards.test.ts
@@ -1,0 +1,238 @@
+import { describe, expect, test } from "bun:test"
+import { Window } from "happy-dom"
+
+import {
+  buildKhalaFleetWorkerCards,
+  createKhalaFleetWorkerCardThrottler,
+  khalaFleetWorkerLifecycleFramesFromNdjson,
+} from "../src/ui/fleet-worker-cards"
+import { mountFleetPanel } from "../src/ui/fleet-status"
+import type {
+  KhalaCodeDesktopFleetStatus,
+  KhalaCodeDesktopFleetWorkerControlRequest,
+} from "../src/shared/rpc"
+
+const assignmentEvent = (patch: Record<string, unknown>): string =>
+  JSON.stringify({
+    assignmentRef: "assignment.public.worker-card",
+    event: "assignment_run.runtime_progress",
+    observedAt: "2026-07-01T00:00:00.000Z",
+    schema: "openagents.pylon.assignment_run_lifecycle_event.v0.1",
+    ...patch,
+  })
+
+const status = (): KhalaCodeDesktopFleetStatus => ({
+  ok: true,
+  observedAt: "2026-07-01T00:00:05.000Z",
+  pylon: {
+    status: "online",
+    pylonRef: "pylon.local.worker_card",
+    message: "online",
+  },
+  availableCodexAssignments: 1,
+  maxCodexAssignments: 2,
+  tokenRate: {
+    activeAdjustedTokensPerMinute: null,
+    completedStatus: "pending",
+    completedTokenRows: null,
+    completedTokensPerMinute: null,
+    inFlightTokens: null,
+    inFlightTokensPerMinute: null,
+    source: "unavailable",
+    unavailableReason: null,
+  },
+  accounts: [],
+  activeAssignments: [{
+    assignmentRef: "assignment.public.worker-card",
+    elapsedMs: 1_000,
+    issueRef: "github.issue.openagents.7840",
+    tokenRate: {
+      source: "fleet.activeAssignments.tokensSoFar",
+      status: "pending",
+      tokenCountKind: null,
+      tokens: null,
+      tokensPerMinute: null,
+    },
+    updatedAt: "2026-07-01T00:00:05.000Z",
+  }],
+  processes: [],
+})
+
+const runProjection = {
+  counters: {
+    activeAssignments: 1,
+    blockedAssignments: 0,
+    completedAssignments: 0,
+    failedAssignments: 0,
+    workUnitsTotal: 1,
+  },
+  createdAt: "2026-07-01T00:00:00.000Z",
+  dispatchKind: "supervised_dispatch" as const,
+  objectiveProjected: false as const,
+  pylonRef: "pylon.local.worker_card",
+  refillPolicy: {
+    cooldownAware: true,
+    maxPerAccount: 1,
+    stopCondition: "backlog_empty" as const,
+  },
+  runRef: "fleet_run.public.worker_card",
+  startedAt: "2026-07-01T00:00:00.000Z",
+  state: "running" as const,
+  targetConcurrency: 1,
+  updatedAt: "2026-07-01T00:00:00.000Z",
+  workerKind: "codex" as const,
+  workSource: { kind: "fixture" as const },
+}
+
+describe("Khala Fleet worker cards", () => {
+  test("builds cards from fixture lifecycle streams without fabricated frames", async () => {
+    const frames = await khalaFleetWorkerLifecycleFramesFromNdjson([
+      "human log line",
+      assignmentEvent({
+        elapsedMs: 2_500,
+        phase: "runtime_active",
+        tokenCountKind: "exact",
+        tokensSoFar: 42,
+      }),
+      JSON.stringify({ schema: "unknown" }),
+    ].join("\n"))
+    const cards = buildKhalaFleetWorkerCards(status(), frames)
+
+    expect(frames).toHaveLength(1)
+    expect(cards).toHaveLength(1)
+    expect(cards[0]?.lifecycle?.line).toBe(
+      "assignment_run.runtime_progress phase=runtime_active tokens=42",
+    )
+    expect(cards[0]?.tokenLabel).toBe("pending exact rows")
+    expect(cards[0]?.assignmentRefHash).toMatch(/^ref\.[0-9a-f]{8}$/)
+    expect(cards[0]?.claimedWorkUnit).toMatch(/^ref\.[0-9a-f]{8}$/)
+  })
+
+  test("throttles worker card updates and flushes the latest frame", () => {
+    const callbacks: Array<() => void> = []
+    const updates: string[] = []
+    const throttler = createKhalaFleetWorkerCardThrottler({
+      intervalMs: 200,
+      onUpdate: update => updates.push(update.frame.event),
+      setTimeout: callback => {
+        callbacks.push(callback)
+        return callbacks.length
+      },
+      clearTimeout: () => undefined,
+    })
+
+    throttler.push({
+      assignmentRef: "assignment.public.worker-card",
+      elapsedMs: null,
+      event: "assignment_run.runtime_started",
+      line: "assignment_run.runtime_started",
+      observedAt: "2026-07-01T00:00:00.000Z",
+      tokenCountKind: null,
+      tokensSoFar: null,
+    })
+    throttler.push({
+      assignmentRef: "assignment.public.worker-card",
+      elapsedMs: null,
+      event: "assignment_run.runtime_progress",
+      line: "assignment_run.runtime_progress",
+      observedAt: "2026-07-01T00:00:01.000Z",
+      tokenCountKind: null,
+      tokensSoFar: null,
+    })
+
+    expect(updates).toEqual([])
+    callbacks[0]?.()
+    expect(updates).toEqual(["assignment_run.runtime_progress"])
+  })
+
+  test("renders worker controls through mocked RPC without exposing raw refs in the card", async () => {
+    const window = new Window()
+    const previousWindow = globalThis.window
+    const previousDocument = globalThis.document
+    const previousCrypto = globalThis.crypto
+    Object.defineProperty(globalThis, "window", { configurable: true, value: window })
+    Object.defineProperty(globalThis, "document", { configurable: true, value: window.document })
+    Object.defineProperty(globalThis, "crypto", {
+      configurable: true,
+      value: { randomUUID: () => "00000000-0000-4000-8000-000000000001" },
+    })
+    window.matchMedia = (() => ({ matches: true })) as unknown as typeof window.matchMedia
+
+    const requests: KhalaCodeDesktopFleetWorkerControlRequest[] = []
+    const container = document.createElement("div")
+    const lifecycleNdjson = async function* (): AsyncIterable<string> {
+      yield `${assignmentEvent({
+        elapsedMs: 3_000,
+        phase: "runtime_active",
+        tokenCountKind: "estimated",
+        tokensSoFar: 9,
+      })}\n`
+    }
+    const panel = mountFleetPanel(container, {
+      connectAccount: async () => ({ ok: false, accountRef: "codex-test", error: "not used", output: "", userCode: null, verificationUrl: null }),
+      delegateRun: async () => {
+        throw new Error("not used")
+      },
+      fetch: async () => status(),
+      fleetRunControl: async request => ({
+        ok: true,
+        previousState: "running",
+        run: { ...runProjection, runRef: request.runRef },
+        supervisorActive: true,
+        verb: request.verb,
+      }),
+      fleetRunList: async () => ({ ok: true, runs: [runProjection] }),
+      fleetRunStart: async () => {
+        throw new Error("not used")
+      },
+      fleetWorkerControl: async request => {
+        requests.push(request)
+        return {
+          accepted: true,
+          assignmentRef: request.assignmentRef,
+          inboxItemRef: request.verb === "flag" ? "inbox.assignment.test" : null,
+          ok: true,
+          runRef: request.runRef,
+          verb: request.verb,
+          workerRefHash: request.workerRefHash,
+        }
+      },
+      lifecycleNdjson,
+      lifecycleUpdateThrottleMs: 0,
+      loadGymDemoProof: async () => {
+        throw new Error("not used")
+      },
+      openExternal: async () => true,
+      removeAccount: async () => ({ ok: true }),
+      startDelegationOptimization: async () => {
+        throw new Error("not used")
+      },
+    })
+
+    try {
+      panel.setVisible(true)
+      for (let index = 0; index < 20; index += 1) {
+        if (container.querySelector<HTMLElement>(".khala-fleet-worker-lifecycle")?.textContent?.includes("assignment_run.runtime_progress")) break
+        await new Promise(resolve => setTimeout(resolve, 10))
+      }
+      expect(container.innerHTML).toContain("khala-fleet-worker-card")
+      const cardHtml = container.querySelector<HTMLElement>(".khala-fleet-worker-card")?.innerHTML ?? ""
+      expect(cardHtml).not.toContain("assignment.public.worker-card")
+      expect(cardHtml).not.toContain("github.issue.openagents.7840")
+      expect(cardHtml).toContain("assignment_run.runtime_progress")
+      expect(cardHtml).toContain("tokens=9")
+      container.querySelector<HTMLButtonElement>('[data-fleet-worker-control="flag"]')?.click()
+      await Promise.resolve()
+      expect(requests).toMatchObject([{
+        assignmentRef: "assignment.public.worker-card",
+        runRef: "fleet_run.public.worker_card",
+        verb: "flag",
+      }])
+    } finally {
+      panel.setVisible(false)
+      Object.defineProperty(globalThis, "window", { configurable: true, value: previousWindow })
+      Object.defineProperty(globalThis, "document", { configurable: true, value: previousDocument })
+      Object.defineProperty(globalThis, "crypto", { configurable: true, value: previousCrypto })
+    }
+  })
+})


### PR DESCRIPTION
Closes #7840

## Summary
- Add worker-card projection/rendering for active Khala Code fleet assignments with hashed public-safe card refs, honest token labels, elapsed time, lifecycle line, and Interrupt/Retry/Flag controls.
- Add an Effect Stream NDJSON lifecycle consumer using the shared Pylon lifecycle wire decoder, plus throttled card updates for live frames.
- Wire `fleetWorkerControl` through shared RPC schemas, preview policy, backend handlers, and the desktop panel.

## Verification
- `bun run --cwd clients/khala-code-desktop typecheck`
- `bun run --cwd clients/khala-code-desktop test` (command.public.pylon_khala.verify.d32c71ee8e1025e99460d008)
