### PR TITLE
T5.3: Account cards

### DIFF
--- a/clients/khala-code-desktop/src/bun/fleet-run-supervisor-rpc-adapter.ts
+++ b/clients/khala-code-desktop/src/bun/fleet-run-supervisor-rpc-adapter.ts
@@ -218,9 +218,13 @@ const plannerFor = (
 
 const capacityFor = (options: KhalaCodexFleetToolOptions | undefined): FleetRunSupervisorCapacity => ({
   accounts: async () => {
-    const status = await inspectCodexFleet({ includeProcesses: false, startPylon: true }, options)
+    const status = await inspectCodexFleet({
+      includeProcesses: false,
+      includeRateLimits: false,
+      startPylon: true,
+    }, options)
     return status.accounts
-      .filter(account => account.provider === "codex")
+      .filter(account => account.provider === "codex" && !account.paused)
       .map(account => ({
         accountRef: account.accountRef,
         advertisedCapacity: Math.max(0, Math.trunc(

--- a/clients/khala-code-desktop/src/bun/fleet-run-supervisor.ts
+++ b/clients/khala-code-desktop/src/bun/fleet-run-supervisor.ts
@@ -17,6 +17,7 @@ export type FleetRunSupervisorAccount = {
   readonly accountRef: string
   readonly advertisedCapacity: number
   readonly cooldownUntil?: Date | string | null
+  readonly paused?: boolean
 }
 
 export type FleetRunSupervisorLifecycleEvent = {
@@ -218,6 +219,7 @@ const pickAccount = (
 ): FleetRunSupervisorAccount | null => {
   const eligible = accounts
     .filter(account => account.advertisedCapacity > 0)
+    .filter(account => account.paused !== true)
     .filter(account => !isCoolingDown(account, now))
     .map(account => ({
       account,
@@ -364,6 +366,7 @@ export async function tickFleetRunSupervisor(
   const activeAssignments = activeAssignmentsForRun(store, run.runRef)
   const targetFreeSlots = Math.max(0, run.targetConcurrency - activeAssignments)
   const advertisedFreeSlots = accounts.reduce((total, account) => {
+    if (account.paused === true) return total
     if (isCoolingDown(account, now)) return total
     return total + Math.max(0, account.advertisedCapacity - (activeCounts.get(account.accountRef) ?? 0))
   }, 0)

--- a/clients/khala-code-desktop/src/bun/khala-codex-fleet-tools.ts
+++ b/clients/khala-code-desktop/src/bun/khala-codex-fleet-tools.ts
@@ -409,6 +409,11 @@ const codexFleetStatusToolDefinition: KhalaToolDefinition = {
         description: "Include a bounded local process snapshot for Pylon and Codex.",
         type: "boolean",
       },
+      include_rate_limits: {
+        default: false,
+        description: "Include per-account Codex rate-limit windows. This may start one Codex app-server per account.",
+        type: "boolean",
+      },
       start_pylon: {
         default: false,
         description: "Start Pylon if it is not online before collecting status.",
@@ -865,6 +870,7 @@ export async function ensureLocalPylon(
 export async function inspectCodexFleet(
   input: {
     readonly includeProcesses?: boolean | undefined
+    readonly includeRateLimits?: boolean | undefined
     readonly startPylon?: boolean | undefined
   } = {},
   options: KhalaCodexFleetToolOptions = {},
@@ -902,16 +908,16 @@ export async function inspectCodexFleet(
   const statusProjection = parseJsonObject(statusResult.stdout)
   const apm = fleetTokenRateProjectionFromApm(apmResult, rawActiveAssignments.length)
   const accountConfig = await readCodexAccountConfig(paths.pylonHome)
-  const accounts = await withAccountRateLimits(
-    withAccountConfig(
-      withAccountCapacity(
-        mergeAccountRows(listProjection, statusProjection),
-        [ensure.providerProjection, statusProjection, listProjection],
-      ),
-      accountConfig,
+  const accountsWithConfig = withAccountConfig(
+    withAccountCapacity(
+      mergeAccountRows(listProjection, statusProjection),
+      [ensure.providerProjection, statusProjection, listProjection],
     ),
-    env,
+    accountConfig,
   )
+  const accounts = input.includeRateLimits === true
+    ? await withAccountRateLimits(accountsWithConfig, env)
+    : accountsWithConfig
   const activeAssignments = mergeActiveAssignmentTokenRates(
     rawActiveAssignments,
     apm.serverAssignments,
@@ -1148,6 +1154,7 @@ function executeCodexFleetStatusTool(
     try {
       const result = await inspectCodexFleet({
         includeProcesses: optionalBoolean(input.include_processes) ?? true,
+        includeRateLimits: optionalBoolean(input.include_rate_limits) ?? false,
         startPylon: optionalBoolean(input.start_pylon) ?? false,
       }, options)
       return khalaToolOk({
@@ -1551,9 +1558,13 @@ export class DefaultKhalaFleetRunSupervisorManager implements KhalaFleetRunSuper
   private capacityFor(): FleetRunSupervisorCapacity {
     return {
       accounts: async () => {
-        const status = await inspectCodexFleet({ includeProcesses: false, startPylon: true }, this.options)
+        const status = await inspectCodexFleet({
+          includeProcesses: false,
+          includeRateLimits: false,
+          startPylon: true,
+        }, this.options)
         return status.accounts
-          .filter(account => account.readiness === "ready")
+          .filter(account => account.readiness === "ready" && !account.paused)
           .map(account => ({
             accountRef: account.accountRef,
             advertisedCapacity: Math.max(0, account.capacity?.available ?? account.capacity?.ready ?? 1),

--- a/clients/khala-code-desktop/src/bun/khala-codex-fleet-tools.ts
+++ b/clients/khala-code-desktop/src/bun/khala-codex-fleet-tools.ts
@@ -58,6 +58,8 @@ import {
   type FleetRunSupervisorTickResult,
 } from "./fleet-run-supervisor.js"
 import { khalaCodeConfigFromRuntimeEnv } from "./khala-code-config.js"
+import { fetchKhalaCodexRateLimitStatus } from "./codex-rate-limits.js"
+import type { KhalaCodexRateLimitProviderStatus } from "../shared/codex-rate-limits.js"
 
 type ChatEnv = Readonly<Record<string, string | undefined>>
 
@@ -174,8 +176,11 @@ type AccountRow = {
   readonly accountRef: string
   readonly accountRefHash: string | null
   readonly capacity: AccountCapacityRow | null
+  readonly home: string | null
+  readonly paused: boolean
   readonly provider: "codex"
   readonly quotaState: string | null
+  readonly rateLimits?: KhalaCodexRateLimitProviderStatus | undefined
   readonly readiness: string
 }
 
@@ -896,9 +901,16 @@ export async function inspectCodexFleet(
   const listProjection = parseJsonObject(listResult.stdout)
   const statusProjection = parseJsonObject(statusResult.stdout)
   const apm = fleetTokenRateProjectionFromApm(apmResult, rawActiveAssignments.length)
-  const accounts = withAccountCapacity(
-    mergeAccountRows(listProjection, statusProjection),
-    [ensure.providerProjection, statusProjection, listProjection],
+  const accountConfig = await readCodexAccountConfig(paths.pylonHome)
+  const accounts = await withAccountRateLimits(
+    withAccountConfig(
+      withAccountCapacity(
+        mergeAccountRows(listProjection, statusProjection),
+        [ensure.providerProjection, statusProjection, listProjection],
+      ),
+      accountConfig,
+    ),
+    env,
   )
   const activeAssignments = mergeActiveAssignmentTokenRates(
     rawActiveAssignments,
@@ -1903,6 +1915,41 @@ function parseJsonObject(raw: string): Record<string, unknown> | null {
   }
 }
 
+type CodexAccountConfigEntry = Readonly<{
+  home: string
+  paused: boolean
+}>
+
+function pylonConfigPath(pylonHome: string): string {
+  return join(pylonHome, "config.json")
+}
+
+async function readCodexAccountConfig(
+  pylonHome: string,
+): Promise<ReadonlyMap<string, CodexAccountConfigEntry>> {
+  try {
+    const parsed = JSON.parse(await readFile(pylonConfigPath(pylonHome), "utf8")) as {
+      dev?: { accounts?: readonly Record<string, unknown>[] }
+    }
+    const out = new Map<string, CodexAccountConfigEntry>()
+    for (const account of parsed.dev?.accounts ?? []) {
+      if (
+        account.provider === "codex" &&
+        typeof account.ref === "string" &&
+        typeof account.home === "string"
+      ) {
+        out.set(account.ref, {
+          home: account.home,
+          paused: account.paused === true,
+        })
+      }
+    }
+    return out
+  } catch {
+    return new Map()
+  }
+}
+
 function mergeAccountRows(
   listProjection: Record<string, unknown> | null,
   statusProjection: Record<string, unknown> | null,
@@ -1921,6 +1968,9 @@ function mergeAccountRows(
         accountKey: row.accountKey ?? previous?.accountKey ?? null,
         accountRefHash: row.accountRefHash ?? previous?.accountRefHash ?? null,
         capacity: row.capacity ?? previous?.capacity ?? null,
+        home: row.home ?? previous?.home ?? null,
+        paused: row.paused || previous?.paused === true,
+        rateLimits: row.rateLimits ?? previous?.rateLimits,
         readiness: row.readiness === "unknown" ? previous?.readiness ?? "unknown" : row.readiness,
       })
     }
@@ -1950,10 +2000,37 @@ function accountRowFrom(value: unknown): AccountRow | null {
     accountRef,
     accountRefHash,
     capacity: null,
+    home: null,
+    paused: false,
     provider: "codex",
     quotaState: stringField(quota, "state"),
     readiness,
   }
+}
+
+function withAccountConfig(
+  accounts: readonly AccountRow[],
+  config: ReadonlyMap<string, CodexAccountConfigEntry>,
+): readonly AccountRow[] {
+  return accounts.map(account => {
+    const entry = config.get(account.accountRef)
+    if (entry === undefined) return account
+    return { ...account, home: entry.home, paused: entry.paused }
+  })
+}
+
+async function withAccountRateLimits(
+  accounts: readonly AccountRow[],
+  env: ChatEnv,
+): Promise<readonly AccountRow[]> {
+  return Promise.all(accounts.map(async account => {
+    if (account.home === null) return account
+    const rateLimits = await fetchKhalaCodexRateLimitStatus({
+      codexHomePath: account.home,
+      env: cleanEnv(env),
+    })
+    return { ...account, rateLimits }
+  }))
 }
 
 function accountKeyFromHash(accountRefHash: string | null): string | null {
@@ -2680,6 +2757,7 @@ function khalaDelegateCapacityFromFleetStatus(
 ): KhalaFleetDelegateCapacity {
   const capacity = capacityFromProviderProjection(projection)
   const accounts = preferredSpawnAccounts(status.accounts, availability, parameters)
+    .filter(account => !account.paused)
     .map(account => khalaDelegateAccountFromRow(account, availability))
   const readyCount = accounts.filter(account => account.readiness === "ready" || account.readiness === "available").length
   const accountAvailable = availability.size === 0
@@ -2735,7 +2813,7 @@ function planDelegatedSpawnAccounts(
     }
   }
   const readyAccounts = preferredSpawnAccounts(
-    status.accounts.filter(account => isReadyAccount(account)),
+    status.accounts.filter(account => isReadyAccount(account) && !account.paused),
     availability,
     parameters,
   )
@@ -3269,6 +3347,9 @@ function resolveSpawnAccounts(
   if (!isReadyAccount(selected)) {
     throw new Error(`Pylon Codex account ${requestedAccountRef} is not ready (${selected.readiness}).`)
   }
+  if (selected.paused) {
+    throw new Error(`Pylon Codex account ${requestedAccountRef} is paused for planning.`)
+  }
   const slots = availability.get(selected.accountRef)
   if (slots !== undefined && slots <= 0) {
     throw new Error(`Pylon Codex account ${requestedAccountRef} has no advertised available slots right now.`)
@@ -3280,6 +3361,7 @@ function dispatchableSpawnAccounts(
   accounts: readonly AccountRow[],
   availability: ReadonlyMap<string, number>,
 ): readonly AccountRow[] {
+  accounts = accounts.filter(account => !account.paused)
   if (availability.size === 0) return accounts
   const positive = accounts.filter(account => (availability.get(account.accountRef) ?? 0) > 0)
   if (positive.length > 0) return positive
@@ -3821,6 +3903,48 @@ export async function collectCodexAccountEmails(
     out[accountRef] = home === null ? null : await codexEmailFromHome(home)
   }
   return out
+}
+
+export async function setCodexAccountPaused(
+  accountRef: string,
+  paused: boolean,
+  options: KhalaCodexFleetToolOptions = {},
+): Promise<{ readonly ok: boolean; readonly removed: boolean; readonly accountRef: string; readonly error?: string }> {
+  if (!/^[A-Za-z0-9._-]+$/.test(accountRef) || accountRef === "(default)") {
+    return { ok: false, removed: false, accountRef, error: "invalid account ref" }
+  }
+  const env = options.env ?? khalaCodeConfigFromRuntimeEnv().env
+  const configPath = pylonConfigPath(resolvePylonHome(env))
+  try {
+    const config = JSON.parse(await readFile(configPath, "utf8")) as {
+      dev?: { accounts?: Record<string, unknown>[] }
+    }
+    const accounts = Array.isArray(config.dev?.accounts) ? config.dev.accounts : []
+    let found = false
+    const nextAccounts = accounts.map(account => {
+      if (account.provider === "codex" && account.ref === accountRef) {
+        found = true
+        return { ...account, paused }
+      }
+      return account
+    })
+    if (!found) return { ok: false, removed: false, accountRef, error: "account ref not found" }
+    const next = {
+      ...config,
+      dev: { ...(config.dev ?? {}), accounts: nextAccounts },
+    }
+    const tempPath = `${configPath}.tmp.${Date.now()}`
+    await writeFile(tempPath, `${JSON.stringify(next, null, 2)}\n`, { mode: 0o600 })
+    await rename(tempPath, configPath)
+    return { ok: true, removed: false, accountRef }
+  } catch (error) {
+    return {
+      ok: false,
+      removed: false,
+      accountRef,
+      error: error instanceof Error ? error.message : String(error),
+    }
+  }
 }
 
 export type CodexConnectStart = {

--- a/clients/khala-code-desktop/src/bun/preview-rpc-policy.ts
+++ b/clients/khala-code-desktop/src/bun/preview-rpc-policy.ts
@@ -41,6 +41,7 @@ export const mutatingPreviewRpcMethods = new Set<KhalaCodeDesktopRpcMethodName>(
   "fleetRunStart",
   "openExternalUrl",
   "removeCodexAccount",
+  "setCodexAccountPaused",
   "slashCommandDispatch",
   "submitChatMessage",
 ])

--- a/clients/khala-code-desktop/src/bun/rpc-handlers.ts
+++ b/clients/khala-code-desktop/src/bun/rpc-handlers.ts
@@ -108,6 +108,7 @@ import {
   type KhalaCodexFleetToolOptions,
   openExternalUrl,
   removeCodexAccount,
+  setCodexAccountPaused,
 } from "./khala-codex-fleet-tools.js"
 
 type ChatEnv = Readonly<Record<string, string | undefined>>
@@ -1812,6 +1813,8 @@ export function createKhalaCodeDesktopRpcRequestHandlers(
           quotaState: account.quotaState,
           accountKey: account.accountKey,
           capacity: account.capacity,
+          paused: account.paused,
+          ...(account.rateLimits === undefined ? {} : { rateLimits: account.rateLimits }),
           homeRole: accountHomeRole(account.accountRef),
           queuePolicy: fleetQueuePolicy(account.capacity, account.readiness),
           sessionRole: accountSessionRole(account.accountRef),
@@ -2155,6 +2158,9 @@ export function createKhalaCodeDesktopRpcRequestHandlers(
     },
     async removeCodexAccount(accountRef: string) {
       return removeCodexAccount(accountRef, { env: input.env })
+    },
+    async setCodexAccountPaused(request) {
+      return setCodexAccountPaused(request.accountRef, request.paused, { env: input.env })
     },
     async pylonStatus() {
       const status = await ensureLocalPylon({

--- a/clients/khala-code-desktop/src/bun/rpc-handlers.ts
+++ b/clients/khala-code-desktop/src/bun/rpc-handlers.ts
@@ -165,6 +165,8 @@ export type KhalaCodeDesktopRpcHandlersInput = {
   readonly codexRateLimitStatus?: () => MaybePromise<KhalaCodexRateLimitProviderStatus>
   readonly codexHarnessStatus?: () => MaybePromise<KhalaCodeDesktopCodexHarnessStatus>
   readonly consumeCodexRateLimitResetCredit?: (input: {
+    readonly accountRef: string
+    readonly codexHomePath: string | null
     readonly idempotencyKey: string
   }) => MaybePromise<KhalaCodexRateLimitResetOutcome>
   readonly codexFleetToolOptions?: KhalaCodexFleetToolOptions
@@ -942,6 +944,18 @@ export function createKhalaCodeDesktopRpcRequestHandlers(
     const rateLimits = await (input.codexRateLimitStatus?.() ??
       fetchKhalaCodexRateLimitStatus({ env: input.env as NodeJS.ProcessEnv }))
     return codexStatusFromRateLimits(rateLimits, harness, input.env)
+  }
+
+  const codexHomePathForResetCredit = async (accountRef: string): Promise<string | null> => {
+    if (accountRef === "default" || accountRef === "(default)") return null
+    const fleet = await inspectCodexFleet(
+      { includeProcesses: false, includeRateLimits: false, startPylon: false },
+      { ...input.codexFleetToolOptions, env: input.env as NodeJS.ProcessEnv },
+    )
+    const account = fleet.accounts.find(candidate => candidate.accountRef === accountRef)
+    if (account === undefined) throw new Error(`Codex account ${accountRef} was not found`)
+    if (account.home === null) throw new Error(`Codex account ${accountRef} does not have an isolated home`)
+    return account.home
   }
 
   const threadIdForSlashCommand = async (
@@ -1788,7 +1802,7 @@ export function createKhalaCodeDesktopRpcRequestHandlers(
     },
     async codexFleetStatus(): Promise<KhalaCodeDesktopFleetStatus> {
       const fleet = await inspectCodexFleet(
-        { includeProcesses: true, startPylon: false },
+        { includeProcesses: true, includeRateLimits: false, startPylon: false },
         { ...input.codexFleetToolOptions, env: input.env as NodeJS.ProcessEnv },
       )
       const emails = await collectCodexAccountEmails(
@@ -2215,14 +2229,20 @@ export function createKhalaCodeDesktopRpcRequestHandlers(
         },
       )
     },
-    async consumeCodexRateLimitResetCredit(): Promise<KhalaCodeDesktopCodexRateLimitResetResult> {
+    async consumeCodexRateLimitResetCredit(request): Promise<KhalaCodeDesktopCodexRateLimitResetResult> {
       const observedAt = new Date().toISOString()
       const idempotencyKey = randomUUID()
       try {
+        const accountRef = request.accountRef.trim()
+        if (accountRef.length === 0) throw new Error("Codex reset accountRef is required")
+        const codexHomePath = await codexHomePathForResetCredit(accountRef)
         const outcome = await (input.consumeCodexRateLimitResetCredit?.({
+          accountRef,
+          codexHomePath,
           idempotencyKey,
         }) ??
           consumeKhalaCodexRateLimitResetCredit({
+            codexHomePath,
             env: input.env as NodeJS.ProcessEnv,
             idempotencyKey,
           }))

--- a/clients/khala-code-desktop/src/shared/rpc.ts
+++ b/clients/khala-code-desktop/src/shared/rpc.ts
@@ -442,6 +442,10 @@ const RpcRateLimitStatus = S.Struct({
   status: S.String,
 })
 
+const RpcRateLimitResetConsumeRequest = S.Struct({
+  accountRef: S.String,
+})
+
 const RpcCodexAccountStatus = S.Struct({
   provider: S.Literal("codex"),
   accountRef: S.Literal("default"),
@@ -1474,7 +1478,7 @@ export const KhalaCodeDesktopRpcMethodSchemas = {
   removeCodexAccount: { parameters: [param(S.String)], result: RpcRemoveAccountResult },
   setCodexAccountPaused: { parameters: [param(S.Struct({ accountRef: S.String, paused: S.Boolean }))], result: RpcRemoveAccountResult },
   codingStatus: { parameters: noParams(), result: RpcRuntimeStatus },
-  consumeCodexRateLimitResetCredit: { parameters: noParams(), result: RpcRateLimitResetResult },
+  consumeCodexRateLimitResetCredit: { parameters: [param(RpcRateLimitResetConsumeRequest)], result: RpcRateLimitResetResult },
   onDeviceDeciderStatus: { parameters: noParams(), result: RpcOnDeviceDeciderSelection },
   pylonStatus: { parameters: noParams(), result: RpcRuntimeStatus },
   slashCommandDispatch: { parameters: [param(RpcSlashCommandDispatchRequest)], result: RpcSlashCommandDispatchResult },
@@ -1616,7 +1620,7 @@ export type KhalaCodeDesktopRPCSchema = {
     removeCodexAccount(accountRef: string): Promise<KhalaCodeDesktopRemoveAccountResult>
     setCodexAccountPaused(request: { accountRef: string; paused: boolean }): Promise<KhalaCodeDesktopRemoveAccountResult>
     codingStatus(): Promise<KhalaCodeDesktopRuntimeStatus>
-    consumeCodexRateLimitResetCredit(): Promise<KhalaCodeDesktopCodexRateLimitResetResult>
+    consumeCodexRateLimitResetCredit(request: { accountRef: string }): Promise<KhalaCodeDesktopCodexRateLimitResetResult>
     onDeviceDeciderStatus(): Promise<OnDeviceDeciderSelection>
     pylonStatus(): Promise<KhalaCodeDesktopRuntimeStatus>
     slashCommandDispatch(request: KhalaCodeDesktopSlashCommandDispatchRequest): Promise<KhalaCodeDesktopSlashCommandDispatchResult>

--- a/clients/khala-code-desktop/src/shared/rpc.ts
+++ b/clients/khala-code-desktop/src/shared/rpc.ts
@@ -1104,6 +1104,8 @@ const RpcFleetAccount = S.Struct({
   quotaState: RpcStringNull,
   accountKey: RpcStringNull,
   capacity: S.NullOr(RpcFleetCapacity),
+  paused: S.optional(S.Boolean),
+  rateLimits: S.optional(RpcRateLimitStatus),
   homeRole: S.optional(RpcFleetHomeRole),
   queuePolicy: S.optional(RpcFleetQueuePolicy),
   sessionRole: S.optional(RpcFleetSessionRole),
@@ -1470,6 +1472,7 @@ export const KhalaCodeDesktopRpcMethodSchemas = {
   connectCodexAccount: { parameters: [param(S.String)], result: RpcConnectStart },
   openExternalUrl: { parameters: [param(S.String)], result: S.Boolean },
   removeCodexAccount: { parameters: [param(S.String)], result: RpcRemoveAccountResult },
+  setCodexAccountPaused: { parameters: [param(S.Struct({ accountRef: S.String, paused: S.Boolean }))], result: RpcRemoveAccountResult },
   codingStatus: { parameters: noParams(), result: RpcRuntimeStatus },
   consumeCodexRateLimitResetCredit: { parameters: noParams(), result: RpcRateLimitResetResult },
   onDeviceDeciderStatus: { parameters: noParams(), result: RpcOnDeviceDeciderSelection },
@@ -1611,6 +1614,7 @@ export type KhalaCodeDesktopRPCSchema = {
     connectCodexAccount(accountRef: string): Promise<KhalaCodeDesktopConnectStart>
     openExternalUrl(url: string): Promise<boolean>
     removeCodexAccount(accountRef: string): Promise<KhalaCodeDesktopRemoveAccountResult>
+    setCodexAccountPaused(request: { accountRef: string; paused: boolean }): Promise<KhalaCodeDesktopRemoveAccountResult>
     codingStatus(): Promise<KhalaCodeDesktopRuntimeStatus>
     consumeCodexRateLimitResetCredit(): Promise<KhalaCodeDesktopCodexRateLimitResetResult>
     onDeviceDeciderStatus(): Promise<OnDeviceDeciderSelection>

--- a/clients/khala-code-desktop/src/ui/fleet-status.ts
+++ b/clients/khala-code-desktop/src/ui/fleet-status.ts
@@ -55,7 +55,9 @@ export type FleetPanelOptions = Readonly<{
   setAccountPaused: (
     request: { readonly accountRef: string; readonly paused: boolean },
   ) => Promise<{ readonly ok: boolean; readonly error?: string }>
-  consumeResetCredit: () => Promise<{ readonly ok: boolean; readonly error?: string }>
+  consumeResetCredit: (
+    request: { readonly accountRef: string },
+  ) => Promise<{ readonly ok: boolean; readonly error?: string }>
   connectAccount: (accountRef: string) => Promise<KhalaCodeDesktopConnectStart>
   openExternal: (url: string) => Promise<boolean>
 }>
@@ -73,7 +75,7 @@ type Handlers = Readonly<{
   onRemove: (accountRef: string) => void
   onConnect: (accountRef: string) => void
   onPauseAccount: (accountRef: string, paused: boolean) => void
-  onConsumeResetCredit: () => void
+  onConsumeResetCredit: (accountRef: string) => void
   onOpenUrl: (url: string) => void
   onCancelConnect: () => void
 }>
@@ -1062,7 +1064,7 @@ const accountCard = (
   ) {
     const reset = iconButton("Reset credits", "Reload", "khala-fleet-reconnect")
     reset.title = "Consume an available Codex rate-limit reset credit"
-    reset.addEventListener("click", handlers.onConsumeResetCredit)
+    reset.addEventListener("click", () => handlers.onConsumeResetCredit(account.accountRef))
     card.append(reset)
   }
 
@@ -1514,7 +1516,7 @@ export const mountFleetPanel = (
     onRemove: (accountRef: string) => onRemove(accountRef),
     onConnect: (accountRef: string) => onConnect(accountRef),
     onPauseAccount: (accountRef: string, paused: boolean) => onPauseAccount(accountRef, paused),
-    onConsumeResetCredit: () => onConsumeResetCredit(),
+    onConsumeResetCredit: accountRef => onConsumeResetCredit(accountRef),
     onOpenUrl: (url: string) => void options.openExternal(url),
     onCancelConnect: () => {
       window.clearTimeout(connectPoll)
@@ -1715,9 +1717,9 @@ export const mountFleetPanel = (
     })()
   }
 
-  const onConsumeResetCredit = (): void => {
+  const onConsumeResetCredit = (accountRef: string): void => {
     void (async () => {
-      const result = await options.consumeResetCredit()
+      const result = await options.consumeResetCredit({ accountRef })
       if (!result.ok) {
         render(
           container,

--- a/clients/khala-code-desktop/src/ui/fleet-status.ts
+++ b/clients/khala-code-desktop/src/ui/fleet-status.ts
@@ -52,6 +52,10 @@ export type FleetPanelOptions = Readonly<{
   removeAccount: (
     accountRef: string,
   ) => Promise<{ readonly ok: boolean; readonly error?: string }>
+  setAccountPaused: (
+    request: { readonly accountRef: string; readonly paused: boolean },
+  ) => Promise<{ readonly ok: boolean; readonly error?: string }>
+  consumeResetCredit: () => Promise<{ readonly ok: boolean; readonly error?: string }>
   connectAccount: (accountRef: string) => Promise<KhalaCodeDesktopConnectStart>
   openExternal: (url: string) => Promise<boolean>
 }>
@@ -68,6 +72,8 @@ type Handlers = Readonly<{
   onRefresh: () => void
   onRemove: (accountRef: string) => void
   onConnect: (accountRef: string) => void
+  onPauseAccount: (accountRef: string, paused: boolean) => void
+  onConsumeResetCredit: () => void
   onOpenUrl: (url: string) => void
   onCancelConnect: () => void
 }>
@@ -286,6 +292,31 @@ const accountCapacityLabel = (
 ): string | null => {
   if (capacity === null) return null
   return `${unknownNumber(capacity.available)}/${unknownNumber(capacity.ready)} free`
+}
+
+export const khalaFleetCountdownLabel = (resetsAtIso: string | null, now: Date): string | null => {
+  if (resetsAtIso === null) return null
+  const deltaMs = Date.parse(resetsAtIso) - now.getTime()
+  if (!Number.isFinite(deltaMs)) return null
+  if (deltaMs <= 0) return "now"
+  const totalMinutes = Math.ceil(deltaMs / 60_000)
+  const days = Math.floor(totalMinutes / 1440)
+  const hours = Math.floor((totalMinutes % 1440) / 60)
+  const minutes = totalMinutes % 60
+  if (days > 0) return hours === 0 ? `${days}d` : `${days}d ${hours}h`
+  if (hours > 0) return minutes === 0 ? `${hours}h` : `${hours}h ${minutes}m`
+  return `${minutes}m`
+}
+
+const rateLimitWindowLabel = (
+  window: NonNullable<KhalaCodeDesktopFleetAccount["rateLimits"]>["session"],
+  now: Date,
+): string | null => {
+  if (window === null) return null
+  const reset = khalaFleetCountdownLabel(window.resetsAtIso, now)
+  return `${Math.round(window.usedPercent)}% used / ${Math.round(window.remainingPercent)}% remaining${
+    reset === null ? "" : `, resets in ${reset}`
+  }`
 }
 
 const sessionRoleLabel = (
@@ -920,6 +951,7 @@ const accountCard = (
   account: KhalaCodeDesktopFleetAccount,
   handlers: Handlers,
 ): HTMLElement => {
+  const now = new Date()
   const state = accountReadinessState(account.readiness)
   const card = el("article", "khala-fleet-account")
   card.dataset.state = state
@@ -939,7 +971,9 @@ const accountCard = (
   identity.append(el("span", "khala-fleet-email", account.email ?? "not signed in"))
   card.append(identity)
 
-  if (state === "ready") {
+  if (account.paused) {
+    card.append(badge("degraded", "Paused"))
+  } else if (state === "ready") {
     card.append(badge("ready", "Ready"))
   } else {
     const reconnect = iconButton("Reconnect", "Reload", "khala-fleet-reconnect")
@@ -977,6 +1011,19 @@ const accountCard = (
   })
   card.append(remove)
 
+  if (!isDisplayOnlyDefaultAccountRef(account.accountRef)) {
+    const pause = iconButton(
+      account.paused ? "Resume planning" : "Pause account",
+      account.paused ? "Play" : "Pause",
+      "khala-fleet-reconnect khala-fleet-pause",
+    )
+    pause.title = account.paused
+      ? `Include ${account.accountRef} in planning`
+      : `Exclude ${account.accountRef} from planning without disconnecting`
+    pause.addEventListener("click", () => handlers.onPauseAccount(account.accountRef, !account.paused))
+    card.append(pause)
+  }
+
   const details = el("div", "khala-fleet-card-details")
   if (isDisplayOnlyDefaultAccountRef(account.accountRef)) {
     appendChip(details, "routing", "default slot")
@@ -987,6 +1034,12 @@ const accountCard = (
   appendChip(details, "home", homeRoleLabel(account.homeRole))
   appendChip(details, "queue", queuePolicyLabel(account.queuePolicy))
   appendChip(details, "cooldown", account.queuePolicy?.cooldown ?? null)
+  appendChip(details, "session limit", rateLimitWindowLabel(account.rateLimits?.session ?? null, now))
+  appendChip(details, "weekly limit", rateLimitWindowLabel(account.rateLimits?.weekly ?? null, now))
+  if (account.rateLimits?.rateLimitResetCredits !== undefined) {
+    const credits = account.rateLimits.rateLimitResetCredits
+    appendChip(details, "reset credits", credits === null ? "unavailable" : String(credits.availableCount))
+  }
   if (account.capacity !== null) {
     appendChip(
       details,
@@ -1001,6 +1054,17 @@ const accountCard = (
   }
   appendChip(details, "quota", account.quotaState)
   card.append(details)
+
+  if (
+    account.rateLimits?.rateLimitResetCredits !== undefined &&
+    account.rateLimits.rateLimitResetCredits !== null &&
+    account.rateLimits.rateLimitResetCredits.availableCount > 0
+  ) {
+    const reset = iconButton("Reset credits", "Reload", "khala-fleet-reconnect")
+    reset.title = "Consume an available Codex rate-limit reset credit"
+    reset.addEventListener("click", handlers.onConsumeResetCredit)
+    card.append(reset)
+  }
 
   return card
 }
@@ -1332,7 +1396,7 @@ export const mountFleetPanel = (
     }
     if (lastData === null) return "Fleet status must load before previewing a run."
     const accounts = lastData.accounts.filter(
-      account => accountReadinessState(account.readiness) === "ready",
+      account => accountReadinessState(account.readiness) === "ready" && account.paused !== true,
     )
     if (accounts.length === 0) return "No ready worker accounts are available for the first wave."
     const slots: FleetRunPreviewSlot[] = []
@@ -1449,6 +1513,8 @@ export const mountFleetPanel = (
     onRefresh: () => void refresh(),
     onRemove: (accountRef: string) => onRemove(accountRef),
     onConnect: (accountRef: string) => onConnect(accountRef),
+    onPauseAccount: (accountRef: string, paused: boolean) => onPauseAccount(accountRef, paused),
+    onConsumeResetCredit: () => onConsumeResetCredit(),
     onOpenUrl: (url: string) => void options.openExternal(url),
     onCancelConnect: () => {
       window.clearTimeout(connectPoll)
@@ -1603,6 +1669,59 @@ export const mountFleetPanel = (
         render(
           container,
           { phase: "error", message: result.error ?? "remove failed" },
+          handlers,
+          activeConnect,
+          delegateForm,
+          delegateRun,
+          activeRun,
+          fleetRunForm,
+          fleetRun,
+          optimizationRun,
+        )
+        return
+      }
+      await refresh()
+    })()
+  }
+
+  const onPauseAccount = (accountRef: string, paused: boolean): void => {
+    if (lastData !== null) {
+      lastData = {
+        ...lastData,
+        accounts: lastData.accounts.map(account =>
+          account.accountRef === accountRef ? { ...account, paused } : account,
+        ),
+      }
+      paint()
+    }
+    void (async () => {
+      const result = await options.setAccountPaused({ accountRef, paused })
+      if (!result.ok) {
+        render(
+          container,
+          { phase: "error", message: result.error ?? "pause failed" },
+          handlers,
+          activeConnect,
+          delegateForm,
+          delegateRun,
+          activeRun,
+          fleetRunForm,
+          fleetRun,
+          optimizationRun,
+        )
+        return
+      }
+      await refresh()
+    })()
+  }
+
+  const onConsumeResetCredit = (): void => {
+    void (async () => {
+      const result = await options.consumeResetCredit()
+      if (!result.ok) {
+        render(
+          container,
+          { phase: "error", message: result.error ?? "reset credit failed" },
           handlers,
           activeConnect,
           delegateForm,

--- a/clients/khala-code-desktop/src/ui/main.ts
+++ b/clients/khala-code-desktop/src/ui/main.ts
@@ -356,10 +356,10 @@ const previewRpc = (): DesktopRpc => ({
       postPreviewRpc<
         Awaited<ReturnType<DesktopRpcRequests["openExternalUrl"]>>
       >("openExternalUrl", url),
-    consumeCodexRateLimitResetCredit: () =>
+    consumeCodexRateLimitResetCredit: request =>
       postPreviewRpc<
         Awaited<ReturnType<DesktopRpcRequests["consumeCodexRateLimitResetCredit"]>>
-      >("consumeCodexRateLimitResetCredit"),
+      >("consumeCodexRateLimitResetCredit", request),
     onDeviceDeciderStatus: () =>
       postPreviewRpc<
         Awaited<ReturnType<DesktopRpcRequests["onDeviceDeciderStatus"]>>
@@ -2336,8 +2336,8 @@ const controls = {
   gymState: (): GymPaneState | null => gymPanel?.snapshot() ?? null,
   openExternalUrl: (url: string) => rpc.request.openExternalUrl(url),
   composerStatus: statusForComposer,
-  consumeCodexRateLimitResetCredit: () =>
-    rpc.request.consumeCodexRateLimitResetCredit(),
+  consumeCodexRateLimitResetCredit: request =>
+    rpc.request.consumeCodexRateLimitResetCredit(request),
   focusComposer: focusComposerInput,
   isComposerFocused: () => document.activeElement === composerInput,
   isPending: () => pendingTurn,
@@ -2556,8 +2556,8 @@ const fleetPanel =
             ...(result.error === undefined ? {} : { error: result.error }),
           }
         },
-        consumeResetCredit: async () => {
-          const result = await controls.consumeCodexRateLimitResetCredit()
+        consumeResetCredit: async request => {
+          const result = await controls.consumeCodexRateLimitResetCredit(request)
           return {
             ok: result.ok,
             ...(result.error === undefined ? {} : { error: result.error }),

--- a/clients/khala-code-desktop/src/ui/main.ts
+++ b/clients/khala-code-desktop/src/ui/main.ts
@@ -372,6 +372,10 @@ const previewRpc = (): DesktopRpc => ({
       postPreviewRpc<
         Awaited<ReturnType<DesktopRpcRequests["removeCodexAccount"]>>
       >("removeCodexAccount", accountRef),
+    setCodexAccountPaused: request =>
+      postPreviewRpc<
+        Awaited<ReturnType<DesktopRpcRequests["setCodexAccountPaused"]>>
+      >("setCodexAccountPaused", request),
     slashCommandDispatch: request =>
       postPreviewRpc<
         Awaited<ReturnType<DesktopRpcRequests["slashCommandDispatch"]>>
@@ -2363,6 +2367,8 @@ const controls = {
   pylonStatus: () => rpc.request.pylonStatus(),
   removeCodexAccount: (accountRef: string) =>
     rpc.request.removeCodexAccount(accountRef),
+  setCodexAccountPaused: (request: { accountRef: string; paused: boolean }) =>
+    rpc.request.setCodexAccountPaused(request),
   slashCommandDispatch: (request: Parameters<DesktopRpcRequests["slashCommandDispatch"]>[0]) =>
     rpc.request.slashCommandDispatch(request),
   slashCommandList: (request?: Parameters<DesktopRpcRequests["slashCommandList"]>[0]) =>
@@ -2538,6 +2544,20 @@ const fleetPanel =
         fetch: () => controls.codexFleetStatus(),
         removeAccount: async accountRef => {
           const result = await controls.removeCodexAccount(accountRef)
+          return {
+            ok: result.ok,
+            ...(result.error === undefined ? {} : { error: result.error }),
+          }
+        },
+        setAccountPaused: async request => {
+          const result = await controls.setCodexAccountPaused(request)
+          return {
+            ok: result.ok,
+            ...(result.error === undefined ? {} : { error: result.error }),
+          }
+        },
+        consumeResetCredit: async () => {
+          const result = await controls.consumeCodexRateLimitResetCredit()
           return {
             ok: result.ok,
             ...(result.error === undefined ? {} : { error: result.error }),

--- a/clients/khala-code-desktop/src/ui/styles.css
+++ b/clients/khala-code-desktop/src/ui/styles.css
@@ -2380,9 +2380,9 @@ button {
   }
 }
 
-/* Account rows get an icon delete button: identity | badge | delete. */
+/* Account rows reserve stable columns for identity, status, destructive action, and planning controls. */
 .khala-fleet-account {
-  grid-template-columns: minmax(0, 1fr) auto auto;
+  grid-template-columns: minmax(0, 1fr) auto auto auto;
 }
 .khala-fleet-delete {
   font: inherit;

--- a/clients/khala-code-desktop/tests/fleet-run-supervisor.test.ts
+++ b/clients/khala-code-desktop/tests/fleet-run-supervisor.test.ts
@@ -269,6 +269,28 @@ describe("FleetRunSupervisor", () => {
     ])
   })
 
+  test("never claims a paused ready account during a supervisor tick", async () => {
+    const { store, run } = createStoreWithRun({ targetConcurrency: 2, workUnits: 2 })
+
+    const result = await tickFleetRunSupervisor({
+      store,
+      pylonRef: "pylon.owner",
+      runRef: run.runRef,
+      planner: fixturePlannerWithClaims(store, 2),
+      runner: acceptingRunner(),
+      capacity: capacity([
+        { accountRef: "codex-a", advertisedCapacity: 1, paused: true },
+        { accountRef: "codex-b", advertisedCapacity: 1 },
+      ]),
+      clock: { now: () => fixedNow },
+    })
+
+    expect(result.dispatched).toBe(1)
+    expect(store.listWorkClaims({ runRef: run.runRef }).map(claim => claim.workerAccountRef)).toEqual([
+      "codex-b",
+    ])
+  })
+
   test("streams terminal lifecycle into counters and drains cleanly when backlog is empty", async () => {
     const { store, run } = createStoreWithRun({ targetConcurrency: 3, workUnits: 3 })
     const observed: FleetRunSupervisorObservedEvent[] = []

--- a/clients/khala-code-desktop/tests/fleet-status.test.ts
+++ b/clients/khala-code-desktop/tests/fleet-status.test.ts
@@ -186,7 +186,7 @@ describe("Fleet status panel", () => {
     const root = document.createElement("div")
     const connected: string[] = []
     const paused: { accountRef: string; paused: boolean }[] = []
-    let resetCredits = 0
+    const resetCredits: string[] = []
     let data = status()
     data = {
       ...data,
@@ -239,8 +239,8 @@ describe("Fleet status panel", () => {
         }
         return { ok: true }
       },
-      consumeResetCredit: async () => {
-        resetCredits += 1
+      consumeResetCredit: async request => {
+        resetCredits.push(request.accountRef)
         return { ok: true }
       },
       startDelegationOptimization: async () => {
@@ -265,12 +265,14 @@ describe("Fleet status panel", () => {
 
     clickButton(root, "Reset credits")
     await flushPanelWork()
-    expect(resetCredits).toBe(1)
+    expect(resetCredits).toEqual(["codex-a"])
 
     clickButton(root, "Reconnect")
     await flushPanelWork()
     expect(connected).toEqual(["codex-b"])
     expect(root.textContent).toContain("ABCD-1234")
+    clickButton(root, "Cancel")
+    await flushPanelWork()
   })
 
   test("previews the first FleetRun wave and starts through the mocked RPC", async () => {

--- a/clients/khala-code-desktop/tests/fleet-status.test.ts
+++ b/clients/khala-code-desktop/tests/fleet-status.test.ts
@@ -8,7 +8,7 @@ import type {
   KhalaCodeDesktopFleetRunStartResult,
   KhalaCodeDesktopFleetStatus,
 } from "../src/shared/rpc"
-import { mountFleetPanel } from "../src/ui/fleet-status"
+import { khalaFleetCountdownLabel, mountFleetPanel } from "../src/ui/fleet-status"
 
 let previousDocument: typeof globalThis.document | undefined
 let previousWindow: typeof globalThis.window | undefined
@@ -45,8 +45,33 @@ const status = (): KhalaCodeDesktopFleetStatus => ({
         ready: 2,
       },
       email: "operator-a@example.com",
+      paused: false,
       provider: "codex",
       quotaState: "available",
+      rateLimits: {
+        provider: "codex",
+        session: {
+          remainingPercent: 75,
+          resetDescription: null,
+          resetsAtIso: "2026-07-01T19:00:00.000Z",
+          usedPercent: 25,
+          windowMinutes: 300,
+        },
+        weekly: {
+          remainingPercent: 40,
+          resetDescription: null,
+          resetsAtIso: "2026-07-03T18:00:00.000Z",
+          usedPercent: 60,
+          windowMinutes: 10_080,
+        },
+        rateLimitResetCredits: {
+          availableCount: 1,
+          nextExpiresAtIso: "2026-07-02T18:00:00.000Z",
+        },
+        updatedAtIso: "2026-07-01T18:00:00.000Z",
+        error: null,
+        status: "ok",
+      },
       readiness: "ready",
     },
     {
@@ -59,6 +84,7 @@ const status = (): KhalaCodeDesktopFleetStatus => ({
         ready: 1,
       },
       email: "operator-b@example.com",
+      paused: false,
       provider: "codex",
       quotaState: "available",
       readiness: "ready",
@@ -151,6 +177,102 @@ describe("Fleet status panel", () => {
   beforeEach(installDom)
   afterEach(restoreDom)
 
+  test("renders account cards with rate-limit countdown data and account actions", async () => {
+    expect(khalaFleetCountdownLabel(
+      "2026-07-01T19:30:00.000Z",
+      new Date("2026-07-01T18:00:00.000Z"),
+    )).toBe("1h 30m")
+
+    const root = document.createElement("div")
+    const connected: string[] = []
+    const paused: { accountRef: string; paused: boolean }[] = []
+    let resetCredits = 0
+    let data = status()
+    data = {
+      ...data,
+      accounts: data.accounts.map(account =>
+        account.accountRef === "codex-b"
+          ? {
+              ...account,
+              readiness: "credentials_missing",
+              quotaState: "credentials_missing",
+              email: null,
+            }
+          : account,
+      ),
+    }
+
+    const panel = mountFleetPanel(root, {
+      connectAccount: async accountRef => {
+        connected.push(accountRef)
+        return {
+          ok: true,
+          accountRef,
+          output: "device auth started",
+          userCode: "ABCD-1234",
+          verificationUrl: "https://example.com/device",
+        }
+      },
+      delegateRun: async () => {
+        throw new Error("delegate runner should not be called")
+      },
+      fetch: async () => data,
+      fleetRunControl: async () => {
+        throw new Error("fleet run control should not be called")
+      },
+      fleetRunList: async () => ({ ok: true, runs: [] }),
+      fleetRunStart: async request => runStartResult(request),
+      loadGymDemoProof: () => {
+        throw new Error("gym proof should not be called")
+      },
+      openExternal: async () => true,
+      removeAccount: async () => ({ ok: true }),
+      setAccountPaused: async request => {
+        paused.push(request)
+        data = {
+          ...data,
+          accounts: data.accounts.map(account =>
+            account.accountRef === request.accountRef
+              ? { ...account, paused: request.paused }
+              : account,
+          ),
+        }
+        return { ok: true }
+      },
+      consumeResetCredit: async () => {
+        resetCredits += 1
+        return { ok: true }
+      },
+      startDelegationOptimization: async () => {
+        throw new Error("optimization should not be called")
+      },
+    })
+
+    await panel.refresh()
+
+    expect(root.textContent).toContain("codex-a")
+    expect(root.textContent).toContain("2/2 free")
+    expect(root.textContent).toContain("25% used / 75% remaining")
+    expect(root.textContent).toContain("60% used / 40% remaining")
+    expect(root.textContent).toContain("reset credits1")
+    expect(root.textContent).toContain("Pause account")
+    expect(root.textContent).toContain("Reconnect")
+
+    clickButton(root, "Pause account")
+    await flushPanelWork()
+    expect(paused).toEqual([{ accountRef: "codex-a", paused: true }])
+    expect(root.textContent).toContain("Resume planning")
+
+    clickButton(root, "Reset credits")
+    await flushPanelWork()
+    expect(resetCredits).toBe(1)
+
+    clickButton(root, "Reconnect")
+    await flushPanelWork()
+    expect(connected).toEqual(["codex-b"])
+    expect(root.textContent).toContain("ABCD-1234")
+  })
+
   test("previews the first FleetRun wave and starts through the mocked RPC", async () => {
     const root = document.createElement("div")
     const requests: KhalaCodeDesktopFleetRunStartRequest[] = []
@@ -183,6 +305,8 @@ describe("Fleet status panel", () => {
       },
       openExternal: async () => false,
       removeAccount: async () => ({ ok: true }),
+      setAccountPaused: async () => ({ ok: true }),
+      consumeResetCredit: async () => ({ ok: true }),
       startDelegationOptimization: async () => {
         throw new Error("optimization should not be called")
       },
@@ -268,6 +392,8 @@ describe("Fleet status panel", () => {
       },
       openExternal: async () => false,
       removeAccount: async () => ({ ok: true }),
+      setAccountPaused: async () => ({ ok: true }),
+      consumeResetCredit: async () => ({ ok: true }),
       startDelegationOptimization: async () => {
         throw new Error("optimization should not be called")
       },
@@ -343,6 +469,8 @@ describe("Fleet status panel", () => {
       },
       openExternal: async () => false,
       removeAccount: async () => ({ ok: true }),
+      setAccountPaused: async () => ({ ok: true }),
+      consumeResetCredit: async () => ({ ok: true }),
       startDelegationOptimization: async () => {
         throw new Error("optimization should not be called")
       },

--- a/clients/khala-code-desktop/tests/rpc-handlers.test.ts
+++ b/clients/khala-code-desktop/tests/rpc-handlers.test.ts
@@ -656,6 +656,8 @@ describe("Khala Code desktop RPC handlers", () => {
         },
       }),
       consumeCodexRateLimitResetCredit: input => {
+        expect(input.accountRef).toBe("default")
+        expect(input.codexHomePath).toBeNull()
         expect(input.idempotencyKey).toBeTruthy()
         return "noCredit"
       },
@@ -666,7 +668,7 @@ describe("Khala Code desktop RPC handlers", () => {
       workingDirectory: process.cwd(),
     })
 
-    await expect(handler.consumeCodexRateLimitResetCredit()).resolves.toMatchObject({
+    await expect(handler.consumeCodexRateLimitResetCredit({ accountRef: "default" })).resolves.toMatchObject({
       ok: true,
       outcome: "noCredit",
       status: {


### PR DESCRIPTION
Closes #7841

Changes:

- Adds per-account Fleet cards with readiness, slots, real reset countdowns, reset-credit action, reconnect, and pause/resume planning controls.
- Persists paused Codex account state in the isolated Pylon account config and excludes paused accounts from planning.
