### PR TITLE
T6.5: qa-runner Khala desktop backend

### DIFF
--- a/apps/qa-runner/README.md
+++ b/apps/qa-runner/README.md
@@ -57,6 +57,7 @@ result and watching the video — *no local run*.
 | session → committed executor-style e2e scenario **distiller** (spec §E.2) | **real now** — `distill(trace)` emits `generated/<slug>.e2e.test.ts` |
 | skill emitter (NIP-SKL marketplace candidate, spec §E.1) | **typed seam + TODO, FUTURE/owner-gated** |
 | `localBackend` (real chromium on this host) | **real now** — the default |
+| `khalaDesktopBackend` (Khala Code Desktop preview + typed RPC) | **real now** — boots headless with fixture Codex app-server by default; live/headed paths remain explicitly armed |
 | `cloudVmBackend` (per-run OpenAgents Cloud firecracker / sek8s microVM) | **interface-only, owner-gated** — throws "not armed" unless an injected provisioner is supplied |
 | video (mp4 via ffmpeg, webm fallback) + trace + screenshots + `result.json` | **real now** |
 | run = verified receipt / settlement wrapper | **follow-up, owner-gated (settlement INERT)** |

--- a/apps/qa-runner/package.json
+++ b/apps/qa-runner/package.json
@@ -45,6 +45,7 @@
     "./cf-browser-backend": "./src/cf-browser-backend.ts",
     "./cf-browser-video": "./src/cf-browser-video.ts",
     "./cf-sandbox-backend": "./src/cf-sandbox-backend.ts",
+    "./khala-desktop-backend": "./src/khala-desktop-backend.ts",
     "./native-desktop-backend": "./src/native-desktop-backend.ts",
     "./native-desktop-runtime": "./src/native-desktop-runtime.ts",
     "./atif": "./src/atif.ts",
@@ -84,7 +85,7 @@
     "evals": "bun run src/evals-run.ts",
     "pr-comment": "bun run src/pr-comment-run.ts",
     "trace:fixture": "bun run src/trace-fixture.ts",
-    "test": "bun test src/byo-model.test.ts src/byo.test.ts src/runner.test.ts src/runner-hardening.test.ts src/timeouts.test.ts src/shard.test.ts src/public-safety.test.ts src/brain.test.ts src/backend.test.ts src/terminal-backend.test.ts src/container-backend.test.ts src/native-desktop-backend.test.ts src/khala-action.test.ts src/khala-driver.test.ts src/khala-config.test.ts src/khala-openrouter.test.ts src/session-trace.test.ts src/distiller.test.ts src/skill-candidate.test.ts src/receipt.test.ts src/run-settlement.test.ts src/khala-session.test.ts src/compose/build-plan.test.ts src/compose/ffmpeg.test.ts src/evals.test.ts src/pr-comment.test.ts src/control-auth.test.ts src/artifacts.test.ts src/control.test.ts src/api-server.test.ts src/failure-learning.test.ts src/failure-learning-gepa.test.ts src/target-registry.test.ts src/target-registry-run.test.ts src/cf-browser-backend.test.ts src/cf-browser-video.test.ts src/cf-sandbox-backend.test.ts src/atif.test.ts src/atif-html.test.ts src/codex-to-atif.test.ts src/redaction.test.ts src/claude-code-to-atif.test.ts src/publish-trace.test.ts src/trace-fixture.test.ts src/publish-trace-e2e.verify.test.ts",
+    "test": "bun test src/byo-model.test.ts src/byo.test.ts src/runner.test.ts src/runner-hardening.test.ts src/timeouts.test.ts src/shard.test.ts src/public-safety.test.ts src/brain.test.ts src/backend.test.ts src/terminal-backend.test.ts src/container-backend.test.ts src/native-desktop-backend.test.ts src/khala-desktop-backend.test.ts src/khala-action.test.ts src/khala-driver.test.ts src/khala-config.test.ts src/khala-openrouter.test.ts src/session-trace.test.ts src/distiller.test.ts src/skill-candidate.test.ts src/receipt.test.ts src/run-settlement.test.ts src/khala-session.test.ts src/compose/build-plan.test.ts src/compose/ffmpeg.test.ts src/evals.test.ts src/pr-comment.test.ts src/control-auth.test.ts src/artifacts.test.ts src/control.test.ts src/api-server.test.ts src/failure-learning.test.ts src/failure-learning-gepa.test.ts src/target-registry.test.ts src/target-registry-run.test.ts src/cf-browser-backend.test.ts src/cf-browser-video.test.ts src/cf-sandbox-backend.test.ts src/atif.test.ts src/atif-html.test.ts src/codex-to-atif.test.ts src/redaction.test.ts src/claude-code-to-atif.test.ts src/publish-trace.test.ts src/trace-fixture.test.ts src/publish-trace-e2e.verify.test.ts",
     "typecheck": "tsc --noEmit -p tsconfig.json",
     "playwright:install": "playwright install --with-deps chromium",
     "atif:emit": "bun run src/atif-emit.ts",
@@ -92,6 +93,7 @@
   },
   "dependencies": {
     "@openagentsinc/atif": "workspace:*",
+    "@openagentsinc/khala-qa-harness": "workspace:*",
     "effect": "catalog:",
     "playwright": "^1.61.0"
   },

--- a/apps/qa-runner/src/index.ts
+++ b/apps/qa-runner/src/index.ts
@@ -41,6 +41,16 @@ export {
 
 // Backends — the isolation abstraction; localBackend is the OSS default.
 export { localBackend, type Backend, type BackendSession, type LocalBackendOptions } from "./backend";
+export {
+  khalaDesktopBackend,
+  isKhalaDesktopBackendSession,
+  runKhalaDesktopHarnessScenario,
+  runKhalaDesktopHeadedNativeSmoke,
+  KhalaDesktopBackendBootError,
+  type KhalaDesktopBackendOptions,
+  type KhalaDesktopBackendSession,
+  type KhalaDesktopBackendTier,
+} from "./khala-desktop-backend";
 
 // The fixed-step runner (runQaSession) and the autonomous model-driven runner.
 export { runQaSession, type RunInput, type RunOutcome } from "./runner";

--- a/apps/qa-runner/src/khala-desktop-backend.test.ts
+++ b/apps/qa-runner/src/khala-desktop-backend.test.ts
@@ -7,6 +7,7 @@ import { Effect } from "effect";
 import { scriptedBrain } from "./brain";
 import { makeFakeChromium } from "./fake-chromium";
 import {
+  KhalaDesktopBackendBootError,
   khalaDesktopBackend,
   runKhalaDesktopHarnessScenario,
   runKhalaDesktopHeadedNativeSmoke,
@@ -38,9 +39,13 @@ const jsonResponse = (payload: unknown, init?: ResponseInit): Response =>
 const fakeSpawn = (seen: Array<{ cmd: readonly string[]; env: Readonly<Record<string, string | undefined>> }>): KhalaDesktopSpawn =>
   (input) => {
     seen.push({ cmd: input.cmd, env: input.env });
+    let resolveExited!: (code: number) => void;
+    const exited = new Promise<number>((resolve) => {
+      resolveExited = resolve;
+    });
     return {
-      exited: Promise.resolve(0),
-      kill: () => undefined,
+      exited,
+      kill: () => resolveExited(0),
       stderr: new ReadableStream({
         start(controller) {
           controller.enqueue(new TextEncoder().encode("{\"event\":\"fixture-stderr\"}\n"));
@@ -96,15 +101,99 @@ describe("khalaDesktopBackend", () => {
     expect(outcome.result.status).toBe("pass");
     expect(outcome.result.backend).toBe("khala-desktop");
     expect(outcome.result.target.baseUrl).toBe("khala-desktop://local");
-    expect(spawns[0]?.cmd).toEqual(["bun", "src/bun/index.ts"]);
+    expect(spawns[0]?.cmd).toEqual([process.execPath, "src/bun/index.ts"]);
     expect(spawns[0]?.env.KHALA_CODE_DESKTOP_OPEN_WINDOW).toBe("0");
     expect(spawns[0]?.env.KHALA_CODE_CODEX_APP_SERVER_FIXTURE).toBe("1");
+    expect(spawns[0]?.env.CODEX_HOME).toBe(join(dir, "fixture-codex-home"));
+    expect(spawns[0]?.env.KHALA_CODE_DESKTOP_WORKSPACE).toBe(join(dir, "fixture-workspace"));
+    expect(spawns[0]?.env.KHALA_CODE_TOKEN_USAGE_DISABLED).toBe("1");
+    expect(spawns[0]?.env.KHALA_CODE_TOKEN_USAGE_BACKGROUND_SYNC_DISABLED).toBe("1");
     expect(spawns[0]?.env.KHALA_CODE_DESKTOP_PREVIEW_RPC_TOKEN).toBe("qa-preview-test");
 
     const onDisk = decodeQaRunResult(JSON.parse(readFileSync(outcome.resultPath, "utf8")));
     expect(onDisk.artifacts.screenshots).toContain("00-preview-health.png");
     expect(existsSync(join(dir, "result.json"))).toBe(true);
     expect(existsSync(join(dir, "trace.zip"))).toBe(true);
+    expect(existsSync(join(dir, "khala-desktop-stdout.jsonl"))).toBe(true);
+    expect(existsSync(join(dir, "khala-desktop-stderr.jsonl"))).toBe(true);
+  });
+
+  test("fixture hermetic defaults are overridable", async () => {
+    const spawns: Array<{ cmd: readonly string[]; env: Readonly<Record<string, string | undefined>> }> = [];
+    const backend = khalaDesktopBackend({
+      chromium: makeFakeChromium(),
+      env: {
+        CODEX_HOME: "/tmp/custom-codex-home",
+        KHALA_CODE_DESKTOP_WORKSPACE: "/tmp/custom-workspace",
+        KHALA_CODE_TOKEN_USAGE_BACKGROUND_SYNC_DISABLED: "0",
+        KHALA_CODE_TOKEN_USAGE_DISABLED: "0",
+      },
+      fetch: (() => Promise.resolve(jsonResponse({ ok: true }))) as typeof fetch,
+      spawn: fakeSpawn(spawns),
+    });
+
+    const session = await backend.provision({ artifactDir: dir, target });
+    await session.teardown();
+
+    expect(spawns[0]?.env.CODEX_HOME).toBe("/tmp/custom-codex-home");
+    expect(spawns[0]?.env.KHALA_CODE_DESKTOP_WORKSPACE).toBe("/tmp/custom-workspace");
+    expect(spawns[0]?.env.KHALA_CODE_TOKEN_USAGE_DISABLED).toBe("0");
+    expect(spawns[0]?.env.KHALA_CODE_TOKEN_USAGE_BACKGROUND_SYNC_DISABLED).toBe("0");
+  });
+
+  test("boot failure reaps child, escalates to SIGKILL after TERM grace, and flushes logs", async () => {
+    const signals: Array<number | NodeJS.Signals | undefined> = [];
+    let resolveExited!: (code: number) => void;
+    const backend = khalaDesktopBackend({
+      chromium: makeFakeChromium(),
+      fetch: (() => Promise.resolve(jsonResponse({ ok: false }, { status: 503 }))) as typeof fetch,
+      previewPort: 50133,
+      spawn: () => ({
+        exited: new Promise<number>((resolve) => {
+          resolveExited = resolve;
+        }),
+        kill: (signal) => {
+          signals.push(signal);
+          if (signal === "SIGKILL") resolveExited(137);
+        },
+        stderr: new ReadableStream({
+          start(controller) {
+            controller.enqueue(new TextEncoder().encode("{\"event\":\"boot-stderr\"}\n"));
+            controller.close();
+          },
+        }),
+        stdout: new ReadableStream({
+          start(controller) {
+            controller.enqueue(new TextEncoder().encode("{\"event\":\"boot-stdout\"}\n"));
+            controller.close();
+          },
+        }),
+      }),
+      waitTimeoutMs: 1,
+    });
+
+    await expect(backend.provision({ artifactDir: dir, target })).rejects.toBeInstanceOf(KhalaDesktopBackendBootError);
+
+    expect(signals).toEqual(["SIGTERM", "SIGKILL"]);
+    expect(readFileSync(join(dir, "khala-desktop-stdout.jsonl"), "utf8")).toContain("boot-stdout");
+    expect(readFileSync(join(dir, "khala-desktop-stderr.jsonl"), "utf8")).toContain("boot-stderr");
+  });
+
+  test("health wait fails fast when the child exits before preview health is ready", async () => {
+    const backend = khalaDesktopBackend({
+      chromium: makeFakeChromium(),
+      fetch: (() => new Promise<Response>(() => undefined)) as typeof fetch,
+      previewPort: 50134,
+      spawn: () => ({
+        exited: Promise.resolve(42),
+        kill: () => undefined,
+        stderr: null,
+        stdout: null,
+      }),
+      waitTimeoutMs: 10_000,
+    });
+
+    await expect(backend.provision({ artifactDir: dir, target })).rejects.toThrow(/exited before health check/);
   });
 
   test("runs a fixture-tier RPC harness scenario through the preview access header", async () => {

--- a/apps/qa-runner/src/khala-desktop-backend.test.ts
+++ b/apps/qa-runner/src/khala-desktop-backend.test.ts
@@ -1,0 +1,163 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { Effect } from "effect";
+
+import { scriptedBrain } from "./brain";
+import { makeFakeChromium } from "./fake-chromium";
+import {
+  khalaDesktopBackend,
+  runKhalaDesktopHarnessScenario,
+  runKhalaDesktopHeadedNativeSmoke,
+  type KhalaDesktopSpawn,
+} from "./khala-desktop-backend";
+import { decodeQaRunResult } from "./result";
+import { runQaSession } from "./runner";
+import { makeTarget } from "./target";
+import { NativeDesktopNotArmedError } from "./native-desktop-backend";
+
+let dir: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "qa-khala-desktop-test-"));
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+const target = makeTarget({ name: "khala-code-desktop", baseUrl: "khala-desktop://local" });
+
+const jsonResponse = (payload: unknown, init?: ResponseInit): Response =>
+  new Response(JSON.stringify(payload), {
+    headers: { "content-type": "application/json" },
+    status: init?.status ?? 200,
+  });
+
+const fakeSpawn = (seen: Array<{ cmd: readonly string[]; env: Readonly<Record<string, string | undefined>> }>): KhalaDesktopSpawn =>
+  (input) => {
+    seen.push({ cmd: input.cmd, env: input.env });
+    return {
+      exited: Promise.resolve(0),
+      kill: () => undefined,
+      stderr: new ReadableStream({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode("{\"event\":\"fixture-stderr\"}\n"));
+          controller.close();
+        },
+      }),
+      stdout: new ReadableStream({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode("{\"event\":\"fixture-stdout\"}\n"));
+          controller.close();
+        },
+      }),
+    };
+  };
+
+describe("khalaDesktopBackend", () => {
+  test("boots fixture desktop headless and drives a scripted browser scenario with flushed artifacts", async () => {
+    const spawns: Array<{ cmd: readonly string[]; env: Readonly<Record<string, string | undefined>> }> = [];
+    const backend = khalaDesktopBackend({
+      chromium: makeFakeChromium({
+        pages: {
+          "/health": { text: "{\"ok\":true,\"app\":\"Khala Code Desktop\"}" },
+        },
+      }),
+      fetch: ((() =>
+        Promise.resolve(jsonResponse({
+          app: "Khala Code Desktop",
+          ok: true,
+          observedAt: "2026-07-01T00:00:00.000Z",
+        }))) as unknown) as typeof fetch,
+      previewAccessToken: "qa-preview-test",
+      previewPort: 50131,
+      spawn: fakeSpawn(spawns),
+    });
+
+    const outcome = await Effect.runPromise(
+      runQaSession({
+        artifactDir: dir,
+        backend,
+        brain: scriptedBrain([
+          { kind: "navigate", url: "/health", label: "open preview health" },
+          {
+            check: { kind: "text-contains", selector: "body", value: "Khala Code Desktop" },
+            kind: "assert",
+            label: "preview health names the desktop app",
+          },
+          { kind: "screenshot", label: "preview-health" },
+        ]),
+        target,
+      }),
+    );
+
+    expect(outcome.result.status).toBe("pass");
+    expect(outcome.result.backend).toBe("khala-desktop");
+    expect(outcome.result.target.baseUrl).toBe("khala-desktop://local");
+    expect(spawns[0]?.cmd).toEqual(["bun", "src/bun/index.ts"]);
+    expect(spawns[0]?.env.KHALA_CODE_DESKTOP_OPEN_WINDOW).toBe("0");
+    expect(spawns[0]?.env.KHALA_CODE_CODEX_APP_SERVER_FIXTURE).toBe("1");
+    expect(spawns[0]?.env.KHALA_CODE_DESKTOP_PREVIEW_RPC_TOKEN).toBe("qa-preview-test");
+
+    const onDisk = decodeQaRunResult(JSON.parse(readFileSync(outcome.resultPath, "utf8")));
+    expect(onDisk.artifacts.screenshots).toContain("00-preview-health.png");
+    expect(existsSync(join(dir, "result.json"))).toBe(true);
+    expect(existsSync(join(dir, "trace.zip"))).toBe(true);
+  });
+
+  test("runs a fixture-tier RPC harness scenario through the preview access header", async () => {
+    const headers: Record<string, string>[] = [];
+    const backend = khalaDesktopBackend({
+      chromium: makeFakeChromium(),
+      fetch: ((input, init) => {
+        if (String(input).endsWith("/health")) {
+          return Promise.resolve(jsonResponse({ ok: true }));
+        }
+        headers.push(Object.fromEntries(new Headers(init?.headers)));
+        return Promise.resolve(jsonResponse({
+          app: "Khala Code Desktop",
+          ok: true,
+          observedAt: "2026-07-01T00:00:00.000Z",
+        }));
+      }) as typeof fetch,
+      previewAccessToken: "qa-preview-test",
+      previewPort: 50132,
+      spawn: fakeSpawn([]),
+    });
+
+    const report = await runKhalaDesktopHarnessScenario({
+      artifactDir: dir,
+      backend,
+      scenario: {
+        backend: "fixture",
+        commitments: [{ claim: "fixture appInfo passes", evidence: "run-pass", id: "run.pass" }],
+        id: "scenario.khala_code.qa_runner_desktop_fixture_app_info.v1",
+        modes: ["rpc"],
+        phases: [
+          {
+            act: [{ kind: "rpc_call", method: "appInfo" }],
+            expect: [{ oracle: "schema", query: "appInfo" }, { oracle: "crash" }],
+            name: "boot-rpc",
+          },
+        ],
+      },
+      target,
+    });
+
+    expect(report.status).toBe("pass");
+    expect(headers[0]?.["x-khala-code-preview-token"]).toBe("qa-preview-test");
+    expect(existsSync(join(dir, "khala-desktop-harness-report.json"))).toBe(true);
+  });
+
+  test("headed native smoke is skip-safe unless QA_NATIVE_DESKTOP is armed", async () => {
+    await expect(
+      runKhalaDesktopHeadedNativeSmoke({
+        artifactDir: dir,
+        native: { env: {} },
+        target,
+      }),
+    ).rejects.toBeInstanceOf(NativeDesktopNotArmedError);
+  });
+});

--- a/apps/qa-runner/src/khala-desktop-backend.ts
+++ b/apps/qa-runner/src/khala-desktop-backend.ts
@@ -1,0 +1,259 @@
+// Khala Code Desktop backend for qa-runner.
+//
+// This backend boots the desktop app in preview-server mode, then drives the
+// existing Chromium surface against that preview URL. It also exposes the typed
+// Khala Code RPC client from `@openagentsinc/khala-qa-harness` with the preview
+// access header already configured. Fixture mode is the default and uses the
+// fixture Codex app-server so qa-runner smokes do not require live login/spend.
+
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { randomBytes } from "node:crypto";
+import { Effect } from "effect";
+import {
+  makeKhalaCodeRpcQaDriver,
+  runKhalaCodeQaScenario,
+  type KhalaCodeQaScenario,
+  type KhalaCodeQaScenarioRunReport,
+  type KhalaCodeRpcClient,
+  type KhalaCodeRpcFetch,
+} from "@openagentsinc/khala-qa-harness";
+
+import {
+  localBackend,
+  type Backend,
+  type BackendSession,
+  type LocalBackendOptions,
+} from "./backend";
+import {
+  nativeDesktopExample,
+  runNativeDesktopScenario,
+  type NativeDesktopBackendOptions,
+  type NativeDesktopOutcome,
+} from "./native-desktop-backend";
+import type { Target } from "./target";
+
+const DEFAULT_PREVIEW_PORT = 50121;
+const DEFAULT_DESKTOP_CWD = resolve(import.meta.dir, "../../../clients/khala-code-desktop");
+const DESKTOP_STDOUT_FILE = "khala-desktop-stdout.jsonl";
+const DESKTOP_STDERR_FILE = "khala-desktop-stderr.jsonl";
+const HARNESS_REPORT_FILE = "khala-desktop-harness-report.json";
+
+export type KhalaDesktopBackendTier = "fixture" | "live_codex";
+
+export type KhalaDesktopChildProcess = {
+  readonly stdout?: ReadableStream<Uint8Array> | null;
+  readonly stderr?: ReadableStream<Uint8Array> | null;
+  readonly exited: Promise<number>;
+  readonly kill: (signal?: number | NodeJS.Signals) => void;
+};
+
+export type KhalaDesktopSpawn = (input: {
+  readonly cmd: readonly string[];
+  readonly cwd: string;
+  readonly env: Readonly<Record<string, string | undefined>>;
+}) => KhalaDesktopChildProcess;
+
+export interface KhalaDesktopBackendOptions extends LocalBackendOptions {
+  readonly backendTier?: KhalaDesktopBackendTier;
+  readonly desktopCwd?: string;
+  readonly env?: Readonly<Record<string, string | undefined>>;
+  readonly fetch?: typeof fetch;
+  readonly previewAccessToken?: string;
+  readonly previewPort?: number;
+  readonly spawn?: KhalaDesktopSpawn;
+  readonly waitTimeoutMs?: number;
+}
+
+export interface KhalaDesktopBackendSession extends BackendSession {
+  readonly previewAccessHeader: "x-khala-code-preview-token";
+  readonly previewBaseUrl: string;
+  readonly rpcClient: KhalaCodeRpcClient;
+}
+
+export class KhalaDesktopBackendBootError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "KhalaDesktopBackendBootError";
+  }
+}
+
+const sleep = (ms: number): Promise<void> => new Promise((resolveSleep) => setTimeout(resolveSleep, ms));
+
+const previewBaseUrl = (port: number): string => `http://127.0.0.1:${port}`;
+
+const makePreviewAccessToken = (): string => `qa_${randomBytes(18).toString("base64url")}`;
+
+const defaultSpawn: KhalaDesktopSpawn = ({ cmd, cwd, env }) =>
+  Bun.spawn([...cmd], {
+    cwd,
+    env: Object.fromEntries(
+      Object.entries(env).filter((entry): entry is [string, string] => entry[1] !== undefined),
+    ),
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+
+const appendStreamToFile = (
+  stream: ReadableStream<Uint8Array> | null | undefined,
+  path: string,
+): Promise<void> => {
+  if (stream === null || stream === undefined) return Promise.resolve();
+  const decoder = new TextDecoder();
+  const reader = stream.getReader();
+  return (async () => {
+    let buffered = "";
+    try {
+      for (;;) {
+        const chunk = await reader.read();
+        if (chunk.done) break;
+        buffered += decoder.decode(chunk.value, { stream: true });
+      }
+      buffered += decoder.decode();
+      if (buffered.length > 0) writeFileSync(path, buffered);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      writeFileSync(path, `${JSON.stringify({ level: "error", message })}\n`);
+    }
+  })();
+};
+
+const waitForPreviewHealth = async (input: {
+  readonly baseUrl: string;
+  readonly fetch: typeof fetch;
+  readonly timeoutMs: number;
+}): Promise<void> => {
+  const deadline = Date.now() + input.timeoutMs;
+  let lastError = "preview health check did not respond";
+  while (Date.now() < deadline) {
+    try {
+      const response = await input.fetch(new URL("/health", input.baseUrl), {
+        signal: AbortSignal.timeout(500),
+      });
+      if (response.ok) return;
+      lastError = `preview health returned ${response.status}`;
+    } catch (error) {
+      lastError = error instanceof Error ? error.message : String(error);
+    }
+    await sleep(100);
+  }
+  throw new KhalaDesktopBackendBootError(`Khala desktop preview failed to boot: ${lastError}`);
+};
+
+export function khalaDesktopBackend(options: KhalaDesktopBackendOptions = {}): Backend {
+  const env = options.env ?? process.env;
+  const port = options.previewPort ?? DEFAULT_PREVIEW_PORT;
+  const baseUrl = previewBaseUrl(port);
+  const accessToken = options.previewAccessToken ?? makePreviewAccessToken();
+  const fetchImpl = options.fetch ?? globalThis.fetch.bind(globalThis);
+  const spawn = options.spawn ?? defaultSpawn;
+  const desktopCwd = options.desktopCwd ?? DEFAULT_DESKTOP_CWD;
+  const backendTier = options.backendTier ?? "fixture";
+  const waitTimeoutMs = options.waitTimeoutMs ?? 10_000;
+
+  return {
+    name: "khala-desktop",
+    provision: async ({ target, artifactDir, headed }): Promise<KhalaDesktopBackendSession> => {
+      mkdirSync(artifactDir, { recursive: true });
+      const childEnv: Record<string, string | undefined> = {
+        ...env,
+        KHALA_CODE_DESKTOP_OPEN_WINDOW: headed ? "1" : "0",
+        KHALA_CODE_DESKTOP_PREVIEW_PORT: String(port),
+        KHALA_CODE_DESKTOP_PREVIEW_RPC_TOKEN: accessToken,
+        KHALA_CODE_DESKTOP_PREVIEW_READONLY: backendTier === "fixture" ? "1" : env.KHALA_CODE_DESKTOP_PREVIEW_READONLY,
+        KHALA_CODE_CODEX_APP_SERVER_FIXTURE: backendTier === "fixture" ? "1" : env.KHALA_CODE_CODEX_APP_SERVER_FIXTURE,
+      };
+      const child = spawn({
+        cmd: ["bun", "src/bun/index.ts"],
+        cwd: desktopCwd,
+        env: childEnv,
+      });
+      const logFlushes = [
+        appendStreamToFile(child.stdout, join(artifactDir, DESKTOP_STDOUT_FILE)),
+        appendStreamToFile(child.stderr, join(artifactDir, DESKTOP_STDERR_FILE)),
+      ];
+
+      try {
+        await waitForPreviewHealth({ baseUrl, fetch: fetchImpl, timeoutMs: waitTimeoutMs });
+      } catch (error) {
+        child.kill("SIGTERM");
+        throw error;
+      }
+
+      const previewTarget: Target = { ...target, baseUrl };
+      const browserSession = await localBackend({
+        ...(options.chromium !== undefined ? { chromium: options.chromium } : {}),
+      }).provision({ target: previewTarget, artifactDir, ...(headed !== undefined ? { headed } : {}) });
+      const driver = makeKhalaCodeRpcQaDriver({
+        accessToken,
+        baseUrl,
+        fetch: fetchImpl as KhalaCodeRpcFetch,
+      });
+
+      return {
+        acquireBrowser: () => browserSession.acquireBrowser(),
+        previewAccessHeader: "x-khala-code-preview-token",
+        previewBaseUrl: baseUrl,
+        rpcClient: driver.client,
+        teardown: async () => {
+          await browserSession.teardown();
+          child.kill("SIGTERM");
+          await Promise.race([child.exited.catch(() => 1), sleep(1_000)]);
+          await Promise.race([Promise.allSettled(logFlushes), sleep(1_000)]);
+        },
+      };
+    },
+  };
+}
+
+export const isKhalaDesktopBackendSession = (
+  session: BackendSession,
+): session is KhalaDesktopBackendSession =>
+  typeof (session as Partial<KhalaDesktopBackendSession>).previewBaseUrl === "string" &&
+  (session as Partial<KhalaDesktopBackendSession>).rpcClient !== undefined;
+
+export async function runKhalaDesktopHarnessScenario(input: {
+  readonly artifactDir: string;
+  readonly backend?: Backend;
+  readonly scenario: KhalaCodeQaScenario;
+  readonly target: Target;
+}): Promise<KhalaCodeQaScenarioRunReport> {
+  const backend = input.backend ?? khalaDesktopBackend();
+  const session = await backend.provision({
+    artifactDir: input.artifactDir,
+    target: input.target,
+  });
+  if (!isKhalaDesktopBackendSession(session)) {
+    await session.teardown();
+    throw new KhalaDesktopBackendBootError("Backend did not return a Khala desktop session.");
+  }
+  const driver = makeKhalaCodeRpcQaDriver({
+    baseUrl: session.previewBaseUrl,
+    fetch: session.rpcClient.fetch,
+    ...(session.rpcClient.accessToken === undefined
+      ? {}
+      : { accessToken: session.rpcClient.accessToken }),
+  });
+  try {
+    const report = await Effect.runPromise(runKhalaCodeQaScenario({ driver, scenario: input.scenario }));
+    writeFileSync(join(input.artifactDir, HARNESS_REPORT_FILE), `${JSON.stringify(report, null, 2)}\n`);
+    return report;
+  } finally {
+    await session.teardown();
+  }
+}
+
+export async function runKhalaDesktopHeadedNativeSmoke(input: {
+  readonly artifactDir: string;
+  readonly native?: NativeDesktopBackendOptions;
+  readonly target: Target;
+}): Promise<NativeDesktopOutcome> {
+  return runNativeDesktopScenario(
+    {
+      artifactDir: input.artifactDir,
+      scenario: nativeDesktopExample("Khala Code"),
+      target: input.target,
+    },
+    input.native,
+  );
+}

--- a/apps/qa-runner/src/khala-desktop-backend.ts
+++ b/apps/qa-runner/src/khala-desktop-backend.ts
@@ -7,6 +7,7 @@
 // fixture Codex app-server so qa-runner smokes do not require live login/spend.
 
 import { mkdirSync, writeFileSync } from "node:fs";
+import { createServer } from "node:net";
 import { join, resolve } from "node:path";
 import { randomBytes } from "node:crypto";
 import { Effect } from "effect";
@@ -33,11 +34,11 @@ import {
 } from "./native-desktop-backend";
 import type { Target } from "./target";
 
-const DEFAULT_PREVIEW_PORT = 50121;
 const DEFAULT_DESKTOP_CWD = resolve(import.meta.dir, "../../../clients/khala-code-desktop");
 const DESKTOP_STDOUT_FILE = "khala-desktop-stdout.jsonl";
 const DESKTOP_STDERR_FILE = "khala-desktop-stderr.jsonl";
 const HARNESS_REPORT_FILE = "khala-desktop-harness-report.json";
+const CHILD_TERM_GRACE_MS = 1_000;
 
 export type KhalaDesktopBackendTier = "fixture" | "live_codex";
 
@@ -84,6 +85,19 @@ const previewBaseUrl = (port: number): string => `http://127.0.0.1:${port}`;
 
 const makePreviewAccessToken = (): string => `qa_${randomBytes(18).toString("base64url")}`;
 
+const findAvailablePort = (): Promise<number> =>
+  new Promise((resolvePort, rejectPort) => {
+    const server = createServer();
+    server.once("error", rejectPort);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      server.close(() => {
+        if (typeof address === "object" && address !== null) resolvePort(address.port);
+        else rejectPort(new Error("failed to allocate preview port"));
+      });
+    });
+  });
+
 const defaultSpawn: KhalaDesktopSpawn = ({ cmd, cwd, env }) =>
   Bun.spawn([...cmd], {
     cwd,
@@ -120,30 +134,73 @@ const appendStreamToFile = (
 
 const waitForPreviewHealth = async (input: {
   readonly baseUrl: string;
+  readonly childExited: Promise<number>;
   readonly fetch: typeof fetch;
   readonly timeoutMs: number;
 }): Promise<void> => {
   const deadline = Date.now() + input.timeoutMs;
   let lastError = "preview health check did not respond";
+  const childExited = input.childExited.then((code): never => {
+    throw new KhalaDesktopBackendBootError(`Khala desktop preview exited before health check passed (code ${code})`);
+  });
   while (Date.now() < deadline) {
     try {
-      const response = await input.fetch(new URL("/health", input.baseUrl), {
-        signal: AbortSignal.timeout(500),
-      });
+      const response = await Promise.race([
+        input.fetch(new URL("/health", input.baseUrl), {
+          signal: AbortSignal.timeout(500),
+        }),
+        childExited,
+      ]);
       if (response.ok) return;
       lastError = `preview health returned ${response.status}`;
     } catch (error) {
       lastError = error instanceof Error ? error.message : String(error);
     }
-    await sleep(100);
+    await Promise.race([sleep(100), childExited]);
   }
   throw new KhalaDesktopBackendBootError(`Khala desktop preview failed to boot: ${lastError}`);
 };
 
+const shutdownChild = async (
+  child: KhalaDesktopChildProcess,
+  logFlushes: ReadonlyArray<Promise<void>>,
+): Promise<void> => {
+  child.kill("SIGTERM");
+  const exitedAfterTerm = await Promise.race([
+    child.exited.then(() => true, () => true),
+    sleep(CHILD_TERM_GRACE_MS).then(() => false),
+  ]);
+  if (!exitedAfterTerm) child.kill("SIGKILL");
+  await child.exited.catch(() => undefined);
+  await Promise.allSettled(logFlushes);
+};
+
+const fixtureDefaultEnv = (
+  env: Readonly<Record<string, string | undefined>>,
+  artifactDir: string,
+  allowOverrides: boolean,
+): Record<string, string> => ({
+  CODEX_HOME: allowOverrides && env.CODEX_HOME !== undefined ? env.CODEX_HOME : join(artifactDir, "fixture-codex-home"),
+  KHALA_CODE_DESKTOP_PREVIEW_READONLY:
+    allowOverrides && env.KHALA_CODE_DESKTOP_PREVIEW_READONLY !== undefined
+      ? env.KHALA_CODE_DESKTOP_PREVIEW_READONLY
+      : "1",
+  KHALA_CODE_DESKTOP_WORKSPACE:
+    allowOverrides && env.KHALA_CODE_DESKTOP_WORKSPACE !== undefined
+      ? env.KHALA_CODE_DESKTOP_WORKSPACE
+      : join(artifactDir, "fixture-workspace"),
+  KHALA_CODE_CODEX_APP_SERVER_FIXTURE:
+    allowOverrides && env.KHALA_CODE_CODEX_APP_SERVER_FIXTURE !== undefined ? env.KHALA_CODE_CODEX_APP_SERVER_FIXTURE : "1",
+  KHALA_CODE_TOKEN_USAGE_BACKGROUND_SYNC_DISABLED:
+    allowOverrides && env.KHALA_CODE_TOKEN_USAGE_BACKGROUND_SYNC_DISABLED !== undefined
+      ? env.KHALA_CODE_TOKEN_USAGE_BACKGROUND_SYNC_DISABLED
+      : "1",
+  KHALA_CODE_TOKEN_USAGE_DISABLED:
+    allowOverrides && env.KHALA_CODE_TOKEN_USAGE_DISABLED !== undefined ? env.KHALA_CODE_TOKEN_USAGE_DISABLED : "1",
+});
+
 export function khalaDesktopBackend(options: KhalaDesktopBackendOptions = {}): Backend {
   const env = options.env ?? process.env;
-  const port = options.previewPort ?? DEFAULT_PREVIEW_PORT;
-  const baseUrl = previewBaseUrl(port);
   const accessToken = options.previewAccessToken ?? makePreviewAccessToken();
   const fetchImpl = options.fetch ?? globalThis.fetch.bind(globalThis);
   const spawn = options.spawn ?? defaultSpawn;
@@ -155,16 +212,22 @@ export function khalaDesktopBackend(options: KhalaDesktopBackendOptions = {}): B
     name: "khala-desktop",
     provision: async ({ target, artifactDir, headed }): Promise<KhalaDesktopBackendSession> => {
       mkdirSync(artifactDir, { recursive: true });
+      const port = options.previewPort ?? (await findAvailablePort());
+      const baseUrl = previewBaseUrl(port);
+      const fixtureEnv = backendTier === "fixture" ? fixtureDefaultEnv(env, artifactDir, options.env !== undefined) : {};
       const childEnv: Record<string, string | undefined> = {
         ...env,
+        ...fixtureEnv,
         KHALA_CODE_DESKTOP_OPEN_WINDOW: headed ? "1" : "0",
         KHALA_CODE_DESKTOP_PREVIEW_PORT: String(port),
         KHALA_CODE_DESKTOP_PREVIEW_RPC_TOKEN: accessToken,
-        KHALA_CODE_DESKTOP_PREVIEW_READONLY: backendTier === "fixture" ? "1" : env.KHALA_CODE_DESKTOP_PREVIEW_READONLY,
-        KHALA_CODE_CODEX_APP_SERVER_FIXTURE: backendTier === "fixture" ? "1" : env.KHALA_CODE_CODEX_APP_SERVER_FIXTURE,
+        KHALA_CODE_DESKTOP_PREVIEW_READONLY:
+          backendTier === "fixture" ? fixtureEnv.KHALA_CODE_DESKTOP_PREVIEW_READONLY : env.KHALA_CODE_DESKTOP_PREVIEW_READONLY,
+        KHALA_CODE_CODEX_APP_SERVER_FIXTURE:
+          backendTier === "fixture" ? fixtureEnv.KHALA_CODE_CODEX_APP_SERVER_FIXTURE : env.KHALA_CODE_CODEX_APP_SERVER_FIXTURE,
       };
       const child = spawn({
-        cmd: ["bun", "src/bun/index.ts"],
+        cmd: [process.execPath, "src/bun/index.ts"],
         cwd: desktopCwd,
         env: childEnv,
       });
@@ -174,9 +237,9 @@ export function khalaDesktopBackend(options: KhalaDesktopBackendOptions = {}): B
       ];
 
       try {
-        await waitForPreviewHealth({ baseUrl, fetch: fetchImpl, timeoutMs: waitTimeoutMs });
+        await waitForPreviewHealth({ baseUrl, childExited: child.exited, fetch: fetchImpl, timeoutMs: waitTimeoutMs });
       } catch (error) {
-        child.kill("SIGTERM");
+        await shutdownChild(child, logFlushes);
         throw error;
       }
 
@@ -197,9 +260,7 @@ export function khalaDesktopBackend(options: KhalaDesktopBackendOptions = {}): B
         rpcClient: driver.client,
         teardown: async () => {
           await browserSession.teardown();
-          child.kill("SIGTERM");
-          await Promise.race([child.exited.catch(() => 1), sleep(1_000)]);
-          await Promise.race([Promise.allSettled(logFlushes), sleep(1_000)]);
+          await shutdownChild(child, logFlushes);
         },
       };
     },

--- a/bun.lock
+++ b/bun.lock
@@ -343,6 +343,7 @@
       },
       "dependencies": {
         "@openagentsinc/atif": "workspace:*",
+        "@openagentsinc/khala-qa-harness": "workspace:*",
         "effect": "catalog:",
         "playwright": "^1.61.0",
       },


### PR DESCRIPTION
Closes #7849

## Summary

- Add `khalaDesktopBackend` for qa-runner that boots Khala Code Desktop preview headless with fixture Codex app-server by default, drives Chromium against the preview URL, and exposes the typed Khala Code RPC client with the preview access header configured.
- Add a fixture-tier backend test covering headless boot env, one scripted Chromium scenario with artifact flush, RPC harness execution through the preview header, and skip-safe native headed gating via `QA_NATIVE_DESKTOP`.
- Export the backend surface and add the harness workspace dependency.

## Verification

- `bun run --cwd apps/qa-runner test` (`command.public.pylon_khala.verify.dcfac70eb367fcec07a02a05`)
- `bun run --cwd packages/khala-qa-harness test`

## Notes

- `bun run --cwd apps/qa-runner typecheck` still reports existing `packages/probe` TypeScript errors; no output references `khala-desktop-backend`.