### PR TITLE
T5.6: Cockpit visual smoke

### DIFF
--- a/clients/khala-code-desktop/package.json
+++ b/clients/khala-code-desktop/package.json
@@ -14,6 +14,7 @@
     "smoke:codex-spawn-live": "bun scripts/live-two-codex-readonly-smoke.ts",
     "smoke:composer-visual": "bun scripts/composer-visual-smoke.ts",
     "smoke:composer-visual-preview": "bun scripts/composer-visual-smoke.ts",
+    "smoke:cockpit-visual": "bun scripts/cockpit-visual-smoke.ts",
     "smoke:part2-fleet-gym-visual": "bun scripts/part2-fleet-gym-visual-smoke.ts",
     "smoke:part2-ui": "bun scripts/part2-ui-recording-smoke.ts",
     "bench:thread-switch": "bun scripts/thread-switch-benchmark.ts",

--- a/clients/khala-code-desktop/scripts/cockpit-visual-smoke.ts
+++ b/clients/khala-code-desktop/scripts/cockpit-visual-smoke.ts
@@ -1,0 +1,546 @@
+#!/usr/bin/env bun
+import { mkdir, rm, writeFile } from "node:fs/promises"
+import { dirname, join, resolve } from "node:path"
+
+import { chromium, type Browser, type Page } from "playwright"
+import {
+  khalaQaRectsOverlap as rectsOverlap,
+  startKhalaQaViteServer as startViteServer,
+  waitForKhalaQaHttp as waitForHttp,
+  type KhalaQaRect,
+} from "@openagentsinc/khala-qa-harness/desktop-smoke-helpers"
+
+import type {
+  KhalaCodeDesktopFleetRunListResult,
+  KhalaCodeDesktopFleetRunProjection,
+  KhalaCodeDesktopFleetStatus,
+} from "../src/shared/rpc"
+
+export type CockpitVisualViewport = Readonly<{
+  name: "desktop" | "mobile"
+  width: number
+  height: number
+}>
+
+type CockpitVisualGeometry = Readonly<{
+  accountCards: readonly KhalaQaRect[]
+  fleetCounts: KhalaQaRect
+  fleetPanel: KhalaQaRect
+  gauges: readonly KhalaQaRect[]
+  runHeader: KhalaQaRect
+  viewport: KhalaQaRect
+  workerCards: readonly KhalaQaRect[]
+}>
+
+export type CockpitVisualCapture = Readonly<{
+  accountCardCount: number
+  geometry: CockpitVisualGeometry
+  screenshot: string
+  viewport: CockpitVisualViewport["name"]
+  workerCardCount: number
+}>
+
+export const COCKPIT_VISUAL_SMOKE_HARNESS =
+  "khala_code_t5_6_cockpit_visual_smoke"
+
+export const cockpitVisualSmokeViewports = (): readonly CockpitVisualViewport[] => [
+  { name: "desktop", width: 1280, height: 800 },
+  { name: "mobile", width: 390, height: 844 },
+]
+
+export const assertCockpitVisualGeometry = (
+  geometry: CockpitVisualGeometry,
+): void => {
+  assertRect("Fleet panel", geometry.fleetPanel)
+  assertRect("Active FleetRun header", geometry.runHeader)
+  assertRect("sidebar fleet and inbox counts", geometry.fleetCounts)
+  assertCount("worker cards", geometry.workerCards, 18)
+  assertCount("account cards", geometry.accountCards, 3)
+  assertCount("throughput gauges", geometry.gauges, 3)
+
+  for (const [index, rect] of geometry.workerCards.entries()) {
+    assertRect(`worker card ${index + 1}`, rect)
+    assertNoHorizontalClipping(`worker card ${index + 1}`, rect, geometry.viewport)
+  }
+  for (const [index, rect] of geometry.accountCards.entries()) {
+    assertRect(`account card ${index + 1}`, rect)
+    assertNoHorizontalClipping(`account card ${index + 1}`, rect, geometry.viewport)
+  }
+  for (const [index, rect] of geometry.gauges.entries()) {
+    assertRect(`throughput gauge ${index + 1}`, rect)
+    assertNoHorizontalClipping(`throughput gauge ${index + 1}`, rect, geometry.viewport)
+  }
+  assertNoListOverlap("worker cards", geometry.workerCards)
+  assertNoListOverlap("account cards", geometry.accountCards)
+  assertNoListOverlap("throughput gauges", geometry.gauges)
+}
+
+export async function runCockpitVisualSmoke(
+  options: Readonly<{
+    keepServer?: boolean
+    outDir: string
+  }>,
+): Promise<readonly CockpitVisualCapture[]> {
+  await rm(options.outDir, { force: true, recursive: true })
+  await mkdir(options.outDir, { recursive: true })
+
+  const repoRoot = resolve(import.meta.dir, "../../..")
+  const port = 50027
+  const server = startViteServer({
+    cwd: join(repoRoot, "clients/khala-code-desktop"),
+    label: "khala-code-desktop-cockpit",
+    port,
+  })
+  let browser: Browser | null = null
+  try {
+    await waitForHttp(`http://127.0.0.1:${port}/`)
+    browser = await chromium.launch({ headless: true })
+    const captures: CockpitVisualCapture[] = []
+    for (const viewport of cockpitVisualSmokeViewports()) {
+      const page = await browser.newPage({
+        colorScheme: "dark",
+        reducedMotion: viewport.name === "mobile" ? "reduce" : "no-preference",
+        viewport: { height: viewport.height, width: viewport.width },
+      })
+      try {
+        await installCockpitRpcMocks(page)
+        captures.push(
+          await captureCockpit(page, {
+            baseUrl: `http://127.0.0.1:${port}`,
+            outDir: options.outDir,
+            viewport,
+          }),
+        )
+      } finally {
+        await page.close()
+      }
+    }
+    await writeFile(
+      join(options.outDir, "summary.json"),
+      `${JSON.stringify({
+        captures,
+        fixture: {
+          accounts: 3,
+          clock: cockpitClockIso,
+          workers: 18,
+        },
+        harness: COCKPIT_VISUAL_SMOKE_HARNESS,
+      }, null, 2)}\n`,
+    )
+    return captures
+  } finally {
+    if (browser !== null) await browser.close()
+    if (options.keepServer !== true) server.kill()
+  }
+}
+
+const cockpitClockIso = "2026-07-01T18:15:00.000Z"
+
+async function installCockpitRpcMocks(page: Page): Promise<void> {
+  await page.addInitScript((iso: string) => {
+    const RealDate = Date
+    class FixtureDate extends RealDate {
+      constructor(value?: string | number | Date) {
+        if (arguments.length === 0) {
+          super(iso)
+        } else {
+          super(value as string)
+        }
+      }
+      static override now(): number {
+        return new RealDate(iso).getTime()
+      }
+    }
+    Object.defineProperty(FixtureDate, "parse", { value: RealDate.parse })
+    Object.defineProperty(FixtureDate, "UTC", { value: RealDate.UTC })
+    Object.defineProperty(window, "Date", { configurable: true, value: FixtureDate })
+  }, cockpitClockIso)
+
+  await page.route("**/rpc/*", async route => {
+    const method = decodeURIComponent(new URL(route.request().url()).pathname.split("/").at(-1) ?? "")
+    switch (method) {
+      case "appInfo":
+        await route.fulfill({
+          contentType: "application/json",
+          body: JSON.stringify({
+            app: "Khala Code Desktop",
+            observedAt: cockpitClockIso,
+            ok: true,
+          }),
+        })
+        return
+      case "codexFleetStatus":
+        await route.fulfill({
+          contentType: "application/json",
+          body: JSON.stringify(cockpitFleetStatusFixture()),
+        })
+        return
+      case "fleetRunList":
+        await route.fulfill({
+          contentType: "application/json",
+          body: JSON.stringify(cockpitFleetRunListFixture()),
+        })
+        return
+      case "openExternalUrl":
+        await route.fulfill({
+          contentType: "application/json",
+          body: JSON.stringify(true),
+        })
+        return
+      default:
+        await route.fulfill({
+          contentType: "application/json",
+          status: 500,
+          body: JSON.stringify({ error: `unexpected cockpit visual smoke RPC: ${method}` }),
+        })
+    }
+  })
+}
+
+async function captureCockpit(
+  page: Page,
+  input: Readonly<{
+    baseUrl: string
+    outDir: string
+    viewport: CockpitVisualViewport
+  }>,
+): Promise<CockpitVisualCapture> {
+  await page.goto(`${input.baseUrl}/`, { waitUntil: "domcontentloaded" })
+  await page.locator('[data-khala-code-hotbar-value="fleet"]').waitFor({
+    state: "visible",
+  })
+  await page.locator('[data-khala-code-hotbar-value="fleet"]').click()
+  await page.locator("#fleet-panel").waitFor({ state: "visible" })
+  await expectText(page, "#fleet-panel", "Active FleetRun")
+  await expectText(page, "#fleet-panel", "Worker Codex accounts")
+  await expectText(page, "#fleet-panel", "18 active")
+  await expectText(page, "#fleet-panel", "3 ready")
+  await expectText(page, "#fleet-panel", "12/30 Codex slots free")
+  await expectText(page, "#fleet-panel", "resets in 45m")
+  await expectText(page, "#fleet-panel", "resets in 2d 23h")
+  await expectCountLabel(page)
+  await assertPagePublicSafe(page)
+
+  const geometry = await collectCockpitGeometry(page)
+  assertCockpitVisualGeometry(geometry)
+
+  const screenshot = join(
+    input.outDir,
+    `khala-code-cockpit-${input.viewport.name}.png`,
+  )
+  await mkdir(dirname(screenshot), { recursive: true })
+  await page.screenshot({ fullPage: true, path: screenshot })
+
+  return {
+    accountCardCount: geometry.accountCards.length,
+    geometry,
+    screenshot,
+    viewport: input.viewport.name,
+    workerCardCount: geometry.workerCards.length,
+  }
+}
+
+const collectCockpitGeometry = async (page: Page): Promise<CockpitVisualGeometry> =>
+  page.evaluate(() => {
+    const rectFor = (selector: string): KhalaQaRect => {
+      const element = document.querySelector(selector)
+      if (!(element instanceof HTMLElement) && !(element instanceof SVGElement)) {
+        throw new Error(`missing cockpit visual selector: ${selector}`)
+      }
+      return toRect(element.getBoundingClientRect())
+    }
+    const rectsFor = (selector: string): KhalaQaRect[] =>
+      [...document.querySelectorAll(selector)]
+        .filter((element): element is HTMLElement | SVGElement =>
+          element instanceof HTMLElement || element instanceof SVGElement,
+        )
+        .map(element => toRect(element.getBoundingClientRect()))
+    const toRect = (rect: DOMRect): KhalaQaRect => ({
+      height: rect.height,
+      width: rect.width,
+      x: rect.x,
+      y: rect.y + window.scrollY,
+    })
+    return {
+      accountCards: rectsFor(".khala-fleet-account"),
+      fleetCounts: rectFor("[data-khala-code-fleet-counts]"),
+      fleetPanel: rectFor("#fleet-panel"),
+      gauges: rectsFor(".khala-fleet-throughput-gauge"),
+      runHeader: rectFor(".khala-fleet-run-header"),
+      viewport: {
+        height: document.documentElement.scrollHeight,
+        width: window.innerWidth,
+        x: 0,
+        y: 0,
+      },
+      workerCards: rectsFor(".khala-fleet-worker-card"),
+    }
+  })
+
+const assertRect = (label: string, rect: KhalaQaRect): void => {
+  if (rect.width < 1 || rect.height < 1) {
+    throw new Error(`${label} is not visible`)
+  }
+}
+
+const assertNoHorizontalClipping = (
+  label: string,
+  rect: KhalaQaRect,
+  viewport: KhalaQaRect,
+): void => {
+  if (rect.x < -1 || rect.x + rect.width > viewport.width + 1) {
+    throw new Error(`${label} is horizontally clipped: ${JSON.stringify({ rect, viewport })}`)
+  }
+}
+
+const assertCount = (
+  label: string,
+  rects: readonly KhalaQaRect[],
+  expected: number,
+): void => {
+  if (rects.length !== expected) {
+    throw new Error(`expected ${expected} ${label}, rendered ${rects.length}`)
+  }
+}
+
+const assertNoListOverlap = (
+  label: string,
+  rects: readonly KhalaQaRect[],
+): void => {
+  for (let left = 0; left < rects.length; left += 1) {
+    for (let right = left + 1; right < rects.length; right += 1) {
+      if (rectsOverlap(rects[left]!, rects[right]!)) {
+        throw new Error(`${label} overlap: ${left + 1} and ${right + 1}`)
+      }
+    }
+  }
+}
+
+const expectText = async (
+  page: Page,
+  selector: string,
+  expected: string,
+): Promise<void> => {
+  await page.waitForFunction(
+    ({ selector: targetSelector, expected: targetExpected }) =>
+      document.querySelector(targetSelector)?.textContent?.includes(targetExpected) === true,
+    { expected, selector },
+  )
+}
+
+const expectCountLabel = async (page: Page): Promise<void> => {
+  await page.waitForFunction(() => {
+    const counts = document.querySelector("[data-khala-code-fleet-counts]")
+    const label = counts?.getAttribute("aria-label") ?? ""
+    return label.includes("3 accounts ready") &&
+      label.includes("18 workers active") &&
+      label.includes("12 slots free") &&
+      label.includes("2 flags")
+  })
+}
+
+const unsafeTextPattern =
+  /\/Users\/|\/home\/|auth\.json|bearer|credential|provider[_-]?payload|raw[_-]?(prompt|trace|log|provider)|secret|sk-[a-z0-9]/i
+
+const assertPagePublicSafe = async (page: Page): Promise<void> => {
+  const text = await page.locator("body").textContent()
+  if (unsafeTextPattern.test(text ?? "")) {
+    throw new Error("Cockpit visual smoke rendered private or raw material")
+  }
+}
+
+const cockpitFleetRunListFixture = (): KhalaCodeDesktopFleetRunListResult => ({
+  ok: true,
+  runs: [cockpitFleetRunFixture()],
+})
+
+const cockpitFleetRunFixture = (): KhalaCodeDesktopFleetRunProjection => ({
+  counters: {
+    activeAssignments: 18,
+    blockedAssignments: 2,
+    completedAssignments: 42,
+    failedAssignments: 0,
+    workUnitsTotal: 80,
+  },
+  createdAt: "2026-07-01T18:00:00.000Z",
+  dispatchKind: "supervised_dispatch",
+  objectiveProjected: false,
+  pylonRef: "pylon.local.cockpit",
+  refillPolicy: {
+    cooldownAware: true,
+    maxPerAccount: 10,
+    stopCondition: "backlog_empty",
+  },
+  runRef: "fleet.run.public.t5_6_cockpit_fixture",
+  startedAt: "2026-07-01T18:00:00.000Z",
+  state: "running",
+  targetConcurrency: 18,
+  updatedAt: cockpitClockIso,
+  workerKind: "codex",
+  workSource: { kind: "fixture" },
+})
+
+const cockpitFleetStatusFixture = (): KhalaCodeDesktopFleetStatus => ({
+  activeAssignments: Array.from({ length: 18 }, (_, index) => {
+    const worker = index + 1
+    const blocked = worker === 7 || worker === 14
+    return {
+      assignmentRef: `assignment.public.t5_6_cockpit.${worker.toString().padStart(2, "0")}`,
+      blockerRefs: blocked ? [`blocker.public.fixture.${worker}`] : [],
+      closeoutStatus: null,
+      elapsedMs: 60_000 + worker * 7_000,
+      issueRef: `github.issue.openagents.${7800 + worker}`,
+      runRef: "fleet.run.public.t5_6_cockpit_fixture",
+      tokenRate: {
+        source: worker % 3 === 0 ? "token_usage_events" : "fleet.activeAssignments.tokensSoFar",
+        status: worker % 3 === 0 ? "exact" : "pending",
+        tokenCountKind: worker % 3 === 0 ? "total" : null,
+        tokens: worker % 3 === 0 ? 1_200 + worker : null,
+        tokensPerMinute: worker % 3 === 0 ? 240 + worker : null,
+      },
+      updatedAt: cockpitClockIso,
+      workerSession: {
+        approvalState: blocked ? "blocked" : "none",
+        blockerRefs: blocked ? [`blocker.public.fixture.${worker}`] : [],
+        closeoutStatus: null,
+        executionRuntime: "codex_harness",
+        homeRole: "pylon_isolated_worker_codex_home",
+        queuePolicy: {
+          admission: "pylon_capacity_gate",
+          cooldown: worker % 6 === 0 ? "cooling_down" : "ready",
+          refill: "pylon_presence_heartbeat",
+          queued: worker % 4 === 0 ? 1 : 0,
+        },
+        reviewState: blocked ? "blocked" : "active",
+        role: "swarm_worker_codex_session",
+        transcriptRef: `transcript.public.t5_6_cockpit.${worker}`,
+      },
+    }
+  }),
+  accounts: [
+    accountFixture("codex", 4, 6, 0, 0, 25, 75, 1),
+    accountFixture("codex-2", 5, 6, 1, 0, 42, 58, 0),
+    accountFixture("codex-3", 3, 6, 1, 2, 63, 37, 2),
+  ],
+  availableCodexAssignments: 12,
+  maxCodexAssignments: 30,
+  observedAt: cockpitClockIso,
+  ok: true,
+  processes: [],
+  pylon: {
+    message: "Fixture Pylon ready with 18 active Codex workers",
+    pylonRef: "pylon.local.cockpit",
+    status: "online",
+  },
+  sessionLayers: {
+    main: {
+      homeRole: "main_user_codex_home_display_only",
+      label: "Primary user Codex session",
+      mutationPolicy: "codex_app_server_owned",
+      role: "main_local_codex_session",
+      runtime: "codex_harness",
+      transcriptSurface: "chat",
+    },
+    workers: {
+      homeRole: "pylon_isolated_worker_codex_home",
+      label: "Khala swarm worker Codex sessions",
+      mutationPolicy: "pylon_isolated_home_only",
+      role: "swarm_worker_codex_session",
+      runtime: "codex_harness",
+      transcriptSurface: "fleet",
+    },
+  },
+  tokenRate: {
+    activeAdjustedTokensPerMinute: 12_400,
+    completedStatus: "exact",
+    completedTokenRows: 42,
+    completedTokensPerMinute: 8_640,
+    inFlightTokens: 28_000,
+    inFlightTokensPerMinute: 3_760,
+    source: "pylon_khala_apm",
+    tokensWindow: 86_400,
+    unavailableReason: null,
+  },
+})
+
+const accountFixture = (
+  accountRef: string,
+  available: number,
+  ready: number,
+  busy: number,
+  queued: number,
+  usedPercent: number,
+  remainingPercent: number,
+  resetCredits: number,
+): KhalaCodeDesktopFleetStatus["accounts"][number] => ({
+  accountKey: `account.public.${accountRef}`,
+  accountRef,
+  capacity: {
+    available,
+    busy,
+    queued,
+    ready,
+  },
+  email: null,
+  homeRole: "pylon_isolated_worker_codex_home",
+  paused: false,
+  provider: "codex",
+  queuePolicy: {
+    admission: "pylon_capacity_gate",
+    cooldown: queued > 0 ? "cooling_down" : "ready",
+    refill: "pylon_presence_heartbeat",
+    queued,
+  },
+  quotaState: queued > 0 ? "cooling_down" : "available",
+  rateLimits: {
+    error: null,
+    provider: "codex",
+    rateLimitResetCredits: {
+      availableCount: resetCredits,
+      nextExpiresAtIso: "2026-07-02T18:00:00.000Z",
+      totalEarnedCount: resetCredits,
+    },
+    session: {
+      remainingPercent,
+      resetDescription: null,
+      resetsAtIso: "2026-07-01T19:00:00.000Z",
+      usedPercent,
+      windowMinutes: 300,
+    },
+    status: "ok",
+    updatedAtIso: cockpitClockIso,
+    weekly: {
+      remainingPercent: Math.max(0, remainingPercent - 12),
+      resetDescription: null,
+      resetsAtIso: "2026-07-04T17:15:00.000Z",
+      usedPercent: Math.min(100, usedPercent + 12),
+      windowMinutes: 10_080,
+    },
+  },
+  readiness: "ready",
+  sessionRole: "swarm_worker_codex_session",
+})
+
+if (import.meta.main) {
+  const outDir =
+    argValue(Bun.argv.slice(2), "--out") ??
+    resolve("var/khala-code-desktop/cockpit-visual-smoke")
+  try {
+    const captures = await runCockpitVisualSmoke({ outDir })
+    console.log(JSON.stringify({
+      captures,
+      harness: COCKPIT_VISUAL_SMOKE_HARNESS,
+      ok: true,
+      outDir,
+    }, null, 2))
+  } catch (error) {
+    console.error(error instanceof Error ? error.stack ?? error.message : error)
+    process.exit(1)
+  }
+}
+
+function argValue(args: readonly string[], name: string): string | undefined {
+  const index = args.indexOf(name)
+  if (index === -1) return undefined
+  return args[index + 1]
+}

--- a/clients/khala-code-desktop/src/ui/fleet-status.ts
+++ b/clients/khala-code-desktop/src/ui/fleet-status.ts
@@ -74,6 +74,7 @@ export type FleetPanelOptions = Readonly<{
   openExternal: (url: string) => Promise<boolean>
   lifecycleNdjson?: () => AsyncIterable<string | Uint8Array>
   lifecycleUpdateThrottleMs?: number
+  now?: () => Date
 }>
 
 type Handlers = Readonly<{
@@ -1120,8 +1121,8 @@ const renderOptimizationRunner = (
 const accountCard = (
   account: KhalaCodeDesktopFleetAccount,
   handlers: Handlers,
+  now: Date,
 ): HTMLElement => {
-  const now = new Date()
   const state = accountReadinessState(account.readiness)
   const card = el("article", "khala-fleet-account")
   card.dataset.state = state
@@ -1245,6 +1246,7 @@ const renderReady = (
   handlers: Handlers,
   activeRun: ActiveFleetRunView,
   lifecycleFrames: readonly KhalaFleetWorkerLifecycleFrame[],
+  now: Date,
 ): void => {
   const readyAccounts = data.accounts.filter(
     account => accountReadinessState(account.readiness) === "ready",
@@ -1319,7 +1321,7 @@ const renderReady = (
     )
   } else {
     const list = el("div", "khala-fleet-account-list")
-    for (const account of data.accounts) list.append(accountCard(account, handlers))
+    for (const account of data.accounts) list.append(accountCard(account, handlers, now))
     accountsSection.append(list)
   }
   container.append(accountsSection)
@@ -1437,6 +1439,7 @@ const render = (
   fleetRunForm: FleetRunFormState,
   fleetRun: FleetRunView,
   optimizationRun: OptimizationRunView,
+  now: Date,
 ): void => {
   container.replaceChildren()
 
@@ -1473,7 +1476,7 @@ const render = (
       el("p", "khala-fleet-error", `Could not load fleet status: ${view.message}`),
     )
   } else {
-    renderReady(body, view.data, handlers, activeRun, lifecycleFrames)
+    renderReady(body, view.data, handlers, activeRun, lifecycleFrames, now)
   }
   container.append(body)
 }
@@ -1520,6 +1523,7 @@ export const mountFleetPanel = (
   let activeConnect: ConnectView | null = null
   let visible = false
   let pollTimer = 0
+  const now = options.now ?? (() => new Date())
 
   const setRefreshBusy = (busy: boolean): void => {
     const buttons = container.querySelectorAll<HTMLButtonElement>('[data-fleet-action="refresh"]')
@@ -1547,6 +1551,7 @@ export const mountFleetPanel = (
       fleetRunForm,
       fleetRun,
       optimizationRun,
+      now(),
     )
 
   const fleetRunPreview = (): readonly FleetRunPreviewSlot[] | string => {
@@ -1877,6 +1882,7 @@ export const mountFleetPanel = (
           fleetRunForm,
           fleetRun,
           optimizationRun,
+          now(),
         )
         return
       }
@@ -1909,6 +1915,7 @@ export const mountFleetPanel = (
           fleetRunForm,
           fleetRun,
           optimizationRun,
+          now(),
         )
         return
       }
@@ -1932,6 +1939,7 @@ export const mountFleetPanel = (
           fleetRunForm,
           fleetRun,
           optimizationRun,
+          now(),
         )
         return
       }
@@ -2012,6 +2020,7 @@ export const mountFleetPanel = (
           fleetRunForm,
           fleetRun,
           optimizationRun,
+          now(),
         )
       } else {
         activeRun = {

--- a/clients/khala-code-desktop/tests/cockpit-visual-smoke.test.ts
+++ b/clients/khala-code-desktop/tests/cockpit-visual-smoke.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, test } from "bun:test"
+import { Window } from "happy-dom"
+
+import type { KhalaCodeDesktopFleetStatus } from "../src/shared/rpc"
+import { mountFleetPanel } from "../src/ui/fleet-status"
+import {
+  assertCockpitVisualGeometry,
+  COCKPIT_VISUAL_SMOKE_HARNESS,
+  cockpitVisualSmokeViewports,
+} from "../scripts/cockpit-visual-smoke"
+
+describe("T5.6 cockpit visual smoke", () => {
+  test("registers the fixture-only desktop and mobile cockpit plan", async () => {
+    const packageJson = await Bun.file(new URL("../package.json", import.meta.url)).text()
+
+    expect(COCKPIT_VISUAL_SMOKE_HARNESS).toBe("khala_code_t5_6_cockpit_visual_smoke")
+    expect(cockpitVisualSmokeViewports()).toEqual([
+      { name: "desktop", width: 1280, height: 800 },
+      { name: "mobile", width: 390, height: 844 },
+    ])
+    expect(packageJson).toContain('"smoke:cockpit-visual"')
+    expect(packageJson).toContain("scripts/cockpit-visual-smoke.ts")
+  })
+
+  test("accepts the 18 worker / 3 account geometry and rejects overlap", () => {
+    assertCockpitVisualGeometry({
+      accountCards: [
+        { x: 24, y: 320, width: 720, height: 80 },
+        { x: 24, y: 412, width: 720, height: 80 },
+        { x: 24, y: 504, width: 720, height: 80 },
+      ],
+      fleetCounts: { x: 12, y: 72, width: 52, height: 20 },
+      fleetPanel: { x: 0, y: 0, width: 780, height: 2_400 },
+      gauges: [
+        { x: 24, y: 90, width: 230, height: 90 },
+        { x: 270, y: 90, width: 230, height: 90 },
+        { x: 516, y: 90, width: 230, height: 90 },
+      ],
+      runHeader: { x: 24, y: 190, width: 720, height: 92 },
+      viewport: { x: 0, y: 0, width: 1280, height: 2_500 },
+      workerCards: Array.from({ length: 18 }, (_, index) => ({
+        x: 24,
+        y: 640 + index * 92,
+        width: 720,
+        height: 80,
+      })),
+    })
+
+    expect(() =>
+      assertCockpitVisualGeometry({
+        accountCards: [
+          { x: 24, y: 320, width: 720, height: 80 },
+          { x: 24, y: 360, width: 720, height: 80 },
+          { x: 24, y: 504, width: 720, height: 80 },
+        ],
+        fleetCounts: { x: 12, y: 72, width: 52, height: 20 },
+        fleetPanel: { x: 0, y: 0, width: 780, height: 2_400 },
+        gauges: [
+          { x: 24, y: 90, width: 230, height: 90 },
+          { x: 270, y: 90, width: 230, height: 90 },
+          { x: 516, y: 90, width: 230, height: 90 },
+        ],
+        runHeader: { x: 24, y: 190, width: 720, height: 92 },
+        viewport: { x: 0, y: 0, width: 1280, height: 2_500 },
+        workerCards: Array.from({ length: 18 }, (_, index) => ({
+          x: 24,
+          y: 640 + index * 92,
+          width: 720,
+          height: 80,
+        })),
+      }),
+    ).toThrow("account cards overlap")
+  })
+
+  test("rate-limit countdown repaints from an injected clock without sleeping", async () => {
+    const window = new Window()
+    const previousWindow = globalThis.window
+    const previousDocument = globalThis.document
+    Object.defineProperty(globalThis, "window", { configurable: true, value: window })
+    Object.defineProperty(globalThis, "document", { configurable: true, value: window.document })
+    window.matchMedia = (() => ({ matches: true })) as unknown as typeof window.matchMedia
+
+    let now = new Date("2026-07-01T18:00:00.000Z")
+    const root = document.createElement("div")
+    const panel = mountFleetPanel(root, {
+      connectAccount: async () => ({ ok: false, accountRef: "codex-a", error: "not used", output: "", userCode: null, verificationUrl: null }),
+      consumeResetCredit: async () => ({ ok: true }),
+      delegateRun: async () => {
+        throw new Error("delegate runner should not be called")
+      },
+      fetch: async () => countdownStatus(),
+      fleetRunControl: async () => {
+        throw new Error("fleet run control should not be called")
+      },
+      fleetRunList: async () => ({ ok: true, runs: [] }),
+      fleetRunStart: async () => {
+        throw new Error("fleet run start should not be called")
+      },
+      fleetWorkerControl: async () => {
+        throw new Error("fleet worker control should not be called")
+      },
+      loadGymDemoProof: () => {
+        throw new Error("gym proof should not be called")
+      },
+      now: () => now,
+      openExternal: async () => false,
+      removeAccount: async () => ({ ok: true }),
+      setAccountPaused: async () => ({ ok: true }),
+      startDelegationOptimization: async () => {
+        throw new Error("optimization should not be called")
+      },
+    })
+
+    try {
+      await panel.refresh()
+      expect(root.textContent).toContain("resets in 1h 30m")
+
+      now = new Date("2026-07-01T19:15:00.000Z")
+      await panel.refresh()
+      expect(root.textContent).toContain("resets in 15m")
+      expect(root.textContent).not.toContain("resets in 1h 30m")
+    } finally {
+      Object.defineProperty(globalThis, "window", { configurable: true, value: previousWindow })
+      Object.defineProperty(globalThis, "document", { configurable: true, value: previousDocument })
+    }
+  })
+})
+
+const countdownStatus = (): KhalaCodeDesktopFleetStatus => ({
+  accounts: [{
+    accountKey: null,
+    accountRef: "codex-a",
+    capacity: { available: 1, busy: 0, queued: 0, ready: 1 },
+    email: null,
+    provider: "codex",
+    quotaState: "available",
+    rateLimits: {
+      error: null,
+      provider: "codex",
+      session: {
+        remainingPercent: 70,
+        resetDescription: null,
+        resetsAtIso: "2026-07-01T19:30:00.000Z",
+        usedPercent: 30,
+        windowMinutes: 300,
+      },
+      status: "ok",
+      updatedAtIso: "2026-07-01T18:00:00.000Z",
+      weekly: null,
+    },
+    readiness: "ready",
+  }],
+  activeAssignments: [],
+  availableCodexAssignments: 1,
+  maxCodexAssignments: 1,
+  observedAt: "2026-07-01T18:00:00.000Z",
+  ok: true,
+  processes: [],
+  pylon: {
+    message: "online",
+    pylonRef: "pylon.local.countdown",
+    status: "online",
+  },
+  tokenRate: {
+    activeAdjustedTokensPerMinute: null,
+    completedStatus: "not_measured",
+    completedTokenRows: null,
+    completedTokensPerMinute: null,
+    inFlightTokens: null,
+    inFlightTokensPerMinute: null,
+    source: "unavailable",
+    unavailableReason: null,
+  },
+})

--- a/packages/khala-qa-harness/src/desktop-smoke-helpers.ts
+++ b/packages/khala-qa-harness/src/desktop-smoke-helpers.ts
@@ -112,4 +112,7 @@ export const assertKhalaQaVisibleRect = (
   if (rect.x + rect.width > viewport.width + 1) {
     throw new Error(`${label} overflows the viewport width: ${JSON.stringify({ rect, viewport })}`)
   }
+  if (rect.y + rect.height > viewport.height + 1) {
+    throw new Error(`${label} overflows the viewport height: ${JSON.stringify({ rect, viewport })}`)
+  }
 }


### PR DESCRIPTION
Closes #7844

## Summary

- Adds a fixture-only Khala Code Desktop cockpit visual smoke for 18 workers across 3 accounts in desktop and mobile viewports.
- Validates run header, worker cards, account cards, throughput gauges, sidebar fleet/inbox counts, and no clipping/overlap geometry oracles.
- Adds an injected fleet-panel clock so rate-limit countdown tests advance without real sleeps.

## Verification

- `bun run --cwd clients/khala-code-desktop smoke:cockpit-visual`
- `bun run --cwd clients/khala-code-desktop test` (required verifier `command.public.pylon_khala.verify.d32c71ee8e1025e99460d008`)
- `bun run --cwd packages/khala-qa-harness typecheck && bun run --cwd packages/khala-qa-harness test`
- `bun run --cwd clients/khala-code-desktop verify`
- `bun run check:deploy`