### PR TITLE
T8.3: Claude approvals/telemetry/MCP/settings

### DIFF
--- a/clients/khala-code-desktop/src/bun/claude-app-sdk-chat-runtime.ts
+++ b/clients/khala-code-desktop/src/bun/claude-app-sdk-chat-runtime.ts
@@ -25,10 +25,26 @@ import {
   type ClaudeSessionStore,
 } from "./claude-session-store.js"
 import { createClaudeThreadItemProjector } from "./claude-thread-item-projector.js"
+import {
+  createClaudeApprovalService,
+  type ClaudeApprovalService,
+} from "./claude-approvals.js"
+import {
+  createKhalaCodeDesktopClaudeTokenUsageReporter,
+  type KhalaCodeDesktopClaudeTokenUsageReporter,
+} from "./claude-token-usage-telemetry.js"
+import { withClaudeFleetMcpBridgeOptions } from "./claude-fleet-mcp-bridge.js"
+import {
+  projectKhalaCodeDesktopClaudeSettings,
+  type KhalaCodeDesktopClaudeSettingsProjection,
+} from "../shared/claude-settings.js"
 
 type ClaudeQuery = AsyncIterable<unknown> & {
+  readonly accountInfo?: () => Promise<unknown>
   readonly close?: () => Promise<void> | void
+  readonly initializationResult?: () => Promise<unknown>
   readonly interrupt?: () => Promise<void> | void
+  readonly supportedModels?: () => Promise<unknown>
 }
 
 type ClaudeQueryFn = (input: {
@@ -37,7 +53,9 @@ type ClaudeQueryFn = (input: {
 }) => ClaudeQuery
 
 type ClaudeSdkModule = {
+  readonly accountInfo?: () => Promise<unknown>
   readonly query: ClaudeQueryFn
+  readonly supportedModels?: () => Promise<unknown>
 }
 
 class ClaudeSdkRuntimeError extends Data.TaggedError("ClaudeSdkRuntimeError")<{
@@ -52,12 +70,19 @@ const claudeSdkRuntimeError = (error: unknown): ClaudeSdkRuntimeError =>
   })
 
 export type CreateClaudeAppSdkChatRuntimeOptions = {
+  readonly approvalService?: ClaudeApprovalService
   readonly env?: Readonly<Record<string, string | undefined>>
   readonly importer?: (specifier: string) => Promise<unknown>
   readonly onEvent?: (event: KhalaCodeDesktopChatTurnEvent) => void
   readonly query?: ClaudeQueryFn
+  readonly repoRoot?: string
   readonly sessionStore?: ClaudeSessionStore
+  readonly tokenUsageReporter?: KhalaCodeDesktopClaudeTokenUsageReporter
   readonly workingDirectory: string
+}
+
+export type ClaudeAppSdkChatRuntime = CodexAppServerChatRuntime & {
+  readonly claudeSettingsRead: () => Promise<KhalaCodeDesktopClaudeSettingsProjection>
 }
 
 type ActiveClaudeTurn = {
@@ -79,6 +104,28 @@ const sdkSessionId = (value: unknown): string | null => {
   return typeof candidate === "string" && candidate.length > 0 ? candidate : null
 }
 
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value)
+
+const numberField = (value: Record<string, unknown>, field: string): number | undefined => {
+  const candidate = value[field]
+  return typeof candidate === "number" && Number.isFinite(candidate) ? candidate : undefined
+}
+
+const resultModel = (value: unknown): string | null => {
+  if (!isRecord(value)) return null
+  const model = typeof value.model === "string" && value.model.length > 0 ? value.model : null
+  if (model !== null) return model
+  const modelUsage = isRecord(value.modelUsage) ? value.modelUsage : null
+  const [firstModel] = modelUsage === null ? [] : Object.keys(modelUsage)
+  return firstModel ?? null
+}
+
+const resultTotalCostUsd = (value: unknown): number | undefined => {
+  if (!isRecord(value)) return undefined
+  return numberField(value, "total_cost_usd") ?? numberField(value, "totalCostUsd")
+}
+
 const loadQuery = async (
   options: CreateClaudeAppSdkChatRuntimeOptions,
 ): Promise<ClaudeQueryFn> => {
@@ -96,11 +143,19 @@ const runScoped = async <A>(effect: Effect.Effect<A, unknown, never>): Promise<A
 
 export function createClaudeAppSdkChatRuntime(
   options: CreateClaudeAppSdkChatRuntimeOptions,
-): CodexAppServerChatRuntime {
+): ClaudeAppSdkChatRuntime {
   const sessionStore = options.sessionStore ?? createClaudeSessionStore({
     ...(options.env === undefined ? {} : { env: options.env }),
   })
+  const approvalService = options.approvalService ?? createClaudeApprovalService()
+  const tokenUsageReporter = options.tokenUsageReporter ??
+    createKhalaCodeDesktopClaudeTokenUsageReporter({
+      ...(options.env === undefined ? {} : { env: options.env }),
+    })
   const activeTurns = new Map<string, ActiveClaudeTurn>()
+  let lastAccountInfo: unknown
+  let lastInitializationResult: unknown
+  let lastSupportedModels: unknown
 
   const startThread = async (
     request: KhalaCodeDesktopCodexThreadStartRequest = {},
@@ -153,20 +208,28 @@ export function createClaudeAppSdkChatRuntime(
     })
     let resolvedThreadId = threadId ?? null
 
+    let resultMessage: unknown
+    const baseQueryOptions = {
+      abortController: controller,
+      canUseTool: approvalService.canUseTool,
+      cwd: request.cwd ?? options.workingDirectory,
+      includePartialMessages: true,
+      permissionMode: options.env?.KHALA_CODE_DESKTOP_CLAUDE_PERMISSION_MODE ?? "acceptEdits",
+      ...(shouldResume ? { resume: threadId } : { sessionId: freshSessionId }),
+      env: {
+        ...options.env,
+        ...(options.env?.CLAUDE_CONFIG_DIR === undefined ? {} : { CLAUDE_CONFIG_DIR: options.env.CLAUDE_CONFIG_DIR }),
+      },
+    }
+    const queryOptions = withClaudeFleetMcpBridgeOptions({
+      env: options.env ?? {},
+      options: baseQueryOptions,
+      repoRoot: options.repoRoot ?? options.workingDirectory,
+    })
     const acquireQuery = Effect.tryPromise({
       try: async () => query({
         prompt,
-        options: {
-          abortController: controller,
-          cwd: request.cwd ?? options.workingDirectory,
-          includePartialMessages: true,
-          permissionMode: options.env?.KHALA_CODE_DESKTOP_CLAUDE_PERMISSION_MODE ?? "acceptEdits",
-          ...(shouldResume ? { resume: threadId } : { sessionId: freshSessionId }),
-          env: {
-            ...options.env,
-            ...(options.env?.CLAUDE_CONFIG_DIR === undefined ? {} : { CLAUDE_CONFIG_DIR: options.env.CLAUDE_CONFIG_DIR }),
-          },
-        },
+        options: queryOptions,
       }),
       catch: claudeSdkRuntimeError,
     })
@@ -180,6 +243,16 @@ export function createClaudeAppSdkChatRuntime(
               query: handle,
               sessionId: request.sessionId,
             })
+          })),
+          Effect.tap(handle => Effect.promise(async () => {
+            const [initializationResult, supportedModels, accountInfo] = await Promise.all([
+              handle.initializationResult?.().catch(error => ({ error: error instanceof Error ? error.message : String(error) })),
+              handle.supportedModels?.().catch(error => ({ error: error instanceof Error ? error.message : String(error) })),
+              handle.accountInfo?.().catch(error => ({ error: error instanceof Error ? error.message : String(error) })),
+            ])
+            if (initializationResult !== undefined) lastInitializationResult = initializationResult
+            if (supportedModels !== undefined) lastSupportedModels = supportedModels
+            if (accountInfo !== undefined) lastAccountInfo = accountInfo
           })),
         ),
         handle => Effect.promise(async () => {
@@ -197,6 +270,10 @@ export function createClaudeAppSdkChatRuntime(
               Effect.sync(() => {
                 const sessionId = sdkSessionId(message)
                 if (sessionId !== null) resolvedThreadId = sessionId
+                if (isRecord(message) && message.type === "result") resultMessage = message
+                if (isRecord(message) && message.type === "system" && message.subtype === "init") {
+                  lastInitializationResult = message
+                }
                 const projected = projector.project(message)
                 for (const event of projected.events) options.onEvent?.(event)
               }),
@@ -211,6 +288,21 @@ export function createClaudeAppSdkChatRuntime(
       sessionId: finalThreadId,
       lastTurnId: desktopTurnId,
     })
+    const usage = projector.usage()
+    if (usage !== undefined) {
+      const totalCostUsd = resultTotalCostUsd(resultMessage)
+      await Effect.runPromise(tokenUsageReporter({
+        claudeSessionId: finalThreadId,
+        desktopSessionId: request.sessionId,
+        desktopTurnId,
+        model: resultModel(resultMessage) ?? "openagents/claude-direct-local",
+        observedAt: new Date().toISOString(),
+        sequence: 1,
+        ...(totalCostUsd === undefined ? {} : { totalCostUsd }),
+        turnStatus: projector.status(),
+        usage,
+      }).pipe(Effect.catchCause(() => Effect.void)))
+    }
     const messages = projector.messages()
     return {
       backend: {
@@ -281,6 +373,13 @@ export function createClaudeAppSdkChatRuntime(
     desktopSessionId: request.sessionId ?? "",
     ...(!("threadId" in request) || request.threadId === undefined ? {} : { threadId: request.threadId }),
   })
+  const claudeSettingsRead = async (): Promise<KhalaCodeDesktopClaudeSettingsProjection> =>
+    projectKhalaCodeDesktopClaudeSettings({
+      accountInfo: lastAccountInfo,
+      initializationResult: lastInitializationResult,
+      permissionMode: options.env?.KHALA_CODE_DESKTOP_CLAUDE_PERMISSION_MODE ?? "acceptEdits",
+      supportedModels: lastSupportedModels,
+    })
 
   return {
     archiveThread: request => mutationUnsupported("archive", request),
@@ -296,6 +395,7 @@ export function createClaudeAppSdkChatRuntime(
     startTurn,
     steerTurn: actionUnsupported,
     threadIdForSession,
+    claudeSettingsRead,
     unarchiveThread: request => mutationUnsupported("unarchive", request),
   }
 }

--- a/clients/khala-code-desktop/src/bun/claude-app-sdk-gap-matrix.ts
+++ b/clients/khala-code-desktop/src/bun/claude-app-sdk-gap-matrix.ts
@@ -27,14 +27,14 @@ export const CLAUDE_APP_SDK_GAP_MATRIX: readonly ClaudeAppSdkGapMatrixRow[] = [
   {
     id: "claude.phase2.approvals",
     phase: "phase_2",
-    status: "deferred",
-    note: "Claude-native canUseTool approvals are intentionally deferred to T8.3.",
+    status: "covered",
+    note: "canUseTool is bridged through a Deferred/Queue-backed approval service and resolved by renderer Claude-native allow/deny decisions.",
   },
   {
     id: "claude.phase2.telemetry_ingest",
     phase: "phase_2",
-    status: "deferred",
-    note: "Phase 1 returns exact SDK result usage locally; ingest route selection remains a T8.3 decision.",
+    status: "covered",
+    note: "Exact SDK result usage/modelUsage is recorded on the desktop stats token path as pylon-claude-direct-local; khala_fleet MCP is injected via query options, and settings project SDK init/model/account data.",
   },
   {
     id: "claude.phase3.sidebar_catalog",
@@ -43,4 +43,3 @@ export const CLAUDE_APP_SDK_GAP_MATRIX: readonly ClaudeAppSdkGapMatrixRow[] = [
     note: "SDK listSessions()/getSessionMessages() backing for the sidebar is deferred to T8.4.",
   },
 ]
-

--- a/clients/khala-code-desktop/src/bun/claude-approvals.ts
+++ b/clients/khala-code-desktop/src/bun/claude-approvals.ts
@@ -1,0 +1,133 @@
+import { Deferred, Effect, Queue } from "effect"
+
+export type ClaudeApprovalSuggestion = {
+  readonly [key: string]: unknown
+}
+
+export type ClaudeApprovalRequest = {
+  readonly id: string
+  readonly input: Record<string, unknown>
+  readonly options: {
+    readonly blockedPath?: string
+    readonly decisionReason?: string
+    readonly description?: string
+    readonly displayName?: string
+    readonly suggestions?: readonly ClaudeApprovalSuggestion[]
+    readonly title?: string
+  }
+  readonly toolName: string
+}
+
+export type ClaudeApprovalDecision =
+  | {
+      readonly behavior: "allow"
+      readonly decisionClassification?: string
+      readonly updatedInput?: Record<string, unknown>
+      readonly updatedPermissions?: readonly ClaudeApprovalSuggestion[]
+    }
+  | {
+      readonly behavior: "deny"
+      readonly decisionClassification?: string
+      readonly interrupt?: boolean
+      readonly message: string
+    }
+
+export type ClaudeApprovalPending = {
+  readonly deferred: Deferred.Deferred<ClaudeApprovalDecision>
+  readonly request: ClaudeApprovalRequest
+}
+
+export type ClaudeApprovalService = {
+  readonly canUseTool: (
+    toolName: string,
+    input: Record<string, unknown>,
+    options: ClaudeApprovalRequest["options"] & { readonly signal?: AbortSignal },
+  ) => Promise<ClaudeApprovalDecision>
+  readonly pending: () => readonly ClaudeApprovalRequest[]
+  readonly respond: (id: string, decision: ClaudeApprovalDecision) => Promise<boolean>
+  readonly take: () => Promise<ClaudeApprovalPending>
+}
+
+const nonEmpty = (value: unknown): string | undefined =>
+  typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined
+
+const suggestionsFrom = (value: unknown): readonly ClaudeApprovalSuggestion[] | undefined =>
+  Array.isArray(value)
+    ? value.filter((item): item is ClaudeApprovalSuggestion =>
+      typeof item === "object" && item !== null && !Array.isArray(item))
+    : undefined
+
+const requestOptionsFrom = (
+  options: ClaudeApprovalRequest["options"] & { readonly signal?: AbortSignal },
+): ClaudeApprovalRequest["options"] => {
+  const blockedPath = nonEmpty(options.blockedPath)
+  const decisionReason = nonEmpty(options.decisionReason)
+  const description = nonEmpty(options.description)
+  const displayName = nonEmpty(options.displayName)
+  const suggestions = suggestionsFrom(options.suggestions)
+  const title = nonEmpty(options.title)
+  return {
+    ...(blockedPath === undefined ? {} : { blockedPath }),
+    ...(decisionReason === undefined ? {} : { decisionReason }),
+    ...(description === undefined ? {} : { description }),
+    ...(displayName === undefined ? {} : { displayName }),
+    ...(suggestions === undefined ? {} : { suggestions }),
+    ...(title === undefined ? {} : { title }),
+  }
+}
+
+export const createClaudeApprovalService = (): ClaudeApprovalService => {
+  const pending = new Map<string, ClaudeApprovalPending>()
+  const queue = Effect.runSync(Queue.unbounded<ClaudeApprovalPending>())
+  let sequence = 0
+
+  const respond = async (id: string, decision: ClaudeApprovalDecision): Promise<boolean> => {
+    const item = pending.get(id)
+    if (item === undefined) return false
+    pending.delete(id)
+    await Effect.runPromise(Deferred.succeed(item.deferred, decision))
+    return true
+  }
+
+  return {
+    async canUseTool(toolName, input, options) {
+      if (options.signal?.aborted === true) {
+        return {
+          behavior: "deny",
+          decisionClassification: "aborted",
+          interrupt: true,
+          message: "Claude tool approval was aborted.",
+        }
+      }
+      const id = `claude-approval-${Date.now().toString(36)}-${++sequence}`
+      const deferred = Effect.runSync(Deferred.make<ClaudeApprovalDecision>())
+      const request = {
+        id,
+        input,
+        options: requestOptionsFrom(options),
+        toolName,
+      }
+      const item = { deferred, request }
+      pending.set(id, item)
+      const onAbort = (): void => {
+        void respond(id, {
+          behavior: "deny",
+          decisionClassification: "aborted",
+          interrupt: true,
+          message: "Claude tool approval was aborted.",
+        })
+      }
+      options.signal?.addEventListener("abort", onAbort, { once: true })
+      await Effect.runPromise(Queue.offer(queue, item))
+      try {
+        return await Effect.runPromise(Deferred.await(deferred))
+      } finally {
+        options.signal?.removeEventListener("abort", onAbort)
+        pending.delete(id)
+      }
+    },
+    pending: () => [...pending.values()].map(item => item.request),
+    respond,
+    take: () => Effect.runPromise(Queue.take(queue)),
+  }
+}

--- a/clients/khala-code-desktop/src/bun/claude-fleet-mcp-bridge.ts
+++ b/clients/khala-code-desktop/src/bun/claude-fleet-mcp-bridge.ts
@@ -1,0 +1,54 @@
+import { resolve } from "node:path"
+
+type FleetMcpBridgeEnv = Readonly<Record<string, string | undefined>>
+const CLAUDE_FLEET_MCP_SERVER_NAME = "khala_fleet"
+
+export type ClaudeFleetMcpServerDescriptor = {
+  readonly args: readonly string[]
+  readonly command: string
+  readonly cwd: string
+  readonly type: "stdio"
+}
+
+export function claudeFleetMcpBridgeEnabled(env: FleetMcpBridgeEnv): boolean {
+  return env.KHALA_CODE_DESKTOP_FLEET_MCP_BRIDGE !== "0"
+}
+
+export function claudeFleetMcpServerDescriptor(input: {
+  readonly bunCommand?: string | undefined
+  readonly repoRoot: string
+}): ClaudeFleetMcpServerDescriptor {
+  const serverScript = resolve(
+    input.repoRoot,
+    "clients/khala-code-desktop/src/bun/khala-fleet-mcp-server.ts",
+  )
+  return {
+    args: [serverScript],
+    command: input.bunCommand?.trim() || "bun",
+    cwd: input.repoRoot,
+    type: "stdio",
+  }
+}
+
+export function withClaudeFleetMcpBridgeOptions(
+  input: {
+    readonly env: FleetMcpBridgeEnv
+    readonly options: Record<string, unknown>
+    readonly repoRoot: string
+  },
+): Record<string, unknown> {
+  if (!claudeFleetMcpBridgeEnabled(input.env)) return input.options
+  const existing = typeof input.options.mcpServers === "object" && input.options.mcpServers !== null
+    ? input.options.mcpServers as Record<string, unknown>
+    : {}
+  return {
+    ...input.options,
+    mcpServers: {
+      ...existing,
+      [CLAUDE_FLEET_MCP_SERVER_NAME]: claudeFleetMcpServerDescriptor({
+        bunCommand: input.env.KHALA_CODE_DESKTOP_BUN_COMMAND,
+        repoRoot: input.repoRoot,
+      }),
+    },
+  }
+}

--- a/clients/khala-code-desktop/src/bun/claude-thread-item-projector.ts
+++ b/clients/khala-code-desktop/src/bun/claude-thread-item-projector.ts
@@ -100,6 +100,11 @@ const numberField = (value: Record<string, unknown> | null | undefined, field: s
   return typeof candidate === "number" && Number.isFinite(candidate) ? candidate : 0
 }
 
+const numberFields = (
+  value: Record<string, unknown> | null | undefined,
+  fields: readonly string[],
+): number => fields.reduce((sum, field) => sum + numberField(value, field), 0)
+
 const isObject = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null && !Array.isArray(value)
 
@@ -120,10 +125,11 @@ const messageId = (
 
 const usageFromUsageObject = (usage: Record<string, unknown> | null): KhalaCodeDesktopUsage | undefined => {
   if (usage === null) return undefined
-  const input = numberField(usage, "input_tokens") + numberField(usage, "cache_creation_input_tokens")
-  const cachedInput = numberField(usage, "cache_read_input_tokens")
-  const output = numberField(usage, "output_tokens")
-  const reasoningOutput = numberField(usage, "reasoning_output_tokens")
+  const input = numberFields(usage, ["input_tokens", "inputTokens"]) +
+    numberFields(usage, ["cache_creation_input_tokens", "cacheCreationInputTokens"])
+  const cachedInput = numberFields(usage, ["cache_read_input_tokens", "cacheReadInputTokens"])
+  const output = numberFields(usage, ["output_tokens", "outputTokens"])
+  const reasoningOutput = numberFields(usage, ["reasoning_output_tokens", "reasoningOutputTokens"])
   if (input + cachedInput + output + reasoningOutput === 0) return undefined
   return { input, cachedInput, output, reasoningOutput }
 }
@@ -134,11 +140,11 @@ const usageFromClaude = (message: Record<string, unknown>): KhalaCodeDesktopUsag
 const usageObjectsFrom = (value: Record<string, unknown> | null): readonly Record<string, unknown>[] => {
   if (value === null) return []
   if (
-    numberField(value, "input_tokens") +
-    numberField(value, "cache_creation_input_tokens") +
-    numberField(value, "cache_read_input_tokens") +
-    numberField(value, "output_tokens") +
-    numberField(value, "reasoning_output_tokens") > 0
+    numberFields(value, ["input_tokens", "inputTokens"]) +
+    numberFields(value, ["cache_creation_input_tokens", "cacheCreationInputTokens"]) +
+    numberFields(value, ["cache_read_input_tokens", "cacheReadInputTokens"]) +
+    numberFields(value, ["output_tokens", "outputTokens"]) +
+    numberFields(value, ["reasoning_output_tokens", "reasoningOutputTokens"]) > 0
   ) return [value]
   return Object.values(value).filter(isObject)
 }

--- a/clients/khala-code-desktop/src/bun/claude-token-usage-telemetry.ts
+++ b/clients/khala-code-desktop/src/bun/claude-token-usage-telemetry.ts
@@ -1,0 +1,224 @@
+import { createHash } from "node:crypto"
+import { readFileSync } from "node:fs"
+import { appendFile, mkdir, writeFile } from "node:fs/promises"
+import { homedir } from "node:os"
+import { dirname, join } from "node:path"
+import { Effect } from "effect"
+
+import type { KhalaCodeDesktopUsage } from "../shared/rpc.js"
+import { khalaCodeConfigFromRuntimeEnv } from "./khala-code-config.js"
+import { KhalaCodeDesktopTokenUsagePersistentFailure } from "./codex-token-usage-telemetry.js"
+
+type FetchLike = (url: URL, init: RequestInit) => Promise<Response>
+
+export type KhalaCodeDesktopClaudeTokenUsageReport = {
+  readonly claudeSessionId: string
+  readonly desktopSessionId: string
+  readonly desktopTurnId: string
+  readonly model: string
+  readonly observedAt: string
+  readonly sequence: number
+  readonly totalCostUsd?: number
+  readonly turnStatus?: string
+  readonly usage: KhalaCodeDesktopUsage
+}
+
+export type KhalaCodeDesktopClaudeTokenUsageReporter = (
+  report: KhalaCodeDesktopClaudeTokenUsageReport,
+) => Effect.Effect<void, KhalaCodeDesktopTokenUsagePersistentFailure>
+
+const DEFAULT_BASE_URL = "https://openagents.com"
+
+const stableJson = (value: unknown): string => {
+  if (Array.isArray(value)) return `[${value.map(stableJson).join(",")}]`
+  if (value !== null && typeof value === "object") {
+    return `{${Object.entries(value)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, item]) => `${JSON.stringify(key)}:${stableJson(item)}`)
+      .join(",")}}`
+  }
+  return JSON.stringify(value)
+}
+
+const digest = (value: unknown): string =>
+  createHash("sha256").update(stableJson(value)).digest("hex")
+
+const boundedCount = (value: number): number =>
+  Number.isFinite(value) && value > 0 ? Math.trunc(value) : 0
+
+const totalTokens = (usage: KhalaCodeDesktopUsage): number =>
+  boundedCount(usage.input) +
+  boundedCount(usage.cachedInput) +
+  boundedCount(usage.output) +
+  boundedCount(usage.reasoningOutput)
+
+const nonEmpty = (value: string | undefined): string | null => {
+  const trimmed = value?.trim()
+  return trimmed === undefined || trimmed.length === 0 ? null : trimmed
+}
+
+const boolEnv = (value: string | undefined): boolean => {
+  const normalized = value?.trim().toLowerCase()
+  return normalized === "1" || normalized === "true" || normalized === "yes" || normalized === "on"
+}
+
+const secretTokenFromFile = (path: string | undefined): string | null => {
+  const filePath = nonEmpty(path)
+  if (filePath === null) return null
+  try {
+    const text = readFileSync(filePath, "utf8")
+    const match = text.match(/(?:KHALA_CODE_TOKEN_USAGE_BEARER_TOKEN|OPENAGENTS_ADMIN_API_TOKEN)=([^\n\r]+)/u)
+    return nonEmpty(match?.[1])
+  } catch {
+    return null
+  }
+}
+
+const resolveConfig = (
+  env: Readonly<Record<string, string | undefined>>,
+  localLedgerPath: string | undefined,
+) => {
+  const root = join(homedir(), ".khala-code")
+  return {
+    baseUrl: nonEmpty(env.KHALA_CODE_TOKEN_USAGE_BASE_URL) ?? DEFAULT_BASE_URL,
+    bearerToken:
+      nonEmpty(env.KHALA_CODE_TOKEN_USAGE_BEARER_TOKEN) ??
+      nonEmpty(env.OPENAGENTS_ADMIN_API_TOKEN) ??
+      secretTokenFromFile(env.KHALA_CODE_TOKEN_USAGE_SECRET_PATH),
+    localLedgerPath: localLedgerPath ?? join(root, "claude-token-usage-events.jsonl"),
+    remoteDisabled: boolEnv(env.KHALA_CODE_TOKEN_USAGE_SECRET_DISABLED) ||
+      boolEnv(env.KHALA_CODE_TOKEN_USAGE_REMOTE_DISABLED),
+  }
+}
+
+export const khalaCodeDesktopClaudeTokenUsageEvent = (
+  report: KhalaCodeDesktopClaudeTokenUsageReport,
+): Record<string, unknown> => {
+  const usage = {
+    cachedInputTokens: boundedCount(report.usage.cachedInput),
+    inputTokens: boundedCount(report.usage.input),
+    outputTokens: boundedCount(report.usage.output),
+    reasoningOutputTokens: boundedCount(report.usage.reasoningOutput),
+    totalTokens: totalTokens(report.usage),
+  }
+  const eventDigest = digest({
+    claudeSessionId: report.claudeSessionId,
+    desktopTurnId: report.desktopTurnId,
+    sequence: report.sequence,
+    usage,
+  }).slice(0, 24)
+  const sourceDigest = digest({
+    claudeSessionId: report.claudeSessionId,
+    desktopSessionId: report.desktopSessionId,
+  }).slice(0, 24)
+  const model = report.model.trim().length === 0
+    ? "openagents/claude-direct-local"
+    : report.model.trim()
+  return {
+    schemaVersion: "openagents.token_usage_event.v1",
+    backendProfile: "claude-agent-sdk",
+    demand: {
+      demandChannel: "direct_local",
+      demandKind: "own_capacity",
+      demandSource: "direct_local_claude",
+      demandClient: "khala_code_desktop",
+    },
+    eventId: `token_usage_event.khala_code_claude_direct_local.${eventDigest}`,
+    idempotencyKey:
+      `khala-code-desktop:direct-local-claude:${report.claudeSessionId}:${report.desktopTurnId}:${report.sequence}`,
+    model,
+    observedAt: report.observedAt,
+    privacy: { leaderboardEligible: true, privacyOptOut: false },
+    producerSystem: "pylon",
+    provider: "pylon-claude-direct-local",
+    safeMetadata: {
+      agentSurface: "khala_code_desktop",
+      captureMethod: "claude_result_usage",
+      claudeSessionId: report.claudeSessionId,
+      desktopSessionId: report.desktopSessionId,
+      desktopTurnId: report.desktopTurnId,
+      runtimeMode: "claude_agent_sdk",
+      totalCostUsd: report.totalCostUsd ?? null,
+      turnStatus: report.turnStatus ?? "completed",
+      usageEventIndex: report.sequence,
+    },
+    sourceRefs: {
+      anonymizedSourceRef: `claude_turn.${sourceDigest}`,
+      runRef: `claude.turn.${report.desktopTurnId}`,
+      sessionRef: `claude.session.${report.claudeSessionId}`,
+      taskRef: `khala_code_desktop.turn.${report.desktopTurnId}`,
+    },
+    sourceRoute: "pylon_claude_direct_local",
+    tokenCounts: {
+      cacheReadTokens: usage.cachedInputTokens,
+      cacheWrite1hTokens: 0,
+      cacheWrite5mTokens: 0,
+      inputTokens: usage.inputTokens,
+      outputTokens: usage.outputTokens,
+      reasoningTokens: usage.reasoningOutputTokens,
+      totalTokens: usage.totalTokens,
+    },
+    usageTruth: "exact",
+  }
+}
+
+const appendJsonLine = async (path: string, value: unknown): Promise<void> => {
+  await mkdir(dirname(path), { recursive: true })
+  await appendFile(path, `${JSON.stringify(value)}\n`, "utf8")
+}
+
+export function createKhalaCodeDesktopClaudeTokenUsageReporter(
+  options: {
+    readonly env?: Readonly<Record<string, string | undefined>>
+    readonly fetch?: FetchLike
+    readonly localLedgerPath?: string
+  } = {},
+): KhalaCodeDesktopClaudeTokenUsageReporter {
+  const env = options.env ?? khalaCodeConfigFromRuntimeEnv().env
+  const config = resolveConfig(env, options.localLedgerPath)
+  const fetchImpl: FetchLike = options.fetch ?? ((url, init) => globalThis.fetch(url, init))
+  return report =>
+    Effect.tryPromise({
+      try: async () => {
+        const event = khalaCodeDesktopClaudeTokenUsageEvent(report)
+        await appendJsonLine(config.localLedgerPath, {
+          schemaVersion: "khala-code-desktop.claude-token-usage.local.v1",
+          event,
+          submitted: false,
+        })
+        if (config.remoteDisabled || config.bearerToken === null) return
+        const response = await fetchImpl(
+          new URL("/api/stats/token-usage/events", config.baseUrl),
+          {
+            body: JSON.stringify(event),
+            headers: {
+              authorization: `Bearer ${config.bearerToken}`,
+              "content-type": "application/json",
+            },
+            method: "POST",
+          },
+        )
+        if (!response.ok) throw new Error(`Claude token usage reporting failed (${response.status})`)
+        await appendJsonLine(join(dirname(config.localLedgerPath), "claude-token-usage-report-successes.jsonl"), {
+          eventId: event.eventId,
+          idempotencyKey: event.idempotencyKey,
+          observedAt: new Date().toISOString(),
+        })
+      },
+      catch: error => {
+        const event = khalaCodeDesktopClaudeTokenUsageEvent(report)
+        const reason = error instanceof Error ? error.message : String(error)
+        void writeFile(
+          join(dirname(config.localLedgerPath), "claude-token-usage-report-failures.jsonl"),
+          `${JSON.stringify({ eventId: event.eventId, idempotencyKey: event.idempotencyKey, reason })}\n`,
+          { flag: "a" },
+        )
+        return new KhalaCodeDesktopTokenUsagePersistentFailure({
+          eventId: String(event.eventId),
+          idempotencyKey: String(event.idempotencyKey),
+          inboxFlagRef: `inbox.token_usage_reporting.${digest(event).slice(0, 16)}`,
+          reason,
+        })
+      },
+    })
+}

--- a/clients/khala-code-desktop/src/bun/index.ts
+++ b/clients/khala-code-desktop/src/bun/index.ts
@@ -23,6 +23,7 @@ import {
 } from "./headless.js"
 import { createCodexAppServerChatRuntime } from "./codex-app-server-chat-runtime.js"
 import { createClaudeAppSdkChatRuntime } from "./claude-app-sdk-chat-runtime.js"
+import { createKhalaCodeDesktopClaudeTokenUsageReporter } from "./claude-token-usage-telemetry.js"
 import { createCodexAppServerHost } from "./codex-app-server-client.js"
 import {
   createKhalaCodeDesktopCodexMessageTokenAuditRecorder,
@@ -427,6 +428,8 @@ if (argv.includes("--json")) {
           ? createClaudeAppSdkChatRuntime({
             env: khalaCodeEnv,
             onEvent,
+            repoRoot: resolveSourceRepositoryRoot(),
+            tokenUsageReporter: createKhalaCodeDesktopClaudeTokenUsageReporter({ env: khalaCodeEnv }),
             workingDirectory,
           })
           : createCodexAppServerChatRuntime({

--- a/clients/khala-code-desktop/src/bun/preview-rpc-policy.ts
+++ b/clients/khala-code-desktop/src/bun/preview-rpc-policy.ts
@@ -3,6 +3,7 @@ import type { KhalaCodeDesktopRpcMethodName } from "../shared/rpc.js"
 // Read-only preview mode classification. EVERY RPC method must appear in
 // exactly one of these sets; the coverage test fails closed on drift.
 export const mutatingPreviewRpcMethods = new Set<KhalaCodeDesktopRpcMethodName>([
+  "claudeApprovalRespond",
   "codexAppServerRestart",
   "codexAppServerStart",
   "codexAppServerStop",
@@ -51,6 +52,8 @@ export const mutatingPreviewRpcMethods = new Set<KhalaCodeDesktopRpcMethodName>(
 export const readOnlySafePreviewRpcMethods = new Set<KhalaCodeDesktopRpcMethodName>([
   "appInfo",
   "appleFmReadiness",
+  "claudeApprovalPending",
+  "claudeSettingsRead",
   "codexAccountsStatus",
   "codexAppServerStatus",
   "codexBackgroundTerminalsList",

--- a/clients/khala-code-desktop/src/bun/rpc-handlers.ts
+++ b/clients/khala-code-desktop/src/bun/rpc-handlers.ts
@@ -96,6 +96,11 @@ import { inspectCodexHarnessStatus } from "./codex-harness-status.js"
 import { createClaudeAppSdkChatRuntime } from "./claude-app-sdk-chat-runtime.js"
 import { inspectClaudeHarnessStatus } from "./claude-harness-status.js"
 import {
+  createClaudeApprovalService,
+  type ClaudeApprovalService,
+} from "./claude-approvals.js"
+import { createKhalaCodeDesktopClaudeTokenUsageReporter } from "./claude-token-usage-telemetry.js"
+import {
   khalaCodeDesktopRuntimeEnvOverride,
   readKhalaCodeDesktopHarnessSetting,
   readKhalaCodeDesktopPersistedHarnessMode,
@@ -174,6 +179,7 @@ export type KhalaCodeDesktopRpcHandlersInput = {
   readonly codexAppServerHost?: CodexAppServerHost
   readonly codexChatRuntime?: CodexAppServerChatRuntime
   readonly claudeChatRuntime?: CodexAppServerChatRuntime
+  readonly claudeApprovalService?: ClaudeApprovalService
   readonly enableFleetMcpBridge?: boolean
   readonly codexRateLimitStatus?: () => MaybePromise<KhalaCodexRateLimitProviderStatus>
   readonly codexHarnessStatus?: () => MaybePromise<KhalaCodeDesktopCodexHarnessStatus>
@@ -776,6 +782,7 @@ export function createKhalaCodeDesktopRpcRequestHandlers(
         workingDirectory: input.workingDirectory,
       }))
   const legacyChatTurn = input.legacyChatTurn ?? runKhalaCodeDesktopChatTurn
+  const claudeApprovalService = input.claudeApprovalService ?? createClaudeApprovalService()
   const requireCodexChatRuntime = (): CodexAppServerChatRuntime => {
     if (codexChatRuntime === null) {
       throw new Error("Codex app-server chat runtime is not configured.")
@@ -789,8 +796,11 @@ export function createKhalaCodeDesktopRpcRequestHandlers(
   const requireClaudeChatRuntime = (): ChatRuntime => {
     if (input.claudeChatRuntime !== undefined) return input.claudeChatRuntime
     lazyClaudeChatRuntime ??= createClaudeAppSdkChatRuntime({
+      approvalService: claudeApprovalService,
       env: input.env,
       ...(input.emitChatTurnEvent === undefined ? {} : { onEvent: input.emitChatTurnEvent }),
+      repoRoot: input.fleetMcpBridgeRepoRoot ?? input.workingDirectory,
+      tokenUsageReporter: createKhalaCodeDesktopClaudeTokenUsageReporter({ env: input.env }),
       workingDirectory: input.workingDirectory,
     })
     return lazyClaudeChatRuntime
@@ -1924,6 +1934,59 @@ export function createKhalaCodeDesktopRpcRequestHandlers(
         throw new Error("fleetWorkerControl requires fleet-run supervisor worker control")
       }
       return supervisor.workerControl(request)
+    },
+    async claudeApprovalPending() {
+      return {
+        ok: true,
+        requests: claudeApprovalService.pending(),
+      }
+    },
+    async claudeApprovalRespond(request) {
+      try {
+        const decision = request.decision as unknown as Parameters<ClaudeApprovalService["respond"]>[1]
+        const ok = await claudeApprovalService.respond(request.requestId, decision)
+        return {
+          ok,
+          requestId: request.requestId,
+          decision,
+          ...(ok ? {} : { error: "Claude approval request is not pending." }),
+        }
+      } catch (error) {
+        return {
+          ok: false,
+          requestId: request.requestId,
+          decision: request.decision,
+          error: error instanceof Error ? error.message : String(error),
+        }
+      }
+    },
+    async claudeSettingsRead() {
+      const runtime = requireClaudeChatRuntime()
+      if (!("claudeSettingsRead" in runtime) || typeof runtime.claudeSettingsRead !== "function") {
+        return {
+          ok: false,
+          observedAt: new Date().toISOString(),
+          errors: ["Claude settings are unavailable for the injected runtime."],
+          account: {
+            apiProvider: null,
+            apiKeySource: null,
+            email: null,
+            organization: null,
+            subscriptionType: null,
+            tokenSource: null,
+          },
+          init: {
+            permissionMode: input.env.KHALA_CODE_DESKTOP_CLAUDE_PERMISSION_MODE ?? "acceptEdits",
+            model: null,
+            system: null,
+          },
+          models: {
+            options: [],
+            selected: null,
+          },
+        }
+      }
+      return runtime.claudeSettingsRead()
     },
     async codexHarnessStatus() {
       return codexHarnessStatus()

--- a/clients/khala-code-desktop/src/shared/claude-settings.ts
+++ b/clients/khala-code-desktop/src/shared/claude-settings.ts
@@ -1,0 +1,102 @@
+export type KhalaCodeDesktopClaudeSettingsModel = {
+  readonly description: string | null
+  readonly displayName: string
+  readonly selected: boolean
+  readonly supportsAdaptiveThinking: boolean | null
+  readonly supportsEffort: boolean | null
+  readonly supportedEffortLevels: readonly string[]
+  readonly value: string
+}
+
+export type KhalaCodeDesktopClaudeSettingsProjection = {
+  readonly ok: boolean
+  readonly observedAt: string
+  readonly errors: readonly string[]
+  readonly account: {
+    readonly apiProvider: string | null
+    readonly apiKeySource: string | null
+    readonly email: string | null
+    readonly organization: string | null
+    readonly subscriptionType: string | null
+    readonly tokenSource: string | null
+  }
+  readonly init: {
+    readonly permissionMode: string | null
+    readonly model: string | null
+    readonly system: unknown
+  }
+  readonly models: {
+    readonly options: readonly KhalaCodeDesktopClaudeSettingsModel[]
+    readonly selected: KhalaCodeDesktopClaudeSettingsModel | null
+  }
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value)
+
+const stringValue = (value: unknown): string | null =>
+  typeof value === "string" && value.length > 0 ? value : null
+
+const booleanValue = (value: unknown): boolean | null =>
+  typeof value === "boolean" ? value : null
+
+const stringArray = (value: unknown): readonly string[] =>
+  Array.isArray(value) ? value.filter((item): item is string => typeof item === "string") : []
+
+const modelOptionsFrom = (
+  supportedModels: unknown,
+  selectedModel: string | null,
+): readonly KhalaCodeDesktopClaudeSettingsModel[] =>
+  (Array.isArray(supportedModels) ? supportedModels : [])
+    .filter(isRecord)
+    .map(model => {
+      const value = stringValue(model.value) ?? stringValue(model.id) ?? stringValue(model.model) ?? ""
+      return {
+        description: stringValue(model.description),
+        displayName: stringValue(model.displayName) ?? value,
+        selected: selectedModel !== null && value === selectedModel,
+        supportsAdaptiveThinking: booleanValue(model.supportsAdaptiveThinking),
+        supportsEffort: booleanValue(model.supportsEffort),
+        supportedEffortLevels: stringArray(model.supportedEffortLevels),
+        value,
+      }
+    })
+    .filter(model => model.value.length > 0)
+
+export function projectKhalaCodeDesktopClaudeSettings(input: {
+  readonly accountInfo?: unknown
+  readonly errors?: readonly string[]
+  readonly initializationResult?: unknown
+  readonly observedAt?: string
+  readonly permissionMode?: string | null
+  readonly supportedModels?: unknown
+}): KhalaCodeDesktopClaudeSettingsProjection {
+  const init = isRecord(input.initializationResult) ? input.initializationResult : {}
+  const account = isRecord(input.accountInfo) ? input.accountInfo : {}
+  const selectedModel = stringValue(init.model) ?? stringValue(init.selectedModel)
+  const models = modelOptionsFrom(input.supportedModels, selectedModel)
+  const selected = models.find(model => model.selected) ?? models[0] ?? null
+  const errors = input.errors ?? []
+  return {
+    ok: errors.length === 0,
+    observedAt: input.observedAt ?? new Date().toISOString(),
+    errors,
+    account: {
+      apiProvider: stringValue(account.apiProvider),
+      apiKeySource: stringValue(account.apiKeySource),
+      email: stringValue(account.email),
+      organization: stringValue(account.organization),
+      subscriptionType: stringValue(account.subscriptionType),
+      tokenSource: stringValue(account.tokenSource),
+    },
+    init: {
+      permissionMode: input.permissionMode ?? stringValue(init.permissionMode),
+      model: selectedModel,
+      system: init.system ?? init,
+    },
+    models: {
+      options: models,
+      selected,
+    },
+  }
+}

--- a/clients/khala-code-desktop/src/shared/rpc.ts
+++ b/clients/khala-code-desktop/src/shared/rpc.ts
@@ -5,6 +5,7 @@ import type {
   KhalaCodeDesktopSlashCommandWithAvailability,
 } from "./codex-slash-commands.js"
 import type { OnDeviceDeciderSelection } from "./on-device-decider.js"
+import type { KhalaCodeDesktopClaudeSettingsProjection } from "./claude-settings.js"
 
 // Electrobun treats Infinity as no local request timeout; chat turns stream progress
 // over events while hosted model calls and local tools can legitimately exceed 30s.
@@ -122,6 +123,10 @@ export type KhalaCodeDesktopCodexTurnActionResult = typeof RpcTurnActionResult.T
 export type KhalaCodeDesktopCodexThreadCompactRequest = typeof RpcThreadCompactRequest.Type
 export type KhalaCodeDesktopCodexApprovalRespondRequest = typeof RpcApprovalRespondRequest.Type
 export type KhalaCodeDesktopCodexApprovalRespondResult = typeof RpcApprovalRespondResult.Type
+export type KhalaCodeDesktopClaudeApprovalPendingResult = typeof RpcClaudeApprovalPendingResult.Type
+export type KhalaCodeDesktopClaudeApprovalRespondRequest = typeof RpcClaudeApprovalRespondRequest.Type
+export type KhalaCodeDesktopClaudeApprovalRespondResult = typeof RpcClaudeApprovalRespondResult.Type
+export type KhalaCodeDesktopClaudeSettingsReadResult = typeof RpcClaudeSettingsProjection.Type
 export type KhalaCodeDesktopCodexSettingsReadRequest = typeof RpcCodexSettingsReadRequest.Type
 export type KhalaCodeDesktopCodexSettingsReadResult = typeof RpcCodexSettingsProjection.Type
 export type KhalaCodeDesktopCodexConfigValueWriteRequest = typeof RpcCodexConfigValueWriteRequest.Type
@@ -651,6 +656,48 @@ const RpcApprovalRespondResult = S.Struct({
   requestId: S.Union([S.String, S.Number]),
   error: S.optional(S.String),
 })
+const RpcClaudeApprovalDecision = S.Union([
+  S.Struct({
+    behavior: S.Literal("allow"),
+    decisionClassification: S.optional(S.String),
+    updatedInput: S.optional(S.Record(S.String, S.Unknown)),
+    updatedPermissions: S.optional(S.Array(S.Record(S.String, S.Unknown))),
+  }),
+  S.Struct({
+    behavior: S.Literal("deny"),
+    decisionClassification: S.optional(S.String),
+    interrupt: S.optional(S.Boolean),
+    message: S.String,
+  }),
+])
+const RpcClaudeApprovalRequestProjection = S.Struct({
+  id: S.String,
+  input: S.Record(S.String, S.Unknown),
+  options: S.Struct({
+    blockedPath: S.optional(S.String),
+    decisionReason: S.optional(S.String),
+    description: S.optional(S.String),
+    displayName: S.optional(S.String),
+    suggestions: S.optional(S.Array(S.Record(S.String, S.Unknown))),
+    title: S.optional(S.String),
+  }),
+  toolName: S.String,
+})
+const RpcClaudeApprovalPendingResult = S.Struct({
+  ok: S.Boolean,
+  requests: S.Array(RpcClaudeApprovalRequestProjection),
+})
+const RpcClaudeApprovalRespondRequest = S.Struct({
+  decision: RpcClaudeApprovalDecision,
+  requestId: S.String,
+})
+const RpcClaudeApprovalRespondResult = S.Struct({
+  ok: S.Boolean,
+  requestId: S.String,
+  decision: RpcClaudeApprovalDecision,
+  error: S.optional(S.String),
+})
+const RpcClaudeSettingsProjection = S.Unknown as S.Schema<KhalaCodeDesktopClaudeSettingsProjection>
 
 const RpcCodexSettingsReadRequest = S.Struct({
   cwd: S.optional(S.String),
@@ -1480,6 +1527,9 @@ export const KhalaCodeDesktopRpcMethodSchemas = {
   fleetRunStart: { parameters: [param(RpcFleetRunStartRequest)], result: RpcFleetRunStartResult },
   fleetRunStatus: { parameters: [param(RpcFleetRunStatusRequest)], result: RpcFleetRunStatusResult },
   fleetWorkerControl: { parameters: [param(RpcFleetWorkerControlRequest)], result: RpcFleetWorkerControlResult },
+  claudeApprovalPending: { parameters: noParams(), result: RpcClaudeApprovalPendingResult },
+  claudeApprovalRespond: { parameters: [param(RpcClaudeApprovalRespondRequest)], result: RpcClaudeApprovalRespondResult },
+  claudeSettingsRead: { parameters: noParams(), result: RpcClaudeSettingsProjection },
   codexHarnessStatus: { parameters: noParams(), result: RpcCodexHarnessStatus },
   codexApprovalRespond: { parameters: [param(RpcApprovalRespondRequest)], result: RpcApprovalRespondResult },
   codexBackgroundTerminalsClean: { parameters: [param(RpcBackgroundTerminalsCleanRequest)], result: RpcCodexAppServerActionResult },
@@ -1625,6 +1675,9 @@ export type KhalaCodeDesktopRPCSchema = {
     fleetRunStart(request: KhalaCodeDesktopFleetRunStartRequest): Promise<KhalaCodeDesktopFleetRunStartResult>
     fleetRunStatus(request: KhalaCodeDesktopFleetRunStatusRequest): Promise<KhalaCodeDesktopFleetRunStatusResult>
     fleetWorkerControl(request: KhalaCodeDesktopFleetWorkerControlRequest): Promise<KhalaCodeDesktopFleetWorkerControlResult>
+    claudeApprovalPending(): Promise<KhalaCodeDesktopClaudeApprovalPendingResult>
+    claudeApprovalRespond(request: KhalaCodeDesktopClaudeApprovalRespondRequest): Promise<KhalaCodeDesktopClaudeApprovalRespondResult>
+    claudeSettingsRead(): Promise<KhalaCodeDesktopClaudeSettingsReadResult>
     codexHarnessStatus(): Promise<KhalaCodeDesktopCodexHarnessStatus>
     codexApprovalRespond(request: KhalaCodeDesktopCodexApprovalRespondRequest): Promise<KhalaCodeDesktopCodexApprovalRespondResult>
     codexBackgroundTerminalsClean(request: KhalaCodeDesktopCodexBackgroundTerminalsCleanRequest): Promise<KhalaCodeDesktopCodexAppServerActionResult>

--- a/clients/khala-code-desktop/src/ui/claude-settings-panel.ts
+++ b/clients/khala-code-desktop/src/ui/claude-settings-panel.ts
@@ -1,0 +1,76 @@
+import type { KhalaCodeDesktopClaudeSettingsProjection } from "../shared/claude-settings"
+
+export type ClaudeSettingsSectionHandle = {
+  readonly refresh: () => Promise<void>
+}
+
+const el = <Tag extends keyof HTMLElementTagNameMap>(
+  tag: Tag,
+  className?: string,
+  text?: string,
+): HTMLElementTagNameMap[Tag] => {
+  const node = document.createElement(tag)
+  if (className !== undefined) node.className = className
+  if (text !== undefined) node.textContent = text
+  return node
+}
+
+const compact = (value: unknown): string => {
+  if (value === null || value === undefined || value === "") return "Unset"
+  if (Array.isArray(value)) return value.join(", ") || "Unset"
+  if (typeof value === "object") return "Available"
+  return String(value)
+}
+
+const metric = (label: string, value: unknown): HTMLElement => {
+  const item = el("div", "khala-settings-metric")
+  item.append(
+    el("span", "khala-settings-metric-label", label),
+    el("span", "khala-settings-metric-value", compact(value)),
+  )
+  return item
+}
+
+export const mountClaudeSettingsSection = (
+  container: HTMLElement,
+  options: {
+    readonly fetch: () => Promise<KhalaCodeDesktopClaudeSettingsProjection>
+  },
+): ClaudeSettingsSectionHandle => {
+  let settings: KhalaCodeDesktopClaudeSettingsProjection | null = null
+
+  const render = (): void => {
+    const existing = container.querySelector(".khala-settings-section--claude")
+    existing?.remove()
+    const section = el("section", "khala-settings-section khala-settings-section--claude")
+    section.append(el("h3", "khala-settings-section-title", "Claude"))
+    if (settings === null) {
+      section.append(el("div", "khala-settings-empty", "No Claude settings loaded"))
+      container.append(section)
+      return
+    }
+    if (!settings.ok) {
+      const status = el("div", "khala-settings-status khala-settings-status--error")
+      status.textContent = settings.errors.join("\n")
+      section.append(status)
+    }
+    const selected = settings.models.selected
+    section.append(
+      metric("Model", selected?.displayName ?? settings.init.model),
+      metric("Permission mode", settings.init.permissionMode),
+      metric("Account", settings.account.email),
+      metric("Organization", settings.account.organization),
+      metric("Plan", settings.account.subscriptionType),
+      metric("API provider", settings.account.apiProvider),
+      metric("Supported models", settings.models.options.map(model => model.displayName)),
+    )
+    container.append(section)
+  }
+
+  return {
+    async refresh() {
+      settings = await options.fetch()
+      render()
+    },
+  }
+}

--- a/clients/khala-code-desktop/src/ui/codex-settings-panel.ts
+++ b/clients/khala-code-desktop/src/ui/codex-settings-panel.ts
@@ -17,6 +17,7 @@ export type CodexSettingsPanelHandle = {
 export type CodexSettingsPanelOptions = {
   readonly fetch: () => Promise<KhalaCodeDesktopCodexSettingsProjection>
   readonly fetchEcosystem?: () => Promise<KhalaCodeDesktopCodexEcosystemProjection>
+  readonly onRender?: () => void
   readonly write: (
     request: KhalaCodeDesktopCodexConfigValueWriteRequest,
   ) => Promise<{
@@ -422,10 +423,12 @@ export const mountCodexSettingsPanel = (
 
     if (loading && settings === null) {
       container.append(el("div", "khala-settings-empty", "Loading Codex settings"))
+      options.onRender?.()
       return
     }
     if (settings === null) {
       container.append(el("div", "khala-settings-empty", "No Codex settings loaded"))
+      options.onRender?.()
       return
     }
 
@@ -446,6 +449,7 @@ export const mountCodexSettingsPanel = (
       renderRequirementsSection(settings),
       ...(options.fetchEcosystem === undefined ? [] : [renderEcosystemSection(ecosystem)]),
     )
+    options.onRender?.()
   }
 
   async function refreshSettings(): Promise<void> {

--- a/clients/khala-code-desktop/src/ui/main.ts
+++ b/clients/khala-code-desktop/src/ui/main.ts
@@ -60,6 +60,7 @@ import {
 import { renderMessageBody } from "./transcript-render"
 import { mountFleetPanel } from "./fleet-status"
 import { mountCodexSettingsPanel } from "./codex-settings-panel"
+import { mountClaudeSettingsSection } from "./claude-settings-panel"
 import {
   mountCodexThreadSidebar,
   type CodexThreadSelectionSource,
@@ -198,6 +199,18 @@ const previewRpc = (): DesktopRpc => ({
       postPreviewRpc<
         Awaited<ReturnType<DesktopRpcRequests["fleetWorkerControl"]>>
       >("fleetWorkerControl", request),
+    claudeApprovalPending: () =>
+      postPreviewRpc<
+        Awaited<ReturnType<DesktopRpcRequests["claudeApprovalPending"]>>
+      >("claudeApprovalPending"),
+    claudeApprovalRespond: request =>
+      postPreviewRpc<
+        Awaited<ReturnType<DesktopRpcRequests["claudeApprovalRespond"]>>
+      >("claudeApprovalRespond", request),
+    claudeSettingsRead: () =>
+      postPreviewRpc<
+        Awaited<ReturnType<DesktopRpcRequests["claudeSettingsRead"]>>
+      >("claudeSettingsRead"),
     codexHarnessStatus: () =>
       postPreviewRpc<
         Awaited<ReturnType<DesktopRpcRequests["codexHarnessStatus"]>>
@@ -1897,6 +1910,62 @@ const respondToCodexApproval = async (button: HTMLButtonElement): Promise<void> 
   }])
 }
 
+const handledClaudeApprovals = new Set<string>()
+let claudeApprovalDialogOpen = false
+
+const respondToClaudeApprovalRequest = async (
+  request: Awaited<ReturnType<DesktopRpcRequests["claudeApprovalPending"]>>["requests"][number],
+): Promise<void> => {
+  const title = request.options.title ?? request.options.displayName ?? `Claude wants to use ${request.toolName}`
+  const detail = [
+    title,
+    request.options.description,
+    request.options.decisionReason,
+    request.options.blockedPath === undefined ? null : `Path: ${request.options.blockedPath}`,
+    "",
+    "Type always to allow and remember suggested permissions, allow to allow once, or deny.",
+  ].filter((line): line is string => line !== null && line !== undefined).join("\n")
+  const answer = window.prompt(detail, "allow")?.trim().toLowerCase() ?? "deny"
+  const allow = answer === "allow" || answer === "always"
+  const result = await controls.claudeApprovalRespond({
+    requestId: request.id,
+    decision: allow
+      ? {
+          behavior: "allow",
+          decisionClassification: answer === "always" ? "always_allow" : "allow_once",
+          ...(answer === "always" && request.options.suggestions !== undefined
+            ? { updatedPermissions: request.options.suggestions }
+            : {}),
+        }
+      : {
+          behavior: "deny",
+          decisionClassification: "deny",
+          message: "Denied by the Khala Code Desktop operator.",
+        },
+  })
+  appendMessages([{
+    body: result.ok
+      ? `Sent Claude approval decision: ${allow ? "allow" : "deny"}.`
+      : `Claude approval decision failed: ${result.error ?? "unknown error"}`,
+    id: nextMessageId("system"),
+    role: "system",
+  }])
+}
+
+const pollClaudeApprovals = async (): Promise<void> => {
+  if (claudeApprovalDialogOpen) return
+  const pending = await controls.claudeApprovalPending().catch(() => null)
+  const request = pending?.requests.find(item => !handledClaudeApprovals.has(item.id))
+  if (request === undefined) return
+  handledClaudeApprovals.add(request.id)
+  claudeApprovalDialogOpen = true
+  try {
+    await respondToClaudeApprovalRequest(request)
+  } finally {
+    claudeApprovalDialogOpen = false
+  }
+}
+
 const attachmentSummaryForSubmit = (
   attachments: readonly ComposerAttachment[],
 ): string => {
@@ -2343,6 +2412,9 @@ for (const target of [composerForm, composerRail]) {
 }
 
 window.addEventListener("resize", resizeComposerHud)
+window.setInterval(() => {
+  void pollClaudeApprovals()
+}, 1000)
 messageList.addEventListener("click", event => {
   const target = event.target
   if (!(target instanceof Element)) return
@@ -2414,6 +2486,10 @@ const controls = {
     rpc.request.fleetRunStart(request),
   fleetWorkerControl: (request: Parameters<DesktopRpcRequests["fleetWorkerControl"]>[0]) =>
     rpc.request.fleetWorkerControl(request),
+  claudeApprovalPending: () => rpc.request.claudeApprovalPending(),
+  claudeApprovalRespond: (request: Parameters<DesktopRpcRequests["claudeApprovalRespond"]>[0]) =>
+    rpc.request.claudeApprovalRespond(request),
+  claudeSettingsRead: () => rpc.request.claudeSettingsRead(),
   codexHarnessStatus: () => rpc.request.codexHarnessStatus(),
   codexApprovalRespond: (request: Parameters<DesktopRpcRequests["codexApprovalRespond"]>[0]) =>
     rpc.request.codexApprovalRespond(request),
@@ -2758,11 +2834,16 @@ const inboxPanel =
 const gymPanel =
   gymPanelEl === null ? null : mountGymPane(gymPanelEl, initialGymState)
 
+let claudeSettingsSection: ReturnType<typeof mountClaudeSettingsSection> | null = null
+
 const settingsPanel =
   settingsPanelEl === null
     ? null
     : mountCodexSettingsPanel(settingsPanelEl, {
         fetch: () => controls.codexSettingsRead({ includeHiddenModels: true }),
+        onRender: () => {
+          void claudeSettingsSection?.refresh()
+        },
         write: async request => {
           const result = await controls.codexConfigValueWrite(request)
           return {
@@ -2772,6 +2853,11 @@ const settingsPanel =
           }
         },
       })
+claudeSettingsSection = settingsPanelEl === null
+  ? null
+  : mountClaudeSettingsSection(settingsPanelEl, {
+      fetch: () => controls.claudeSettingsRead(),
+    })
 
 const prefetchRecentThreadMessages = (
   threads: readonly KhalaCodeDesktopCodexThreadSummary[],
@@ -2852,6 +2938,7 @@ const setActiveView = (value: string): void => {
   fleetPanel?.setVisible(showFleet)
   inboxPanel?.setVisible(showInbox)
   settingsPanel?.setVisible(showSettings)
+  if (showSettings) void claudeSettingsSection?.refresh()
   threadSidebar?.setVisible(showChat)
   if (showChat) {
     requestAnimationFrame(focusComposerInput)

--- a/clients/khala-code-desktop/tests/claude-app-sdk-chat-runtime.test.ts
+++ b/clients/khala-code-desktop/tests/claude-app-sdk-chat-runtime.test.ts
@@ -2,9 +2,12 @@ import { afterEach, describe, expect, test } from "bun:test"
 import { mkdtemp, readFile, rm } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
+import { Effect } from "effect"
 
 import { createClaudeAppSdkChatRuntime } from "../src/bun/claude-app-sdk-chat-runtime"
 import { CLAUDE_APP_SDK_GAP_MATRIX } from "../src/bun/claude-app-sdk-gap-matrix"
+import { createClaudeApprovalService } from "../src/bun/claude-approvals"
+import { khalaCodeDesktopClaudeTokenUsageEvent } from "../src/bun/claude-token-usage-telemetry"
 import { createClaudeSessionStore } from "../src/bun/claude-session-store"
 import { createClaudeThreadItemProjector } from "../src/bun/claude-thread-item-projector"
 import type { KhalaCodeDesktopChatTurnEvent } from "../src/shared/rpc"
@@ -377,6 +380,197 @@ describe("Claude Agent SDK chat runtime", () => {
       "claude.phase3.sidebar_catalog",
     ])
     expect(CLAUDE_APP_SDK_GAP_MATRIX.filter(row => row.status === "covered").map(row => row.phase))
-      .toEqual(["phase_1", "phase_1", "phase_1"])
+      .toEqual(["phase_1", "phase_1", "phase_1", "phase_2", "phase_2"])
+  })
+
+  test("bridges canUseTool through the Claude approval queue with native decision shapes", async () => {
+    const approvalService = createClaudeApprovalService()
+    const statePath = await tempPath("claude-approval-state.json")
+    let decision: unknown
+    const runtime = createClaudeAppSdkChatRuntime({
+      approvalService,
+      query: input => ({
+        async *[Symbol.asyncIterator]() {
+          const canUseTool = input.options.canUseTool as (
+            toolName: string,
+            toolInput: Record<string, unknown>,
+            options: Record<string, unknown>,
+          ) => Promise<unknown>
+          decision = await canUseTool("Bash", { command: "pwd" }, {
+            signal: new AbortController().signal,
+            suggestions: [{ toolName: "Bash", rule: "allow" }],
+            title: "Claude wants to run pwd",
+          })
+          yield { type: "result", subtype: "success", session_id: "claude-approval-session" }
+        },
+      }),
+      sessionStore: createClaudeSessionStore({ path: statePath }),
+      workingDirectory: "/repo",
+    })
+
+    const turn = runtime.startTurn({
+      messages: [{ body: "run pwd", id: "user-approval", role: "user" }],
+      sessionId: "desktop-approval",
+      turnId: "turn-approval",
+    })
+    while (approvalService.pending().length === 0) await new Promise(resolve => setTimeout(resolve, 0))
+    const pending = approvalService.pending()[0]
+    expect(pending).toMatchObject({
+      toolName: "Bash",
+      options: { title: "Claude wants to run pwd" },
+    })
+    const suggestedPermissions = pending!.options.suggestions ?? []
+    await approvalService.respond(pending!.id, {
+      behavior: "allow",
+      decisionClassification: "always_allow",
+      updatedPermissions: suggestedPermissions,
+    })
+    await turn
+
+    expect(decision).toEqual({
+      behavior: "allow",
+      decisionClassification: "always_allow",
+      updatedPermissions: [{ toolName: "Bash", rule: "allow" }],
+    })
+  })
+
+  test("injects khala_fleet into Claude mcpServers at startTurn without config mutation", async () => {
+    const statePath = await tempPath("claude-mcp-state.json")
+    const queryCalls: unknown[] = []
+    const runtime = createClaudeAppSdkChatRuntime({
+      env: { KHALA_CODE_DESKTOP_BUN_COMMAND: "bun-test" },
+      query: input => {
+        queryCalls.push(input)
+        return messages([{ type: "result", subtype: "success", session_id: "claude-mcp-session" }])
+      },
+      repoRoot: "/repo/openagents",
+      sessionStore: createClaudeSessionStore({ path: statePath }),
+      workingDirectory: "/repo/workspace",
+    })
+
+    await runtime.startTurn({
+      messages: [{ body: "fleet status", id: "user-mcp", role: "user" }],
+      sessionId: "desktop-mcp",
+      turnId: "turn-mcp",
+    })
+
+    expect((queryCalls[0] as { options: Record<string, unknown> }).options).toMatchObject({
+      mcpServers: {
+        khala_fleet: {
+          args: ["/repo/openagents/clients/khala-code-desktop/src/bun/khala-fleet-mcp-server.ts"],
+          command: "bun-test",
+          cwd: "/repo/openagents",
+          type: "stdio",
+        },
+      },
+    })
+  })
+
+  test("reports exact Claude result usage through the desktop token path", async () => {
+    const statePath = await tempPath("claude-token-state.json")
+    const reports: unknown[] = []
+    const runtime = createClaudeAppSdkChatRuntime({
+      query: () => messages([{
+        modelUsage: {
+          "claude-sonnet-4": {
+            cacheReadInputTokens: 3,
+            inputTokens: 10,
+            outputTokens: 7,
+            reasoningOutputTokens: 2,
+          },
+        },
+        session_id: "claude-token-session",
+        subtype: "success",
+        total_cost_usd: 0.01,
+        type: "result",
+      }]),
+      sessionStore: createClaudeSessionStore({ path: statePath }),
+      tokenUsageReporter: report => {
+        reports.push(report)
+        return Effect.void as never
+      },
+      workingDirectory: "/repo",
+    })
+
+    await runtime.startTurn({
+      messages: [{ body: "count tokens", id: "user-token", role: "user" }],
+      sessionId: "desktop-token",
+      turnId: "turn-token",
+    })
+
+    expect(reports).toMatchObject([{
+      claudeSessionId: "claude-token-session",
+      desktopSessionId: "desktop-token",
+      desktopTurnId: "turn-token",
+      model: "claude-sonnet-4",
+      totalCostUsd: 0.01,
+      usage: {
+        cachedInput: 3,
+        input: 10,
+        output: 7,
+        reasoningOutput: 2,
+      },
+    }])
+    expect(khalaCodeDesktopClaudeTokenUsageEvent(reports[0] as never)).toMatchObject({
+      provider: "pylon-claude-direct-local",
+      sourceRoute: "pylon_claude_direct_local",
+      tokenCounts: {
+        totalTokens: 22,
+      },
+      usageTruth: "exact",
+    })
+  })
+
+  test("projects Claude settings from SDK init supportedModels and accountInfo", async () => {
+    const statePath = await tempPath("claude-settings-state.json")
+    const runtime = createClaudeAppSdkChatRuntime({
+      env: { KHALA_CODE_DESKTOP_CLAUDE_PERMISSION_MODE: "plan" },
+      query: () => ({
+        accountInfo: async () => ({
+          apiProvider: "firstParty",
+          email: "operator@example.com",
+          organization: "OpenAgents",
+          subscriptionType: "pro",
+        }),
+        async *[Symbol.asyncIterator]() {
+          yield { subtype: "init", type: "system", model: "claude-sonnet-4" }
+          yield { type: "result", subtype: "success", session_id: "claude-settings-session" }
+        },
+        initializationResult: async () => ({ model: "claude-sonnet-4", permissionMode: "plan" }),
+        supportedModels: async () => [{
+          description: "Fast coding model",
+          displayName: "Claude Sonnet 4",
+          supportsEffort: true,
+          supportedEffortLevels: ["low", "medium", "high"],
+          value: "claude-sonnet-4",
+        }],
+      }),
+      sessionStore: createClaudeSessionStore({ path: statePath }),
+      workingDirectory: "/repo",
+    })
+
+    await runtime.startTurn({
+      messages: [{ body: "settings", id: "user-settings", role: "user" }],
+      sessionId: "desktop-settings",
+      turnId: "turn-settings",
+    })
+
+    await expect(runtime.claudeSettingsRead()).resolves.toMatchObject({
+      account: {
+        email: "operator@example.com",
+        subscriptionType: "pro",
+      },
+      init: {
+        model: "claude-sonnet-4",
+        permissionMode: "plan",
+      },
+      models: {
+        selected: {
+          displayName: "Claude Sonnet 4",
+          value: "claude-sonnet-4",
+        },
+      },
+      ok: true,
+    })
   })
 })


### PR DESCRIPTION
Closes #7867

## Summary
- Adds Claude-native canUseTool approval queue bridged to renderer decisions.
- Records exact Claude result usage/modelUsage on the desktop stats token path and injects khala_fleet via options.mcpServers at startTurn.
- Adds Claude settings projection/section from SDK init, supportedModels, and accountInfo.

## Verification
- PASS: bun test clients/khala-code-desktop/tests/claude-app-sdk-chat-runtime.test.ts
- PASS: bun run --cwd clients/khala-code-desktop typecheck
- PASS: bun test clients/khala-code-desktop/tests/claude-app-sdk-chat-runtime.test.ts clients/khala-code-desktop/tests/preview-bridge.test.ts --test-name-pattern "Claude Agent SDK chat runtime|preview rpc read-only classification"
- RAN: bun run --cwd clients/khala-code-desktop verify (command.public.pylon_khala.verify.c2cf893c3b48c76502ade240). It fails in this bounded checkout because clients/khala-code-desktop/node_modules is a symlink to an external shared cache with broken workspace-package links. Failures are import/bootstrap ENOENTs for @openagentsinc/khala-tools, @openagentsinc/agent-runtime-schema, @openagentsinc/arbiter-effect, @openagentsinc/ui, @openagentsinc/composer-state, and @openagentsinc/khala-qa-harness. The command reaches typecheck before failing in tests; the Claude-focused tests and preview RPC classification pass.