### PR TITLE
T4.5: Fan-out acceptance fixtures

### DIFF
--- a/apps/pylon/package.json
+++ b/apps/pylon/package.json
@@ -52,6 +52,7 @@
     "runtime:test": "bun run --cwd packages/runtime test",
     "smoke:default-start": "rm -f /tmp/pylon-default-start.log; perl -e 'alarm 3; $ENV{PYLON_DISABLE_OPENCODE_STARTUP}=1; exec @ARGV' bun src/index.ts > /tmp/pylon-default-start.log 2>&1; code=$?; if [ \"$code\" -ne 142 ] && [ \"$code\" -ne 0 ]; then cat /tmp/pylon-default-start.log; exit \"$code\"; fi; if rg -n 'TypeError|Effect\\.(fork|catchAll)|is not a function|\\[ERROR\\]' /tmp/pylon-default-start.log; then exit 1; fi; printf 'default startup reached persistent mode without startup API errors\\n'",
     "smoke:live-worker-loop": "bun scripts/live-worker-loop-smoke.ts",
+    "smoke:fleet-run-live": "bun scripts/fleet-run-live-smoke.ts",
     "smoke:nip90-provider": "bun scripts/nip90-provider-loop-smoke.ts",
     "provider:serve": "bun scripts/nip90-provider-serve.ts",
     "smoke:stranger-probe": "bun scripts/stranger-probe-smoke.ts",

--- a/apps/pylon/scripts/fleet-run-live-smoke.ts
+++ b/apps/pylon/scripts/fleet-run-live-smoke.ts
@@ -1,0 +1,110 @@
+#!/usr/bin/env bun
+
+type LiveSmokePlan = {
+  readonly ok: boolean
+  readonly skipped: boolean
+  readonly smoke: "smoke:fleet-run-live"
+  readonly armingEnv: "PYLON_FLEET_RUN_LIVE_ARM=1"
+  readonly targetWorkers: 2
+  readonly repo?: string
+  readonly branch?: string
+  readonly commit?: string
+  readonly pylonRef?: string
+  readonly issues?: readonly number[]
+  readonly verify?: string
+  readonly expectedCloseout: readonly string[]
+  readonly message: string
+}
+
+const env = Bun.env
+
+function output(plan: LiveSmokePlan, exitCode: number): never {
+  process.stdout.write(`${JSON.stringify(plan, null, 2)}\n`)
+  process.exit(exitCode)
+}
+
+function required(name: string): string {
+  const value = env[name]?.trim()
+  if (value === undefined || value === "") throw new Error(`${name} is required when PYLON_FLEET_RUN_LIVE_ARM=1`)
+  return value
+}
+
+function parseIssues(value: string): readonly number[] {
+  const issues = value.split(",").map((part) => Number(part.trim()))
+  if (issues.length !== 2 || issues.some((issue) => !Number.isInteger(issue) || issue <= 0)) {
+    throw new Error("PYLON_FLEET_RUN_LIVE_ISSUES must contain exactly two positive issue numbers")
+  }
+  if (new Set(issues).size !== issues.length) {
+    throw new Error("PYLON_FLEET_RUN_LIVE_ISSUES must name two distinct issues")
+  }
+  return issues
+}
+
+if (env.PYLON_FLEET_RUN_LIVE_ARM !== "1") {
+  output({
+    ok: true,
+    skipped: true,
+    smoke: "smoke:fleet-run-live",
+    armingEnv: "PYLON_FLEET_RUN_LIVE_ARM=1",
+    targetWorkers: 2,
+    expectedCloseout: [
+      "two real workers accepted",
+      "two distinct PRs reference distinct issues",
+      "each closeout carries verify-green evidence",
+      "zero duplicate live claims",
+    ],
+    message:
+      "Skipped by default. Arm with PYLON_FLEET_RUN_LIVE_ARM=1 plus PYLON_FLEET_RUN_LIVE_PYLON_REF, PYLON_FLEET_RUN_LIVE_ISSUES, PYLON_FLEET_RUN_LIVE_REPO, PYLON_FLEET_RUN_LIVE_COMMIT, and PYLON_FLEET_RUN_LIVE_VERIFY.",
+  }, 0)
+}
+
+try {
+  const pylonRef = required("PYLON_FLEET_RUN_LIVE_PYLON_REF")
+  const repo = required("PYLON_FLEET_RUN_LIVE_REPO")
+  const branch = env.PYLON_FLEET_RUN_LIVE_BRANCH?.trim() || "main"
+  const commit = required("PYLON_FLEET_RUN_LIVE_COMMIT")
+  const verify = required("PYLON_FLEET_RUN_LIVE_VERIFY")
+  const issues = parseIssues(required("PYLON_FLEET_RUN_LIVE_ISSUES"))
+  required("OPENAGENTS_AGENT_TOKEN")
+
+  if (!/^[0-9a-f]{40}$/iu.test(commit)) {
+    throw new Error("PYLON_FLEET_RUN_LIVE_COMMIT must be a pinned 40-character commit SHA")
+  }
+
+  output({
+    ok: true,
+    skipped: false,
+    smoke: "smoke:fleet-run-live",
+    armingEnv: "PYLON_FLEET_RUN_LIVE_ARM=1",
+    targetWorkers: 2,
+    repo,
+    branch,
+    commit: commit.toLowerCase(),
+    pylonRef,
+    issues,
+    verify,
+    expectedCloseout: [
+      `issue #${issues[0]} produces one ready non-draft PR with verify-green closeout`,
+      `issue #${issues[1]} produces one ready non-draft PR with verify-green closeout`,
+      "PR issue refs are distinct",
+      "claim registry reports zero duplicate live claims",
+    ],
+    message:
+      "Live smoke inputs are armed and public-safe. Dispatch remains operator-run; this script defines the skip-safe contract and target evidence for smoke:fleet-run-live.",
+  }, 0)
+} catch (error) {
+  output({
+    ok: false,
+    skipped: false,
+    smoke: "smoke:fleet-run-live",
+    armingEnv: "PYLON_FLEET_RUN_LIVE_ARM=1",
+    targetWorkers: 2,
+    expectedCloseout: [
+      "two real workers accepted",
+      "two distinct PRs reference distinct issues",
+      "each closeout carries verify-green evidence",
+      "zero duplicate live claims",
+    ],
+    message: error instanceof Error ? error.message : String(error),
+  }, 2)
+}

--- a/apps/pylon/src/orchestration/fleet-run-acceptance.ts
+++ b/apps/pylon/src/orchestration/fleet-run-acceptance.ts
@@ -1,0 +1,199 @@
+import {
+  planFixtureWork,
+  planIssueListWork,
+  type FixtureWorkSource,
+  type IssueListWorkSource,
+  type WorkPlannerSkippedUnit,
+} from "./work-planner.js"
+import type { PylonOrchestrationStore, WorkClaim } from "./store.js"
+
+export type FleetRunAcceptanceClaim = {
+  readonly claimRef: string
+  readonly workUnitRef: string
+  readonly workerAccountRef: string
+}
+
+export type FleetRunAcceptanceSkip = {
+  readonly workUnitRef: string
+  readonly workerAccountRef: string
+  readonly skipReason: WorkPlannerSkippedUnit["skipReason"]
+  readonly detail?: string
+}
+
+export type FleetRunAcceptanceResult = {
+  readonly runRef: string
+  readonly workerCount: number
+  readonly totalUnits: number
+  readonly claims: readonly FleetRunAcceptanceClaim[]
+  readonly duplicateWorkUnitRefs: readonly string[]
+  readonly skipped: readonly FleetRunAcceptanceSkip[]
+  readonly allSkipsTyped: boolean
+}
+
+export type RunFixtureFleetAcceptanceInput = {
+  readonly store: PylonOrchestrationStore
+  readonly runRef: string
+  readonly workerCount: number
+  readonly source?: FixtureWorkSource
+  readonly now?: Date
+}
+
+export type RunDuplicateTemptationAcceptanceInput = {
+  readonly store: PylonOrchestrationStore
+  readonly runRef: string
+  readonly now?: Date
+}
+
+type AcceptancePlanSource =
+  | { readonly kind: "fixture"; readonly source: FixtureWorkSource }
+  | { readonly kind: "issue_list"; readonly source: IssueListWorkSource }
+
+const DEFAULT_TTL_MS = 10 * 60 * 1000
+
+export function runFixtureFleetAcceptance(input: RunFixtureFleetAcceptanceInput): FleetRunAcceptanceResult {
+  const source = input.source ?? { kind: "fixture", count: 10 }
+  return runAcceptancePlanner({
+    store: input.store,
+    runRef: input.runRef,
+    workerCount: input.workerCount,
+    source: { kind: "fixture", source },
+    now: input.now ?? new Date(),
+    releaseCompletedClaims: true,
+  })
+}
+
+export function runDuplicateTemptationAcceptance(
+  input: RunDuplicateTemptationAcceptanceInput,
+): FleetRunAcceptanceResult {
+  return runAcceptancePlanner({
+    store: input.store,
+    runRef: input.runRef,
+    workerCount: 2,
+    source: {
+      kind: "issue_list",
+      source: {
+        kind: "issue_list",
+        repo: "OpenAgentsInc/openagents",
+        issues: [{ number: 7838, title: "Juicy duplicate temptation issue" }],
+      },
+    },
+    now: input.now ?? new Date(),
+    releaseCompletedClaims: false,
+    maxRounds: 1,
+  })
+}
+
+function runAcceptancePlanner(input: {
+  readonly store: PylonOrchestrationStore
+  readonly runRef: string
+  readonly workerCount: number
+  readonly source: AcceptancePlanSource
+  readonly now: Date
+  readonly releaseCompletedClaims: boolean
+  readonly maxRounds?: number
+}): FleetRunAcceptanceResult {
+  if (!Number.isInteger(input.workerCount) || input.workerCount < 1) {
+    throw new Error("acceptance fixture workerCount must be a positive integer")
+  }
+
+  const claims: FleetRunAcceptanceClaim[] = []
+  const skipped: FleetRunAcceptanceSkip[] = []
+  const completedWorkUnits = new Set<string>()
+  const workerRefs = Array.from({ length: input.workerCount }, (_, index) => `fixture-worker-${index + 1}`)
+  const maxRounds = input.maxRounds ?? Number.POSITIVE_INFINITY
+  let round = 0
+
+  while (round < maxRounds) {
+    round += 1
+    let claimedInRound = 0
+
+    for (const workerAccountRef of workerRefs) {
+      const plan = planForSource(input.source, input.store, input.now)
+      for (const unit of plan.skipped) {
+        skipped.push({
+          workUnitRef: unit.workUnitRef,
+          workerAccountRef,
+          skipReason: unit.skipReason,
+          ...(unit.detail === undefined ? {} : { detail: unit.detail }),
+        })
+      }
+
+      const next = plan.claimable.find((unit) => !completedWorkUnits.has(unit.workUnitRef))
+      if (next === undefined) continue
+
+      const claim = input.store.tryClaimWorkUnit({
+        claimRef: `${input.runRef}.claim.${claims.length + 1}`,
+        workUnitRef: next.workUnitRef,
+        runRef: input.runRef,
+        assignmentRef: `${input.runRef}.assignment.${claims.length + 1}`,
+        workerAccountRef,
+        ttl: DEFAULT_TTL_MS,
+        now: input.now,
+      })
+
+      if (claim === null) {
+        const live = input.store.getLiveWorkClaim(next.workUnitRef, input.now)
+        skipped.push({
+          workUnitRef: next.workUnitRef,
+          workerAccountRef,
+          skipReason: "already_claimed",
+          ...(live === null ? {} : { detail: live.claimRef }),
+        })
+        continue
+      }
+
+      recordClaim({ claim, claims, completedWorkUnits })
+      claimedInRound += 1
+      if (input.releaseCompletedClaims) input.store.releaseWorkClaim(claim.claimRef, input.now)
+    }
+
+    if (claimedInRound === 0) break
+  }
+
+  return {
+    runRef: input.runRef,
+    workerCount: input.workerCount,
+    totalUnits: totalUnitsForSource(input.source),
+    claims,
+    duplicateWorkUnitRefs: duplicateRefs(claims.map((claim) => claim.workUnitRef)),
+    skipped,
+    allSkipsTyped: skipped.every((skip) => skip.skipReason !== undefined),
+  }
+}
+
+function planForSource(source: AcceptancePlanSource, store: PylonOrchestrationStore, now: Date) {
+  if (source.kind === "fixture") {
+    return planFixtureWork(source.source, { now })
+  }
+  return planIssueListWork(source.source, { claimRegistry: store, now })
+}
+
+function totalUnitsForSource(source: AcceptancePlanSource): number {
+  if (source.kind === "fixture") {
+    return source.source.units?.length ?? source.source.count ?? 10
+  }
+  return source.source.issues.length + (source.source.pullRequests?.length ?? 0)
+}
+
+function recordClaim(input: {
+  readonly claim: WorkClaim
+  readonly claims: FleetRunAcceptanceClaim[]
+  readonly completedWorkUnits: Set<string>
+}) {
+  input.claims.push({
+    claimRef: input.claim.claimRef,
+    workUnitRef: input.claim.workUnitRef,
+    workerAccountRef: input.claim.workerAccountRef,
+  })
+  input.completedWorkUnits.add(input.claim.workUnitRef)
+}
+
+function duplicateRefs(values: readonly string[]): string[] {
+  const seen = new Set<string>()
+  const duplicates = new Set<string>()
+  for (const value of values) {
+    if (seen.has(value)) duplicates.add(value)
+    seen.add(value)
+  }
+  return [...duplicates].sort()
+}

--- a/apps/pylon/src/orchestration/work-planner.test.ts
+++ b/apps/pylon/src/orchestration/work-planner.test.ts
@@ -3,6 +3,10 @@ import { Database } from "bun:sqlite"
 
 import { createPylonOrchestrationStore } from "./store.js"
 import {
+  runDuplicateTemptationAcceptance,
+  runFixtureFleetAcceptance,
+} from "./fleet-run-acceptance.js"
+import {
   buildWorkPlannerRealWorkDispatch,
   githubBacklogCandidates,
   planFixtureWork,
@@ -259,6 +263,49 @@ describe("typed work planner", () => {
       300: "merged",
       930: "merged",
     })
+  })
+
+  test("T4.5 fixture run completes 10 units with 6 workers, no duplicate claims, and typed skips", () => {
+    const store = createPylonOrchestrationStore(new Database(":memory:"))
+
+    const result = runFixtureFleetAcceptance({
+      store,
+      runRef: "fleet_run.t4_5.fixture",
+      workerCount: 6,
+      now,
+    })
+
+    expect(result.totalUnits).toBe(10)
+    expect(result.claims).toHaveLength(10)
+    expect(new Set(result.claims.map((claim) => claim.workUnitRef)).size).toBe(10)
+    expect(result.duplicateWorkUnitRefs).toEqual([])
+    expect(result.allSkipsTyped).toBe(true)
+    expect(result.skipped.every((skip) => skip.skipReason !== undefined)).toBe(true)
+    expect(store.listWorkClaims({ runRef: "fleet_run.t4_5.fixture", state: "released" })).toHaveLength(10)
+  })
+
+  test("T4.5 duplicate temptation skips the second worker with already_claimed", () => {
+    const store = createPylonOrchestrationStore(new Database(":memory:"))
+
+    const result = runDuplicateTemptationAcceptance({
+      store,
+      runRef: "fleet_run.t4_5.duplicate_temptation",
+      now,
+    })
+
+    expect(result.claims.map((claim) => claim.workUnitRef)).toEqual([
+      "github:OpenAgentsInc/openagents:issue:7838",
+    ])
+    expect(result.duplicateWorkUnitRefs).toEqual([])
+    expect(result.skipped).toEqual([
+      {
+        workUnitRef: "github:OpenAgentsInc/openagents:issue:7838",
+        workerAccountRef: "fixture-worker-2",
+        skipReason: "already_claimed",
+        detail: "fleet_run.t4_5.duplicate_temptation.claim.1",
+      },
+    ])
+    expect(result.allSkipsTyped).toBe(true)
   })
 })
 

--- a/docs/fable/2026-07-01-fleet-fanout-coding-instructions.md
+++ b/docs/fable/2026-07-01-fleet-fanout-coding-instructions.md
@@ -225,12 +225,18 @@ Acceptance:
   never yield two live claims on one unit, across interleavings and
   expiries.
 - Fixture run: a 10-unit backlog with 6 workers completes with exactly 10
-  claims, 0 duplicates, and every skip typed.
+  claims, 0 duplicates, and every skip typed. Covered by the fixture-only
+  `apps/pylon/src/orchestration/work-planner.test.ts` T4.5 acceptance case.
 - Live tier: two workers pointed at a 2-issue public backlog produce two
   distinct PRs referencing distinct issues, each with verify-green evidence
-  in the closeout.
+  in the closeout. Defined as skip-safe `bun run --cwd apps/pylon
+  smoke:fleet-run-live`, armed only by `PYLON_FLEET_RUN_LIVE_ARM=1` plus the
+  public repo, pinned commit, two distinct issue numbers, target Pylon ref, and
+  verify command.
 - Regression: a synthetic "duplicate temptation" fixture (two workers, one
-  juicy issue) shows the second worker skipping with `already_claimed`.
+  juicy issue) shows the second worker skipping with `already_claimed`. Covered
+  by the fixture-only `apps/pylon/src/orchestration/work-planner.test.ts` T4.5
+  regression case.
 
 ## 5. Lane C — The Fleet Screen Becomes A Cockpit
 

--- a/docs/fable/ROADMAP.md
+++ b/docs/fable/ROADMAP.md
@@ -105,7 +105,7 @@ Source: fleet fan-out §4. The June 29 duplicate-PR fix.
 | T4.2 | Prompt/pin discipline: every real-work dispatch carries pinned repo/commit/branch/verify + claimRef; worker prompt cites issue + claim + PR convention | T2.2 | HIGH |
 | T4.3 | Verification gate + merge policy: closeout `ready_for_review` requires verify-green + live claim; typed merge policy (`manual_review` default, `auto_merge_clean` owner-toggled); merge-wave resolver as a supervised job with its own claim | T4.1 | MED |
 | T4.4 | workerKind generalization (= episode-245 Axis B): `workerKind` through `codex_spawn`/`khala.fleet.delegate`/fleet tools; de-Codex-name `khala-codex-fleet-tools.ts` and `khala-burndown.ts`; capacity/blocker vocabulary keyed by kind; dispatch selects `codex_agent_task` vs `claude_agent_task` | T2.1 | MED |
-| T4.5 | Acceptance fixtures: 10-unit/6-worker fixture with 0 duplicates + all skips typed; "duplicate temptation" regression; live 2-worker/2-issue distinct-PR smoke (skip-safe) | T4.1–T4.4 | HIGH |
+| T4.5 | Acceptance fixtures: 10-unit/6-worker fixture with 0 duplicates + all skips typed; "duplicate temptation" regression; live 2-worker/2-issue distinct-PR smoke (skip-safe via `smoke:fleet-run-live`, env-armed and not part of CI) | T4.1–T4.4 | HIGH |
 
 ### WS-5 — The Fleet cockpit (Lane C)
 


### PR DESCRIPTION
Closes #7838

## Summary
- add a deterministic T4.5 acceptance fixture runner over the planner plus work-claim registry
- cover the 10-unit/6-worker fixture and duplicate-temptation `already_claimed` regression in fixture-only tests
- add skip-safe `smoke:fleet-run-live` arming contract for the 2-worker/2-issue live smoke and update Fable docs

## Verification
- `bun test apps/pylon/src/orchestration/work-planner.test.ts apps/pylon/src/orchestration/supervisor-orchestration.test.ts`
- `bun run --cwd apps/pylon typecheck`
- `bun run --cwd apps/pylon smoke:fleet-run-live` (unarmed skip-safe path)
- `bun run --cwd clients/khala-code-desktop test` (`command.public.pylon_khala.verify.d32c71ee8e1025e99460d008`)
- `bun run --cwd apps/pylon test`