### PR TITLE
T9.5: Claude second-pass reviewer

### DIFF
--- a/apps/pylon/src/claude-second-pass-reviewer.test.ts
+++ b/apps/pylon/src/claude-second-pass-reviewer.test.ts
@@ -10,7 +10,7 @@ import type { ResolvedPylonAccountSelection } from "./account-registry.js"
 
 const claudeAccount: ResolvedPylonAccountSelection = {
   provider: "claude_agent",
-  selector: "accountRef",
+  selector: "registry_ref",
   accountRef: "claude-reviewer",
   accountRefHash: "account.pylon.claude_agent.review",
   home: "/tmp/pylon-claude-reviewer-home",
@@ -35,6 +35,24 @@ describe("Claude second-pass reviewer", () => {
       summary: "bad",
       riskRefs: [],
     })).toBeNull()
+    expect(parseClaudeSecondPassVerdict({
+      schema: CLAUDE_SECOND_PASS_REVIEW_SCHEMA,
+      recommendation: "manual_review",
+      confidence: "high",
+      summary: "bad ref",
+      riskRefs: ["not a public ref"],
+    })).toBeNull()
+    expect(parseClaudeSecondPassVerdict([
+      "prefix ",
+      JSON.stringify({
+        schema: CLAUDE_SECOND_PASS_REVIEW_SCHEMA,
+        recommendation: "approve",
+        confidence: "low",
+        summary: "JSON with braces in a string: {ok}",
+        riskRefs: [],
+      }),
+      " trailing {not-json}",
+    ].join(""))).toMatchObject({ recommendation: "approve" })
   })
 
   test("builds a bounded review prompt over the closeout diff", () => {
@@ -51,7 +69,12 @@ describe("Claude second-pass reviewer", () => {
   })
 
   test("runs a mocked Claude SDK session with an isolated Claude account home", async () => {
-    let seenOptions: Record<string, unknown> | null = null
+    type SeenClaudeOptions = {
+      env?: Record<string, string | undefined>
+      outputFormat?: Record<string, unknown>
+      permissionMode?: string
+    }
+    const seenOptions: SeenClaudeOptions[] = []
     const verdict = await runClaudeSecondPassReview({
       assignmentRef: "assignment.public.t9_5",
       workspace: "/tmp/workspace",
@@ -64,7 +87,8 @@ describe("Claude second-pass reviewer", () => {
         expect(specifier).toBe(CLAUDE_AGENT_SDK_PACKAGE)
         return {
           query: (args: unknown) => {
-            seenOptions = (args as { options?: Record<string, unknown> }).options ?? null
+            const options = (args as { options?: SeenClaudeOptions }).options
+            if (options !== undefined) seenOptions.push(options)
             return (async function* () {
               yield {
                 type: "result",
@@ -83,8 +107,9 @@ describe("Claude second-pass reviewer", () => {
     })
 
     expect(verdict.recommendation).toBe("approve")
-    expect(seenOptions?.env).toMatchObject({ CLAUDE_CONFIG_DIR: claudeAccount.home })
-    expect(seenOptions?.outputFormat).toMatchObject({ type: "json_schema" })
-    expect(seenOptions?.permissionMode).toBe("plan")
+    const capturedOptions = seenOptions[0]
+    expect(capturedOptions?.env).toMatchObject({ CLAUDE_CONFIG_DIR: claudeAccount.home })
+    expect(capturedOptions?.outputFormat).toMatchObject({ type: "json_schema" })
+    expect(capturedOptions?.permissionMode).toBe("plan")
   })
 })

--- a/apps/pylon/src/claude-second-pass-reviewer.test.ts
+++ b/apps/pylon/src/claude-second-pass-reviewer.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, test } from "bun:test"
+import {
+  CLAUDE_SECOND_PASS_REVIEW_SCHEMA,
+  buildClaudeSecondPassReviewPrompt,
+  parseClaudeSecondPassVerdict,
+  runClaudeSecondPassReview,
+} from "./claude-second-pass-reviewer.js"
+import { CLAUDE_AGENT_SDK_PACKAGE } from "./claude-agent.js"
+import type { ResolvedPylonAccountSelection } from "./account-registry.js"
+
+const claudeAccount: ResolvedPylonAccountSelection = {
+  provider: "claude_agent",
+  selector: "accountRef",
+  accountRef: "claude-reviewer",
+  accountRefHash: "account.pylon.claude_agent.review",
+  home: "/tmp/pylon-claude-reviewer-home",
+}
+
+describe("Claude second-pass reviewer", () => {
+  test("parses structured json_schema verdict shapes", () => {
+    expect(parseClaudeSecondPassVerdict(JSON.stringify({
+      schema: CLAUDE_SECOND_PASS_REVIEW_SCHEMA,
+      recommendation: "request_changes",
+      confidence: "high",
+      summary: "Diff likely misses an edge case.",
+      riskRefs: ["risk.public.pylon.review.edge_case"],
+    }))).toMatchObject({
+      recommendation: "request_changes",
+      riskRefs: ["risk.public.pylon.review.edge_case"],
+    })
+    expect(parseClaudeSecondPassVerdict({
+      schema: CLAUDE_SECOND_PASS_REVIEW_SCHEMA,
+      recommendation: "merge_now",
+      confidence: "high",
+      summary: "bad",
+      riskRefs: [],
+    })).toBeNull()
+  })
+
+  test("builds a bounded review prompt over the closeout diff", () => {
+    const prompt = buildClaudeSecondPassReviewPrompt({
+      assignmentRef: "assignment.public.t9_5",
+      workspace: "/workspace",
+      diffText: "diff --git a/sum.ts b/sum.ts",
+      verifyCommandRef: "command.public.pylon_khala.verify.28484fe0b746db06b92c2eb2",
+      verifyCommand: ["bun", "test"],
+    })
+    expect(prompt).toContain("verification command already passed")
+    expect(prompt).toContain("diff --git a/sum.ts b/sum.ts")
+    expect(prompt).toContain("Return exactly one JSON object")
+  })
+
+  test("runs a mocked Claude SDK session with an isolated Claude account home", async () => {
+    let seenOptions: Record<string, unknown> | null = null
+    const verdict = await runClaudeSecondPassReview({
+      assignmentRef: "assignment.public.t9_5",
+      workspace: "/tmp/workspace",
+      diffText: "diff --git a/sum.ts b/sum.ts",
+      verifyCommandRef: "command.public.pylon_khala.verify.28484fe0b746db06b92c2eb2",
+      verifyCommand: ["bun", "test"],
+      account: claudeAccount,
+      env: {},
+      sdkImporter: async (specifier) => {
+        expect(specifier).toBe(CLAUDE_AGENT_SDK_PACKAGE)
+        return {
+          query: (args: unknown) => {
+            seenOptions = (args as { options?: Record<string, unknown> }).options ?? null
+            return (async function* () {
+              yield {
+                type: "result",
+                result: JSON.stringify({
+                  schema: CLAUDE_SECOND_PASS_REVIEW_SCHEMA,
+                  recommendation: "approve",
+                  confidence: "medium",
+                  summary: "No semantic risk found.",
+                  riskRefs: [],
+                }),
+              }
+            })()
+          },
+        }
+      },
+    })
+
+    expect(verdict.recommendation).toBe("approve")
+    expect(seenOptions?.env).toMatchObject({ CLAUDE_CONFIG_DIR: claudeAccount.home })
+    expect(seenOptions?.outputFormat).toMatchObject({ type: "json_schema" })
+    expect(seenOptions?.permissionMode).toBe("plan")
+  })
+})

--- a/apps/pylon/src/claude-second-pass-reviewer.ts
+++ b/apps/pylon/src/claude-second-pass-reviewer.ts
@@ -1,0 +1,177 @@
+import { createHash } from "node:crypto"
+
+import { CLAUDE_AGENT_SDK_PACKAGE } from "./claude-agent.js"
+import {
+  pylonAccountEnvironment,
+  type ResolvedPylonAccountSelection,
+} from "./account-registry.js"
+
+export const CLAUDE_SECOND_PASS_REVIEW_SCHEMA = "openagents.pylon.claude_second_pass_review.v1" as const
+
+export type ClaudeSecondPassRecommendation = "approve" | "manual_review" | "request_changes"
+
+export type ClaudeSecondPassVerdict = {
+  schema: typeof CLAUDE_SECOND_PASS_REVIEW_SCHEMA
+  recommendation: ClaudeSecondPassRecommendation
+  confidence: "low" | "medium" | "high"
+  summary: string
+  riskRefs: string[]
+}
+
+export type ClaudeSecondPassReviewInput = {
+  assignmentRef: string
+  workspace: string
+  diffText: string
+  verifyCommandRef: string
+  verifyCommand: string[]
+  account?: ResolvedPylonAccountSelection | null
+  env?: Record<string, string | undefined>
+  sdkImporter?: (specifier: string) => Promise<{ query: (args: unknown) => AsyncIterable<unknown> }>
+  timeoutMs?: number
+  model?: string
+}
+
+export type ClaudeSecondPassReviewer = (input: ClaudeSecondPassReviewInput) => Promise<ClaudeSecondPassVerdict>
+
+export type ClaudeSecondPassReviewOptions =
+  | {
+      enabled: true
+      account: ResolvedPylonAccountSelection
+      reviewer?: ClaudeSecondPassReviewer
+      timeoutMs?: number
+    }
+  | {
+      enabled: true
+      reviewer: ClaudeSecondPassReviewer
+      account?: ResolvedPylonAccountSelection | null
+      timeoutMs?: number
+    }
+
+const DEFAULT_TIMEOUT_MS = 120_000
+const MAX_DIFF_CHARS = 40_000
+
+export function claudeSecondPassVerdictRef(verdict: ClaudeSecondPassVerdict): string {
+  return `review.public.pylon.claude_second_pass.${createHash("sha256")
+    .update(JSON.stringify(verdict))
+    .digest("hex")
+    .slice(0, 24)}`
+}
+
+export function parseClaudeSecondPassVerdict(value: unknown): ClaudeSecondPassVerdict | null {
+  let parsed = value
+  if (typeof parsed === "string") {
+    const start = parsed.indexOf("{")
+    const end = parsed.lastIndexOf("}")
+    if (start === -1 || end <= start) return null
+    try {
+      parsed = JSON.parse(parsed.slice(start, end + 1))
+    } catch {
+      return null
+    }
+  }
+  if (parsed === null || typeof parsed !== "object") return null
+  const record = parsed as Record<string, unknown>
+  if (record.schema !== CLAUDE_SECOND_PASS_REVIEW_SCHEMA) return null
+  if (
+    record.recommendation !== "approve" &&
+    record.recommendation !== "manual_review" &&
+    record.recommendation !== "request_changes"
+  ) return null
+  if (record.confidence !== "low" && record.confidence !== "medium" && record.confidence !== "high") return null
+  if (typeof record.summary !== "string" || record.summary.trim().length === 0) return null
+  if (!Array.isArray(record.riskRefs) || !record.riskRefs.every((ref) => typeof ref === "string")) return null
+  return {
+    schema: CLAUDE_SECOND_PASS_REVIEW_SCHEMA,
+    recommendation: record.recommendation,
+    confidence: record.confidence,
+    summary: record.summary.trim().slice(0, 500),
+    riskRefs: record.riskRefs.map((ref) => ref.trim()).filter(Boolean).slice(0, 20),
+  }
+}
+
+export function buildClaudeSecondPassReviewPrompt(input: ClaudeSecondPassReviewInput): string {
+  const diff =
+    input.diffText.length > MAX_DIFF_CHARS
+      ? `${input.diffText.slice(0, MAX_DIFF_CHARS)}\n...(diff truncated)`
+      : input.diffText
+  return [
+    "You are a second-pass semantic reviewer for a verified Codex worker closeout.",
+    "The verification command already passed and remains the authority.",
+    "Review only the unified diff below for semantic risk, missed scope, and likely regressions.",
+    "Do not approve execution or merge. Your verdict is advisory and may only request manual review.",
+    "Return exactly one JSON object matching the requested schema.",
+    "",
+    `Assignment ref: ${input.assignmentRef}`,
+    `Verification command ref: ${input.verifyCommandRef}`,
+    `Verification command argv: ${input.verifyCommand.join(" ")}`,
+    "",
+    "Unified diff:",
+    diff.length === 0 ? "(empty diff)" : diff,
+  ].join("\n")
+}
+
+export async function runClaudeSecondPassReview(input: ClaudeSecondPassReviewInput): Promise<ClaudeSecondPassVerdict> {
+  if (input.account === undefined || input.account === null || input.account.provider !== "claude_agent") {
+    throw new Error("Claude second-pass reviewer requires an isolated claude_agent account")
+  }
+  const env = pylonAccountEnvironment(input.env ?? Bun.env, input.account)
+  const sdk = input.sdkImporter === undefined
+    ? await import(CLAUDE_AGENT_SDK_PACKAGE) as { query: (args: unknown) => AsyncIterable<unknown> }
+    : await input.sdkImporter(CLAUDE_AGENT_SDK_PACKAGE)
+  const abort = new AbortController()
+  const timer = setTimeout(() => abort.abort(), input.timeoutMs ?? DEFAULT_TIMEOUT_MS)
+  let text = ""
+  try {
+    const session = sdk.query({
+      prompt: buildClaudeSecondPassReviewPrompt(input),
+      options: {
+        cwd: input.workspace,
+        env,
+        allowedTools: ["Read", "Grep", "Glob"],
+        maxTurns: 2,
+        permissionMode: "plan",
+        settingSources: [],
+        abortController: abort,
+        outputFormat: {
+          type: "json_schema",
+          schema: {
+            type: "object",
+            additionalProperties: false,
+            required: ["schema", "recommendation", "confidence", "summary", "riskRefs"],
+            properties: {
+              schema: { const: CLAUDE_SECOND_PASS_REVIEW_SCHEMA },
+              recommendation: { enum: ["approve", "manual_review", "request_changes"] },
+              confidence: { enum: ["low", "medium", "high"] },
+              summary: { type: "string", minLength: 1, maxLength: 500 },
+              riskRefs: {
+                type: "array",
+                maxItems: 20,
+                items: { type: "string", minLength: 1, maxLength: 160 },
+              },
+            },
+          },
+        },
+        ...(input.model === undefined ? {} : { model: input.model }),
+      },
+    })
+    for await (const message of session) {
+      const record = message as Record<string, unknown>
+      if (typeof record.result === "string") text += record.result
+      if (typeof record.text === "string") text += record.text
+      if (typeof record.content === "string") text += record.content
+      if (Array.isArray(record.content)) {
+        for (const item of record.content) {
+          const content = item as { text?: unknown }
+          if (typeof content.text === "string") text += content.text
+        }
+      }
+    }
+  } finally {
+    clearTimeout(timer)
+  }
+  const verdict = parseClaudeSecondPassVerdict(text)
+  if (verdict === null) {
+    throw new Error("Claude second-pass reviewer returned an invalid structured verdict")
+  }
+  return verdict
+}

--- a/apps/pylon/src/claude-second-pass-reviewer.ts
+++ b/apps/pylon/src/claude-second-pass-reviewer.ts
@@ -49,6 +49,8 @@ export type ClaudeSecondPassReviewOptions =
 
 const DEFAULT_TIMEOUT_MS = 120_000
 const MAX_DIFF_CHARS = 40_000
+const REF_SHAPED_PATTERN = /^[a-z][a-z0-9_-]*(?:\.[a-z0-9][a-z0-9_-]*)+$/
+const MAX_PUBLIC_REF_CHARS = 160
 
 export function claudeSecondPassVerdictRef(verdict: ClaudeSecondPassVerdict): string {
   return `review.public.pylon.claude_second_pass.${createHash("sha256")
@@ -60,11 +62,10 @@ export function claudeSecondPassVerdictRef(verdict: ClaudeSecondPassVerdict): st
 export function parseClaudeSecondPassVerdict(value: unknown): ClaudeSecondPassVerdict | null {
   let parsed = value
   if (typeof parsed === "string") {
-    const start = parsed.indexOf("{")
-    const end = parsed.lastIndexOf("}")
-    if (start === -1 || end <= start) return null
+    const sliced = sliceFirstJsonObject(parsed)
+    if (sliced === null) return null
     try {
-      parsed = JSON.parse(parsed.slice(start, end + 1))
+      parsed = JSON.parse(sliced)
     } catch {
       return null
     }
@@ -79,14 +80,59 @@ export function parseClaudeSecondPassVerdict(value: unknown): ClaudeSecondPassVe
   ) return null
   if (record.confidence !== "low" && record.confidence !== "medium" && record.confidence !== "high") return null
   if (typeof record.summary !== "string" || record.summary.trim().length === 0) return null
-  if (!Array.isArray(record.riskRefs) || !record.riskRefs.every((ref) => typeof ref === "string")) return null
+  if (!Array.isArray(record.riskRefs)) return null
+  const riskRefs: string[] = []
+  for (const value of record.riskRefs) {
+    const ref = normalizeClaudeSecondPassRiskRef(value)
+    if (ref === null) return null
+    riskRefs.push(ref)
+  }
   return {
     schema: CLAUDE_SECOND_PASS_REVIEW_SCHEMA,
     recommendation: record.recommendation,
     confidence: record.confidence,
     summary: record.summary.trim().slice(0, 500),
-    riskRefs: record.riskRefs.map((ref) => ref.trim()).filter(Boolean).slice(0, 20),
+    riskRefs: riskRefs.slice(0, 20),
   }
+}
+
+function normalizeClaudeSecondPassRiskRef(value: unknown): string | null {
+  if (typeof value !== "string") return null
+  const ref = value.trim()
+  if (ref.length === 0 || ref.length > MAX_PUBLIC_REF_CHARS) return null
+  if (!REF_SHAPED_PATTERN.test(ref)) return null
+  return ref
+}
+
+function sliceFirstJsonObject(text: string): string | null {
+  const start = text.indexOf("{")
+  if (start === -1) return null
+  let depth = 0
+  let inString = false
+  let escaped = false
+  for (let index = start; index < text.length; index += 1) {
+    const char = text[index]
+    if (inString) {
+      if (escaped) {
+        escaped = false
+      } else if (char === "\\") {
+        escaped = true
+      } else if (char === "\"") {
+        inString = false
+      }
+      continue
+    }
+    if (char === "\"") {
+      inString = true
+      continue
+    }
+    if (char === "{") depth += 1
+    if (char === "}") {
+      depth -= 1
+      if (depth === 0) return text.slice(start, index + 1)
+    }
+  }
+  return null
 }
 
 export function buildClaudeSecondPassReviewPrompt(input: ClaudeSecondPassReviewInput): string {
@@ -146,7 +192,7 @@ export async function runClaudeSecondPassReview(input: ClaudeSecondPassReviewInp
               riskRefs: {
                 type: "array",
                 maxItems: 20,
-                items: { type: "string", minLength: 1, maxLength: 160 },
+                items: { type: "string", minLength: 1, maxLength: MAX_PUBLIC_REF_CHARS, pattern: REF_SHAPED_PATTERN.source },
               },
             },
           },

--- a/apps/pylon/src/codex-agent-executor.ts
+++ b/apps/pylon/src/codex-agent-executor.ts
@@ -56,6 +56,11 @@ import {
   type PylonCodexAccountFailure,
 } from "./codex-account-health.js"
 import { recordCodexAccountHealthFailure } from "./codex-account-health-ledger.js"
+import {
+  claudeSecondPassVerdictRef,
+  runClaudeSecondPassReview,
+  type ClaudeSecondPassReviewOptions,
+} from "./claude-second-pass-reviewer.js"
 
 /**
  * The local Codex executor gate (issue #4789, epic #4793, promise
@@ -180,6 +185,7 @@ export type CodexAgentExecutionOptions = {
    * diff, pushes a scoped branch, and opens one PR against the base branch.
    */
   pullRequestPublisher?: AssignmentPullRequestPublisher
+  claudeSecondPassReview?: ClaudeSecondPassReviewOptions
   onProgress?: (progress: CodexAgentRuntimeProgress) => void | Promise<void>
 }
 
@@ -1634,6 +1640,13 @@ export async function executeCodexAgentAssignment(
   )
   const passed = verification.exitCode === 0
   const sessionRefs = run.sessionRef === null ? [] : [run.sessionRef]
+  const claudeReview = await maybeRunClaudeSecondPassReview({
+    assignmentRef: lease.assignmentRef,
+    commandRef,
+    materialized,
+    options: options.claudeSecondPassReview,
+    passed,
+  })
 
   // PR-per-assignment (#6439). When a git_checkout assignment produces a
   // verified, non-empty diff, open exactly one scoped pull request and record
@@ -1669,6 +1682,7 @@ export async function executeCodexAgentAssignment(
         ? `result.public.pylon.codex_agent_task.${materialized.acceptanceResultRef}_passed`
         : `result.public.pylon.codex_agent_task.${materialized.acceptanceResultRef}_failed`,
       `result.public.pylon.codex_agent_task.edited_files.${run.editedFileCount}`,
+      ...claudeReview.resultRefs,
       ...pullRequest.resultRefs,
       ...workspaceCleanup.resultRefs,
     ],
@@ -1678,8 +1692,69 @@ export async function executeCodexAgentAssignment(
       passed
         ? `summary.public.pylon.codex_agent_task.${materialized.acceptanceResultRef}_passed`
         : `summary.public.pylon.codex_agent_task.${materialized.acceptanceResultRef}_failed`,
+      ...claudeReview.summaryRefs,
     ],
     testRefs: [commandRef],
+  }
+}
+
+type ClaudeSecondPassCloseoutContribution = {
+  resultRefs: string[]
+  summaryRefs: string[]
+}
+
+const EMPTY_CLAUDE_SECOND_PASS_CONTRIBUTION: ClaudeSecondPassCloseoutContribution = {
+  resultRefs: [],
+  summaryRefs: [],
+}
+
+async function gitDiffForClaudeSecondPass(workspace: string): Promise<string> {
+  const proc = Bun.spawn(["git", "diff", "--", "."], { cwd: workspace, stdout: "pipe", stderr: "pipe" })
+  const [stdout, exitCode] = await Promise.all([new Response(proc.stdout).text(), proc.exited])
+  if (exitCode !== 0) return ""
+  return stdout
+}
+
+async function maybeRunClaudeSecondPassReview(input: {
+  assignmentRef: string
+  commandRef: string
+  materialized: Awaited<ReturnType<typeof materializeCodexAgentWorkspace>>
+  options?: ClaudeSecondPassReviewOptions
+  passed: boolean
+}): Promise<ClaudeSecondPassCloseoutContribution> {
+  if (!input.passed || input.options?.enabled !== true) return EMPTY_CLAUDE_SECOND_PASS_CONTRIBUTION
+  try {
+    const diffText = await gitDiffForClaudeSecondPass(input.materialized.workspace)
+    const reviewer = input.options.reviewer ?? runClaudeSecondPassReview
+    if (input.options.reviewer === undefined && input.options.account?.provider !== "claude_agent") {
+      return {
+        resultRefs: ["result.public.pylon.codex_agent_task.claude_second_pass_unavailable"],
+        summaryRefs: ["summary.public.pylon.codex_agent_task.claude_second_pass_unavailable"],
+      }
+    }
+    const verdict = await reviewer({
+      assignmentRef: input.assignmentRef,
+      workspace: input.materialized.workspace,
+      diffText,
+      verifyCommandRef: input.commandRef,
+      verifyCommand: input.materialized.verificationArgs,
+      account: input.options.account ?? null,
+      ...(input.options.timeoutMs === undefined ? {} : { timeoutMs: input.options.timeoutMs }),
+    })
+    const verdictRef = claudeSecondPassVerdictRef(verdict)
+    return {
+      resultRefs: [
+        verdictRef,
+        `result.public.pylon.codex_agent_task.claude_second_pass.${verdict.recommendation}`,
+        ...verdict.riskRefs,
+      ],
+      summaryRefs: [`summary.public.pylon.codex_agent_task.claude_second_pass.${verdict.recommendation}`],
+    }
+  } catch {
+    return {
+      resultRefs: ["result.public.pylon.codex_agent_task.claude_second_pass_unavailable"],
+      summaryRefs: ["summary.public.pylon.codex_agent_task.claude_second_pass_unavailable"],
+    }
   }
 }
 

--- a/apps/pylon/src/codex-agent-executor.ts
+++ b/apps/pylon/src/codex-agent-executor.ts
@@ -1708,11 +1708,47 @@ const EMPTY_CLAUDE_SECOND_PASS_CONTRIBUTION: ClaudeSecondPassCloseoutContributio
   summaryRefs: [],
 }
 
-async function gitDiffForClaudeSecondPass(workspace: string): Promise<string> {
-  const proc = Bun.spawn(["git", "diff", "--", "."], { cwd: workspace, stdout: "pipe", stderr: "pipe" })
+type ClaudeSecondPassDiffCapture =
+  | { state: "captured"; diffText: string }
+  | { state: "skipped"; reason: ClaudeSecondPassSkipReason }
+
+type ClaudeSecondPassSkipReason = "fixture_workspace" | "not_git_workspace" | "empty_diff" | "diff_unavailable"
+
+function skippedClaudeSecondPassContribution(reason: ClaudeSecondPassSkipReason): ClaudeSecondPassCloseoutContribution {
+  return {
+    resultRefs: [`result.public.pylon.codex_agent_task.claude_second_pass_skipped.${reason}`],
+    summaryRefs: [`summary.public.pylon.codex_agent_task.claude_second_pass_skipped.${reason}`],
+  }
+}
+
+async function runGitForClaudeSecondPass(args: string[], workspace: string): Promise<{ stdout: string; exitCode: number }> {
+  const proc = Bun.spawn(args, { cwd: workspace, stdout: "pipe", stderr: "pipe" })
   const [stdout, exitCode] = await Promise.all([new Response(proc.stdout).text(), proc.exited])
-  if (exitCode !== 0) return ""
-  return stdout
+  return { stdout, exitCode }
+}
+
+async function gitDiffForClaudeSecondPass(
+  materialized: Awaited<ReturnType<typeof materializeCodexAgentWorkspace>>,
+): Promise<ClaudeSecondPassDiffCapture> {
+  if (materialized.workspaceStateRoot === undefined) {
+    return { state: "skipped", reason: "fixture_workspace" }
+  }
+  const inside = await runGitForClaudeSecondPass(["git", "rev-parse", "--is-inside-work-tree"], materialized.workspace)
+  if (inside.exitCode !== 0 || inside.stdout.trim() !== "true") {
+    return { state: "skipped", reason: "not_git_workspace" }
+  }
+  const intentToAdd = await runGitForClaudeSecondPass(["git", "add", "-N", "--", "."], materialized.workspace)
+  if (intentToAdd.exitCode !== 0) {
+    return { state: "skipped", reason: "diff_unavailable" }
+  }
+  const diff = await runGitForClaudeSecondPass(["git", "diff", "--", "."], materialized.workspace)
+  if (diff.exitCode !== 0) {
+    return { state: "skipped", reason: "diff_unavailable" }
+  }
+  if (diff.stdout.trim().length === 0) {
+    return { state: "skipped", reason: "empty_diff" }
+  }
+  return { state: "captured", diffText: diff.stdout }
 }
 
 async function maybeRunClaudeSecondPassReview(input: {
@@ -1724,7 +1760,8 @@ async function maybeRunClaudeSecondPassReview(input: {
 }): Promise<ClaudeSecondPassCloseoutContribution> {
   if (!input.passed || input.options?.enabled !== true) return EMPTY_CLAUDE_SECOND_PASS_CONTRIBUTION
   try {
-    const diffText = await gitDiffForClaudeSecondPass(input.materialized.workspace)
+    const diff = await gitDiffForClaudeSecondPass(input.materialized)
+    if (diff.state === "skipped") return skippedClaudeSecondPassContribution(diff.reason)
     const reviewer = input.options.reviewer ?? runClaudeSecondPassReview
     if (input.options.reviewer === undefined && input.options.account?.provider !== "claude_agent") {
       return {
@@ -1735,7 +1772,7 @@ async function maybeRunClaudeSecondPassReview(input: {
     const verdict = await reviewer({
       assignmentRef: input.assignmentRef,
       workspace: input.materialized.workspace,
-      diffText,
+      diffText: diff.diffText,
       verifyCommandRef: input.commandRef,
       verifyCommand: input.materialized.verificationArgs,
       account: input.options.account ?? null,

--- a/apps/pylon/src/orchestration/merge-policy.ts
+++ b/apps/pylon/src/orchestration/merge-policy.ts
@@ -52,6 +52,12 @@ export type MergePolicyInput = {
   hasConflicts: boolean
   diffWithinScope: boolean
   siblingConflictRefs?: readonly string[]
+  advisoryReview?: {
+    reviewer: "claude_second_pass"
+    recommendation: "approve" | "manual_review" | "request_changes"
+    verdictRef: string
+    riskRefs?: readonly string[]
+  } | null
 }
 
 export type MergePolicyDecisionAction =
@@ -143,6 +149,10 @@ export function decideMergePolicy(input: MergePolicyInput): MergePolicyDecision 
     ...input.closeout.refs,
   ]
   const blockerRefs = [...input.closeout.blockerRefs]
+  const advisoryReview = input.advisoryReview ?? null
+  if (advisoryReview !== null) {
+    refs.push(advisoryReview.verdictRef, `review-advisory.public.pylon.${advisoryReview.reviewer}.${advisoryReview.recommendation}`)
+  }
 
   if (!input.closeout.readyForReview || !input.verifyGreen) {
     return {
@@ -163,6 +173,21 @@ export function decideMergePolicy(input: MergePolicyInput): MergePolicyDecision 
       ownerToggleRequired: true,
       refs: [...refs, "merge-wave.public.pylon.required"],
       blockerRefs: [...blockerRefs, "blocker.public.pylon.merge_conflict_wave"],
+    }
+  }
+
+  if (advisoryReview !== null && advisoryReview.recommendation !== "approve") {
+    return {
+      schema: MERGE_POLICY_SCHEMA,
+      mode,
+      action: "manual_review",
+      ownerToggleRequired: false,
+      refs,
+      blockerRefs: [
+        ...blockerRefs,
+        "blocker.public.pylon.merge.claude_second_pass_manual_review",
+        ...(advisoryReview.riskRefs ?? []),
+      ],
     }
   }
 

--- a/apps/pylon/src/orchestration/supervisor-orchestration.test.ts
+++ b/apps/pylon/src/orchestration/supervisor-orchestration.test.ts
@@ -923,6 +923,66 @@ describe("Pylon supervisor orchestration store", () => {
     })
   })
 
+  test("Claude second-pass review is advisory: it can demote auto_merge_clean but never approve", () => {
+    const now = new Date("2026-07-01T12:00:00.000Z")
+    const store = createPylonOrchestrationStore(new Database(":memory:"))
+    const claim = store.tryClaimWorkUnit({
+      claimRef: "claim.t9_5.policy",
+      workUnitRef: "issue.7874",
+      runRef: "fleet_run.t9_5",
+      workerAccountRef: "codex-1",
+      ttl: 60_000,
+      now,
+    })
+    const closeout = evaluateCloseoutReviewGate({
+      pinnedVerifyCommandRef: "command.public.pylon_khala.verify.28484fe0b746db06b92c2eb2",
+      claim,
+      verify: greenVerifyEvidence(),
+      now,
+    })
+
+    expect(decideMergePolicy({
+      mode: "manual_review",
+      closeout,
+      mergeable: true,
+      verifyGreen: true,
+      hasConflicts: false,
+      diffWithinScope: true,
+      advisoryReview: {
+        reviewer: "claude_second_pass",
+        recommendation: "approve",
+        verdictRef: "review.public.pylon.claude_second_pass.clean",
+      },
+    })).toMatchObject({
+      mode: "manual_review",
+      action: "manual_review",
+      ownerToggleRequired: false,
+    })
+
+    expect(decideMergePolicy({
+      mode: "auto_merge_clean",
+      closeout,
+      mergeable: true,
+      verifyGreen: true,
+      hasConflicts: false,
+      diffWithinScope: true,
+      advisoryReview: {
+        reviewer: "claude_second_pass",
+        recommendation: "request_changes",
+        verdictRef: "review.public.pylon.claude_second_pass.risky",
+        riskRefs: ["risk.public.pylon.review.semantic_regression"],
+      },
+    })).toMatchObject({
+      mode: "auto_merge_clean",
+      action: "manual_review",
+      ownerToggleRequired: false,
+      blockerRefs: [
+        "blocker.public.pylon.merge.claude_second_pass_manual_review",
+        "risk.public.pylon.review.semantic_regression",
+      ],
+    })
+  })
+
   test("merge-wave resolver has one live claim per wave work unit", () => {
     const now = new Date("2026-07-01T12:00:00.000Z")
     const store = createPylonOrchestrationStore(new Database(":memory:"))

--- a/apps/pylon/tests/codex-agent-executor.test.ts
+++ b/apps/pylon/tests/codex-agent-executor.test.ts
@@ -108,6 +108,18 @@ async function withState<T>(fn: (state: Awaited<ReturnType<typeof ensurePylonLoc
   }
 }
 
+async function runGit(args: string[], cwd: string) {
+  const proc = Bun.spawn(["git", ...args], { cwd, stdout: "pipe", stderr: "pipe" })
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ])
+  if (exitCode !== 0) {
+    throw new Error(`git ${args.join(" ")} failed: ${stdout}${stderr}`)
+  }
+}
+
 describe("codex agent task recognition", () => {
   test("recognizes the typed work class and passes everything else through", async () => {
     expect(codexAgentTaskFrom(codexAgentCodingAssignment)).not.toBeNull()
@@ -191,10 +203,9 @@ describe("codex agent task recognition", () => {
 
   test("optional Claude second-pass reviewer runs after verify-green and records advisory verdict refs", async () => {
     await withState(async (state) => {
-      let reviewedDiff = ""
+      let reviewerCalled = false
       const reviewer: ClaudeSecondPassReviewer = async (input) => {
-        reviewedDiff = input.diffText
-        expect(input.verifyCommand).toEqual(["bun", "test", "sum.test.ts"])
+        reviewerCalled = true
         return {
           schema: CLAUDE_SECOND_PASS_REVIEW_SCHEMA,
           recommendation: "manual_review",
@@ -208,11 +219,11 @@ describe("codex agent task recognition", () => {
         codexAgentProbe: readyProbe,
         claudeSecondPassReview: { enabled: true, reviewer },
       })
-      expect(reviewedDiff).toContain("left + right")
+      expect(reviewerCalled).toBe(false)
       expect(record?.status).toBe("accepted")
-      expect(record?.resultRefs).toContain("result.public.pylon.codex_agent_task.claude_second_pass.manual_review")
-      expect(record?.resultRefs).toContain("risk.public.pylon.review.fixture_manual")
-      expect(record?.resultRefs.some((ref) => ref.startsWith("review.public.pylon.claude_second_pass."))).toBe(true)
+      expect(record?.resultRefs).toContain(
+        "result.public.pylon.codex_agent_task.claude_second_pass_skipped.fixture_workspace",
+      )
       assertPublicProjectionSafe(record)
     })
   })
@@ -889,6 +900,83 @@ describe("codex git_checkout workspace (shared B2 contract)", () => {
       const projected = JSON.stringify(record)
       expect(projected).not.toContain(state.paths.cache)
       expect(projected).not.toContain("Repair the failing sum test.")
+    })
+  })
+
+  test("captures git diffs with intent-to-add before Claude second-pass review", async () => {
+    await withState(async (state) => {
+      const checkoutRunner = async (workspace: string) => {
+        await mkdir(workspace, { recursive: true })
+        await writeFile(
+          join(workspace, "package.json"),
+          `${JSON.stringify({ private: true, type: "module" })}\n`,
+        )
+        await writeFile(
+          join(workspace, "sum.ts"),
+          "export const sum = (left: number, right: number) => left - right\n",
+        )
+        await writeFile(
+          join(workspace, "sum.test.ts"),
+          [
+            'import { describe, expect, test } from "bun:test"',
+            'import { sum } from "./sum"',
+            'describe("sum", () => { test("adds", () => { expect(sum(2, 3)).toBe(5) }) })',
+            "",
+          ].join("\n"),
+        )
+        await runGit(["init"], workspace)
+        await runGit(["config", "user.email", "pylon@example.invalid"], workspace)
+        await runGit(["config", "user.name", "Pylon Test"], workspace)
+        await runGit(["add", "-A"], workspace)
+        await runGit(["commit", "-m", "baseline"], workspace)
+      }
+      const fixingWithUntrackedFile: CodexAgentRunner = async (input) => {
+        await writeFile(
+          join(input.cwd, "sum.ts"),
+          "export const sum = (left: number, right: number) => left + right\n",
+        )
+        await writeFile(join(input.cwd, "notes.md"), "review me\n")
+        return { outcome: "completed", turnCount: 1, editedFileCount: 2, commandCount: 1, sessionRef: null }
+      }
+      let reviewedDiff: string | null = null
+      const reviewer: ClaudeSecondPassReviewer = async (input) => {
+        reviewedDiff = input.diffText
+        expect(input.verifyCommand).toEqual(["bun", "test", "sum.test.ts"])
+        return {
+          schema: CLAUDE_SECOND_PASS_REVIEW_SCHEMA,
+          recommendation: "manual_review",
+          confidence: "medium",
+          summary: "Review captured tracked and untracked changes.",
+          riskRefs: ["risk.public.pylon.review.git_diff"],
+        }
+      }
+
+      const record = await executeCodexAgentAssignment(
+        state,
+        { ...lease, codingAssignment: checkoutAssignment },
+        now,
+        {
+          checkoutRunner,
+          codexAgentRunner: fixingWithUntrackedFile,
+          codexAgentProbe: readyProbe,
+          claudeSecondPassReview: { enabled: true, reviewer },
+          pullRequestPublisher: async () => ({
+            state: "opened",
+            prUrl: "https://github.com/OpenAgentsInc/openagents/pull/99002",
+            prNumber: 99002,
+            branch: "pylon/assignment-cafecafe",
+            changedCount: 2,
+            reused: false,
+          }),
+        },
+      )
+
+      expect(record?.status).toBe("accepted")
+      expect(reviewedDiff).toContain("left + right")
+      expect(reviewedDiff).toContain("diff --git a/notes.md b/notes.md")
+      expect(record?.resultRefs).toContain("result.public.pylon.codex_agent_task.claude_second_pass.manual_review")
+      expect(record?.resultRefs).toContain("risk.public.pylon.review.git_diff")
+      assertPublicProjectionSafe(record)
     })
   })
 

--- a/apps/pylon/tests/codex-agent-executor.test.ts
+++ b/apps/pylon/tests/codex-agent-executor.test.ts
@@ -34,6 +34,11 @@ import {
   workspaceLeaseRecordFor,
 } from "../src/workspace-materializer"
 import {
+  CLAUDE_SECOND_PASS_REVIEW_SCHEMA,
+  parseClaudeSecondPassVerdict,
+  type ClaudeSecondPassReviewer,
+} from "../src/claude-second-pass-reviewer"
+import {
   PylonRuntimeRetrySchedules,
   scopedTimeout,
 } from "../src/effect-runtime-patterns"
@@ -164,14 +169,71 @@ describe("codex agent task recognition", () => {
     })
   })
 
+  test("parses Claude second-pass structured verdicts and rejects malformed shapes", () => {
+    expect(parseClaudeSecondPassVerdict(JSON.stringify({
+      schema: CLAUDE_SECOND_PASS_REVIEW_SCHEMA,
+      recommendation: "request_changes",
+      confidence: "high",
+      summary: "Diff likely misses an edge case.",
+      riskRefs: ["risk.public.pylon.review.edge_case"],
+    }))).toMatchObject({
+      recommendation: "request_changes",
+      riskRefs: ["risk.public.pylon.review.edge_case"],
+    })
+    expect(parseClaudeSecondPassVerdict({
+      schema: CLAUDE_SECOND_PASS_REVIEW_SCHEMA,
+      recommendation: "merge_now",
+      confidence: "high",
+      summary: "bad",
+      riskRefs: [],
+    })).toBeNull()
+  })
+
+  test("optional Claude second-pass reviewer runs after verify-green and records advisory verdict refs", async () => {
+    await withState(async (state) => {
+      let reviewedDiff = ""
+      const reviewer: ClaudeSecondPassReviewer = async (input) => {
+        reviewedDiff = input.diffText
+        expect(input.verifyCommand).toEqual(["bun", "test", "sum.test.ts"])
+        return {
+          schema: CLAUDE_SECOND_PASS_REVIEW_SCHEMA,
+          recommendation: "manual_review",
+          confidence: "medium",
+          summary: "Fixture passes but reviewer requests human inspection.",
+          riskRefs: ["risk.public.pylon.review.fixture_manual"],
+        }
+      }
+      const record = await executeCodexAgentAssignment(state, lease, now, {
+        codexAgentRunner: fixingRunner,
+        codexAgentProbe: readyProbe,
+        claudeSecondPassReview: { enabled: true, reviewer },
+      })
+      expect(reviewedDiff).toContain("left + right")
+      expect(record?.status).toBe("accepted")
+      expect(record?.resultRefs).toContain("result.public.pylon.codex_agent_task.claude_second_pass.manual_review")
+      expect(record?.resultRefs).toContain("risk.public.pylon.review.fixture_manual")
+      expect(record?.resultRefs.some((ref) => ref.startsWith("review.public.pylon.claude_second_pass."))).toBe(true)
+      assertPublicProjectionSafe(record)
+    })
+  })
+
   test("rejects with codex_agent_test_failed when the agent does not fix the fixture", async () => {
     await withState(async (state) => {
+      let reviewerCalled = false
       const record = await executeCodexAgentAssignment(state, lease, now, {
         codexAgentRunner: idleRunner,
         codexAgentProbe: readyProbe,
+        claudeSecondPassReview: {
+          enabled: true,
+          reviewer: async () => {
+            reviewerCalled = true
+            throw new Error("should not review verify-red closeout")
+          },
+        },
       })
       expect(record?.status).toBe("rejected")
       expect(record?.blockerRefs).toEqual(["blocker.assignment.codex_agent_test_failed"])
+      expect(reviewerCalled).toBe(false)
       assertPublicProjectionSafe(record)
     })
   })


### PR DESCRIPTION
Closes #7874

## Summary

- Adds a typed Claude second-pass reviewer for verified Codex closeouts, using a structured `json_schema` verdict over the closeout diff.
- Wires the optional reviewer into the Codex executor behind a typed disabled-by-default option, requiring an isolated `claude_agent` account for the real SDK path.
- Feeds Claude review verdicts into the T4.3 merge policy as advisory-only signal: negative/manual verdicts demote `auto_merge_clean` to `manual_review`, while approvals never elevate manual review.

## Verification

- PASS: `bun test apps/pylon/src/claude-second-pass-reviewer.test.ts apps/pylon/src/orchestration/supervisor-orchestration.test.ts`
- PASS: `bun build apps/pylon/src/claude-second-pass-reviewer.ts apps/pylon/src/orchestration/merge-policy.ts --target bun --outdir /tmp/t9-5-build-check`
- PASS: `git diff --check`
- FAIL: `bun run --cwd apps/pylon test` (`command.public.pylon_khala.verify.28484fe0b746db06b92c2eb2`) fails in this checkout on existing workspace package resolution errors for packages including `@openagentsinc/tassadar-executor`, `@openagentsinc/autopilot-control-protocol`, `@openagentsinc/nip90`, plus pre-existing one-shot JSON/exit-code failures in `spark-backup-status-oneshot.test.ts` and `operator-snapshot-oneshot.test.ts`.