### PR TITLE
T10.2: Live /pro from the status spine

### DIFF
--- a/apps/openagents.com/apps/web/src/page/loggedIn/initial-commands.ts
+++ b/apps/openagents.com/apps/web/src/page/loggedIn/initial-commands.ts
@@ -33,6 +33,7 @@ import { LoadMulletBootstrap } from './mullet/transitions'
 import { notificationInitialCommands } from './notifications/transitions'
 import { LoadOnboardingRepositories } from './onboarding/transitions'
 import { LoadProviderAccountPool } from './providers/commands'
+import { LoadProAgentDashboard } from './pro/transitions'
 import { LoadTokenUsageStats } from './stats/transitions'
 import { LoadSyncSnapshot } from './sync/commands'
 import { syncSnapshotHref } from './sync/projection'
@@ -133,6 +134,10 @@ export const initialCommands = (
 
   if (model.route._tag === 'Mullet') {
     return [InstallAccountMenuOutsideClick(), LoadMulletBootstrap()]
+  }
+
+  if (model.route._tag === 'Pro') {
+    return [InstallAccountMenuOutsideClick(), LoadProAgentDashboard()]
   }
 
   const baseCommands = [

--- a/apps/openagents.com/apps/web/src/page/loggedIn/message.ts
+++ b/apps/openagents.com/apps/web/src/page/loggedIn/message.ts
@@ -61,6 +61,7 @@ import {
   ImageGenerationModelId,
   ImageGenerationProvider,
   PrefilledWorkspaceResponse,
+  ProAgentDashboardResponse,
   ProviderAccountPoolManualResetResponse,
   ProviderAccountPoolResponse,
   SubmitCustomerSiteFeedbackResponse,
@@ -713,6 +714,18 @@ export const FailedLoadTokenUsageStats = m('FailedLoadTokenUsageStats', {
 export const UpdatedTokenUsageStatsFilter = m('UpdatedTokenUsageStatsFilter', {
   field: TokenUsageStatsFilterKey,
   value: S.String,
+})
+export const RequestedLoadProAgentDashboard = m(
+  'RequestedLoadProAgentDashboard',
+)
+export const SucceededLoadProAgentDashboard = m(
+  'SucceededLoadProAgentDashboard',
+  {
+    response: ProAgentDashboardResponse,
+  },
+)
+export const FailedLoadProAgentDashboard = m('FailedLoadProAgentDashboard', {
+  error: S.String,
 })
 export const RequestedLoadPrefilledWorkspace = m(
   'RequestedLoadPrefilledWorkspace',
@@ -1416,6 +1429,9 @@ export const Message = S.Union([
   SucceededLoadTokenUsageStats,
   FailedLoadTokenUsageStats,
   UpdatedTokenUsageStatsFilter,
+  RequestedLoadProAgentDashboard,
+  SucceededLoadProAgentDashboard,
+  FailedLoadProAgentDashboard,
   RequestedLoadPrefilledWorkspace,
   SucceededLoadPrefilledWorkspace,
   FailedLoadPrefilledWorkspace,

--- a/apps/openagents.com/apps/web/src/page/loggedIn/model.ts
+++ b/apps/openagents.com/apps/web/src/page/loggedIn/model.ts
@@ -506,6 +506,74 @@ export const TokenUsageStatsState = S.Union([
 ])
 export type TokenUsageStatsState = typeof TokenUsageStatsState.Type
 
+export const ProAgentState = S.Literals([
+  'working',
+  'blocked',
+  'waiting',
+  'done',
+])
+export type ProAgentState = typeof ProAgentState.Type
+
+export const ProAgentStateHistoryEntry = S.Struct({
+  state: ProAgentState,
+  label: S.String,
+  at: S.String,
+})
+export type ProAgentStateHistoryEntry =
+  typeof ProAgentStateHistoryEntry.Type
+
+export const ProAgentStatusEntry = S.Struct({
+  id: S.String,
+  agentLabel: S.String,
+  worktreeLabel: S.String,
+  state: ProAgentState,
+  prompt: S.String,
+  updatedAt: S.String,
+  stateStartedAt: S.String,
+  acknowledgedAt: S.String,
+  unread: S.Boolean,
+  toolName: S.String,
+  lastAssistantMessage: S.String,
+  stateHistory: S.Array(ProAgentStateHistoryEntry),
+})
+export type ProAgentStatusEntry = typeof ProAgentStatusEntry.Type
+
+export const ProDiffComment = S.Struct({
+  id: S.String,
+  filePath: S.String,
+  lineLabel: S.String,
+  body: S.String,
+  selectedText: S.String,
+  targetAgentLabel: S.String,
+  sentAt: S.String,
+})
+export type ProDiffComment = typeof ProDiffComment.Type
+
+export const ProAgentDashboardResponse = S.Struct({
+  generatedAt: S.String,
+  liveEntries: S.Array(ProAgentStatusEntry),
+  retainedEntries: S.Array(ProAgentStatusEntry),
+  diffComments: S.Array(ProDiffComment),
+})
+export type ProAgentDashboardResponse =
+  typeof ProAgentDashboardResponse.Type
+
+export const ProAgentDashboardIdle = ts('ProAgentDashboardIdle', {})
+export const ProAgentDashboardLoading = ts('ProAgentDashboardLoading', {})
+export const ProAgentDashboardLoaded = ts('ProAgentDashboardLoaded', {
+  response: ProAgentDashboardResponse,
+})
+export const ProAgentDashboardFailed = ts('ProAgentDashboardFailed', {
+  error: S.String,
+})
+export const ProAgentDashboardState = S.Union([
+  ProAgentDashboardIdle,
+  ProAgentDashboardLoading,
+  ProAgentDashboardLoaded,
+  ProAgentDashboardFailed,
+])
+export type ProAgentDashboardState = typeof ProAgentDashboardState.Type
+
 export const PrefilledWorkspaceStatus = S.Literals([
   'draft',
   'invited',
@@ -7087,6 +7155,7 @@ export const Model = ts('LoggedIn', {
   onboarding: OnboardingFlowModel,
   providerAccountPool: ProviderAccountPoolState,
   providerConnectionAction: ProviderConnectionAction,
+  proAgentDashboard: ProAgentDashboardState,
   prefilledWorkspace: PrefilledWorkspaceState,
   runMetadataDialog: RunMetadataDialog,
   route: LoggedInRoute,
@@ -7646,6 +7715,7 @@ export const init = (route: LoggedInRoute, auth: AuthBootstrap): Model =>
     prefilledWorkspace: PrefilledWorkspaceIdle(),
     providerAccountPool: ProviderAccountPoolIdle(),
     providerConnectionAction: IdleProviderConnectionAction(),
+    proAgentDashboard: ProAgentDashboardIdle(),
     runMetadataDialog: ClosedRunMetadataDialog(),
     route,
     session: auth.session,

--- a/apps/openagents.com/apps/web/src/page/loggedIn/page/pro.test.ts
+++ b/apps/openagents.com/apps/web/src/page/loggedIn/page/pro.test.ts
@@ -1,0 +1,148 @@
+import type { Html } from 'foldkit/html'
+import { describe, expect, test } from 'vitest'
+
+import { authBootstrapFromSession } from '../../../domain/session'
+import { ProRoute } from '../../../route'
+import {
+  ProAgentDashboardLoaded,
+  init as initLoggedIn,
+} from '../model'
+import { view } from './pro'
+
+type VNodeLike = Readonly<{
+  sel?: string
+  text?: string
+  children?: ReadonlyArray<VNodeLike | string | null>
+  data?: {
+    attrs?: Record<string, unknown>
+    props?: Record<string, unknown>
+    class?: Record<string, boolean>
+  }
+}>
+
+const isVNodeLike = (value: unknown): value is VNodeLike =>
+  typeof value === 'object' && value !== null
+
+const attrsToString = (node: VNodeLike): string => {
+  const attrs = node.data?.attrs ?? {}
+  const props = node.data?.props ?? {}
+  const classes = Object.entries(node.data?.class ?? {})
+    .filter(([, enabled]) => enabled)
+    .map(([className]) => className)
+    .join(' ')
+  const pairs = [
+    ...Object.entries(attrs),
+    ...Object.entries(props),
+    ...(classes.length === 0 ? [] : [['class', classes] as const]),
+  ]
+
+  return pairs
+    .filter(
+      ([, value]) => value !== false && value !== undefined && value !== null,
+    )
+    .map(([name, value]) =>
+      value === true ? ` ${name}` : ` ${name}="${String(value)}"`,
+    )
+    .join('')
+}
+
+const renderHtml = (html: Html): string => {
+  if (html === null || !isVNodeLike(html)) {
+    return ''
+  }
+
+  const tag = html.sel ?? 'node'
+  const children = (html.children ?? [])
+    .map(child =>
+      typeof child === 'string'
+        ? child
+        : child === null
+          ? ''
+          : renderHtml(child),
+    )
+    .join('')
+  const text = html.text ?? ''
+
+  return `<${tag}${attrsToString(html)}>${text}${children}</${tag}>`
+}
+
+describe('/pro page', () => {
+  test('renders live and retained dashboard rows from fixture projection rows', () => {
+    const model = initLoggedIn(
+      ProRoute(),
+      authBootstrapFromSession({
+        email: 'operator@example.com',
+        name: 'Operator',
+        userId: 'user.public.operator',
+      }),
+    )
+    const loaded = {
+      ...model,
+      proAgentDashboard: ProAgentDashboardLoaded({
+        response: {
+          generatedAt: '2026-07-01T12:05:00.000Z',
+          liveEntries: [
+            {
+              acknowledgedAt: '2026-07-01T12:00:00.000Z',
+              agentLabel: 'codex_sdk',
+              id: 'runner.public.codex.1',
+              lastAssistantMessage: 'status.public.runner.working',
+              prompt: 'task.public.t10_2',
+              state: 'working',
+              stateHistory: [
+                {
+                  at: '2026-07-01T11:59:00.000Z',
+                  label: 'Waiting',
+                  state: 'waiting',
+                },
+                {
+                  at: '2026-07-01T12:00:00.000Z',
+                  label: 'Working',
+                  state: 'working',
+                },
+              ],
+              stateStartedAt: '2026-07-01T12:00:00.000Z',
+              toolName: 'status.list',
+              unread: true,
+              updatedAt: '2026-07-01T12:02:00.000Z',
+              worktreeLabel: 'issue-7878',
+            },
+          ],
+          retainedEntries: [
+            {
+              acknowledgedAt: '2026-07-01T12:04:30.000Z',
+              agentLabel: 'codex_sdk',
+              id: 'runner.public.codex.1',
+              lastAssistantMessage: 'Done from runner status spine.',
+              prompt: 'assignment.public.issue_7878',
+              state: 'done',
+              stateHistory: [
+                {
+                  at: '2026-07-01T12:04:00.000Z',
+                  label: 'Done',
+                  state: 'done',
+                },
+              ],
+              stateStartedAt: '2026-07-01T12:04:00.000Z',
+              toolName: 'codex_sdk',
+              unread: false,
+              updatedAt: '2026-07-01T12:04:30.000Z',
+              worktreeLabel: 'issue-7878',
+            },
+          ],
+          diffComments: [],
+        },
+      }),
+    }
+
+    const rendered = renderHtml(view(loaded))
+
+    expect(rendered).toContain('Agent operations')
+    expect(rendered).toContain('codex_sdk')
+    expect(rendered).toContain('2026-07-01T12:00:00.000Z')
+    expect(rendered).toContain('status.public.runner.working')
+    expect(rendered).toContain('retained')
+    expect(rendered).not.toContain('Codex lane 1')
+    expect(rendered).not.toContain('future-runner-fixture')
+  })
+})

--- a/apps/openagents.com/apps/web/src/page/loggedIn/page/pro.ts
+++ b/apps/openagents.com/apps/web/src/page/loggedIn/page/pro.ts
@@ -1,6 +1,5 @@
 import type { Html } from 'foldkit/html'
 
-import type { Session } from '../../../domain/session'
 import {
   orderRouter,
   proRouter,
@@ -9,6 +8,7 @@ import {
 } from '../../../route'
 import * as Ui from '../../../ui'
 import type { Message } from '../message'
+import type { Model, ProAgentDashboardResponse } from '../model'
 import { SAMPLE_COMPARE_PATH_IDS } from '../../trace-compare/sample'
 import { SAMPLE_TRACE_UUID } from '../../trace/sample'
 
@@ -16,9 +16,9 @@ import { SAMPLE_TRACE_UUID } from '../../trace/sample'
 // /pro — operator / power-user console SHELL (issue 6179)
 // ---------------------------------------------------------------------------
 //
-// This module ships the FRAME + a bounded operator dashboard model. The live
-// ingest/send endpoints remain explicit follow-ups; this page only renders
-// public-safe sample state that matches the production contract shape.
+// This module ships the FRAME + a bounded operator dashboard model. The agent
+// rows are loaded from the owner-scoped runner-neutral status spine; no local
+// sample agents are rendered.
 //
 // All class-bearing markup lives in the shared `@openagentsinc/ui` Pro console
 // primitives (proConsoleShell / proTopStrip / proRegister / ...). This page only
@@ -42,163 +42,49 @@ const SECTIONS: ReadonlyArray<Ui.ProConsoleSection> = [
   { label: 'Settings', disabled: true },
 ]
 
-const agentDashboardSnapshot: Ui.ProAgentDashboardSnapshot = {
-  generatedAt: '2026-06-27T18:44:00Z',
-  liveEntries: [
-    {
-      id: 'pane.codex-1',
-      agentLabel: 'Codex lane 1',
-      worktreeLabel: 'issue-6406-agent-dashboard',
-      state: 'working',
-      prompt: 'Build the operator dashboard status model and review queue.',
-      updatedAt: '18:43:58Z',
-      stateStartedAt: '18:36:14Z',
-      acknowledgedAt: '18:31:09Z',
-      unread: true,
-      toolName: 'bun test',
-      lastAssistantMessage:
-        'Status model is shaped; wiring the Pro surface and scene coverage now.',
-      stateHistory: [
-        {
-          state: 'waiting',
-          label: 'Workspace materialized',
-          at: '18:31Z',
-        },
-        {
-          state: 'working',
-          label: 'Dashboard implementation started',
-          at: '18:36Z',
-        },
-      ],
-    },
-    {
-      id: 'pane.claude-1',
-      agentLabel: 'Claude lane 1',
-      worktreeLabel: 'status-ingest-runbook',
-      state: 'blocked',
-      prompt: 'Verify owner-scoped status ingest prerequisites.',
-      updatedAt: '18:42:10Z',
-      stateStartedAt: '18:39:02Z',
-      acknowledgedAt: '18:39:02Z',
-      unread: false,
-      toolName: 'owner gate',
-      lastAssistantMessage:
-        'NEEDS-OWNER: confirm the live relay endpoint before enabling send.',
-      stateHistory: [
-        {
-          state: 'working',
-          label: 'Read relay docs',
-          at: '18:33Z',
-        },
-        {
-          state: 'blocked',
-          label: 'Owner endpoint confirmation needed',
-          at: '18:39Z',
-        },
-      ],
-    },
-    {
-      id: 'pane.opencode-1',
-      agentLabel: 'OpenCode lane',
-      worktreeLabel: 'future-runner-fixture',
-      state: 'waiting',
-      prompt: 'Hold for runner registry integration.',
-      updatedAt: '18:40:25Z',
-      stateStartedAt: '18:40:25Z',
-      acknowledgedAt: '18:40:25Z',
-      unread: false,
-      toolName: 'queue',
-      lastAssistantMessage:
-        'Waiting for a registry-backed runner before assignment.',
-      stateHistory: [
-        {
-          state: 'waiting',
-          label: 'Queued behind available Codex capacity',
-          at: '18:40Z',
-        },
-      ],
-    },
-  ],
-  retainedEntries: [
-    {
-      id: 'pane.codex-0',
-      agentLabel: 'Codex lane 0',
-      worktreeLabel: 'trace-compare-polish',
-      state: 'done',
-      prompt: 'Retain the completed run until the operator dismisses it.',
-      updatedAt: '18:22:31Z',
-      stateStartedAt: '18:22:31Z',
-      acknowledgedAt: '18:25:00Z',
-      unread: false,
-      toolName: 'verify',
-      lastAssistantMessage:
-        'Proof-ready with public trace refs; retained for review.',
-      stateHistory: [
-        {
-          state: 'working',
-          label: 'Compared trace variants',
-          at: '18:07Z',
-        },
-        {
-          state: 'done',
-          label: 'Verification completed',
-          at: '18:22Z',
-        },
-      ],
-    },
-  ],
-  diffComments: [
-    {
-      id: 'diff-comment-1',
-      filePath: 'apps/openagents.com/apps/web/src/page/loggedIn/page/pro.ts',
-      lineLabel: 'agent dashboard',
-      body: 'Keep stateStartedAt distinct from updatedAt so tool pings do not clear unread state.',
-      selectedText: 'stateStartedAt drives unread; updatedAt only shows freshness.',
-      targetAgentLabel: 'Codex lane 1',
-      sentAt: 'staged',
-    },
-    {
-      id: 'diff-comment-2',
-      filePath: 'packages/ui/src/pro.ts',
-      lineLabel: 'diff queue',
-      body: 'Group queued review comments by target agent before enabling the send endpoint.',
-      selectedText: 'diffComments are retained as operator review intent.',
-      targetAgentLabel: 'Claude lane 1',
-      sentAt: 'staged',
-    },
-  ],
-}
-
-// LOADING STATE: skeleton rows (not a center spinner). Exported so the shell can
-// render it while the future run/session index is fetching.
 export const loadingView = (): Html =>
   Ui.proMainPane<Message>([Ui.proSkeletonRows<Message>()])
 
-// ERROR STATE: a compact inline error strip (not a full-page error). Exported so
-// the shell can surface a failed future fetch without losing the console frame.
 export const errorView = (detail: string): Html =>
   Ui.proMainPane<Message>([Ui.proErrorStrip<Message>(detail)])
 
-const topStrip = (session: Session): Html =>
+const topStrip = (model: Model): Html =>
   Ui.proTopStrip<Message>({
     homeHref: proRouter(),
     breadcrumb: 'Operator console',
     creditsLabel: 'credits',
     creditsState: 'soon',
     creditsHint: 'Usage metering is coming to Pro — not active yet.',
-    accountLabel: session.email,
+    accountLabel: model.session.email,
   })
 
-// The Pro console shell. Rendered as a top-level page (see view.ts) so it owns
-// the full top-strip + left-register + main-pane layout, independent of the
-// workroom sidebar shell.
-export const view = (session: Session): Html =>
+const dashboardView = (response: ProAgentDashboardResponse): Html =>
+  Ui.proMainPane<Message>([
+    Ui.proAgentDashboard<Message>(response as Ui.ProAgentDashboardSnapshot),
+  ])
+
+const mainPane = (model: Model): Html => {
+  const state = model.proAgentDashboard
+
+  if (
+    state._tag === 'ProAgentDashboardIdle' ||
+    state._tag === 'ProAgentDashboardLoading'
+  ) {
+    return loadingView()
+  }
+
+  if (state._tag === 'ProAgentDashboardFailed') {
+    return errorView(state.error)
+  }
+
+  return dashboardView(state.response)
+}
+
+export const view = (model: Model): Html =>
   Ui.proConsoleShell<Message>({
-    topStrip: topStrip(session),
+    topStrip: topStrip(model),
     register: Ui.proRegister<Message>(SECTIONS),
-    main: Ui.proMainPane<Message>([
-      Ui.proAgentDashboard<Message>(agentDashboardSnapshot),
-    ]),
+    main: mainPane(model),
   })
 
 // A safe forward path for any "go back" affordance the shell may need.

--- a/apps/openagents.com/apps/web/src/page/loggedIn/pro/transitions.ts
+++ b/apps/openagents.com/apps/web/src/page/loggedIn/pro/transitions.ts
@@ -1,0 +1,73 @@
+import { Effect, Match as M, Option } from 'effect'
+import { Command } from 'foldkit'
+import { evo } from 'foldkit/struct'
+
+import { errorMessageFromUnknown, requestJson } from '../commands/api'
+import {
+  FailedLoadProAgentDashboard,
+  Message,
+  SucceededLoadProAgentDashboard,
+} from '../message'
+import {
+  Model,
+  ProAgentDashboardFailed,
+  ProAgentDashboardLoaded,
+  ProAgentDashboardLoading,
+  ProAgentDashboardResponse,
+} from '../model'
+import { type UpdateReturn, noUpdate } from '../transition'
+
+const withUpdateReturn = M.withReturnType<UpdateReturn>()
+
+export const LoadProAgentDashboard = Command.define(
+  'LoadProAgentDashboard',
+  SucceededLoadProAgentDashboard,
+  FailedLoadProAgentDashboard,
+)(
+  requestJson({
+    init: {
+      cache: 'no-store',
+      credentials: 'include',
+      headers: { accept: 'application/json' },
+    },
+    name: 'loggedIn.pro.agentDashboard.load',
+    request: '/api/operator/pro/status',
+    schema: ProAgentDashboardResponse,
+  }).pipe(
+    Effect.map(response => SucceededLoadProAgentDashboard({ response })),
+    Effect.catch(error =>
+      Effect.succeed(
+        FailedLoadProAgentDashboard({
+          error: errorMessageFromUnknown(error),
+        }),
+      ),
+    ),
+  ),
+)
+
+export const updatePro = (model: Model, message: Message): UpdateReturn =>
+  M.value(message).pipe(
+    withUpdateReturn,
+    M.tags({
+      RequestedLoadProAgentDashboard: () => [
+        evo(model, { proAgentDashboard: () => ProAgentDashboardLoading() }),
+        [LoadProAgentDashboard()],
+        Option.none(),
+      ],
+      SucceededLoadProAgentDashboard: ({ response }) => [
+        evo(model, {
+          proAgentDashboard: () => ProAgentDashboardLoaded({ response }),
+        }),
+        [],
+        Option.none(),
+      ],
+      FailedLoadProAgentDashboard: ({ error }) => [
+        evo(model, {
+          proAgentDashboard: () => ProAgentDashboardFailed({ error }),
+        }),
+        [],
+        Option.none(),
+      ],
+    }),
+    M.orElse(() => noUpdate(model)),
+  )

--- a/apps/openagents.com/apps/web/src/page/loggedIn/update-dispatch.ts
+++ b/apps/openagents.com/apps/web/src/page/loggedIn/update-dispatch.ts
@@ -14,6 +14,7 @@ import { updateMullet } from './mullet/transitions'
 import { updateNotifications } from './notifications/transitions'
 import { updateOnboarding } from './onboarding/transitions'
 import { updateProviders } from './providers/transitions'
+import { updatePro } from './pro/transitions'
 import { updateRunState } from './runs/transitions'
 import { updateSessionChrome } from './session/transitions'
 import { updateStats } from './stats/transitions'
@@ -54,6 +55,7 @@ export {
 } from './thread-files/commands'
 export { LoadTeamChatMessages, PostTeamChatMessage } from './team-chat/commands'
 export { LoadMulletBootstrap } from './mullet/transitions'
+export { LoadProAgentDashboard } from './pro/transitions'
 export { LoadTokenUsageStats } from './stats/transitions'
 export { LoadPrefilledWorkspace } from './workspace/transitions'
 export {
@@ -239,6 +241,9 @@ export const update = (model: Model, message: Message): UpdateReturn => {
       SucceededLoadTokenUsageStats: () => updateStats(model, message),
       FailedLoadTokenUsageStats: () => updateStats(model, message),
       UpdatedTokenUsageStatsFilter: () => updateStats(model, message),
+      RequestedLoadProAgentDashboard: () => updatePro(model, message),
+      SucceededLoadProAgentDashboard: () => updatePro(model, message),
+      FailedLoadProAgentDashboard: () => updatePro(model, message),
       RequestedLoadPrefilledWorkspace: () =>
         updatePrefilledWorkspace(model, message),
       SucceededLoadPrefilledWorkspace: () =>

--- a/apps/openagents.com/apps/web/src/page/loggedIn/view.scene.test.ts
+++ b/apps/openagents.com/apps/web/src/page/loggedIn/view.scene.test.ts
@@ -1823,38 +1823,11 @@ describe('logged-in workroom sidebar', () => {
       ).toExist(),
       Scene.expect(Scene.selector('[data-component="pro-register"]')).toExist(),
       Scene.expect(
-        Scene.selector('[data-component="pro-agent-dashboard-summary"]'),
+        Scene.selector('[data-component="pro-overview-loading"]'),
       ).toExist(),
-      Scene.expect(
-        Scene.role('heading', {
-          name: 'Agent operations',
-        }),
-      ).toExist(),
-      Scene.expect(Scene.text('Live agents')).toExist(),
-      Scene.expect(Scene.text('Retained agents')).toExist(),
-      Scene.expect(Scene.text('Codex lane 1')).toExist(),
-      Scene.expect(Scene.text('Claude lane 1')).toExist(),
-      Scene.expect(Scene.text('OpenCode lane')).toExist(),
-      Scene.expect(Scene.text('Codex lane 0')).toExist(),
-      Scene.expect(Scene.text('working')).toExist(),
-      Scene.expect(Scene.text('blocked')).toExist(),
-      Scene.expect(Scene.text('waiting')).toExist(),
-      Scene.expect(Scene.text('done')).toExist(),
-      Scene.expect(Scene.text('unread')).toExist(),
-      Scene.expect(Scene.text('stateStartedAt')).toExist(),
-      Scene.expect(Scene.text('stateHistory')).toExist(),
-      Scene.expect(
-        Scene.text(
-          'Keep stateStartedAt distinct from updatedAt so tool pings do not clear unread state.',
-        ),
-      ).toExist(),
-      Scene.expect(Scene.text('Annotate diff -> ship back')).toExist(),
-      Scene.expect(
-        Scene.selector('[data-component="pro-diff-comment-queue"]'),
-      ).toExist(),
-      Scene.expect(
-        Scene.role('button', { name: 'Send comments' }),
-      ).toBeDisabled(),
+      Scene.expect(Scene.text('Codex lane 1')).not.toExist(),
+      Scene.expect(Scene.text('Claude lane 1')).not.toExist(),
+      Scene.expect(Scene.text('OpenCode lane')).not.toExist(),
       // #6215: sharing lives at /trace, so the console links out to the public
       // shareable trace surfaces from the section register.
       Scene.expect(

--- a/apps/openagents.com/apps/web/src/page/loggedIn/view.ts
+++ b/apps/openagents.com/apps/web/src/page/loggedIn/view.ts
@@ -685,7 +685,7 @@ const routeView = (model: Model): Html => {
           // (its own top-strip + register + pane), so this workroom-shell case
           // is a defensive fallback only and never normally reached.
           Pro: () =>
-            Ui.workroomScrollableRoute<Message>([Pro.view(model.session)]),
+            Ui.workroomScrollableRoute<Message>([Pro.view(model)]),
           OperatorDashboard: () =>
             Ui.workroomScrollableRoute<Message>([
               ArtanisDashboard.view(model),
@@ -737,7 +737,7 @@ export const view = Submodel.defineView<Model, Message>((model): Html => {
 
   if (model.route._tag === 'Pro') {
     return Ui.pageShell<Message>(
-      [Pro.view(model.session)],
+      [Pro.view(model)],
       [
         h.Key('logged-in-pro-shell'),
         h.DataAttribute('component', 'logged-in-pro-shell'),

--- a/apps/openagents.com/workers/api/migrations/0268_agent_runner_status_events.sql
+++ b/apps/openagents.com/workers/api/migrations/0268_agent_runner_status_events.sql
@@ -1,0 +1,22 @@
+CREATE TABLE IF NOT EXISTS pylon_agent_runner_status_events (
+  event_ref TEXT PRIMARY KEY,
+  owner_agent_user_id TEXT NOT NULL,
+  runner_ref TEXT NOT NULL,
+  runner_kind TEXT NOT NULL,
+  pylon_ref TEXT,
+  assignment_ref TEXT,
+  state TEXT NOT NULL,
+  state_started_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  retention_state TEXT NOT NULL,
+  event_json TEXT NOT NULL,
+  created_at TEXT NOT NULL,
+  retained_at TEXT,
+  archived_at TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_pylon_agent_runner_status_owner_retention_updated
+  ON pylon_agent_runner_status_events(owner_agent_user_id, retention_state, updated_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_pylon_agent_runner_status_owner_runner_live
+  ON pylon_agent_runner_status_events(owner_agent_user_id, runner_ref, retention_state);

--- a/apps/openagents.com/workers/api/src/index.ts
+++ b/apps/openagents.com/workers/api/src/index.ts
@@ -776,6 +776,7 @@ import { makeOperatorBillingHandlers } from './operator-billing-routes'
 import { makeOperatorBuyModeRoutes } from './operator-buy-mode-routes'
 import { makeOperatorEmailInspectionRoutes } from './operator-email-inspection-routes'
 import { makeOperatorFleetStatusRoutes } from './operator-fleet-status-routes'
+import { makeOperatorProStatusRoutes } from './operator-pro-status-routes'
 import { makeOperatorOrderTriageRoutes } from './operator-order-triage-routes'
 import { makeOperatorProviderAccountRoutes } from './operator-provider-account-routes'
 import { makeOperatorPylonMarketplaceRoutes } from './operator-pylon-marketplace-routes'
@@ -9049,6 +9050,21 @@ const operatorFleetStatusRoutes = makeOperatorFleetStatusRoutes({
   requireAdminApiToken,
 })
 
+const operatorProStatusRoutes = makeOperatorProStatusRoutes({
+  appendRefreshedSessionCookies,
+  authenticateAgentToken: async (request, env) => {
+    const token = readBearerToken(request)
+    if (token === undefined) return undefined
+    const session = await authenticateProgrammaticAgent(
+      makeD1AgentRegistrationStore(openAgentsDatabase(env)),
+      token,
+    )
+    return session === undefined ? undefined : { userId: session.user.id }
+  },
+  requireAdminApiToken,
+  requireBrowserSession,
+})
+
 const nexusPylonVisibilityRoutes = makeNexusPylonVisibilityRoutes({
   appendRefreshedSessionCookies,
   currentIsoTimestamp,
@@ -11464,6 +11480,13 @@ const exactRouteRegistry = makeExactRouteRegistry<Env>([
     handler: (request, env) =>
       Effect.promise(() =>
         operatorFleetStatusRoutes.handleOperatorFleetStatusApi(request, env),
+      ),
+  },
+  {
+    path: '/api/operator/pro/status',
+    handler: (request, env, ctx) =>
+      Effect.promise(() =>
+        operatorProStatusRoutes.handleOperatorProStatusApi(request, env, ctx),
       ),
   },
   {

--- a/apps/openagents.com/workers/api/src/index.ts
+++ b/apps/openagents.com/workers/api/src/index.ts
@@ -9061,6 +9061,13 @@ const operatorProStatusRoutes = makeOperatorProStatusRoutes({
     )
     return session === undefined ? undefined : { userId: session.user.id }
   },
+  isOpenAgentsAdminEmail,
+  listLinkedAgentsForOpenAuthUser: (openauthUserId, limit, env) => {
+    const agentStore = makeD1AgentRegistrationStore(openAgentsDatabase(env))
+    return agentStore.listLinkedAgentsForOpenAuthUser === undefined
+      ? Promise.resolve([])
+      : agentStore.listLinkedAgentsForOpenAuthUser(openauthUserId, limit)
+  },
   requireAdminApiToken,
   requireBrowserSession,
 })

--- a/apps/openagents.com/workers/api/src/operator-pro-status-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/operator-pro-status-routes.test.ts
@@ -66,11 +66,11 @@ class FakeD1 {
 
     if (sql.includes('FROM pylon_agent_runner_status_events')) {
       const retention = String(bindings[0])
-      const owner = bindings[1] === undefined ? undefined : String(bindings[1])
+      const owners = bindings.slice(1).map(value => String(value))
       return this.statuses
         .filter(row => row.archived_at === null)
         .filter(row => row.retention_state === retention)
-        .filter(row => owner === undefined || row.owner_agent_user_id === owner)
+        .filter(row => owners.length === 0 || owners.includes(row.owner_agent_user_id))
         .sort((left, right) => right.updated_at.localeCompare(left.updated_at))
     }
 
@@ -131,9 +131,10 @@ class FakeD1 {
         archived_at: null,
       }
 
+      const conflictOwner = bindings[13] === undefined ? undefined : String(bindings[13])
       if (existing === undefined) {
         this.statuses.push(next)
-      } else {
+      } else if (existing.owner_agent_user_id === conflictOwner) {
         Object.assign(existing, next)
       }
     }
@@ -264,5 +265,139 @@ describe('operator pro status route', () => {
     )
 
     expect(response.status).toBe(400)
+  })
+
+  test('browser reads resolve linked agent user ids instead of the raw OpenAuth user id', async () => {
+    const db = new FakeD1()
+    db.statuses.push({
+      event_ref: 'event.public.runner_status.linked',
+      owner_agent_user_id: 'agent_user.linked',
+      runner_ref: 'runner.public.codex.linked',
+      runner_kind: 'codex_sdk',
+      pylon_ref: 'pylon.public.codex',
+      assignment_ref: 'assignment.public.linked',
+      state: 'working',
+      state_started_at: '2026-07-01T12:00:00.000Z',
+      updated_at: '2026-07-01T12:02:00.000Z',
+      retention_state: 'live',
+      event_json: JSON.stringify(statusEvent({
+        eventRef: 'event.public.runner_status.linked',
+        runnerRef: 'runner.public.codex.linked',
+      })),
+      created_at: '2026-07-01T12:03:00.000Z',
+      retained_at: null,
+      archived_at: null,
+    })
+    db.statuses.push({
+      ...db.statuses[0]!,
+      event_ref: 'event.public.runner_status.human',
+      owner_agent_user_id: 'openauth_user.human',
+      runner_ref: 'runner.public.codex.human',
+      event_json: JSON.stringify(statusEvent({
+        eventRef: 'event.public.runner_status.human',
+        runnerRef: 'runner.public.codex.human',
+      })),
+    })
+    const routes = makeOperatorProStatusRoutes({
+      isOpenAgentsAdminEmail: email => email.endsWith('@openagents.com'),
+      listLinkedAgentsForOpenAuthUser: async openauthUserId => [
+        { agentUserId: 'agent_user.linked', openauthUserId },
+      ],
+      requireBrowserSession: async () => ({
+        user: {
+          email: 'operator@openagents.com',
+          userId: 'openauth_user.human',
+        },
+      }),
+    })
+
+    const read = await routes.handleOperatorProStatusApi(
+      request('GET'),
+      { OPENAGENTS_DB: db as unknown as D1Database },
+      {} as ExecutionContext,
+    )
+    const body = await read.json() as {
+      liveEntries: ReadonlyArray<{ id: string }>
+    }
+
+    expect(body.liveEntries.map(entry => entry.id)).toEqual([
+      'runner.public.codex.linked',
+    ])
+  })
+
+  test('browser read still enforces the admin email gate', async () => {
+    const routes = makeOperatorProStatusRoutes({
+      isOpenAgentsAdminEmail: () => false,
+      listLinkedAgentsForOpenAuthUser: async () => [
+        { agentUserId: 'agent_user.linked' },
+      ],
+      requireBrowserSession: async () => ({
+        user: {
+          email: 'external@example.com',
+          userId: 'openauth_user.external',
+        },
+      }),
+    })
+
+    const read = await routes.handleOperatorProStatusApi(
+      request('GET'),
+      { OPENAGENTS_DB: new FakeD1() as unknown as D1Database },
+      {} as ExecutionContext,
+    )
+
+    expect(read.status).toBe(403)
+  })
+
+  test('does not let a different owner overwrite an existing event ref', async () => {
+    const db = new FakeD1({ 'pylon.public.codex': 'agent_user.owner' })
+    const ownerRoutes = makeOperatorProStatusRoutes({
+      authenticateAgentToken: async () => ({ userId: 'agent_user.owner' }),
+      currentIsoTimestamp: () => '2026-07-01T12:03:00.000Z',
+    })
+    await ownerRoutes.handleOperatorProStatusApi(
+      request('POST', statusEvent()),
+      { OPENAGENTS_DB: db as unknown as D1Database },
+      {} as ExecutionContext,
+    )
+    const attackerRoutes = makeOperatorProStatusRoutes({
+      authenticateAgentToken: async () => ({ userId: 'agent_user.attacker' }),
+      currentIsoTimestamp: () => '2026-07-01T12:04:00.000Z',
+    })
+
+    const response = await attackerRoutes.handleOperatorProStatusApi(
+      request('POST', statusEvent({
+        pylonRef: undefined,
+        state: 'blocked',
+        updatedAt: '2026-07-01T12:04:00.000Z',
+      })),
+      { OPENAGENTS_DB: db as unknown as D1Database },
+      {} as ExecutionContext,
+    )
+
+    expect(response.status).toBe(200)
+    expect(db.statuses).toHaveLength(1)
+    expect(db.statuses[0]?.owner_agent_user_id).toBe('agent_user.owner')
+    expect(db.statuses[0]?.state).toBe('working')
+  })
+
+  test('rejects non-ISO timestamp fields before storing the event', async () => {
+    const db = new FakeD1()
+    const routes = makeOperatorProStatusRoutes({
+      authenticateAgentToken: async () => ({ userId: 'agent_user.owner' }),
+    })
+
+    const response = await routes.handleOperatorProStatusApi(
+      request('POST', statusEvent({
+        updatedAt: 'raw prompt text',
+      })),
+      { OPENAGENTS_DB: db as unknown as D1Database },
+      {} as ExecutionContext,
+    )
+    const body = await response.json() as { error: string; message: string }
+
+    expect(response.status).toBe(400)
+    expect(body.error).toBe('invalid_agent_runner_status_event')
+    expect(body.message).toContain('updatedAt')
+    expect(db.statuses).toHaveLength(0)
   })
 })

--- a/apps/openagents.com/workers/api/src/operator-pro-status-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/operator-pro-status-routes.test.ts
@@ -1,0 +1,268 @@
+import { describe, expect, test } from 'vitest'
+
+import { makeOperatorProStatusRoutes } from './operator-pro-status-routes'
+
+type StoredStatus = {
+  event_ref: string
+  owner_agent_user_id: string
+  runner_ref: string
+  runner_kind: string
+  pylon_ref: string | null
+  assignment_ref: string | null
+  state: string
+  state_started_at: string
+  updated_at: string
+  retention_state: 'live' | 'retained'
+  event_json: string
+  created_at: string
+  retained_at: string | null
+  archived_at: string | null
+}
+
+class FakeStatement {
+  constructor(
+    private readonly db: FakeD1,
+    private readonly sql: string,
+    private readonly bindings: ReadonlyArray<unknown> = [],
+  ) {}
+
+  bind(...bindings: ReadonlyArray<unknown>): FakeStatement {
+    return new FakeStatement(this.db, this.sql, bindings)
+  }
+
+  async all<T>(): Promise<{ results: ReadonlyArray<T> }> {
+    return { results: this.db.all(this.sql, this.bindings) as ReadonlyArray<T> }
+  }
+
+  async first<T>(): Promise<T | null> {
+    return (this.db.all(this.sql, this.bindings)[0] ?? null) as T | null
+  }
+
+  async run(): Promise<{ success: true }> {
+    this.db.run(this.sql, this.bindings)
+    return { success: true }
+  }
+}
+
+class FakeD1 {
+  readonly statuses: Array<StoredStatus> = []
+
+  constructor(
+    readonly pylonOwners: Record<string, string> = {
+      'pylon.public.codex': 'agent_user.owner',
+    },
+  ) {}
+
+  prepare(sql: string): FakeStatement {
+    return new FakeStatement(this, sql)
+  }
+
+  all(sql: string, bindings: ReadonlyArray<unknown>): ReadonlyArray<unknown> {
+    if (sql.includes('FROM pylon_api_registrations')) {
+      const pylonRef = String(bindings[0])
+      const owner = this.pylonOwners[pylonRef]
+      return owner === undefined ? [] : [{ owner_agent_user_id: owner }]
+    }
+
+    if (sql.includes('FROM pylon_agent_runner_status_events')) {
+      const retention = String(bindings[0])
+      const owner = bindings[1] === undefined ? undefined : String(bindings[1])
+      return this.statuses
+        .filter(row => row.archived_at === null)
+        .filter(row => row.retention_state === retention)
+        .filter(row => owner === undefined || row.owner_agent_user_id === owner)
+        .sort((left, right) => right.updated_at.localeCompare(left.updated_at))
+    }
+
+    return []
+  }
+
+  run(sql: string, bindings: ReadonlyArray<unknown>): void {
+    if (sql.startsWith('UPDATE pylon_agent_runner_status_events')) {
+      const [retainedAt, owner, runnerRef, eventRef] = bindings.map(value =>
+        String(value),
+      )
+      for (const row of this.statuses) {
+        if (
+          row.owner_agent_user_id === owner &&
+          row.runner_ref === runnerRef &&
+          row.event_ref !== eventRef &&
+          row.retention_state === 'live' &&
+          row.archived_at === null
+        ) {
+          row.retention_state = 'retained'
+          row.retained_at = row.retained_at ?? retainedAt ?? null
+        }
+      }
+      return
+    }
+
+    if (sql.startsWith('INSERT INTO pylon_agent_runner_status_events')) {
+      const [
+        eventRef,
+        owner,
+        runnerRef,
+        runnerKind,
+        pylonRef,
+        assignmentRef,
+        state,
+        stateStartedAt,
+        updatedAt,
+        retentionState,
+        eventJson,
+        createdAt,
+        retainedAt,
+      ] = bindings
+      const existing = this.statuses.find(row => row.event_ref === eventRef)
+      const next = {
+        event_ref: String(eventRef),
+        owner_agent_user_id: String(owner),
+        runner_ref: String(runnerRef),
+        runner_kind: String(runnerKind),
+        pylon_ref: pylonRef === null ? null : String(pylonRef),
+        assignment_ref: assignmentRef === null ? null : String(assignmentRef),
+        state: String(state),
+        state_started_at: String(stateStartedAt),
+        updated_at: String(updatedAt),
+        retention_state: retentionState as 'live' | 'retained',
+        event_json: String(eventJson),
+        created_at: String(createdAt),
+        retained_at: retainedAt === null ? null : String(retainedAt),
+        archived_at: null,
+      }
+
+      if (existing === undefined) {
+        this.statuses.push(next)
+      } else {
+        Object.assign(existing, next)
+      }
+    }
+  }
+}
+
+const statusEvent = (overrides: Record<string, unknown> = {}) => ({
+  schemaVersion: 'openagents.pylon.agent_runner_status_event.v1',
+  eventRef: 'event.public.runner_status.1',
+  runnerRef: 'runner.public.codex.1',
+  runnerKind: 'codex_sdk',
+  state: 'working',
+  stateStartedAt: '2026-07-01T12:00:00.000Z',
+  updatedAt: '2026-07-01T12:02:00.000Z',
+  assignmentRef: 'assignment.public.issue_7878',
+  taskId: 'task.public.t10_2',
+  pylonRef: 'pylon.public.codex',
+  worktreeId: 'issue-7878',
+  refs: ['status.public.runner.working'],
+  stateHistory: [
+    {
+      state: 'waiting',
+      stateStartedAt: '2026-07-01T11:59:00.000Z',
+    },
+    {
+      state: 'working',
+      stateStartedAt: '2026-07-01T12:00:00.000Z',
+    },
+  ],
+  ...overrides,
+})
+
+const request = (method: string, body?: unknown) =>
+  new Request('https://openagents.com/api/operator/pro/status', {
+    method,
+    ...(body === undefined
+      ? {}
+      : {
+          body: JSON.stringify(body),
+          headers: { 'content-type': 'application/json' },
+        }),
+  })
+
+describe('operator pro status route', () => {
+  test('ingests public-safe runner status events and projects live rows', async () => {
+    const db = new FakeD1()
+    const routes = makeOperatorProStatusRoutes({
+      authenticateAgentToken: async () => ({ userId: 'agent_user.owner' }),
+      currentIsoTimestamp: () => '2026-07-01T12:03:00.000Z',
+    })
+
+    const ingest = await routes.handleOperatorProStatusApi(
+      request('POST', statusEvent()),
+      { OPENAGENTS_DB: db as unknown as D1Database },
+      {} as ExecutionContext,
+    )
+    expect(ingest.status).toBe(200)
+
+    const read = await routes.handleOperatorProStatusApi(
+      request('GET'),
+      { OPENAGENTS_DB: db as unknown as D1Database },
+      {} as ExecutionContext,
+    )
+    const body = await read.json() as {
+      liveEntries: ReadonlyArray<{ stateStartedAt: string; stateHistory: unknown[] }>
+      retainedEntries: ReadonlyArray<unknown>
+    }
+
+    expect(body.liveEntries).toHaveLength(1)
+    expect(body.retainedEntries).toHaveLength(0)
+    expect(body.liveEntries[0]?.stateStartedAt).toBe('2026-07-01T12:00:00.000Z')
+    expect(body.liveEntries[0]?.stateHistory).toHaveLength(2)
+  })
+
+  test('moves previous live event to retained when the runner posts a new state', async () => {
+    const db = new FakeD1()
+    const routes = makeOperatorProStatusRoutes({
+      authenticateAgentToken: async () => ({ userId: 'agent_user.owner' }),
+      currentIsoTimestamp: () => '2026-07-01T12:05:00.000Z',
+    })
+
+    await routes.handleOperatorProStatusApi(
+      request('POST', statusEvent()),
+      { OPENAGENTS_DB: db as unknown as D1Database },
+      {} as ExecutionContext,
+    )
+    await routes.handleOperatorProStatusApi(
+      request('POST', statusEvent({
+        eventRef: 'event.public.runner_status.2',
+        state: 'done',
+        stateStartedAt: '2026-07-01T12:04:00.000Z',
+        updatedAt: '2026-07-01T12:04:30.000Z',
+        stateHistory: [
+          ...statusEvent().stateHistory,
+          { state: 'done', stateStartedAt: '2026-07-01T12:04:00.000Z' },
+        ],
+      })),
+      { OPENAGENTS_DB: db as unknown as D1Database },
+      {} as ExecutionContext,
+    )
+
+    const read = await routes.handleOperatorProStatusApi(
+      request('GET'),
+      { OPENAGENTS_DB: db as unknown as D1Database },
+      {} as ExecutionContext,
+    )
+    const body = await read.json() as {
+      liveEntries: ReadonlyArray<unknown>
+      retainedEntries: ReadonlyArray<{ state: string }>
+    }
+
+    expect(body.liveEntries).toHaveLength(0)
+    expect(body.retainedEntries.map(entry => entry.state)).toEqual([
+      'done',
+      'working',
+    ])
+  })
+
+  test('rejects private local refs in public projections', async () => {
+    const routes = makeOperatorProStatusRoutes({
+      authenticateAgentToken: async () => ({ userId: 'agent_user.owner' }),
+    })
+
+    const response = await routes.handleOperatorProStatusApi(
+      request('POST', statusEvent({ worktreeRef: '/Users/operator/private' })),
+      { OPENAGENTS_DB: new FakeD1() as unknown as D1Database },
+      {} as ExecutionContext,
+    )
+
+    expect(response.status).toBe(400)
+  })
+})

--- a/apps/openagents.com/workers/api/src/operator-pro-status-routes.ts
+++ b/apps/openagents.com/workers/api/src/operator-pro-status-routes.ts
@@ -1,0 +1,520 @@
+import { jsonResponse } from '@openagentsinc/sync-worker'
+import { Schema as S } from 'effect'
+
+import {
+  forbidden,
+  methodNotAllowed,
+  noStoreJsonResponse,
+  unauthorized,
+} from './http/responses'
+import {
+  decodeUnknownWithSchema,
+  optionalString,
+  parseJsonWithSchema,
+  readJsonObject,
+} from './json-boundary'
+import { openAgentsDatabase } from './runtime'
+import { currentIsoTimestamp } from './runtime-primitives'
+
+export const OPERATOR_PRO_STATUS_PATH = '/api/operator/pro/status'
+export const PYLON_AGENT_RUNNER_STATUS_EVENT_SCHEMA_VERSION =
+  'openagents.pylon.agent_runner_status_event.v1'
+
+type OperatorProStatusEnv = Readonly<{
+  OPENAGENTS_DB: D1Database
+}>
+
+type OperatorProSession = Readonly<{
+  user: Readonly<{
+    email: string
+    userId: string
+  }>
+}>
+
+type HttpResponse = Response
+
+type OperatorProStatusDependencies<
+  Session extends OperatorProSession,
+  Bindings extends OperatorProStatusEnv,
+> = Readonly<{
+  appendRefreshedSessionCookies?: (
+    response: HttpResponse,
+    session: Session,
+  ) => HttpResponse
+  authenticateAgentToken?: (
+    request: Request,
+    env: Bindings,
+  ) => Promise<{ userId: string } | undefined>
+  currentIsoTimestamp?: () => string
+  isOpenAgentsAdminEmail?: (email: string) => boolean
+  requireAdminApiToken?: (request: Request, env: Bindings) => Promise<boolean>
+  requireBrowserSession?: (
+    request: Request,
+    env: Bindings,
+    ctx: ExecutionContext,
+  ) => Promise<Session | undefined>
+}>
+
+type ProAgentState = 'working' | 'blocked' | 'waiting' | 'done'
+
+const AgentRunnerNeutralStateSchema = S.Literals([
+  'idle',
+  'queued',
+  'working',
+  'waiting',
+  'blocked',
+  'done',
+  'failed',
+  'offline',
+])
+
+const AgentRunnerControlVerb = S.Literals([
+  'status.list',
+  'task.list',
+  'task.update',
+  'task.dispatch',
+  'dispatch.cancel',
+])
+
+const AgentRunnerStatusHistoryEntry = S.Struct({
+  state: AgentRunnerNeutralStateSchema,
+  stateStartedAt: S.String,
+})
+
+const AgentRunnerStatusEvent = S.Struct({
+  schemaVersion: S.Literal(PYLON_AGENT_RUNNER_STATUS_EVENT_SCHEMA_VERSION),
+  eventRef: S.String,
+  runnerRef: S.String,
+  runnerKind: S.String,
+  state: AgentRunnerNeutralStateSchema,
+  stateStartedAt: S.String,
+  updatedAt: S.String,
+  assignmentRef: S.optionalKey(S.String),
+  taskId: S.optionalKey(S.String),
+  dispatchContextId: S.optionalKey(S.String),
+  assigneeHandle: S.optionalKey(S.String),
+  pylonRef: S.optionalKey(S.String),
+  worktreeId: S.optionalKey(S.String),
+  worktreeRef: S.optionalKey(S.String),
+  capabilityRefs: S.optionalKey(S.Array(S.String)),
+  supportedControlVerbs: S.optionalKey(S.Array(AgentRunnerControlVerb)),
+  refs: S.optionalKey(S.Array(S.String)),
+  blockerRefs: S.optionalKey(S.Array(S.String)),
+  stateHistory: S.optionalKey(S.Array(AgentRunnerStatusHistoryEntry)),
+})
+type AgentRunnerStatusEvent = typeof AgentRunnerStatusEvent.Type
+
+type StatusRow = Readonly<{
+  event_ref: string
+  owner_agent_user_id: string
+  runner_ref: string
+  runner_kind: string
+  pylon_ref: string | null
+  assignment_ref: string | null
+  state: string
+  state_started_at: string
+  updated_at: string
+  retention_state: 'live' | 'retained'
+  event_json: string
+}>
+
+type PylonOwnerRow = Readonly<{
+  owner_agent_user_id: string
+}>
+
+type ReadScope<Session extends OperatorProSession> =
+  | Readonly<{ kind: 'admin' }>
+  | Readonly<{ kind: 'browser'; session: Session }>
+  | Readonly<{ kind: 'agent'; userId: string }>
+
+const unsafeProjectionValue =
+  /(\/Users\/|[A-Za-z]:\\|raw[_-]?(prompt|trace|payload|event|log)|secret|token|wallet|credential|auth\.json)/i
+
+const publicRefPattern =
+  /^(agent|assignment|blocker|capability|command|dispatch|event|issue|pylon|runner|task|worktree|ref|status)\.[A-Za-z0-9_.:-]+$/
+
+const bounded = (value: string | undefined, fallback: string, max: number): string => {
+  const trimmed = value?.trim()
+  const safe = trimmed === undefined || trimmed === '' ? fallback : trimmed
+  return safe.slice(0, max)
+}
+
+const isSafeText = (value: string): boolean => !unsafeProjectionValue.test(value)
+
+const safeRefArray = (
+  values: ReadonlyArray<string> | undefined,
+): ReadonlyArray<string> =>
+  (values ?? [])
+    .filter(value => publicRefPattern.test(value) && isSafeText(value))
+    .slice(0, 32)
+
+const validatePublicSafeEvent = (event: AgentRunnerStatusEvent): string | null => {
+  const refs = [
+    event.eventRef,
+    event.runnerRef,
+    event.assignmentRef,
+    event.taskId,
+    event.dispatchContextId,
+    event.pylonRef,
+    event.worktreeRef,
+    ...(event.refs ?? []),
+    ...(event.blockerRefs ?? []),
+    ...(event.capabilityRefs ?? []),
+  ].filter((value): value is string => value !== undefined)
+
+  const unsafeRef = refs.find(value => !publicRefPattern.test(value) || !isSafeText(value))
+  if (unsafeRef !== undefined) {
+    return `unsafe public ref: ${unsafeRef}`
+  }
+
+  const textFields = [
+    event.runnerKind,
+    event.assigneeHandle,
+    event.worktreeId,
+  ].filter((value): value is string => value !== undefined)
+
+  const unsafeText = textFields.find(value => !isSafeText(value))
+  return unsafeText === undefined ? null : 'unsafe public projection text'
+}
+
+const proStateFromRunnerState = (state: string): ProAgentState =>
+  state === 'working'
+    ? 'working'
+    : state === 'done'
+      ? 'done'
+      : state === 'blocked' || state === 'failed' || state === 'offline'
+        ? 'blocked'
+        : 'waiting'
+
+const terminalState = (state: string): boolean =>
+  state === 'done' || state === 'failed' || state === 'offline'
+
+const readRows = async <T>(
+  db: D1Database,
+  sql: string,
+  ...bindings: ReadonlyArray<unknown>
+): Promise<ReadonlyArray<T>> => {
+  const statement = bindings.length === 0
+    ? db.prepare(sql)
+    : db.prepare(sql).bind(...bindings)
+  const result = await statement.all<T>()
+  return result.results ?? []
+}
+
+const readFirst = async <T>(
+  db: D1Database,
+  sql: string,
+  ...bindings: ReadonlyArray<unknown>
+): Promise<T | null> => {
+  const statement = bindings.length === 0
+    ? db.prepare(sql)
+    : db.prepare(sql).bind(...bindings)
+  return await statement.first<T>()
+}
+
+const runSql = async (
+  db: D1Database,
+  sql: string,
+  ...bindings: ReadonlyArray<unknown>
+): Promise<void> => {
+  const statement = bindings.length === 0
+    ? db.prepare(sql)
+    : db.prepare(sql).bind(...bindings)
+  await statement.run()
+}
+
+const eventFromRow = (row: StatusRow): AgentRunnerStatusEvent | null => {
+  try {
+    return parseJsonWithSchema(AgentRunnerStatusEvent, row.event_json)
+  } catch {
+    return null
+  }
+}
+
+const statusLabel = (state: string): string =>
+  state === 'working'
+    ? 'Working'
+    : state === 'done'
+      ? 'Done'
+      : state === 'blocked'
+        ? 'Blocked'
+        : state === 'failed'
+          ? 'Failed'
+          : state === 'offline'
+            ? 'Offline'
+            : 'Waiting'
+
+const rowToProEntry = (row: StatusRow) => {
+  const event = eventFromRow(row)
+  const state = proStateFromRunnerState(row.state)
+  const stateHistory = (event?.stateHistory ?? [])
+    .slice(-20)
+    .map(entry => ({
+      at: entry.stateStartedAt,
+      label: statusLabel(entry.state),
+      state: proStateFromRunnerState(entry.state),
+    }))
+
+  return {
+    acknowledgedAt: row.retention_state === 'retained'
+      ? row.updated_at
+      : row.state_started_at,
+    agentLabel: bounded(event?.assigneeHandle, row.runner_kind, 80),
+    id: row.runner_ref,
+    lastAssistantMessage: bounded(
+      event?.blockerRefs?.[0] ?? event?.refs?.[0],
+      `${statusLabel(row.state)} from runner status spine.`,
+      180,
+    ),
+    prompt: bounded(
+      event?.taskId ?? event?.assignmentRef ?? event?.dispatchContextId,
+      'Runner status projection',
+      180,
+    ),
+    state,
+    stateHistory,
+    stateStartedAt: row.state_started_at,
+    toolName: bounded(event?.supportedControlVerbs?.[0], row.runner_kind, 80),
+    unread: row.retention_state === 'live' && row.state !== 'idle',
+    updatedAt: row.updated_at,
+    worktreeLabel: bounded(event?.worktreeId ?? event?.worktreeRef, 'owner-scoped runner', 80),
+  }
+}
+
+const listRows = async (
+  db: D1Database,
+  scope: ReadScope<OperatorProSession>,
+  retentionState: 'live' | 'retained',
+): Promise<ReadonlyArray<StatusRow>> => {
+  const ownerClause = scope.kind === 'admin' ? '' : 'AND owner_agent_user_id = ?'
+  const bindings = scope.kind === 'admin' ? [] : [scope.kind === 'agent' ? scope.userId : scope.session.user.userId]
+  return readRows<StatusRow>(
+    db,
+    `SELECT event_ref, owner_agent_user_id, runner_ref, runner_kind, pylon_ref,
+            assignment_ref, state, state_started_at, updated_at,
+            retention_state, event_json
+       FROM pylon_agent_runner_status_events
+      WHERE archived_at IS NULL
+        AND retention_state = ?
+        ${ownerClause}
+      ORDER BY updated_at DESC
+      LIMIT 100`,
+    retentionState,
+    ...bindings,
+  )
+}
+
+const buildSnapshot = async (
+  db: D1Database,
+  scope: ReadScope<OperatorProSession>,
+  generatedAt: string,
+) => {
+  const [liveRows, retainedRows] = await Promise.all([
+    listRows(db, scope, 'live'),
+    listRows(db, scope, 'retained'),
+  ])
+
+  return {
+    generatedAt,
+    liveEntries: liveRows.map(rowToProEntry),
+    retainedEntries: retainedRows.map(rowToProEntry),
+    diffComments: [],
+  }
+}
+
+const authorizeRead = async <
+  Session extends OperatorProSession,
+  Bindings extends OperatorProStatusEnv,
+>(
+  dependencies: OperatorProStatusDependencies<Session, Bindings>,
+  request: Request,
+  env: Bindings,
+  ctx: ExecutionContext,
+): Promise<ReadScope<Session> | HttpResponse> => {
+  if (await dependencies.requireAdminApiToken?.(request, env)) {
+    return { kind: 'admin' }
+  }
+
+  const agent = await dependencies.authenticateAgentToken?.(request, env)
+  if (agent !== undefined) {
+    return { kind: 'agent', userId: agent.userId }
+  }
+
+  const session = await dependencies.requireBrowserSession?.(request, env, ctx)
+  if (session === undefined) {
+    return unauthorized()
+  }
+
+  if (
+    dependencies.isOpenAgentsAdminEmail !== undefined &&
+    !dependencies.isOpenAgentsAdminEmail(session.user.email)
+  ) {
+    return forbidden()
+  }
+
+  return { kind: 'browser', session }
+}
+
+const ownerForPylon = async (
+  db: D1Database,
+  pylonRef: string | undefined,
+): Promise<string | null> => {
+  if (pylonRef === undefined) {
+    return null
+  }
+
+  const row = await readFirst<PylonOwnerRow>(
+    db,
+    `SELECT owner_agent_user_id
+       FROM pylon_api_registrations
+      WHERE pylon_ref = ?
+        AND archived_at IS NULL
+      LIMIT 1`,
+    pylonRef,
+  )
+  return row?.owner_agent_user_id ?? null
+}
+
+const ingestEvent = async (
+  db: D1Database,
+  event: AgentRunnerStatusEvent,
+  ownerUserId: string,
+  nowIso: string,
+): Promise<void> => {
+  const retentionState = terminalState(event.state) ? 'retained' : 'live'
+
+  await runSql(
+    db,
+    `UPDATE pylon_agent_runner_status_events
+        SET retention_state = 'retained',
+            retained_at = COALESCE(retained_at, ?)
+      WHERE owner_agent_user_id = ?
+        AND runner_ref = ?
+        AND event_ref <> ?
+        AND retention_state = 'live'
+        AND archived_at IS NULL`,
+    event.stateStartedAt,
+    ownerUserId,
+    event.runnerRef,
+    event.eventRef,
+  )
+
+  await runSql(
+    db,
+    `INSERT INTO pylon_agent_runner_status_events (
+       event_ref, owner_agent_user_id, runner_ref, runner_kind, pylon_ref,
+       assignment_ref, state, state_started_at, updated_at, retention_state,
+       event_json, created_at, retained_at, archived_at
+     ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL)
+     ON CONFLICT(event_ref) DO UPDATE SET
+       runner_kind = excluded.runner_kind,
+       pylon_ref = excluded.pylon_ref,
+       assignment_ref = excluded.assignment_ref,
+       state = excluded.state,
+       state_started_at = excluded.state_started_at,
+       updated_at = excluded.updated_at,
+       retention_state = excluded.retention_state,
+       event_json = excluded.event_json,
+       retained_at = excluded.retained_at`,
+    event.eventRef,
+    ownerUserId,
+    event.runnerRef,
+    bounded(event.runnerKind, 'runner', 80),
+    event.pylonRef ?? null,
+    event.assignmentRef ?? null,
+    event.state,
+    event.stateStartedAt,
+    event.updatedAt,
+    retentionState,
+    JSON.stringify({
+      ...event,
+      capabilityRefs: safeRefArray(event.capabilityRefs),
+      refs: safeRefArray(event.refs),
+      blockerRefs: safeRefArray(event.blockerRefs),
+      stateHistory: (event.stateHistory ?? []).slice(-20),
+    }),
+    nowIso,
+    retentionState === 'retained' ? event.updatedAt : null,
+  )
+}
+
+export const makeOperatorProStatusRoutes = <
+  Session extends OperatorProSession,
+  Bindings extends OperatorProStatusEnv,
+>(
+  dependencies: OperatorProStatusDependencies<Session, Bindings>,
+) => ({
+  handleOperatorProStatusApi: async (
+    request: Request,
+    env: Bindings,
+    ctx: ExecutionContext,
+  ) => {
+    const db = openAgentsDatabase(env)
+
+    if (request.method === 'GET') {
+      const scope = await authorizeRead(dependencies, request, env, ctx)
+      if (scope instanceof Response) {
+        return scope
+      }
+
+      const snapshot = await buildSnapshot(
+        db,
+        scope,
+        dependencies.currentIsoTimestamp?.() ?? currentIsoTimestamp(),
+      )
+      const response = noStoreJsonResponse(snapshot)
+
+      return scope.kind === 'browser' && dependencies.appendRefreshedSessionCookies !== undefined
+        ? dependencies.appendRefreshedSessionCookies(response, scope.session)
+        : response
+    }
+
+    if (request.method !== 'POST') {
+      return methodNotAllowed(['GET', 'POST'])
+    }
+
+    const agent = await dependencies.authenticateAgentToken?.(request, env)
+    if (agent === undefined) {
+      return unauthorized()
+    }
+
+    let event: AgentRunnerStatusEvent
+    try {
+      event = decodeUnknownWithSchema(AgentRunnerStatusEvent, await readJsonObject(request))
+    } catch {
+      return jsonResponse(
+        {
+          error: 'invalid_agent_runner_status_event',
+          schemaVersion: PYLON_AGENT_RUNNER_STATUS_EVENT_SCHEMA_VERSION,
+        },
+        { status: 400 },
+      )
+    }
+
+    const safetyError = validatePublicSafeEvent(event)
+    if (safetyError !== null) {
+      return jsonResponse(
+        { error: 'unsafe_agent_runner_status_projection', message: safetyError },
+        { status: 400 },
+      )
+    }
+
+    const pylonOwner = await ownerForPylon(db, optionalString(event.pylonRef))
+    if (pylonOwner !== null && pylonOwner !== agent.userId) {
+      return forbidden()
+    }
+
+    await ingestEvent(
+      db,
+      event,
+      pylonOwner ?? agent.userId,
+      dependencies.currentIsoTimestamp?.() ?? currentIsoTimestamp(),
+    )
+
+    return noStoreJsonResponse({
+      ok: true,
+      eventRef: event.eventRef,
+      retentionState: terminalState(event.state) ? 'retained' : 'live',
+    })
+  },
+})

--- a/apps/openagents.com/workers/api/src/operator-pro-status-routes.ts
+++ b/apps/openagents.com/workers/api/src/operator-pro-status-routes.ts
@@ -47,6 +47,11 @@ type OperatorProStatusDependencies<
   ) => Promise<{ userId: string } | undefined>
   currentIsoTimestamp?: () => string
   isOpenAgentsAdminEmail?: (email: string) => boolean
+  listLinkedAgentsForOpenAuthUser?: (
+    openauthUserId: string,
+    limit: number,
+    env: Bindings,
+  ) => Promise<ReadonlyArray<{ agentUserId: string; openauthUserId?: string | null }>>
   requireAdminApiToken?: (request: Request, env: Bindings) => Promise<boolean>
   requireBrowserSession?: (
     request: Request,
@@ -124,7 +129,7 @@ type PylonOwnerRow = Readonly<{
 
 type ReadScope<Session extends OperatorProSession> =
   | Readonly<{ kind: 'admin' }>
-  | Readonly<{ kind: 'browser'; session: Session }>
+  | Readonly<{ kind: 'browser'; ownerAgentUserIds: ReadonlyArray<string>; session: Session }>
   | Readonly<{ kind: 'agent'; userId: string }>
 
 const unsafeProjectionValue =
@@ -175,6 +180,30 @@ const validatePublicSafeEvent = (event: AgentRunnerStatusEvent): string | null =
 
   const unsafeText = textFields.find(value => !isSafeText(value))
   return unsafeText === undefined ? null : 'unsafe public projection text'
+}
+
+const isoTimestampPattern =
+  /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{3})?Z$/
+
+const isIsoTimestamp = (value: string): boolean => {
+  if (!isoTimestampPattern.test(value)) {
+    return false
+  }
+  const parsed = Date.parse(value)
+  return Number.isFinite(parsed) && new Date(parsed).toISOString() === value
+}
+
+const validateIsoTimestamps = (event: AgentRunnerStatusEvent): string | null => {
+  const fields: ReadonlyArray<readonly [string, string]> = [
+    ['stateStartedAt', event.stateStartedAt],
+    ['updatedAt', event.updatedAt],
+    ...(event.stateHistory ?? []).map((entry, index): readonly [string, string] => [
+      `stateHistory[${index}].stateStartedAt`,
+      entry.stateStartedAt,
+    ]),
+  ]
+  const invalid = fields.find(([, value]) => !isIsoTimestamp(value))
+  return invalid === undefined ? null : `invalid ISO timestamp: ${invalid[0]}`
 }
 
 const proStateFromRunnerState = (state: string): ProAgentState =>
@@ -286,8 +315,18 @@ const listRows = async (
   scope: ReadScope<OperatorProSession>,
   retentionState: 'live' | 'retained',
 ): Promise<ReadonlyArray<StatusRow>> => {
-  const ownerClause = scope.kind === 'admin' ? '' : 'AND owner_agent_user_id = ?'
-  const bindings = scope.kind === 'admin' ? [] : [scope.kind === 'agent' ? scope.userId : scope.session.user.userId]
+  if (scope.kind === 'browser' && scope.ownerAgentUserIds.length === 0) {
+    return []
+  }
+  const ownerAgentUserIds =
+    scope.kind === 'admin'
+      ? []
+      : scope.kind === 'agent'
+        ? [scope.userId]
+        : scope.ownerAgentUserIds
+  const ownerClause = scope.kind === 'admin'
+    ? ''
+    : `AND owner_agent_user_id IN (${ownerAgentUserIds.map(() => '?').join(', ')})`
   return readRows<StatusRow>(
     db,
     `SELECT event_ref, owner_agent_user_id, runner_ref, runner_kind, pylon_ref,
@@ -300,8 +339,38 @@ const listRows = async (
       ORDER BY updated_at DESC
       LIMIT 100`,
     retentionState,
-    ...bindings,
+    ...ownerAgentUserIds,
   )
+}
+
+const resolveBrowserOwnerAgentUserIds = async <
+  Session extends OperatorProSession,
+  Bindings extends OperatorProStatusEnv,
+>(
+  dependencies: OperatorProStatusDependencies<Session, Bindings>,
+  env: Bindings,
+  session: Session,
+): Promise<ReadonlyArray<string>> => {
+  const linkedAgents = await dependencies.listLinkedAgentsForOpenAuthUser?.(
+    session.user.userId,
+    100,
+    env,
+  )
+  if (linkedAgents === undefined) {
+    return []
+  }
+  return [
+    ...new Set(
+      linkedAgents
+        .filter(agent =>
+          agent.openauthUserId === undefined ||
+          agent.openauthUserId === null ||
+          agent.openauthUserId === session.user.userId,
+        )
+        .map(agent => agent.agentUserId)
+        .filter(agentUserId => agentUserId.trim() !== ''),
+    ),
+  ]
 }
 
 const buildSnapshot = async (
@@ -352,7 +421,11 @@ const authorizeRead = async <
     return forbidden()
   }
 
-  return { kind: 'browser', session }
+  return {
+    kind: 'browser',
+    ownerAgentUserIds: await resolveBrowserOwnerAgentUserIds(dependencies, env, session),
+    session,
+  }
 }
 
 const ownerForPylon = async (
@@ -415,7 +488,8 @@ const ingestEvent = async (
        updated_at = excluded.updated_at,
        retention_state = excluded.retention_state,
        event_json = excluded.event_json,
-       retained_at = excluded.retained_at`,
+       retained_at = excluded.retained_at
+     WHERE owner_agent_user_id = ?`,
     event.eventRef,
     ownerUserId,
     event.runnerRef,
@@ -435,6 +509,7 @@ const ingestEvent = async (
     }),
     nowIso,
     retentionState === 'retained' ? event.updatedAt : null,
+    ownerUserId,
   )
 }
 
@@ -495,6 +570,14 @@ export const makeOperatorProStatusRoutes = <
     if (safetyError !== null) {
       return jsonResponse(
         { error: 'unsafe_agent_runner_status_projection', message: safetyError },
+        { status: 400 },
+      )
+    }
+
+    const timestampError = validateIsoTimestamps(event)
+    if (timestampError !== null) {
+      return jsonResponse(
+        { error: 'invalid_agent_runner_status_event', message: timestampError },
         { status: 400 },
       )
     }

--- a/apps/openagents.com/workers/api/src/operator-pro-status-routes.ts
+++ b/apps/openagents.com/workers/api/src/operator-pro-status-routes.ts
@@ -14,7 +14,7 @@ import {
   readJsonObject,
 } from './json-boundary'
 import { openAgentsDatabase } from './runtime'
-import { currentIsoTimestamp } from './runtime-primitives'
+import { currentIsoTimestamp, isoTimestampToDate, normalizeIsoTimestamp } from './runtime-primitives'
 
 export const OPERATOR_PRO_STATUS_PATH = '/api/operator/pro/status'
 export const PYLON_AGENT_RUNNER_STATUS_EVENT_SCHEMA_VERSION =
@@ -189,8 +189,8 @@ const isIsoTimestamp = (value: string): boolean => {
   if (!isoTimestampPattern.test(value)) {
     return false
   }
-  const parsed = Date.parse(value)
-  return Number.isFinite(parsed) && new Date(parsed).toISOString() === value
+  const time = isoTimestampToDate(value).getTime()
+  return Number.isFinite(time) && normalizeIsoTimestamp(value) === value
 }
 
 const validateIsoTimestamps = (event: AgentRunnerStatusEvent): string | null => {

--- a/apps/pylon/src/assignment-status-producer.test.ts
+++ b/apps/pylon/src/assignment-status-producer.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, test } from "bun:test"
+
+import { postAssignmentRunnerStatusEvent } from "./assignment.js"
+
+describe("assignment status producer", () => {
+  test("posts public-safe agent runner status events to the operator spine", async () => {
+    const requests: Array<{ body: Record<string, unknown>; headers: Headers; url: string }> = []
+    const fetchImpl = (async (
+      url: Parameters<typeof fetch>[0],
+      init: Parameters<typeof fetch>[1],
+    ) => {
+      requests.push({
+        body: JSON.parse(String(init?.body)) as Record<string, unknown>,
+        headers: new Headers(init?.headers),
+        url: String(url),
+      })
+      return new Response(JSON.stringify({ ok: true }), { status: 200 })
+    }) as unknown as typeof fetch
+
+    const posted = await postAssignmentRunnerStatusEvent({
+      agentToken: "agent-token-fixture",
+      baseUrl: "https://openagents.example",
+      event: {
+        schema: "openagents.pylon.assignment_run_lifecycle_event.v0.1",
+        event: "assignment_run.accepted",
+        observedAt: "2026-07-01T12:00:00.000Z",
+        assignmentRef: "assignment.public.fixture",
+        leaseRef: "lease.public.fixture",
+        statusRef: "assignment.accepted.fixture",
+      },
+      fetch: fetchImpl,
+      pylonRef: "pylon.public.fixture",
+    })
+
+    expect(posted).toBe(true)
+    expect(requests).toHaveLength(1)
+    expect(requests[0]?.url).toBe("https://openagents.example/api/operator/pro/status")
+    expect(requests[0]?.headers.get("authorization")).toBe("Bearer agent-token-fixture")
+    expect(requests[0]?.body).toMatchObject({
+      schemaVersion: "openagents.pylon.agent_runner_status_event.v1",
+      state: "queued",
+      runnerKind: "local_command",
+      stateStartedAt: "2026-07-01T12:00:00.000Z",
+      updatedAt: "2026-07-01T12:00:00.000Z",
+    })
+    expect(String(requests[0]?.body.eventRef)).toStartWith("event.public.pylon.runner_status.")
+    expect(String(requests[0]?.body.assignmentRef)).toStartWith("assignment.public.pylon.")
+    expect(JSON.stringify(requests[0]?.body)).not.toContain("lease.public.fixture")
+  })
+
+  test("skips status publication when no agent credential is available", async () => {
+    let called = false
+    const posted = await postAssignmentRunnerStatusEvent({
+      baseUrl: "https://openagents.example",
+      event: {
+        schema: "openagents.pylon.assignment_run_lifecycle_event.v0.1",
+        event: "assignment_run.poll_complete",
+        observedAt: "2026-07-01T12:00:00.000Z",
+      },
+      fetch: (async () => {
+        called = true
+        return new Response(null, { status: 204 })
+      }) as unknown as typeof fetch,
+      pylonRef: "pylon.public.fixture",
+    })
+
+    expect(posted).toBe(false)
+    expect(called).toBe(false)
+  })
+})

--- a/apps/pylon/src/assignment.ts
+++ b/apps/pylon/src/assignment.ts
@@ -13,6 +13,7 @@ import {
   encodePylonAssignmentRunLifecycleEvent,
   type PylonAssignmentRunLifecycleEvent,
 } from "@openagentsinc/agent-runtime-schema"
+import { encodeAgentRunnerStatusEventForAssignmentLifecycleEvent } from "./orchestration/status-control.js"
 import type { BootstrapSummary } from "./bootstrap.js"
 import {
   loadClaudeAgentConfig,
@@ -276,6 +277,7 @@ type PublicPylonAssignmentProjection = Readonly<{
 }>
 
 const DEFAULT_ASSIGNMENT_REQUEST_TIMEOUT_MS = 30_000
+const OPERATOR_PRO_STATUS_PATH = "/api/operator/pro/status"
 
 function stableRef(prefix: string, value: string) {
   return `${prefix}.${createHash("sha256").update(value).digest("hex").slice(0, 24)}`
@@ -1167,6 +1169,43 @@ async function postJson(
   return json
 }
 
+export async function postAssignmentRunnerStatusEvent(input: {
+  agentToken?: string
+  baseUrl: string
+  event: AssignmentRunLifecycleEvent
+  fetch?: typeof fetch
+  pylonRef: string
+  requestTimeoutMs?: number
+  runnerKind?: string
+}): Promise<boolean> {
+  if (input.agentToken === undefined || input.agentToken.trim() === "") {
+    return false
+  }
+  const body = encodeAgentRunnerStatusEventForAssignmentLifecycleEvent({
+    event: input.event,
+    pylonRef: input.pylonRef,
+    ...(input.runnerKind === undefined ? {} : { runnerKind: input.runnerKind }),
+  })
+  assertPublicProjectionSafe(body)
+  const fetchImpl = input.fetch ?? fetch
+  const response = await fetchImpl(
+    new URL(OPERATOR_PRO_STATUS_PATH, input.baseUrl).toString(),
+    {
+      body: JSON.stringify(body),
+      headers: {
+        authorization: `Bearer ${input.agentToken}`,
+        "content-type": "application/json",
+      },
+      method: "POST",
+      signal: assignmentRequestSignal({
+        baseUrl: input.baseUrl,
+        ...(input.requestTimeoutMs === undefined ? {} : { requestTimeoutMs: input.requestTimeoutMs }),
+      }),
+    },
+  )
+  return response.ok
+}
+
 async function getJson(options: AssignmentClientOptions, path: string, state: PylonLocalState) {
   const fetchImpl = options.fetch ?? fetch
   const url = new URL(path, options.baseUrl).toString()
@@ -1655,10 +1694,26 @@ export async function runNoSpendAssignment(summary: BootstrapSummary, options: A
   let lastProgressEvent: AssignmentRunLifecycleEvent["event"] | undefined
   let latestRuntimeTokensSoFar: number | undefined
   let latestRuntimeTokenCountKind: "exact" | "estimated" | undefined
+  let localPylonRef: string | undefined
+  const publishRunnerStatusEvent = async (event: AssignmentRunLifecycleEvent) => {
+    if (localPylonRef === undefined) return
+    try {
+      await postAssignmentRunnerStatusEvent({
+        ...(options.agentToken === undefined ? {} : { agentToken: options.agentToken }),
+        baseUrl: options.baseUrl,
+        event,
+        ...(options.fetch === undefined ? {} : { fetch: options.fetch }),
+        pylonRef: localPylonRef,
+        ...(options.requestTimeoutMs === undefined ? {} : { requestTimeoutMs: options.requestTimeoutMs }),
+      })
+    } catch {
+      // Status spine publication is operator observability. Assignment
+      // execution and closeout remain source-of-truth if the route is down.
+    }
+  }
   const emitLifecycleEvent = async (
     event: Omit<AssignmentRunLifecycleEvent, "schema" | "observedAt">,
   ) => {
-    if (options.onLifecycleEvent === undefined) return
     try {
       const lifecycleEvent: AssignmentRunLifecycleEvent = {
         schema: "openagents.pylon.assignment_run_lifecycle_event.v0.1",
@@ -1667,7 +1722,10 @@ export async function runNoSpendAssignment(summary: BootstrapSummary, options: A
       }
       const encodedLifecycleEvent = encodePylonAssignmentRunLifecycleEvent(lifecycleEvent)
       assertPublicProjectionSafe(encodedLifecycleEvent)
-      await options.onLifecycleEvent(encodedLifecycleEvent)
+      await publishRunnerStatusEvent(encodedLifecycleEvent)
+      if (options.onLifecycleEvent !== undefined) {
+        await options.onLifecycleEvent(encodedLifecycleEvent)
+      }
       if (event.event !== "assignment_run.runtime_progress") {
         lastProgressEvent = event.event
       }
@@ -1741,12 +1799,20 @@ export async function runNoSpendAssignment(summary: BootstrapSummary, options: A
     })
   }
   const state = await ensurePylonLocalState(summary)
+  localPylonRef = state.identity.pylonRef
   const observedAtDate = options.now?.() ?? new Date()
   await closeoutInterruptedNoSpendLeases(summary, state, options, observedAtDate)
   const store = await loadPrunedAssignmentStore(state, observedAtDate, options)
   let presenceRefreshError: unknown
   try {
     await heartbeatRefresh()
+    await publishRunnerStatusEvent({
+      schema: "openagents.pylon.assignment_run_lifecycle_event.v0.1",
+      event: "assignment_run.poll_complete",
+      observedAt: (options.now?.() ?? new Date()).toISOString(),
+      leaseCount: 0,
+      candidateCount: 0,
+    })
   } catch (error) {
     presenceRefreshError = error
   }

--- a/apps/pylon/src/orchestration/status-control.ts
+++ b/apps/pylon/src/orchestration/status-control.ts
@@ -6,6 +6,7 @@ import {
   type AgentRunnerNeutralState,
   type AgentRunnerStatusEvent,
 } from "../agent-status-reporter.js"
+import type { PylonAssignmentRunLifecycleEvent } from "@openagentsinc/agent-runtime-schema"
 import type { DispatchContext, OrchestrationTask } from "./store.js"
 
 const stableRef = (prefix: string, value: string): string =>
@@ -88,4 +89,75 @@ export function encodeAgentRunnerStatusEventForDispatchContext(input: {
   now?: Date
 }): Record<string, unknown> {
   return encodeAgentRunnerStatusEvent(agentRunnerStatusEventForDispatchContext(input))
+}
+
+export function neutralStateForAssignmentLifecycleEvent(
+  event: PylonAssignmentRunLifecycleEvent,
+): AgentRunnerNeutralState {
+  if (event.event === "assignment_run.no_assignment") return "waiting"
+  if (event.event === "assignment_run.runtime_failed") return "failed"
+  if (event.event === "assignment_run.completed") {
+    return event.status === "accepted" ? "done" : "failed"
+  }
+  if (event.event === "assignment_run.poll_complete") return "queued"
+  if (event.event === "assignment_run.accepted") return "queued"
+  if (event.event === "assignment_run.progress_submitted") return "working"
+  if (event.event === "assignment_run.artifacts_submitted") return "working"
+  if (event.event === "assignment_run.closeout_submitted") return "done"
+  return "working"
+}
+
+export function agentRunnerStatusEventForAssignmentLifecycleEvent(input: {
+  event: PylonAssignmentRunLifecycleEvent
+  pylonRef: string
+  runnerKind?: string
+}): AgentRunnerStatusEvent {
+  const state = neutralStateForAssignmentLifecycleEvent(input.event)
+  const assignmentRef = input.event.assignmentRef
+  const leaseRef = input.event.leaseRef
+  const runnerKind = input.runnerKind ?? "local_command"
+  const runnerRef = stableRef(
+    "runner.public.pylon",
+    `${input.pylonRef}:${assignmentRef ?? leaseRef ?? "assignment-poll"}:${runnerKind}`,
+  )
+  const eventRef = stableRef(
+    "event.public.pylon.runner_status",
+    `${runnerRef}:${input.event.event}:${state}:${input.event.observedAt}:${assignmentRef ?? ""}:${leaseRef ?? ""}`,
+  )
+  return {
+    eventRef,
+    runnerRef,
+    runnerKind,
+    state,
+    stateStartedAt: input.event.observedAt,
+    updatedAt: input.event.observedAt,
+    ...(assignmentRef === undefined
+      ? {}
+      : { assignmentRef: stableRef("assignment.public.pylon", assignmentRef) }),
+    ...(input.pylonRef === undefined ? {} : { pylonRef: stableRef("pylon.public", input.pylonRef) }),
+    supportedControlVerbs: PYLON_AGENT_RUNNER_CONTROL_VERBS,
+    refs: [
+      `assignment-event.pylon.${input.event.event.replaceAll("_", "-").replaceAll(".", "-")}`,
+      ...(input.event.status === undefined ? [] : [`assignment-status.pylon.${input.event.status}`]),
+      ...(input.event.statusRef === undefined ? [] : [stableRef("status.public.pylon", input.event.statusRef)]),
+      ...(input.event.progressRef === undefined ? [] : [stableRef("status.public.pylon", input.event.progressRef)]),
+      ...(input.event.artifactRef === undefined ? [] : [stableRef("status.public.pylon", input.event.artifactRef)]),
+      ...(input.event.closeoutRef === undefined ? [] : [stableRef("status.public.pylon", input.event.closeoutRef)]),
+    ],
+    blockerRefs: input.event.blockerRefs ?? [],
+    stateHistory: [
+      {
+        state,
+        stateStartedAt: input.event.observedAt,
+      },
+    ],
+  }
+}
+
+export function encodeAgentRunnerStatusEventForAssignmentLifecycleEvent(input: {
+  event: PylonAssignmentRunLifecycleEvent
+  pylonRef: string
+  runnerKind?: string
+}): Record<string, unknown> {
+  return encodeAgentRunnerStatusEvent(agentRunnerStatusEventForAssignmentLifecycleEvent(input))
 }

--- a/packages/ui/src/pro.ts
+++ b/packages/ui/src/pro.ts
@@ -761,7 +761,7 @@ const proDashboardSummary = <Message>(
         ],
       ),
       h.p([h.Class('m-0 text-xs text-white/35 md:col-span-2')], [
-        `Generated ${snapshot.generatedAt}. Public-safe sample data only; no private prompts, raw logs, wallet material, or provider payloads are rendered.`,
+        `Generated ${snapshot.generatedAt}. Public-safe owner-scoped status data only; no private prompts, raw logs, wallet material, or provider payloads are rendered.`,
       ]),
     ],
   )


### PR DESCRIPTION
Closes #7878

## Summary
- add owner-scoped `agent_runner_status_event.v1` ingest/read storage for `/api/operator/pro/status`
- load `/pro` from the runner-neutral status spine instead of local hardcoded sample rows
- cover ingest safety/projection and `/pro` fixture rendering

## Verification
- `bun run --cwd apps/openagents.com/workers/api typecheck` (command.public.pylon_khala.verify.8f7864b4aca21d6ed4e8726a)
- `bun run --cwd apps/openagents.com/workers/api test -- src/operator-pro-status-routes.test.ts`
- `bun run --cwd apps/openagents.com/apps/web test -- src/page/loggedIn/page/pro.test.ts`
- `bun run --cwd apps/openagents.com/apps/web typecheck`
- `bun run --cwd apps/openagents.com/apps/web test -- src/page/loggedIn/view.scene.test.ts -t "renders the /pro operator dashboard"`
- `bun run --cwd apps/openagents.com check:deploy`