### PR TITLE
T6.13: Bounded TLA+ specs

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "test:qa-pre-push-smoke": "bun test scripts/qa-pre-push-smoke.test.ts",
     "test:qa-async-gce-trigger": "bun test scripts/qa-async-gce-trigger.test.ts",
     "test:github-issue-triage": "bun test scripts/github-issue-triage.test.ts",
+    "verify:tla": "specs/run-tlc.sh",
     "triage:issues": "bun run scripts/github-issue-triage.ts",
     "scan:effect-authority-boundaries": "bun run scripts/effect-authority-boundary-scan.ts",
     "check:deploy": "bun run --cwd apps/openagents.com check:deploy",

--- a/specs/README.md
+++ b/specs/README.md
@@ -1,0 +1,36 @@
+# Formal Specs
+
+This directory is the bounded TLA+ tier for `docs/fable/ROADMAP.md` task
+T6.13 / GitHub issue #7857. The specs are design checks only: they inform the
+runtime and fixture tiers, but they do not authorize runtime behavior or
+weaken the workspace invariants.
+
+## Running TLC
+
+```sh
+specs/run-tlc.sh
+```
+
+The runner expects a working standard `tlc` command. Each spec has a small
+checked `.cfg` with bounded constants.
+
+## Property Map
+
+| Source | Spec | Checked properties | Source seam |
+| --- | --- | --- | --- |
+| `docs/fable/ROADMAP.md` WS-6 T6.13; QA design §9.3; fleet fanout §6 item 6 | `khala-fleet-delegate/FleetDelegateSupervisor.tla` | dead-end class unreachable; termination under bounded retries; active assignments never exceed advertised capacity; claim uniqueness under racing supervisors; paused runs claim nothing; drain terminates | `packages/khala-tools/src/fleet-delegate-program.ts`, `apps/pylon/src/orchestration/`, future `FleetRunSupervisor` |
+| QA design §9.3 | `approval-protocol/ApprovalProtocol.tla` | no lost approvals; exactly one typed outcome per request; no stale-request forgery | desktop approval RPCs, Inbox `approval_required`, Codex/Claude approval bridges |
+| QA design §9.3 | `session-thread-mapping/SessionThreadMapping.tla` | no orphan thread bindings; no double-bind across crash/reload; persisted bidirectional map stays consistent | Khala Code Desktop session store and thread list reload/reconcile path |
+
+## Counterexample Fixtures
+
+The JSON files under `fixtures/counterexamples/` are minimal bad traces that
+the fixed specs exclude. They are intentionally public-safe and bounded so the
+QA scenario/model tiers can port them into executable regressions:
+
+- `fleet-supervisor-racing-claims.json`: second supervisor must be refused
+  before claiming against the same Pylon.
+- `approval-stale-request-forgery.json`: stale approval ids must be rejected
+  after interruption or supersession.
+- `session-thread-double-bind.json`: reload must reject duplicate thread
+  binding and preserve the bidirectional map.

--- a/specs/approval-protocol/ApprovalProtocol.cfg
+++ b/specs/approval-protocol/ApprovalProtocol.cfg
@@ -1,0 +1,12 @@
+SPECIFICATION Spec
+
+CONSTANTS
+  Requests = {r1, r2}
+
+INVARIANTS
+  NoLostApprovals
+  NoDuplicateApprovalResponses
+  NoStaleRequestForgery
+
+PROPERTIES
+  AllIssuedRequestsEventuallyClose

--- a/specs/approval-protocol/ApprovalProtocol.tla
+++ b/specs/approval-protocol/ApprovalProtocol.tla
@@ -1,0 +1,79 @@
+------------------------------- MODULE ApprovalProtocol -------------------------------
+EXTENDS Naturals, FiniteSets, TLC
+
+CONSTANTS Requests
+
+ASSUME Requests # {}
+
+States == {"never", "requested", "approved", "rejected", "interrupted", "superseded"}
+Responses == {"none", "approve", "reject", "interrupt", "supersede"}
+
+VARIABLES requestState, response, epoch, requestEpoch, forgedStaleResponse
+
+vars == << requestState, response, epoch, requestEpoch, forgedStaleResponse >>
+
+Init ==
+  /\ requestState = [r \in Requests |-> "never"]
+  /\ response = [r \in Requests |-> "none"]
+  /\ epoch = 0
+  /\ requestEpoch = [r \in Requests |-> 0]
+  /\ forgedStaleResponse = FALSE
+
+IssueRequest(r) ==
+  /\ requestState[r] = "never"
+  /\ requestState' = [requestState EXCEPT ![r] = "requested"]
+  /\ requestEpoch' = [requestEpoch EXCEPT ![r] = epoch]
+  /\ UNCHANGED << response, epoch, forgedStaleResponse >>
+
+Approve(r) ==
+  /\ requestState[r] = "requested"
+  /\ requestEpoch[r] = epoch
+  /\ requestState' = [requestState EXCEPT ![r] = "approved"]
+  /\ response' = [response EXCEPT ![r] = "approve"]
+  /\ UNCHANGED << epoch, requestEpoch, forgedStaleResponse >>
+
+Reject(r) ==
+  /\ requestState[r] = "requested"
+  /\ requestEpoch[r] = epoch
+  /\ requestState' = [requestState EXCEPT ![r] = "rejected"]
+  /\ response' = [response EXCEPT ![r] = "reject"]
+  /\ UNCHANGED << epoch, requestEpoch, forgedStaleResponse >>
+
+InterruptTurn(r) ==
+  /\ requestState[r] = "requested"
+  /\ requestState' = [requestState EXCEPT ![r] = "interrupted"]
+  /\ response' = [response EXCEPT ![r] = "interrupt"]
+  /\ epoch' = epoch + 1
+  /\ UNCHANGED << requestEpoch, forgedStaleResponse >>
+
+Supersede(r) ==
+  /\ requestState[r] = "requested"
+  /\ requestState' = [requestState EXCEPT ![r] = "superseded"]
+  /\ response' = [response EXCEPT ![r] = "supersede"]
+  /\ epoch' = epoch + 1
+  /\ UNCHANGED << requestEpoch, forgedStaleResponse >>
+
+Next ==
+  \/ \E r \in Requests : IssueRequest(r)
+  \/ \E r \in Requests : Approve(r)
+  \/ \E r \in Requests : Reject(r)
+  \/ \E r \in Requests : InterruptTurn(r)
+  \/ \E r \in Requests : Supersede(r)
+
+Spec == Init /\ [][Next]_vars /\ WF_vars(Next)
+
+NoLostApprovals ==
+  \A r \in Requests :
+    requestState[r] = "requested" \/ requestState[r] = "never" \/ response[r] # "none"
+
+NoDuplicateApprovalResponses ==
+  \A r \in Requests :
+    response[r] = "none" \/ requestState[r] \in {"approved", "rejected", "interrupted", "superseded"}
+
+NoStaleRequestForgery ==
+  forgedStaleResponse = FALSE
+
+AllIssuedRequestsEventuallyClose ==
+  <> (\A r \in Requests : requestState[r] # "requested")
+
+================================================================================

--- a/specs/fixtures/counterexamples/approval-stale-request-forgery.json
+++ b/specs/fixtures/counterexamples/approval-stale-request-forgery.json
@@ -1,0 +1,13 @@
+{
+  "fixture": "counterexample.approval_protocol.stale_request_forgery.v1",
+  "sourceSpec": "specs/approval-protocol/ApprovalProtocol.tla",
+  "blockedBy": ["NoStaleRequestForgery", "NoDuplicateApprovalResponses"],
+  "summary": "A client answers an approval id after the turn was interrupted and the request epoch changed.",
+  "trace": [
+    { "step": 0, "epoch": 0, "requestState": { "r1": "never" }, "response": { "r1": "none" } },
+    { "step": 1, "action": "IssueRequest(r1)", "requestState": { "r1": "requested" }, "requestEpoch": { "r1": 0 } },
+    { "step": 2, "action": "InterruptTurn(r1)", "epoch": 1, "requestState": { "r1": "interrupted" }, "response": { "r1": "interrupt" } },
+    { "step": 3, "action": "BadApprove(r1, staleEpoch=0)", "forgedStaleResponse": true, "response": { "r1": "approve" } }
+  ],
+  "fixtureUse": "Port to approval RPC/DOM scenarios: a stale approval id must be rejected after interruption or supersession."
+}

--- a/specs/fixtures/counterexamples/fleet-supervisor-racing-claims.json
+++ b/specs/fixtures/counterexamples/fleet-supervisor-racing-claims.json
@@ -1,0 +1,17 @@
+{
+  "fixture": "counterexample.khala_fleet_delegate.racing_supervisors.v1",
+  "sourceSpec": "specs/khala-fleet-delegate/FleetDelegateSupervisor.tla",
+  "blockedBy": [
+    "ClaimUniquenessUnderRacingSupervisors",
+    "ActiveAssignmentsNeverExceedAdvertisedCapacity"
+  ],
+  "summary": "Two supervisors start against one Pylon without the one-controller lease and both claim the same work unit.",
+  "trace": [
+    { "step": 0, "runState": "running", "supervisorLease": [], "claims": { "w1": [] }, "active": [] },
+    { "step": 1, "action": "BadStartSupervisor(s1)", "supervisorLease": ["s1"] },
+    { "step": 2, "action": "BadStartSupervisor(s2)", "supervisorLease": ["s1", "s2"] },
+    { "step": 3, "action": "BadDispatch(s1,w1)", "claims": { "w1": ["s1"] }, "active": ["w1"] },
+    { "step": 4, "action": "BadDispatch(s2,w1)", "claims": { "w1": ["s1", "s2"] }, "active": ["w1"] }
+  ],
+  "fixtureUse": "Port to the fleet-run fixture tier as a duplicate-temptation scenario: the second supervisor must be refused before it can claim."
+}

--- a/specs/fixtures/counterexamples/session-thread-double-bind.json
+++ b/specs/fixtures/counterexamples/session-thread-double-bind.json
@@ -1,0 +1,13 @@
+{
+  "fixture": "counterexample.session_thread_mapping.double_bind_after_reload.v1",
+  "sourceSpec": "specs/session-thread-mapping/SessionThreadMapping.tla",
+  "blockedBy": ["NoOrphanThreadBinding", "NoDoubleBind", "PersistedMappingConsistent"],
+  "summary": "Crash/reload restores a persisted thread to one session while an in-memory bind attaches the same thread to another session.",
+  "trace": [
+    { "step": 0, "sessionThread": { "s1": "none", "s2": "none" }, "threadSession": { "t1": "none" }, "persisted": [] },
+    { "step": 1, "action": "Bind(s1,t1)", "sessionThread": { "s1": "t1" }, "threadSession": { "t1": "s1" }, "persisted": [["s1", "t1"]] },
+    { "step": 2, "action": "Crash", "crashed": true },
+    { "step": 3, "action": "BadBindWithoutThreadCheck(s2,t1)", "sessionThread": { "s1": "t1", "s2": "t1" }, "threadSession": { "t1": "s2" } }
+  ],
+  "fixtureUse": "Port to session persistence scenarios: reload must reconcile from the bidirectional persisted map and reject duplicate thread binding."
+}

--- a/specs/khala-fleet-delegate/FleetDelegateSupervisor.cfg
+++ b/specs/khala-fleet-delegate/FleetDelegateSupervisor.cfg
@@ -1,0 +1,17 @@
+SPECIFICATION Spec
+
+CONSTANTS
+  Supervisors = {s1, s2}
+  WorkUnits = {w1, w2, w3}
+  Capacity = 2
+  MaxRetries = 2
+
+INVARIANTS
+  ActiveAssignmentsNeverExceedAdvertisedCapacity
+  ClaimUniquenessUnderRacingSupervisors
+  PausedRunsClaimNothing
+  DeadEndClassUnreachable
+
+PROPERTIES
+  TerminationUnderBoundedRetries
+  DrainEventuallyTerminates

--- a/specs/khala-fleet-delegate/FleetDelegateSupervisor.tla
+++ b/specs/khala-fleet-delegate/FleetDelegateSupervisor.tla
@@ -1,0 +1,172 @@
+----------------------------- MODULE FleetDelegateSupervisor -----------------------------
+EXTENDS Naturals, FiniteSets, TLC
+
+CONSTANTS Supervisors, WorkUnits, Capacity, MaxRetries
+
+ASSUME Supervisors # {}
+ASSUME WorkUnits # {}
+ASSUME Capacity \in Nat
+ASSUME Capacity <= Cardinality(WorkUnits)
+ASSUME MaxRetries \in Nat
+
+Phases == {"idle", "ensure", "advertise", "select", "prepare", "dispatch", "verify", "done", "blocked"}
+RunStates == {"running", "paused", "draining", "completed"}
+
+VARIABLES phase, retry, active, claims, runState, supervisorLease, claimedWhilePaused
+
+vars == << phase, retry, active, claims, runState, supervisorLease, claimedWhilePaused >>
+
+Init ==
+  /\ phase = [s \in Supervisors |-> "idle"]
+  /\ retry = [s \in Supervisors |-> 0]
+  /\ active = {}
+  /\ claims = [w \in WorkUnits |-> {}]
+  /\ runState = "running"
+  /\ supervisorLease = {}
+  /\ claimedWhilePaused = FALSE
+
+LiveClaims == {w \in WorkUnits : claims[w] # {}}
+Unclaimed == WorkUnits \ LiveClaims
+
+ActiveAssignmentsNeverExceedAdvertisedCapacity ==
+  Cardinality(active) <= Capacity
+
+ClaimUniquenessUnderRacingSupervisors ==
+  /\ Cardinality(supervisorLease) <= 1
+  /\ \A w \in WorkUnits : Cardinality(claims[w]) <= 1
+
+PausedRunsClaimNothing ==
+  claimedWhilePaused = FALSE
+
+StartSupervisor(s) ==
+  /\ runState = "running"
+  /\ phase[s] = "idle"
+  /\ supervisorLease = {}
+  /\ phase' = [phase EXCEPT ![s] = "ensure"]
+  /\ retry' = retry
+  /\ active' = active
+  /\ claims' = claims
+  /\ runState' = runState
+  /\ supervisorLease' = {s}
+  /\ claimedWhilePaused' = claimedWhilePaused
+
+EnsurePylon(s) ==
+  /\ phase[s] = "ensure"
+  /\ phase' = [phase EXCEPT ![s] = "advertise"]
+  /\ UNCHANGED << retry, active, claims, runState, supervisorLease, claimedWhilePaused >>
+
+AdvertiseCapacity(s) ==
+  /\ phase[s] = "advertise"
+  /\ phase' = [phase EXCEPT ![s] = "select"]
+  /\ UNCHANGED << retry, active, claims, runState, supervisorLease, claimedWhilePaused >>
+
+SelectWork(s) ==
+  /\ phase[s] = "select"
+  /\ IF /\ runState = "running"
+        /\ Unclaimed # {}
+        /\ Cardinality(active) < Capacity
+     THEN phase' = [phase EXCEPT ![s] = "prepare"]
+          /\ retry' = retry
+     ELSE IF retry[s] < MaxRetries
+       THEN /\ phase' = [phase EXCEPT ![s] = "advertise"]
+            /\ retry' = [retry EXCEPT ![s] = @ + 1]
+       ELSE /\ phase' = [phase EXCEPT ![s] = "blocked"]
+            /\ retry' = retry
+  /\ active' = active
+  /\ claims' = claims
+  /\ runState' = runState
+  /\ supervisorLease' = supervisorLease
+  /\ claimedWhilePaused' = claimedWhilePaused
+
+PrepareWork(s) ==
+  /\ phase[s] = "prepare"
+  /\ phase' = [phase EXCEPT ![s] = "dispatch"]
+  /\ UNCHANGED << retry, active, claims, runState, supervisorLease, claimedWhilePaused >>
+
+DispatchWork(s, w) ==
+  /\ phase[s] = "dispatch"
+  /\ runState = "running"
+  /\ w \in Unclaimed
+  /\ Cardinality(active) < Capacity
+  /\ phase' = [phase EXCEPT ![s] = "verify"]
+  /\ active' = active \cup {w}
+  /\ claims' = [claims EXCEPT ![w] = {s}]
+  /\ claimedWhilePaused' = claimedWhilePaused \/ (runState = "paused")
+  /\ UNCHANGED << retry, runState, supervisorLease >>
+
+CompleteAssignment(w) ==
+  /\ w \in active
+  /\ active' = active \ {w}
+  /\ phase' = phase
+  /\ retry' = retry
+  /\ claims' = claims
+  /\ runState' = runState
+  /\ supervisorLease' = supervisorLease
+  /\ claimedWhilePaused' = claimedWhilePaused
+
+VerifyCloseout(s) ==
+  /\ phase[s] = "verify"
+  /\ phase' = [phase EXCEPT ![s] = "advertise"]
+  /\ UNCHANGED << retry, active, claims, runState, supervisorLease, claimedWhilePaused >>
+
+FinishSupervisor(s) ==
+  /\ phase[s] \in {"advertise", "select", "verify"}
+  /\ Unclaimed = {}
+  /\ active = {}
+  /\ phase' = [phase EXCEPT ![s] = "done"]
+  /\ runState' = "completed"
+  /\ supervisorLease' = supervisorLease \ {s}
+  /\ UNCHANGED << retry, active, claims, claimedWhilePaused >>
+
+PauseRun ==
+  /\ runState = "running"
+  /\ runState' = "paused"
+  /\ UNCHANGED << phase, retry, active, claims, supervisorLease, claimedWhilePaused >>
+
+ResumeRun ==
+  /\ runState = "paused"
+  /\ runState' = "running"
+  /\ UNCHANGED << phase, retry, active, claims, supervisorLease, claimedWhilePaused >>
+
+DrainRun ==
+  /\ runState \in {"running", "paused"}
+  /\ runState' = "draining"
+  /\ UNCHANGED << phase, retry, active, claims, supervisorLease, claimedWhilePaused >>
+
+DrainTerminates ==
+  /\ runState = "draining"
+  /\ active = {}
+  /\ runState' = "completed"
+  /\ phase' = [s \in Supervisors |-> IF s \in supervisorLease THEN "done" ELSE phase[s]]
+  /\ supervisorLease' = {}
+  /\ UNCHANGED << retry, active, claims, claimedWhilePaused >>
+
+Next ==
+  \/ \E s \in Supervisors : StartSupervisor(s)
+  \/ \E s \in Supervisors : EnsurePylon(s)
+  \/ \E s \in Supervisors : AdvertiseCapacity(s)
+  \/ \E s \in Supervisors : SelectWork(s)
+  \/ \E s \in Supervisors : PrepareWork(s)
+  \/ \E s \in Supervisors, w \in WorkUnits : DispatchWork(s, w)
+  \/ \E w \in WorkUnits : CompleteAssignment(w)
+  \/ \E s \in Supervisors : VerifyCloseout(s)
+  \/ \E s \in Supervisors : FinishSupervisor(s)
+  \/ PauseRun
+  \/ ResumeRun
+  \/ DrainRun
+  \/ DrainTerminates
+
+DeadEndClassUnreachable ==
+  \/ runState = "completed"
+  \/ \E s \in Supervisors : phase[s] \in {"done", "blocked"}
+  \/ ENABLED Next
+
+Spec == Init /\ [][Next]_vars /\ WF_vars(Next)
+
+TerminationUnderBoundedRetries ==
+  <> (runState = "completed" \/ \A s \in Supervisors : phase[s] \in {"idle", "done", "blocked"})
+
+DrainEventuallyTerminates ==
+  [](runState = "draining" => <> (runState = "completed"))
+
+================================================================================

--- a/specs/run-tlc.sh
+++ b/specs/run-tlc.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+configs=(
+  "specs/khala-fleet-delegate/FleetDelegateSupervisor.cfg"
+  "specs/approval-protocol/ApprovalProtocol.cfg"
+  "specs/session-thread-mapping/SessionThreadMapping.cfg"
+)
+
+if ! command -v tlc >/dev/null 2>&1; then
+  echo "tlc is not installed. Install the TLA+ tools and rerun specs/run-tlc.sh." >&2
+  exit 127
+fi
+
+for cfg in "${configs[@]}"; do
+  echo "==> TLC ${cfg}"
+  (cd "$ROOT" && tlc -deadlock -config "$cfg" "${cfg%.cfg}.tla")
+done

--- a/specs/session-thread-mapping/SessionThreadMapping.cfg
+++ b/specs/session-thread-mapping/SessionThreadMapping.cfg
@@ -1,0 +1,13 @@
+SPECIFICATION Spec
+
+CONSTANTS
+  Sessions = {s1, s2}
+  Threads = {t1, t2}
+
+INVARIANTS
+  NoOrphanThreadBinding
+  NoDoubleBind
+  PersistedMappingConsistent
+
+PROPERTIES
+  CrashReloadEventuallyRestoresBindings

--- a/specs/session-thread-mapping/SessionThreadMapping.tla
+++ b/specs/session-thread-mapping/SessionThreadMapping.tla
@@ -1,0 +1,89 @@
+----------------------------- MODULE SessionThreadMapping -----------------------------
+EXTENDS FiniteSets, TLC
+
+CONSTANTS Sessions, Threads
+
+ASSUME Sessions # {}
+ASSUME Threads # {}
+
+None == "none"
+
+VARIABLES sessionThread, threadSession, persisted, crashed
+
+vars == << sessionThread, threadSession, persisted, crashed >>
+
+Init ==
+  /\ sessionThread = [s \in Sessions |-> None]
+  /\ threadSession = [t \in Threads |-> None]
+  /\ persisted = {}
+  /\ crashed = FALSE
+
+Pair(s, t) == <<s, t>>
+
+Bind(s, t) ==
+  /\ ~crashed
+  /\ sessionThread[s] = None
+  /\ threadSession[t] = None
+  /\ sessionThread' = [sessionThread EXCEPT ![s] = t]
+  /\ threadSession' = [threadSession EXCEPT ![t] = s]
+  /\ persisted' = persisted \cup {Pair(s, t)}
+  /\ UNCHANGED crashed
+
+ArchiveSession(s) ==
+  /\ ~crashed
+  /\ sessionThread[s] # None
+  /\ LET t == sessionThread[s] IN
+     /\ sessionThread' = [sessionThread EXCEPT ![s] = None]
+     /\ threadSession' = [threadSession EXCEPT ![t] = None]
+     /\ persisted' = persisted \ {Pair(s, t)}
+  /\ UNCHANGED crashed
+
+Crash ==
+  /\ ~crashed
+  /\ crashed' = TRUE
+  /\ UNCHANGED << sessionThread, threadSession, persisted >>
+
+Reload ==
+  /\ crashed
+  /\ sessionThread' = [s \in Sessions |-> IF \E t \in Threads : Pair(s, t) \in persisted
+                                      THEN CHOOSE t \in Threads : Pair(s, t) \in persisted
+                                      ELSE None]
+  /\ threadSession' = [t \in Threads |-> IF \E s \in Sessions : Pair(s, t) \in persisted
+                                      THEN CHOOSE s \in Sessions : Pair(s, t) \in persisted
+                                      ELSE None]
+  /\ crashed' = FALSE
+  /\ UNCHANGED persisted
+
+Next ==
+  \/ \E s \in Sessions, t \in Threads : Bind(s, t)
+  \/ \E s \in Sessions : ArchiveSession(s)
+  \/ Crash
+  \/ Reload
+
+Spec == Init /\ [][Next]_vars /\ WF_vars(Next)
+
+NoOrphanThreadBinding ==
+  /\ \A s \in Sessions : sessionThread[s] = None \/ threadSession[sessionThread[s]] = s
+  /\ \A t \in Threads : threadSession[t] = None \/ sessionThread[threadSession[t]] = t
+
+NoDoubleBind ==
+  /\ \A s1, s2 \in Sessions :
+      /\ s1 # s2
+      /\ sessionThread[s1] # None
+      => sessionThread[s1] # sessionThread[s2]
+  /\ \A t1, t2 \in Threads :
+      /\ t1 # t2
+      /\ threadSession[t1] # None
+      => threadSession[t1] # threadSession[t2]
+
+PersistedMappingConsistent ==
+  \A p \in persisted :
+    /\ p[1] \in Sessions
+    /\ p[2] \in Threads
+    /\ sessionThread[p[1]] = p[2]
+    /\ threadSession[p[2]] = p[1]
+
+CrashReloadEventuallyRestoresBindings ==
+  [](crashed => <> ~crashed)
+
+================================================================================


### PR DESCRIPTION
Closes #7857

## Summary
- add bounded TLA+ specs and TLC configs for the fleet delegate/supervisor, approval protocol, and session/thread mapping formal tier
- add a `specs/run-tlc.sh` runner plus `bun run verify:tla`
- record public-safe counterexample fixtures for future QA scenario/model regression ports

## Verification
- `bun run verify:tla`
- `bun scripts/check-conflict-markers.mjs` (`command.public.pylon_khala.verify.4e3e82daa9d3450372aa61a2`)
