### PR TITLE
khala-code plans: land the #7970 review fixes that missed the merge window

### DIFF
--- a/apps/openagents.com/workers/api/src/inference/inference-privacy-receipt-routes.ts
+++ b/apps/openagents.com/workers/api/src/inference/inference-privacy-receipt-routes.ts
@@ -289,15 +289,18 @@ export const grantPaidPrivacyEntitlement = async (
     )
     .run()
 
+  // Read back by key AND account: the idempotency_key column is globally
+  // unique across purchase surfaces, so without the account guard a key
+  // collision would return (and publicly attribute) another account's receipt.
   return await db
     .prepare(
       `SELECT receipt_ref, entitlement_ref, account_ref, purchase_ref,
               privacy_tier, capture_excluded, reason_ref, created_at, updated_at
          FROM inference_privacy_entitlement_receipts
-        WHERE idempotency_key = ?
+        WHERE idempotency_key = ? AND account_ref = ?
         LIMIT 1`,
     )
-    .bind(input.idempotencyKey)
+    .bind(input.idempotencyKey, input.accountRef)
     .first<PrivacyEntitlementReceiptRow>()
 }
 
@@ -333,15 +336,17 @@ export const recordConfidentialComputeExecutionReceipt = async (
     )
     .run()
 
+  // Same key-collision guard as the entitlement read-back: never return
+  // another account's receipt row on an idempotency-key collision.
   return await db
     .prepare(
       `SELECT receipt_ref, execution_ref, account_ref, request_ref,
               capture_excluded, reason_ref, created_at, updated_at
          FROM inference_confidential_compute_execution_receipts
-        WHERE idempotency_key = ?
+        WHERE idempotency_key = ? AND account_ref = ?
         LIMIT 1`,
     )
-    .bind(input.idempotencyKey)
+    .bind(input.idempotencyKey, input.accountRef)
     .first<ConfidentialComputeReceiptRow>()
 }
 

--- a/apps/openagents.com/workers/api/src/inference/khala-code-plan-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/khala-code-plan-routes.test.ts
@@ -35,7 +35,10 @@ class PlanFakeDb {
           if (sql.includes('FROM inference_privacy_entitlement_receipts')) {
             return (
               Array.from(this.entitlementReceipts.values()).find(
-                row => row.idempotency_key === values[0],
+                row =>
+                  row.idempotency_key === values[0] &&
+                  (!sql.includes('account_ref = ?') ||
+                    row.account_ref === values[1]),
               ) ?? null
             ) as T | null
           }
@@ -200,6 +203,22 @@ describe('handleKhalaCodePlanStatus', () => {
     expect(body.plan.captureExcluded).toBe(true)
   })
 
+  it('still reports a purchased paid plan under confidential-compute mode', async () => {
+    const db = new PlanFakeDb()
+    db.entitlements.set('agent:user-1', { account_ref: 'agent:user-1' })
+    const response = await Effect.runPromise(
+      handleKhalaCodePlanStatus(
+        request(),
+        authedDeps(db, { confidentialComputeEnabled: true }),
+      ),
+    )
+    const body = (await response.json()) as {
+      plan: { kind: string; captureExcluded: boolean }
+    }
+    expect(body.plan.kind).toBe('paid')
+    expect(body.plan.captureExcluded).toBe(true)
+  })
+
   it('fails closed to 503 on an entitlement read error instead of fabricating a plan', async () => {
     const db = new PlanFakeDb()
     db.failReads = true
@@ -292,6 +311,47 @@ describe('handleKhalaCodePlanPurchase', () => {
     const secondBody = (await second.json()) as { receiptRef: string }
     expect(secondBody.receiptRef).toBe(firstBody.receiptRef)
     expect(db.entitlementReceipts.size).toBe(1)
+  })
+
+  it('rejects a supplied-but-invalid idempotency key instead of silently replacing it', async () => {
+    const db = new PlanFakeDb()
+    const deps = authedDeps(db, { paidPlanPurchaseArmed: true })
+    const response = await Effect.runPromise(
+      handleKhalaCodePlanPurchase(
+        request({ idempotencyKey: 'x'.repeat(200) }),
+        deps,
+      ),
+    )
+    expect(response.status).toBe(400)
+    const body = (await response.json()) as { error: string }
+    expect(body.error).toBe('invalid_idempotency_key')
+    expect(db.entitlementReceipts.size).toBe(0)
+  })
+
+  it('confines a reused client idempotency key to its own account', async () => {
+    const db = new PlanFakeDb()
+    const first = await Effect.runPromise(
+      handleKhalaCodePlanPurchase(
+        request({ idempotencyKey: 'shared-key' }),
+        authedDeps(db, { accountRef: 'agent:user-1', paidPlanPurchaseArmed: true }),
+      ),
+    )
+    const second = await Effect.runPromise(
+      handleKhalaCodePlanPurchase(
+        request({ idempotencyKey: 'shared-key' }),
+        authedDeps(db, { accountRef: 'agent:user-2', paidPlanPurchaseArmed: true }),
+      ),
+    )
+    expect(first.status).toBe(201)
+    expect(second.status).toBe(201)
+    const firstBody = (await first.json()) as { receiptRef: string }
+    const secondBody = (await second.json()) as { receiptRef: string }
+    // Each account gets ITS OWN receipt — a key collision must never return
+    // (or publicly attribute) another account's purchase.
+    expect(secondBody.receiptRef).not.toBe(firstBody.receiptRef)
+    expect(db.entitlementReceipts.size).toBe(2)
+    expect(db.entitlements.has('agent:user-1')).toBe(true)
+    expect(db.entitlements.has('agent:user-2')).toBe(true)
   })
 
   it('rejects malformed bodies', async () => {

--- a/apps/openagents.com/workers/api/src/inference/khala-code-plan-routes.ts
+++ b/apps/openagents.com/workers/api/src/inference/khala-code-plan-routes.ts
@@ -24,9 +24,10 @@ import {
   khalaCodePlanCatalog,
 } from './khala-code-plan-catalog'
 import {
-  PAID_PRIVACY_REASON_ACCOUNT_ENTITLEMENT,
+  PAID_PRIVACY_REASON_CONFIDENTIAL_COMPUTE,
+  PAID_PRIVACY_REASON_NONE,
   PAID_PRIVACY_REASON_READ_ERROR,
-  makePaidPrivacyResolver,
+  readAccountPaidPrivacy,
 } from './inference-privacy-entitlement'
 import { grantPaidPrivacyEntitlement } from './inference-privacy-receipt-routes'
 
@@ -112,11 +113,13 @@ export const handleKhalaCodePlanCatalogApi = (
       )
 
 // GET /v1/khala-code/plan — the caller's current plan, resolved SERVER-SIDE
-// from the privacy-entitlement seam. Honest mapping:
+// from the privacy-entitlement seam. Honest mapping: the per-account
+// entitlement row is ALWAYS read (deployment-wide confidential-compute mode
+// must not hide a purchased plan), and:
 //   - account entitlement row        => paid plan, captureExcluded
-//   - confidential-compute mode      => free plan, captureExcluded (the
+//   - confidential-compute mode only => free plan, captureExcluded (the
 //     deployment-wide exclusion is not a purchased plan)
-//   - no entitlement                 => free plan, capturable
+//   - neither                        => free plan, capturable
 //   - entitlement read error         => 503 (fail-closed: never fabricate a
 //     plan the caller did or did not buy)
 export const handleKhalaCodePlanStatus = (
@@ -125,7 +128,7 @@ export const handleKhalaCodePlanStatus = (
 ) =>
   Effect.gen(function* () {
     if (request.method !== 'GET') {
-      return noStoreJsonResponse({ error: 'method_not_allowed' }, { status: 405 })
+      return methodNotAllowed(['GET'])
     }
 
     const session = yield* Effect.promise(() => deps.authenticate(request))
@@ -133,12 +136,8 @@ export const handleKhalaCodePlanStatus = (
       return authResponse()
     }
 
-    const resolver = makePaidPrivacyResolver({
-      confidentialComputeEnabled: deps.confidentialComputeEnabled,
-      db: deps.db,
-    })
     const decision = yield* Effect.promise(() =>
-      resolver(session.accountRef),
+      readAccountPaidPrivacy(deps.db, session.accountRef),
     )
 
     if (decision.reasonRef === PAID_PRIVACY_REASON_READ_ERROR) {
@@ -148,14 +147,19 @@ export const handleKhalaCodePlanStatus = (
       )
     }
 
-    const paid = decision.reasonRef === PAID_PRIVACY_REASON_ACCOUNT_ENTITLEMENT
+    const paid = decision.enabled
+    const captureExcluded = paid || deps.confidentialComputeEnabled
     return noStoreJsonResponse({
       ok: true,
       plan: {
         planId: paid ? KHALA_CODE_PAID_PLAN_ID : KHALA_CODE_FREE_PLAN_ID,
         kind: paid ? 'paid' : 'free',
-        captureExcluded: decision.enabled,
-        reasonRef: decision.reasonRef,
+        captureExcluded,
+        reasonRef: paid
+          ? decision.reasonRef
+          : deps.confidentialComputeEnabled
+            ? PAID_PRIVACY_REASON_CONFIDENTIAL_COMPUTE
+            : PAID_PRIVACY_REASON_NONE,
       },
     })
   })
@@ -172,7 +176,7 @@ export const handleKhalaCodePlanPurchase = (
 ) =>
   Effect.gen(function* () {
     if (request.method !== 'POST') {
-      return noStoreJsonResponse({ error: 'method_not_allowed' }, { status: 405 })
+      return methodNotAllowed(['POST'])
     }
 
     if (!deps.paidPlanPurchaseArmed) {
@@ -201,11 +205,24 @@ export const handleKhalaCodePlanPurchase = (
       )
     }
 
+    // A supplied-but-invalid key is REJECTED, never silently replaced: a
+    // silent fallback would make retries with the same (invalid) key mint
+    // duplicate purchase receipts with no signal to the client.
+    const clientKey = boundedIdempotencyKey(body.idempotencyKey)
+    if (body.idempotencyKey !== undefined && clientKey === undefined) {
+      return noStoreJsonResponse(
+        { error: 'invalid_idempotency_key' },
+        { status: 400 },
+      )
+    }
+
     const nowIso = deps.nowIso?.() ?? currentIsoTimestamp()
     const purchaseRef = compactRandomId('khala_code_paid_plan')
-    const idempotencyKey =
-      boundedIdempotencyKey(body.idempotencyKey) ??
-      `khala-code-plan-purchase:${session.accountRef}:${purchaseRef}`
+    // The effective key is ALWAYS namespaced by route and account: the
+    // idempotency_key column is globally unique across purchase surfaces, so a
+    // raw client key could collide with (and read back) another account's
+    // receipt row. Namespacing confines every client key to its own account.
+    const idempotencyKey = `khala-code-plan-purchase:${session.accountRef}:${clientKey ?? purchaseRef}`
     const row = yield* Effect.tryPromise(() =>
       grantPaidPrivacyEntitlement(deps.db, {
         accountRef: session.accountRef,

--- a/clients/khala-code-desktop/src/bun/rpc-handlers.ts
+++ b/clients/khala-code-desktop/src/bun/rpc-handlers.ts
@@ -307,9 +307,13 @@ const khalaCodePlanRequestUrl = (baseUrl: string, path: string): URL => {
   if (!KHALA_CODE_PLAN_ALLOWED_PATHS.has(path)) {
     throw new Error("Khala Code plan RPC path is not allowlisted.")
   }
+  // Append after the FULL configured base (the khala-chat-runtime join style)
+  // so a reverse-proxied base with a path prefix keeps its prefix; `new
+  // URL(path, base)` would silently drop it and 404 plan requests only.
   const base = new URL(baseUrl)
-  const url = new URL(path, base)
-  if (url.origin !== base.origin || url.pathname !== path) {
+  const basePath = base.pathname.replace(/\/+$/, "")
+  const url = new URL(`${base.origin}${basePath}${path}`)
+  if (url.origin !== base.origin || !url.pathname.endsWith(path)) {
     throw new Error("Khala Code plan RPC path must stay on the resolved OpenAgents origin.")
   }
   return url

--- a/clients/khala-code-desktop/src/ui/plans-panel.ts
+++ b/clients/khala-code-desktop/src/ui/plans-panel.ts
@@ -176,6 +176,12 @@ export const mountKhalaCodePlansPanel = (
     container.append(section)
   }
 
+  // One idempotency key per purchase INTENT, reused across retries: if the
+  // worker committed but the response was lost, the retry replays the same key
+  // and gets the same receipt instead of minting a duplicate purchase. The key
+  // is cleared only after a confirmed success.
+  let pendingPurchaseKey: string | null = null
+
   const purchase = async (): Promise<void> => {
     if (purchasing) return
     // Fail closed: never invoke the purchase transport while the server seam
@@ -188,16 +194,21 @@ export const mountKhalaCodePlansPanel = (
     purchasing = true
     purchaseNote = "Requesting paid plan purchase..."
     render()
+    pendingPurchaseKey ??= purchaseIdempotencyKey()
     try {
-      const result = await options.purchase({ idempotencyKey: purchaseIdempotencyKey() })
+      const result = await options.purchase({ idempotencyKey: pendingPurchaseKey })
       purchaseNote = result.ok
         ? `Paid plan purchase recorded: ${result.receiptRef}`
         : purchaseFailureCopy(result.error)
       if (result.ok) {
-        statusResult = await options.status().catch((): KhalaCodeDesktopPlanStatusResult => ({
-          state: "unavailable",
-        }))
+        pendingPurchaseKey = null
       }
+      // Refresh the server-side plan status after EVERY attempt: a response
+      // that failed to decode may still have granted the entitlement, and the
+      // status read is the honest source of truth.
+      statusResult = await options.status().catch((): KhalaCodeDesktopPlanStatusResult => ({
+        state: "unavailable",
+      }))
     } catch (error) {
       purchaseNote = `Purchase not completed: ${errorMessage(error)}`
     }
@@ -218,11 +229,17 @@ export const mountKhalaCodePlansPanel = (
 
   return {
     async refresh() {
+      // The catalog is static per deployment: fetch it until it loads once,
+      // then keep the loaded copy so settings-panel re-renders only refetch
+      // the (account-scoped) plan status.
+      const loaded = catalogResult
       const [catalog, status] = await Promise.all([
-        options.catalog().catch((): KhalaCodeDesktopPlanCatalogResult => ({
-          ok: false,
-          error: "catalog_unavailable",
-        })),
+        loaded !== null && loaded.ok
+          ? Promise.resolve(loaded)
+          : options.catalog().catch((): KhalaCodeDesktopPlanCatalogResult => ({
+              ok: false,
+              error: "catalog_unavailable",
+            })),
         options.status().catch((): KhalaCodeDesktopPlanStatusResult => ({
           state: "unavailable",
         })),

--- a/clients/khala-code-desktop/tests/plans-panel.test.ts
+++ b/clients/khala-code-desktop/tests/plans-panel.test.ts
@@ -224,4 +224,51 @@ describe("khala code plans panel", () => {
     expect(note?.textContent).toContain("paid plan purchases are not enabled on the server yet")
     expect(note?.textContent).toContain("khala_code_paid_plans_not_enabled")
   })
+
+  test("reuses one idempotency key across purchase retries until a confirmed success", async () => {
+    const container = installDom()
+    const purchaseRequests: Array<KhalaCodeDesktopPlanPurchaseRequest | undefined> = []
+    let statusCalls = 0
+    const panel = mountWith(container, {
+      catalog: async () => ({ ok: true, catalog: fixtureCatalog({ paidArmed: true }) }),
+      purchase: async request => {
+        purchaseRequests.push(request)
+        // First attempt looks lost/unavailable; the retry must replay the SAME
+        // key so a server that already committed returns the same receipt
+        // instead of minting a duplicate purchase.
+        return purchaseRequests.length === 1
+          ? { ok: false, error: "purchase_unavailable" }
+          : {
+              ok: true,
+              captureExcluded: true,
+              entitlementRef: "entitlement.inference.paid_privacy.abc",
+              planId: "khala_code.plan.paid.v1",
+              receiptRef: "receipt.inference.privacy_entitlement.khala_code_paid_plan_x",
+              receiptUrl: "/api/public/inference/privacy-receipts/receipt.x",
+            }
+      },
+      status: async () => {
+        statusCalls += 1
+        return { state: "unauthenticated" }
+      },
+    })
+    await panel.refresh()
+    await flushPanel()
+    const statusCallsAfterRefresh = statusCalls
+
+    const clickPurchase = async () => {
+      container
+        .querySelector<HTMLButtonElement>("[data-khala-plans-action='purchase']")
+        ?.dispatchEvent(new MouseEvent("click", { bubbles: true }))
+      await flushPanel()
+    }
+    await clickPurchase()
+    await clickPurchase()
+
+    expect(purchaseRequests).toHaveLength(2)
+    expect(purchaseRequests[0]?.idempotencyKey).toBe(purchaseRequests[1]?.idempotencyKey)
+    // The plan status is re-read after EVERY attempt (a lost response may
+    // still have granted the entitlement server-side).
+    expect(statusCalls).toBe(statusCallsAfterRefresh + 2)
+  })
 })

--- a/clients/khala-code-desktop/tests/rpc-handlers.test.ts
+++ b/clients/khala-code-desktop/tests/rpc-handlers.test.ts
@@ -3432,6 +3432,21 @@ describe("khala code plan RPC handlers", () => {
     expect(result.ok).toBe(true)
   })
 
+  test("khalaCodePlanCatalog preserves a reverse-proxied base path prefix", async () => {
+    const { fetch: fetchStub, requests } = planFetchStub(() => json(200, planCatalogPayload))
+    const handlers = planHandlers({
+      env: { OPENAGENTS_BASE_URL: "https://proxy.corp/openagents/" },
+      fetch: fetchStub,
+    })
+
+    const result = await handlers.khalaCodePlanCatalog()
+
+    expect(requests[0]?.url).toBe(
+      "https://proxy.corp/openagents/api/public/khala-code/plans",
+    )
+    expect(result.ok).toBe(true)
+  })
+
   test("khalaCodePlanCatalog maps failures and malformed payloads to catalog_unavailable", async () => {
     const failing = planFetchStub(() => json(500, { error: "boom" }))
     expect(await planHandlers({ fetch: failing.fetch }).khalaCodePlanCatalog())


### PR DESCRIPTION
Follow-up to #7970 (PROMISSORY #7966). #7970 was merged from its first pushed revision; the high-effort review fixes were amended onto the branch after the merge had already landed, so they never reached `main`. This PR applies exactly that amend delta (nothing else — the registry edit already landed with #7970):

- **Cross-account receipt attribution (worst finding):** purchase idempotency keys are now ALWAYS namespaced `khala-code-plan-purchase:<accountRef>:<key>`, and the shared privacy receipt read-backs (`grantPaidPrivacyEntitlement`, confidential-compute) now guard on `account_ref` — an idempotency-key collision can never return or publicly attribute another account's receipt.
- **Silent non-idempotency:** a supplied-but-invalid `idempotencyKey` now returns 400 `invalid_idempotency_key` instead of being silently replaced per-request.
- **Hidden purchased plan:** plan status always reads the per-account entitlement row, so deployment-wide confidential-compute mode cannot report a paying customer as free.
- **Desktop retry idempotency:** one idempotency key per purchase intent, reused across retries until confirmed success; plan status re-read after every attempt (covers the granted-but-response-lost case).
- **Reverse-proxied base URLs:** plan request URLs keep the base path prefix (append-join, not `new URL(path, base)`).
- **Efficiency:** static plan catalog cached after first load; settings re-renders refetch only the account-scoped status.

Regression tests for each fix. Verification: worker typecheck clean, 38/38 (plan catalog/routes + privacy receipts + product-promises pins), desktop verify **438 pass / 0 fail**, `check:deploy` exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)