### PR TITLE
T13.1: Foldkit embedding skeleton

### DIFF
--- a/clients/khala-code-desktop/src/ui/foldkit/message.ts
+++ b/clients/khala-code-desktop/src/ui/foldkit/message.ts
@@ -1,0 +1,21 @@
+import { Schema as S } from "effect"
+import { m } from "foldkit/message"
+
+import { KhalaCodeFoldkitHostPortMessage } from "./ports.js"
+
+export const FoldkitDemoClickedPing = m("FoldkitDemoClickedPing")
+export const FoldkitDemoReceivedHostPort = m("FoldkitDemoReceivedHostPort", {
+  message: KhalaCodeFoldkitHostPortMessage,
+})
+export const FoldkitDemoMounted = m("FoldkitDemoMounted")
+export const FoldkitDemoUnmounted = m("FoldkitDemoUnmounted")
+export const FoldkitDemoCompletedPortEmit = m("FoldkitDemoCompletedPortEmit")
+
+export const KhalaCodeFoldkitMessage = S.Union([
+  FoldkitDemoClickedPing,
+  FoldkitDemoReceivedHostPort,
+  FoldkitDemoMounted,
+  FoldkitDemoUnmounted,
+  FoldkitDemoCompletedPortEmit,
+])
+export type KhalaCodeFoldkitMessage = typeof KhalaCodeFoldkitMessage.Type

--- a/clients/khala-code-desktop/src/ui/foldkit/model.ts
+++ b/clients/khala-code-desktop/src/ui/foldkit/model.ts
@@ -1,0 +1,17 @@
+import { Schema as S } from "effect"
+
+export const KhalaCodeFoldkitModel = S.Struct({
+  label: S.String,
+  mountId: S.String,
+  pingCount: S.Number,
+})
+export type KhalaCodeFoldkitModel = typeof KhalaCodeFoldkitModel.Type
+
+export const initialKhalaCodeFoldkitModel = (
+  mountId: string,
+): KhalaCodeFoldkitModel => ({
+  label: "Foldkit skeleton",
+  mountId,
+  pingCount: 0,
+})
+

--- a/clients/khala-code-desktop/src/ui/foldkit/ports.ts
+++ b/clients/khala-code-desktop/src/ui/foldkit/ports.ts
@@ -1,0 +1,87 @@
+import { Schema as S } from "effect"
+import { ts } from "foldkit/schema"
+
+export const KhalaCodeFoldkitHostPortMessage = S.Union([
+  ts("HostPing", {
+    nonce: S.String,
+  }),
+  ts("HostSetLabel", {
+    label: S.String,
+  }),
+])
+export type KhalaCodeFoldkitHostPortMessage =
+  typeof KhalaCodeFoldkitHostPortMessage.Type
+
+export const KhalaCodeFoldkitProgramPortMessage = S.Union([
+  ts("ProgramMounted", {
+    mountId: S.String,
+  }),
+  ts("ProgramPong", {
+    nonce: S.String,
+    count: S.Number,
+  }),
+  ts("ProgramUnmounted", {
+    mountId: S.String,
+  }),
+])
+export type KhalaCodeFoldkitProgramPortMessage =
+  typeof KhalaCodeFoldkitProgramPortMessage.Type
+
+const decodeHostPortMessage = S.decodeUnknownSync(KhalaCodeFoldkitHostPortMessage)
+const decodeProgramPortMessage = S.decodeUnknownSync(KhalaCodeFoldkitProgramPortMessage)
+
+export type KhalaCodeFoldkitPortListener<Message> = (message: Message) => void
+
+export type KhalaCodeFoldkitHostPort = Readonly<{
+  send: (message: unknown) => KhalaCodeFoldkitHostPortMessage
+  subscribe: (
+    listener: KhalaCodeFoldkitPortListener<KhalaCodeFoldkitHostPortMessage>,
+  ) => () => void
+}>
+
+export type KhalaCodeFoldkitProgramPort = Readonly<{
+  emit: (message: unknown) => KhalaCodeFoldkitProgramPortMessage
+  subscribe: (
+    listener: KhalaCodeFoldkitPortListener<KhalaCodeFoldkitProgramPortMessage>,
+  ) => () => void
+}>
+
+const makePort = <Message>(
+  decode: (message: unknown) => Message,
+): Readonly<{
+  publish: (message: unknown) => Message
+  subscribe: (listener: KhalaCodeFoldkitPortListener<Message>) => () => void
+}> => {
+  const listeners = new Set<KhalaCodeFoldkitPortListener<Message>>()
+  return {
+    publish: (message) => {
+      const decoded = decode(message)
+      for (const listener of listeners) listener(decoded)
+      return decoded
+    },
+    subscribe: (listener) => {
+      listeners.add(listener)
+      return () => listeners.delete(listener)
+    },
+  }
+}
+
+export type KhalaCodeFoldkitPorts = Readonly<{
+  host: KhalaCodeFoldkitHostPort
+  program: KhalaCodeFoldkitProgramPort
+}>
+
+export const makeKhalaCodeFoldkitPorts = (): KhalaCodeFoldkitPorts => {
+  const host = makePort(decodeHostPortMessage)
+  const program = makePort(decodeProgramPortMessage)
+  return {
+    host: {
+      send: host.publish,
+      subscribe: host.subscribe,
+    },
+    program: {
+      emit: program.publish,
+      subscribe: program.subscribe,
+    },
+  }
+}

--- a/clients/khala-code-desktop/src/ui/foldkit/runtime.ts
+++ b/clients/khala-code-desktop/src/ui/foldkit/runtime.ts
@@ -1,0 +1,88 @@
+import { Effect, Fiber } from "effect"
+import { Runtime } from "foldkit"
+import type { MakeRuntimeReturn } from "foldkit/runtime"
+
+import { KhalaCodeFoldkitMessage } from "./message.js"
+import { initialKhalaCodeFoldkitModel, KhalaCodeFoldkitModel } from "./model.js"
+import {
+  makeKhalaCodeFoldkitPorts,
+  type KhalaCodeFoldkitPorts,
+} from "./ports.js"
+import { makeKhalaCodeFoldkitSubscriptions } from "./subscriptions.js"
+import { makeKhalaCodeFoldkitUpdate } from "./update.js"
+import { view } from "./view.js"
+
+export type KhalaCodeFoldkitEmbedHandle = Readonly<{
+  mountId: string
+  ports: KhalaCodeFoldkitPorts
+  send: KhalaCodeFoldkitPorts["host"]["send"]
+  unmount: () => void
+}>
+
+export type KhalaCodeFoldkitEmbedOptions = Readonly<{
+  mountId?: string
+  ports?: KhalaCodeFoldkitPorts
+}>
+
+const nextMountId = (() => {
+  let seq = 0
+  return () => {
+    seq += 1
+    return `khala-code-foldkit-${seq}`
+  }
+})()
+
+const startRuntimeFiber = (program: MakeRuntimeReturn): Fiber.Fiber<void> =>
+  Effect.runFork(program.start())
+
+export const embedKhalaCodeFoldkitProgram = (
+  container: HTMLElement,
+  options: KhalaCodeFoldkitEmbedOptions = {},
+): KhalaCodeFoldkitEmbedHandle => {
+  const mountId = options.mountId ?? nextMountId()
+  const ports = options.ports ?? makeKhalaCodeFoldkitPorts()
+  const runtimeContainer = document.createElement("div")
+  runtimeContainer.id = mountId
+  runtimeContainer.dataset.khalaCodeFoldkitRuntime = "true"
+  container.replaceChildren(runtimeContainer)
+
+  const program = Runtime.makeProgram({
+    Model: KhalaCodeFoldkitModel,
+    init: () => [initialKhalaCodeFoldkitModel(mountId), []],
+    update: makeKhalaCodeFoldkitUpdate(ports.program),
+    view,
+    subscriptions: makeKhalaCodeFoldkitSubscriptions(ports.host),
+    container: runtimeContainer,
+    devTools: {
+      show: "Development",
+      Message: KhalaCodeFoldkitMessage,
+    },
+    crash: {
+      report: ({ error }) => {
+        console.error("[khala-code-desktop/foldkit] crash:", error)
+      },
+    },
+  })
+
+  const fiber = startRuntimeFiber(program)
+  let mounted = true
+
+  return {
+    mountId,
+    ports,
+    send: ports.host.send,
+    unmount: () => {
+      if (!mounted) return
+      mounted = false
+      ports.program.emit({ _tag: "ProgramUnmounted", mountId })
+      Effect.runFork(Fiber.interrupt(fiber))
+      container.replaceChildren()
+    },
+  }
+}
+
+export const mountKhalaCodeFoldkitDemo = (
+  container: HTMLElement | null,
+): KhalaCodeFoldkitEmbedHandle | null =>
+  container === null ? null : embedKhalaCodeFoldkitProgram(container)
+

--- a/clients/khala-code-desktop/src/ui/foldkit/subscriptions.ts
+++ b/clients/khala-code-desktop/src/ui/foldkit/subscriptions.ts
@@ -1,0 +1,31 @@
+import { Effect, Queue, Stream } from "effect"
+import { Subscription } from "foldkit"
+
+import { FoldkitDemoMounted, FoldkitDemoReceivedHostPort } from "./message.js"
+import type { KhalaCodeFoldkitMessage } from "./message.js"
+import type { KhalaCodeFoldkitModel } from "./model.js"
+import type { KhalaCodeFoldkitHostPort } from "./ports.js"
+
+const mountedStream = Stream.make(FoldkitDemoMounted())
+
+const hostPortStream = (
+  port: KhalaCodeFoldkitHostPort,
+): Stream.Stream<KhalaCodeFoldkitMessage> =>
+  Stream.callback<KhalaCodeFoldkitMessage>((queue) =>
+    Effect.acquireRelease(
+      Effect.sync(() =>
+        port.subscribe((message) => {
+          Queue.offerUnsafe(queue, FoldkitDemoReceivedHostPort({ message }))
+        }),
+      ),
+      (unsubscribe) => Effect.sync(unsubscribe),
+    ),
+  )
+
+export const makeKhalaCodeFoldkitSubscriptions = (
+  port: KhalaCodeFoldkitHostPort,
+) =>
+  Subscription.make<KhalaCodeFoldkitModel, KhalaCodeFoldkitMessage>()(() => ({
+    mounted: Subscription.persistent(mountedStream),
+    hostPort: Subscription.persistent(hostPortStream(port)),
+  }))

--- a/clients/khala-code-desktop/src/ui/foldkit/update.ts
+++ b/clients/khala-code-desktop/src/ui/foldkit/update.ts
@@ -1,0 +1,92 @@
+import { Effect } from "effect"
+import type { Command } from "foldkit"
+
+import type { KhalaCodeFoldkitMessage } from "./message.js"
+import { FoldkitDemoCompletedPortEmit } from "./message.js"
+import type { KhalaCodeFoldkitModel } from "./model.js"
+import type {
+  KhalaCodeFoldkitProgramPort,
+  KhalaCodeFoldkitProgramPortMessage,
+} from "./ports.js"
+
+type UpdateResult = readonly [
+  KhalaCodeFoldkitModel,
+  ReadonlyArray<Command.Command<KhalaCodeFoldkitMessage>>,
+]
+
+const noCommands: ReadonlyArray<Command.Command<KhalaCodeFoldkitMessage>> = []
+
+const emitProgramPort = (
+  port: KhalaCodeFoldkitProgramPort,
+  message: KhalaCodeFoldkitProgramPortMessage,
+): Command.Command<KhalaCodeFoldkitMessage> => ({
+  name: "KhalaCodeFoldkitEmitProgramPort",
+  args: { tag: message._tag },
+  effect: Effect.sync(() => {
+    port.emit(message)
+    return FoldkitDemoCompletedPortEmit()
+  }),
+})
+
+export const makeKhalaCodeFoldkitUpdate =
+  (port: KhalaCodeFoldkitProgramPort) =>
+  (
+    model: KhalaCodeFoldkitModel,
+    message: KhalaCodeFoldkitMessage,
+  ): UpdateResult => {
+    switch (message._tag) {
+      case "FoldkitDemoClickedPing": {
+        const next = { ...model, pingCount: model.pingCount + 1 }
+        return [
+          next,
+          [
+            emitProgramPort(port, {
+              _tag: "ProgramPong",
+              count: next.pingCount,
+              nonce: `ui:${next.pingCount}`,
+            }),
+          ],
+        ]
+      }
+      case "FoldkitDemoReceivedHostPort":
+        switch (message.message._tag) {
+          case "HostPing": {
+            const next = { ...model, pingCount: model.pingCount + 1 }
+            return [
+              next,
+              [
+                emitProgramPort(port, {
+                  _tag: "ProgramPong",
+                  count: next.pingCount,
+                  nonce: message.message.nonce,
+                }),
+              ],
+            ]
+          }
+          case "HostSetLabel":
+            return [{ ...model, label: message.message.label }, noCommands]
+        }
+      case "FoldkitDemoMounted":
+        return [
+          model,
+          [
+            emitProgramPort(port, {
+              _tag: "ProgramMounted",
+              mountId: model.mountId,
+            }),
+          ],
+        ]
+      case "FoldkitDemoUnmounted":
+        return [
+          model,
+          [
+            emitProgramPort(port, {
+              _tag: "ProgramUnmounted",
+              mountId: model.mountId,
+            }),
+          ],
+        ]
+      case "FoldkitDemoCompletedPortEmit":
+        return [model, noCommands]
+    }
+  }

--- a/clients/khala-code-desktop/src/ui/foldkit/view.ts
+++ b/clients/khala-code-desktop/src/ui/foldkit/view.ts
@@ -1,0 +1,29 @@
+import type { Document } from "foldkit/html"
+import { html } from "foldkit/html"
+
+import { FoldkitDemoClickedPing } from "./message.js"
+import type { KhalaCodeFoldkitMessage } from "./message.js"
+import type { KhalaCodeFoldkitModel } from "./model.js"
+
+const h = html<KhalaCodeFoldkitMessage>()
+
+export const view = (model: KhalaCodeFoldkitModel): Document => ({
+  title: "Khala Code",
+  body: h.section(
+    [
+      h.Class("khala-code-foldkit-demo"),
+      h.DataAttribute("foldkit-mount-id", model.mountId),
+    ],
+    [
+      h.p([h.Class("khala-code-foldkit-demo-label")], [model.label]),
+      h.button(
+        [
+          h.Type("button"),
+          h.Class("khala-code-foldkit-demo-ping"),
+          h.OnClick(FoldkitDemoClickedPing()),
+        ],
+        [`Ping ${model.pingCount}`],
+      ),
+    ],
+  ),
+})

--- a/clients/khala-code-desktop/src/ui/index.html
+++ b/clients/khala-code-desktop/src/ui/index.html
@@ -188,6 +188,12 @@
         aria-label="Codex settings"
         hidden
       ></section>
+      <section
+        id="foldkit-demo-panel"
+        class="khala-code-foldkit-host"
+        aria-label="Foldkit embedding skeleton"
+        hidden
+      ></section>
     </main>
     <script type="module" src="./main.ts"></script>
   </body>

--- a/clients/khala-code-desktop/src/ui/main.ts
+++ b/clients/khala-code-desktop/src/ui/main.ts
@@ -89,6 +89,7 @@ import {
   mountKhalaCodeSidebar,
   projectKhalaCodeSidebarFleetCounts,
 } from "./sidebar"
+import { mountKhalaCodeFoldkitDemo } from "./foldkit/runtime"
 import { mountUnifiedInboxPanel } from "./inbox"
 import type { KhalaCodeDesktopCodexThreadSummary } from "../shared/codex-threads"
 import {
@@ -2773,6 +2774,7 @@ const forumPanelEl = document.getElementById("forum-panel")
 const inboxPanelEl = document.getElementById("inbox-panel")
 const gymPanelEl = document.getElementById("gym-panel")
 const settingsPanelEl = document.getElementById("settings-panel")
+const foldkitDemoPanelEl = document.getElementById("foldkit-demo-panel")
 const threadShell = document.querySelector<HTMLElement>(".khala-code-thread-shell")
 const composerDock = document.querySelector<HTMLElement>(".composer-dock")
 const initialGymState = gymPaneStateFromLocation(globalThis.location)
@@ -2952,6 +2954,8 @@ const forumPanel =
 
 const gymPanel =
   gymPanelEl === null ? null : mountGymPane(gymPanelEl, initialGymState)
+const foldkitDemo =
+  foldkitDemoPanelEl === null ? null : mountKhalaCodeFoldkitDemo(foldkitDemoPanelEl)
 
 let claudeSettingsSection: ReturnType<typeof mountClaudeSettingsSection> | null = null
 let plansSection: ReturnType<typeof mountKhalaCodePlansPanel> | null = null
@@ -3066,6 +3070,7 @@ const setActiveView = (value: string): void => {
   if (forumPanelEl !== null) forumPanelEl.hidden = !showForum
   if (inboxPanelEl !== null) inboxPanelEl.hidden = !showInbox
   if (settingsPanelEl !== null) settingsPanelEl.hidden = !showSettings
+  if (foldkitDemoPanelEl !== null) foldkitDemoPanelEl.hidden = true
   gymPanel?.setVisible(false)
   if (threadShell !== null) threadShell.hidden = showFleet || showForum || showInbox || showSettings
   if (composerDock !== null) composerDock.hidden = showFleet || showForum || showInbox || showSettings
@@ -3090,6 +3095,7 @@ function showGymProofPane(): void {
   if (forumPanelEl !== null) forumPanelEl.hidden = true
   if (inboxPanelEl !== null) inboxPanelEl.hidden = true
   if (settingsPanelEl !== null) settingsPanelEl.hidden = true
+  if (foldkitDemoPanelEl !== null) foldkitDemoPanelEl.hidden = true
   if (threadShell !== null) threadShell.hidden = true
   if (composerDock !== null) composerDock.hidden = true
   gymPanel?.setVisible(true)
@@ -3120,6 +3126,7 @@ const refreshFleetSidebarCounts = async (): Promise<void> => {
 if (sidebarNavRoot !== null) {
   void refreshFleetSidebarCounts()
 }
+void foldkitDemo?.send({ _tag: "HostSetLabel", label: "Foldkit skeleton mounted" })
 setActiveView(initialView)
 renderThreadTokenCounter()
 void refreshThreadTokenSummary()

--- a/clients/khala-code-desktop/src/ui/styles.css
+++ b/clients/khala-code-desktop/src/ui/styles.css
@@ -3499,3 +3499,37 @@ button {
   background: var(--oa-color-component-surface-active);
   color: var(--oa-color-component-text);
 }
+
+.khala-code-foldkit-host {
+  position: fixed;
+  inset: auto 1rem 1rem auto;
+  z-index: 8;
+  max-width: 18rem;
+}
+
+.khala-code-foldkit-demo {
+  display: grid;
+  gap: 0.55rem;
+  padding: 0.75rem;
+  color: var(--oa-color-component-text);
+  background: var(--oa-color-component-surface);
+  border: 1px solid var(--oa-color-component-border);
+  border-radius: 0.5rem;
+}
+
+.khala-code-foldkit-demo-label {
+  margin: 0;
+  font-size: 0.78rem;
+}
+
+.khala-code-foldkit-demo-ping {
+  justify-self: start;
+  font: inherit;
+  font-size: 0.78rem;
+  color: var(--oa-color-component-text);
+  background: var(--oa-color-component-surface-active);
+  border: 1px solid var(--oa-color-component-border);
+  border-radius: 0.4rem;
+  padding: 0.3rem 0.65rem;
+  cursor: pointer;
+}

--- a/clients/khala-code-desktop/tests/app-shell.test.ts
+++ b/clients/khala-code-desktop/tests/app-shell.test.ts
@@ -118,6 +118,8 @@ describe("khala code desktop app shell", () => {
     expect(html).toContain('id="inbox-panel"')
     expect(html).toContain('id="gym-panel"')
     expect(html).toContain('id="settings-panel"')
+    expect(html).toContain('id="foldkit-demo-panel"')
+    expect(html).toContain("Foldkit embedding skeleton")
     expect(html).not.toContain("Pylons")
   })
 

--- a/clients/khala-code-desktop/tests/foldkit-embedding.test.ts
+++ b/clients/khala-code-desktop/tests/foldkit-embedding.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, test } from "bun:test"
+import { Effect, Schema as S } from "effect"
+import { Window } from "happy-dom"
+
+import {
+  KhalaCodeFoldkitHostPortMessage,
+  KhalaCodeFoldkitProgramPortMessage,
+  makeKhalaCodeFoldkitPorts,
+} from "../src/ui/foldkit/ports"
+import { FoldkitDemoReceivedHostPort } from "../src/ui/foldkit/message"
+import { initialKhalaCodeFoldkitModel } from "../src/ui/foldkit/model"
+import { makeKhalaCodeFoldkitUpdate } from "../src/ui/foldkit/update"
+
+const installDom = (): Window => {
+  const window = new Window({
+    url: "https://khala-code-desktop.test/",
+  })
+  const raf = (callback: FrameRequestCallback): number =>
+    Number(setTimeout(() => callback(performance.now()), 0))
+  const caf = (handle: number): void => clearTimeout(handle)
+
+  Object.assign(globalThis, {
+    cancelAnimationFrame: caf,
+    document: window.document,
+    location: window.location,
+    navigator: window.navigator,
+    requestAnimationFrame: raf,
+    window,
+  })
+
+  return window
+}
+
+describe("khala code Foldkit embedding skeleton", () => {
+  test("keeps program update pure until returned commands run", async () => {
+    const ports = makeKhalaCodeFoldkitPorts()
+    const emitted: unknown[] = []
+    ports.program.subscribe(message => emitted.push(message))
+    const update = makeKhalaCodeFoldkitUpdate(ports.program)
+    const model = initialKhalaCodeFoldkitModel("fixture-foldkit")
+
+    const [next, commands] = update(
+      model,
+      FoldkitDemoReceivedHostPort({
+        message: { _tag: "HostPing", nonce: "fixture-nonce" },
+      }),
+    )
+
+    expect(next).toEqual({
+      label: "Foldkit skeleton",
+      mountId: "fixture-foldkit",
+      pingCount: 1,
+    })
+    expect(emitted).toEqual([])
+    expect(commands).toHaveLength(1)
+
+    await Effect.runPromise(commands[0]!.effect)
+
+    expect(emitted).toEqual([
+      { _tag: "ProgramPong", count: 1, nonce: "fixture-nonce" },
+    ])
+  })
+
+  test("decodes both host and program port schemas", () => {
+    expect(S.decodeUnknownSync(KhalaCodeFoldkitHostPortMessage)({
+      _tag: "HostSetLabel",
+      label: "Mounted",
+    })).toEqual({ _tag: "HostSetLabel", label: "Mounted" })
+    expect(S.decodeUnknownSync(KhalaCodeFoldkitProgramPortMessage)({
+      _tag: "ProgramPong",
+      count: 2,
+      nonce: "round-trip",
+    })).toEqual({ _tag: "ProgramPong", count: 2, nonce: "round-trip" })
+
+    expect(() =>
+      S.decodeUnknownSync(KhalaCodeFoldkitHostPortMessage)({
+        _tag: "HostPing",
+        nonce: 42,
+      }),
+    ).toThrow()
+  })
+
+  test("mounts, round-trips ports, and unmounts from a designated container", async () => {
+    installDom()
+    const { embedKhalaCodeFoldkitProgram } = await import("../src/ui/foldkit/runtime")
+    const container = document.createElement("section")
+    container.id = "foldkit-demo-fixture"
+    document.body.append(container)
+    const ports = makeKhalaCodeFoldkitPorts()
+    const emitted: unknown[] = []
+    ports.program.subscribe(message => emitted.push(message))
+
+    const handle = embedKhalaCodeFoldkitProgram(container, {
+      mountId: "foldkit-demo-fixture-runtime",
+      ports,
+    })
+    await new Promise(resolve => setTimeout(resolve, 20))
+
+    expect(container.querySelector("[data-foldkit-mount-id='foldkit-demo-fixture-runtime']")).not.toBeNull()
+    expect(container.textContent ?? "").toContain("Foldkit skeleton")
+    expect(emitted).toContainEqual({
+      _tag: "ProgramMounted",
+      mountId: "foldkit-demo-fixture-runtime",
+    })
+
+    handle.send({ _tag: "HostPing", nonce: "host-fixture" })
+    await new Promise(resolve => setTimeout(resolve, 20))
+
+    expect(container.textContent ?? "").toContain("Ping 1")
+    expect(emitted).toContainEqual({
+      _tag: "ProgramPong",
+      count: 1,
+      nonce: "host-fixture",
+    })
+
+    handle.unmount()
+
+    expect(container.childElementCount).toBe(0)
+    expect(emitted).toContainEqual({
+      _tag: "ProgramUnmounted",
+      mountId: "foldkit-demo-fixture-runtime",
+    })
+  })
+})


### PR DESCRIPTION
Closes #7892

## Summary
- Adds a Foldkit TEA embedding skeleton for Khala Code Desktop with model/message/update/view/subscriptions/runtime modules.
- Adds Schema-typed host/program ports and a hidden demo mount that coexists with the current vanilla DOM shell.
- Adds fixture coverage for update purity, port schema decoding, and embed mount/unmount round-trips.

## Verification
- bun test clients/khala-code-desktop/tests/foldkit-embedding.test.ts
- bun run --cwd clients/khala-code-desktop typecheck

Note: an additional `bun run --cwd clients/khala-code-desktop build:ui` attempt was blocked by this checkout node_modules missing workspace package links for `@openagentsinc/ui/styles.css`; the pinned verification command passed.