### PR TITLE
Fleet supervisor: never auto-revive operator-paused/stopped runs (#7975)

### DIFF
--- a/apps/pylon/src/orchestration/store.ts
+++ b/apps/pylon/src/orchestration/store.ts
@@ -1059,10 +1059,17 @@ export class PylonOrchestrationStore {
     const state: FleetRunState = shouldClose && counters.failedAssignments === 0 && counters.blockedAssignments === 0
       ? "completed"
       : shouldClose ? "stopped" : run.state
+    // Closing a running run is a machine decision and may be undone by the
+    // supervisor when planner backlog remains. Closing a draining run is the
+    // completion of an operator drain: keep operator provenance so the closed
+    // run is never auto-revived (#7975).
+    const stateSource = shouldClose
+      ? (run.state === "draining" ? ("operator" as const) : ("reconcile" as const))
+      : run.stateSource
     return this.upsertFleetRun({
       ...run,
       state,
-      ...(shouldClose ? { stateSource: "reconcile" as const } : {}),
+      ...(stateSource === undefined ? {} : { stateSource }),
       counters,
       updatedAt: iso(now),
     })

--- a/apps/pylon/src/orchestration/store.ts
+++ b/apps/pylon/src/orchestration/store.ts
@@ -120,6 +120,7 @@ export const FleetRunSchema = S.Struct({
   workerKind: FleetRunWorkerKindSchema,
   refillPolicy: FleetRunRefillPolicySchema,
   state: FleetRunStateSchema,
+  stateSource: S.optional(S.Literals(["operator", "reconcile"])),
   dispatchKind: FleetRunDispatchKindSchema,
   dagTracked: S.Boolean,
   startedAt: S.NullOr(S.String),
@@ -401,6 +402,19 @@ export const assertFleetRunControlTransition = (
     throw new Error(`fleetRunControl cannot ${verb} a ${state} fleet run`)
   }
 }
+
+/**
+ * A closed fleet run may be automatically reopened by the supervisor only
+ * when reconciliation closed it (all created tasks terminal while the
+ * planner backlog still holds uncreated units). Operator lifecycle
+ * decisions — pause, drain, stop — are authority and are never auto-revived.
+ * Legacy rows without a stateSource keep the historical auto-revive
+ * behavior for completed/stopped states.
+ */
+export const isAutoRevivableFleetRun = (
+  run: Pick<FleetRun, "state" | "stateSource">,
+): boolean =>
+  (run.state === "completed" || run.state === "stopped") && run.stateSource !== "operator"
 
 const fleetRunControlState = (verb: FleetRunControlVerb): FleetRunState => {
   switch (verb) {
@@ -994,12 +1008,18 @@ export class PylonOrchestrationStore {
     return (rows as FleetRunRow[]).map((row) => fleetRunFromJson(row.record_json))
   }
 
-  updateFleetRunState(runRef: string, state: FleetRunState, now: Date = new Date()): FleetRun {
+  updateFleetRunState(
+    runRef: string,
+    state: FleetRunState,
+    now: Date = new Date(),
+    stateSource: "operator" | "reconcile" = "operator",
+  ): FleetRun {
     const current = this.getFleetRun(runRef)
     if (current === null) throw new Error(`unknown fleet run: ${runRef}`)
     return this.upsertFleetRun({
       ...current,
       state,
+      stateSource,
       startedAt: state === "running" && current.startedAt === null ? iso(now) : current.startedAt,
       updatedAt: iso(now),
     })
@@ -1039,7 +1059,13 @@ export class PylonOrchestrationStore {
     const state: FleetRunState = shouldClose && counters.failedAssignments === 0 && counters.blockedAssignments === 0
       ? "completed"
       : shouldClose ? "stopped" : run.state
-    return this.upsertFleetRun({ ...run, state, counters, updatedAt: iso(now) })
+    return this.upsertFleetRun({
+      ...run,
+      state,
+      ...(shouldClose ? { stateSource: "reconcile" as const } : {}),
+      counters,
+      updatedAt: iso(now),
+    })
   }
 
   reconcileFleetRuns(now: Date = new Date()): FleetRun[] {

--- a/apps/pylon/src/orchestration/supervisor-orchestration.test.ts
+++ b/apps/pylon/src/orchestration/supervisor-orchestration.test.ts
@@ -19,6 +19,7 @@ import {
   WORK_CLAIM_SCHEMA,
   createPylonOrchestrationStore,
   fleetRunOwnerLocalStatePath,
+  isAutoRevivableFleetRun,
   isStoredOrchestrationRunnerKind,
   loadFleetRunOwnerLocalState,
   normalizeOrchestrationRunnerKind,
@@ -595,6 +596,52 @@ describe("Pylon supervisor orchestration store", () => {
 
     expect(reconciled.state).toBe("completed")
     expect(reconciled.counters.completedAssignments).toBe(1)
+  })
+
+  test("tracks state provenance: operator verbs stamp operator, reconcile auto-close stamps reconcile (#7975)", () => {
+    const now = new Date("2026-07-01T12:00:00.000Z")
+    const store = createPylonOrchestrationStore(new Database(":memory:"))
+    store.createFleetRun({
+      runRef: "fleet_run.provenance",
+      objective: "Provenance fixture.",
+      workSource: "fixture",
+      targetConcurrency: 1,
+      workerKind: "codex",
+      state: "running",
+      now,
+    })
+
+    const paused = store.controlFleetRun("fleet_run.provenance", "pause", now).run
+    expect(paused.stateSource).toBe("operator")
+    expect(isAutoRevivableFleetRun(paused)).toBe(false)
+
+    const stopped = store.controlFleetRun("fleet_run.provenance", "stop", now).run
+    expect(stopped.stateSource).toBe("operator")
+    expect(isAutoRevivableFleetRun(stopped)).toBe(false)
+
+    store.createFleetRun({
+      runRef: "fleet_run.provenance.close",
+      objective: "Provenance auto-close fixture.",
+      workSource: "fixture",
+      targetConcurrency: 1,
+      workerKind: "codex",
+      state: "running",
+      now,
+    })
+    store.createTask({
+      id: "task.provenance.done",
+      spec: { ...baseTaskSpec, title: "done", fleetRunRef: "fleet_run.provenance.close" },
+      now,
+    })
+    store.completeTask("task.provenance.done", JSON.stringify({ ok: true }), now)
+    const autoClosed = store.reconcileFleetRun("fleet_run.provenance.close", now)
+    expect(autoClosed.state).toBe("completed")
+    expect(autoClosed.stateSource).toBe("reconcile")
+    expect(isAutoRevivableFleetRun(autoClosed)).toBe(true)
+
+    // Legacy rows without provenance keep the historical auto-revive behavior.
+    expect(isAutoRevivableFleetRun({ state: "completed", stateSource: undefined })).toBe(true)
+    expect(isAutoRevivableFleetRun({ state: "paused", stateSource: undefined })).toBe(false)
   })
 
   test("mirrors FleetRun records to owner-local state and rehydrates a fresh store", async () => {

--- a/apps/pylon/src/orchestration/supervisor-state.ts
+++ b/apps/pylon/src/orchestration/supervisor-state.ts
@@ -144,6 +144,7 @@ try {
         const updated = store.upsertFleetRun({
           ...run,
           state: pausedFlag === "1" ? "paused" : pausedFlag === "0" ? "running" : run.state,
+          ...(pausedFlag === "1" || pausedFlag === "0" ? { stateSource: "operator" as const } : {}),
           targetConcurrency: Math.max(1, desiredSlots),
           counters: {
             ...run.counters,

--- a/clients/khala-code-desktop/src/bun/fleet-run-supervisor.ts
+++ b/clients/khala-code-desktop/src/bun/fleet-run-supervisor.ts
@@ -6,6 +6,7 @@ import type {
   PylonOrchestrationStore,
   WorkClaim,
 } from "../../../../apps/pylon/src/orchestration/store.js"
+import { isAutoRevivableFleetRun } from "../../../../apps/pylon/src/orchestration/store.js"
 import type {
   WorkPlannerClaimableUnit,
   WorkPlannerOutput,
@@ -310,7 +311,16 @@ export async function tickFleetRunSupervisor(
   store.reconcileWorkClaims({ now })
   const expectedWorkUnitsTotal = store.getFleetRun(options.runRef)?.counters.workUnitsTotal ?? 0
   let run = store.reconcileFleetRun(options.runRef, now)
-  if (run.state !== "running" && run.counters.workUnitsTotal < expectedWorkUnitsTotal) {
+  // Reconciliation may auto-close a running run whose created tasks are all
+  // terminal even though the planner backlog still has uncreated work units.
+  // Only that auto-close may be undone: operator lifecycle states (paused,
+  // draining, operator-stopped) are authority and must never be auto-revived
+  // (#7975).
+  if (
+    run.state !== "running" &&
+    isAutoRevivableFleetRun(run) &&
+    run.counters.workUnitsTotal < expectedWorkUnitsTotal
+  ) {
     run = store.upsertFleetRun({
       ...run,
       state: "running",
@@ -341,7 +351,11 @@ export async function tickFleetRunSupervisor(
       await recordTerminalAssignment(options, assignment, result, now)
     }
     run = store.reconcileFleetRun(options.runRef, now)
-    if (run.state !== "running" && run.counters.workUnitsTotal < expectedWorkUnitsTotal) {
+    if (
+      run.state !== "running" &&
+      isAutoRevivableFleetRun(run) &&
+      run.counters.workUnitsTotal < expectedWorkUnitsTotal
+    ) {
       run = store.upsertFleetRun({
         ...run,
         state: "running",
@@ -525,18 +539,20 @@ export async function tickFleetRunSupervisor(
 
   let reconciled = store.reconcileFleetRun(run.runRef, clock.now())
   const hasClaimableBacklog = plan.claimable.length > claimed
+  const reviveForBacklog = hasClaimableBacklog &&
+    (reconciled.state === "running" || isAutoRevivableFleetRun(reconciled))
   if (reconciled.counters.workUnitsTotal < plannedWorkUnitsTotal) {
     reconciled = store.upsertFleetRun({
       ...reconciled,
-      state: hasClaimableBacklog ? "running" : reconciled.state,
+      state: reviveForBacklog ? "running" : reconciled.state,
       counters: {
         ...reconciled.counters,
         workUnitsTotal: plannedWorkUnitsTotal,
       },
       updatedAt: clock.now().toISOString(),
     })
-  } else if (reconciled.state !== "running" && hasClaimableBacklog) {
-    reconciled = store.updateFleetRunState(run.runRef, "running", clock.now())
+  } else if (reconciled.state !== "running" && reviveForBacklog) {
+    reconciled = store.updateFleetRunState(run.runRef, "running", clock.now(), "reconcile")
   }
   if (reconciled.state === "completed") {
     await emit(options.onLifecycle, { kind: "completed", runRef: run.runRef, reason: "drained" })
@@ -547,7 +563,7 @@ export async function tickFleetRunSupervisor(
     activeAssignmentsForRun(store, run.runRef) === 0 &&
     reconciled.refillPolicy.stopCondition === "backlog_empty"
   ) {
-    const completed = store.updateFleetRunState(run.runRef, "completed", clock.now())
+    const completed = store.updateFleetRunState(run.runRef, "completed", clock.now(), "reconcile")
     await emit(options.onLifecycle, { kind: "completed", runRef: run.runRef, reason: "backlog_empty" })
     return {
       activeAssignments: activeAssignmentsForRun(store, run.runRef),

--- a/clients/khala-code-desktop/src/bun/khala-codex-fleet-tools.ts
+++ b/clients/khala-code-desktop/src/bun/khala-codex-fleet-tools.ts
@@ -1432,7 +1432,9 @@ export class DefaultKhalaFleetRunSupervisorManager implements KhalaFleetRunSuper
         scope,
       ))
     } catch (error) {
-      this.store.updateFleetRunState(runRef, "stopped", new Date())
+      // Machine stop on supervisor-startup failure: stamp reconcile so a
+      // later supervisor may reopen the run; operator stop stays authority.
+      this.store.updateFleetRunState(runRef, "stopped", new Date(), "reconcile")
       await Effect.runPromise(Scope.close(scope, Exit.void))
       throw error
     }

--- a/clients/khala-code-desktop/tests/fleet-run-supervisor.test.ts
+++ b/clients/khala-code-desktop/tests/fleet-run-supervisor.test.ts
@@ -312,6 +312,57 @@ describe("FleetRunSupervisor", () => {
     expect(store.getFleetRun(run.runRef)?.state).toBe("paused")
   })
 
+  test("never auto-revives a drained run after drain completes mid-backlog (#7975)", async () => {
+    const { store, run } = createStoreWithRun({ targetConcurrency: 1, workUnits: 3 })
+    store.createTask({
+      id: "task.drain.inflight",
+      spec: {
+        title: "in-flight unit",
+        prompt: run.objective,
+        runnerKind: "codex",
+        issueRef: "work_unit.fixture.drain",
+        fleetRunRef: run.runRef,
+      },
+      now: fixedNow,
+    })
+    store.createDispatchContext({
+      id: "ctx.codex.drain",
+      assigneeHandle: "codex-a",
+      runnerKind: "codex",
+      lastHeartbeatAt: fixedNow,
+      now: fixedNow,
+    })
+    store.markDispatched("task.drain.inflight", "ctx.codex.drain", fixedNow)
+
+    // Operator drains while the unit is still in flight, then the unit
+    // finishes. Reconciliation closes the drain — that close completes the
+    // operator's decision, so later ticks must not reopen the run for the
+    // remaining planner backlog.
+    store.controlFleetRun(run.runRef, "drain", fixedNow)
+    store.recordWorkerDone({
+      contextId: "ctx.codex.drain",
+      taskId: "task.drain.inflight",
+      status: "completed",
+      now: fixedNow,
+    })
+    const drained = store.reconcileFleetRun(run.runRef, fixedNow)
+    expect(drained.state).toBe("completed")
+    expect(drained.stateSource).toBe("operator")
+
+    const after = await tickFleetRunSupervisor({
+      store,
+      pylonRef: "pylon.owner",
+      runRef: run.runRef,
+      planner: fixturePlannerWithClaims(store, 3),
+      runner: acceptingRunner(),
+      capacity: capacity([{ accountRef: "codex-a", advertisedCapacity: 1 }]),
+      clock: { now: () => fixedNow },
+    })
+    expect(after.run.state).toBe("completed")
+    expect(after.claimed).toBe(0)
+    expect(after.dispatched).toBe(0)
+  })
+
   test("still revives a prematurely auto-closed running run with pending backlog", async () => {
     const { store, run } = createStoreWithRun({ targetConcurrency: 1, workUnits: 3 })
     const dispatched: string[] = []

--- a/clients/khala-code-desktop/tests/fleet-run-supervisor.test.ts
+++ b/clients/khala-code-desktop/tests/fleet-run-supervisor.test.ts
@@ -291,6 +291,67 @@ describe("FleetRunSupervisor", () => {
     ])
   })
 
+  test("never auto-revives a paused run mid-backlog (#7975)", async () => {
+    const { store, run } = createStoreWithRun({ targetConcurrency: 2, workUnits: 3 })
+    store.controlFleetRun(run.runRef, "pause", fixedNow)
+
+    const result = await tickFleetRunSupervisor({
+      store,
+      pylonRef: "pylon.owner",
+      runRef: run.runRef,
+      planner: fixturePlannerWithClaims(store, 3),
+      runner: acceptingRunner(),
+      capacity: capacity([{ accountRef: "codex-a", advertisedCapacity: 2 }]),
+      clock: { now: () => fixedNow },
+    })
+
+    expect(result.run.state).toBe("paused")
+    expect(result.claimed).toBe(0)
+    expect(result.dispatched).toBe(0)
+    expect(store.listWorkClaims({ runRef: run.runRef })).toEqual([])
+    expect(store.getFleetRun(run.runRef)?.state).toBe("paused")
+  })
+
+  test("still revives a prematurely auto-closed running run with pending backlog", async () => {
+    const { store, run } = createStoreWithRun({ targetConcurrency: 1, workUnits: 3 })
+    const dispatched: string[] = []
+
+    const first = await tickFleetRunSupervisor({
+      store,
+      pylonRef: "pylon.owner",
+      runRef: run.runRef,
+      planner: fixturePlannerWithClaims(store, 1),
+      runner: {
+        dispatch: async (input: FleetRunSupervisorDispatchInput) => {
+          dispatched.push(input.workUnit.workUnitRef)
+          return {
+            assignmentRef: `assignment.${input.claim.claimRef}`,
+            lifecycle: [{ event: "assignment.completed", status: "completed" }],
+            status: "completed" as const,
+          }
+        },
+      },
+      capacity: capacity([{ accountRef: "codex-a", advertisedCapacity: 1 }]),
+      clock: { now: () => fixedNow },
+    })
+    expect(first.dispatched).toBe(1)
+
+    // All created tasks are terminal while the planner backlog still has
+    // units, so reconciliation auto-closes the running run; the next tick
+    // must undo exactly that auto-close and keep working.
+    const second = await tickFleetRunSupervisor({
+      store,
+      pylonRef: "pylon.owner",
+      runRef: run.runRef,
+      planner: fixturePlannerWithClaims(store, 2),
+      runner: acceptingRunner(dispatched),
+      capacity: capacity([{ accountRef: "codex-a", advertisedCapacity: 1 }]),
+      clock: { now: () => fixedNow },
+    })
+    expect(second.run.state).toBe("running")
+    expect(second.dispatched).toBe(1)
+  })
+
   test("streams terminal lifecycle into counters and drains cleanly when backlog is empty", async () => {
     const { store, run } = createStoreWithRun({ targetConcurrency: 3, workUnits: 3 })
     const observed: FleetRunSupervisorObservedEvent[] = []


### PR DESCRIPTION
Fixes the paused-run revival bug found by the T6.13 formal-tier review: `tickFleetRunSupervisor` flipped any non-running run back to `running` whenever the reconciled `workUnitsTotal` trailed the persisted planner total — the normal mid-backlog condition — so operator pause/drain/stop were silently undone on the next tick.

**Fix:** fleet runs carry state provenance (`stateSource: "operator" | "reconcile"`, optional so legacy rows decode unchanged). Operator verbs (`controlFleetRun` / default `updateFleetRunState`) stamp `operator`; reconciliation auto-close and the supervisor's own machine transitions stamp `reconcile`. All three revive branches now gate on `isAutoRevivableFleetRun` — only reconcile-closed `completed`/`stopped` runs reopen; paused/draining/operator-stopped never do. Machine-closed runs with pending backlog still reopen (existing resilience preserved; regression test included for both directions).

Tests: `clients/khala-code-desktop/tests/fleet-run-supervisor.test.ts` 14 pass (2 new: pause-mid-backlog holds; premature auto-close still revives), `apps/pylon/src/orchestration` 42 pass (1 new provenance test), both package typechecks green.

Closes #7975

🤖 Generated with [Claude Code](https://claude.com/claude-code)