### PR TITLE
T14.4: TestClock migration for real-sleep tests

### DIFF
--- a/clients/khala-code-desktop/src/bun/apple-fm-sidecar.ts
+++ b/clients/khala-code-desktop/src/bun/apple-fm-sidecar.ts
@@ -13,6 +13,7 @@ import { khalaCodeConfigFromRuntimeEnv } from "./khala-code-config.js"
 
 type SidecarLaunchState = "idle" | "launching" | "running" | "failed" | "stopped" | "adopted"
 type HelperSource = "env" | "source-wrapper" | "source-build" | "packaged-resource"
+type AppleFmTimerHandle = number | ReturnType<typeof setTimeout>
 
 type DiscoveredAppleFmBridgeHelper = {
   readonly path: string
@@ -34,6 +35,10 @@ type AppleFmSidecarHostOptions = {
   readonly now?: () => string
   readonly maxRestarts?: number
   readonly restartDelayMs?: number
+  readonly clock?: {
+    readonly setTimeout?: (callback: () => void, ms: number) => AppleFmTimerHandle
+    readonly clearTimeout?: (handle: AppleFmTimerHandle) => void
+  }
 }
 
 const APPLE_FM_BRIDGE_DEFAULT_PORT = 11435
@@ -155,6 +160,11 @@ export function createAppleFmSidecarHost(
   const now = options.now ?? (() => new Date().toISOString())
   const maxRestarts = Math.max(0, options.maxRestarts ?? APPLE_FM_BRIDGE_MAX_RESTARTS)
   const restartDelayMs = Math.max(0, options.restartDelayMs ?? APPLE_FM_BRIDGE_RESTART_DELAY_MS)
+  const clock = {
+    clearTimeout,
+    setTimeout,
+    ...options.clock,
+  }
   const discoverOptions = {
     cwd: process.cwd(),
     env,
@@ -166,12 +176,12 @@ export function createAppleFmSidecarHost(
   let launchState: SidecarLaunchState = "idle"
   let child: ReturnType<typeof Bun.spawn> | null = null
   let restartAttempts = 0
-  let restartTimer: ReturnType<typeof setTimeout> | null = null
+  let restartTimer: AppleFmTimerHandle | null = null
   let stopped = false
 
   const clearRestartTimer = () => {
     if (restartTimer !== null) {
-      clearTimeout(restartTimer)
+      clock.clearTimeout(restartTimer)
       restartTimer = null
     }
   }
@@ -208,7 +218,7 @@ export function createAppleFmSidecarHost(
         if (shouldLaunchHelper() && restartAttempts < maxRestarts) {
           restartAttempts += 1
           launchState = "launching"
-          restartTimer = setTimeout(() => {
+          restartTimer = clock.setTimeout(() => {
             restartTimer = null
             start()
           }, restartDelayMs)

--- a/clients/khala-code-desktop/src/bun/khala-chat-runtime.ts
+++ b/clients/khala-code-desktop/src/bun/khala-chat-runtime.ts
@@ -125,6 +125,13 @@ type ChatTransport = {
 
 type ChatTurnEmitter = (event: KhalaCodeDesktopChatTurnEvent) => void
 
+type KhalaChatTimerHandle = number | ReturnType<typeof setTimeout>
+
+type KhalaChatTimerClock = {
+  readonly setTimeout: (callback: () => void, ms: number) => KhalaChatTimerHandle
+  readonly clearTimeout: (handle: KhalaChatTimerHandle) => void
+}
+
 type ContextCompactionPolicy = {
   readonly keepTailCount: number
   readonly maxTokens: number
@@ -143,6 +150,7 @@ type LocalGroundingCorrection = {
 export type RunKhalaCodeDesktopChatTurnInput = {
   readonly env: ChatEnv
   readonly fetchFn?: typeof fetch
+  readonly liveProgressClock?: Partial<KhalaChatTimerClock>
   readonly request: KhalaCodeDesktopChatTurnRequest
   readonly onEvent?: (event: KhalaCodeDesktopChatTurnEvent) => void
   readonly redaction?: KhalaPrivacyRedactionServiceShape
@@ -274,6 +282,11 @@ export async function runKhalaCodeDesktopChatTurn(
     input.onEvent?.(event)
   }
   const liveToolProgress = new Map<string, LiveToolProgressCard>()
+  const liveProgressClock = {
+    clearTimeout,
+    setTimeout,
+    ...input.liveProgressClock,
+  }
   const toolDispatcher = makeKhalaToolDispatcher({
     hooks: {
       onEvent: context => Effect.sync(() => {
@@ -453,6 +466,7 @@ export async function runKhalaCodeDesktopChatTurn(
       const toolTranscript = hostMessage("tool", toolTranscriptRunningBody(call.function.name))
       emit({ message: toolTranscript, turnId, type: "message_start" })
       const progressCard = createLiveToolProgressCard({
+        clock: liveProgressClock,
         emit,
         toolName: call.function.name,
         toolTranscript,
@@ -1425,13 +1439,15 @@ function turnScopedToolEventId(turnId: string, event: KhalaToolEvent): string {
 }
 
 function createLiveToolProgressCard(input: {
+  readonly clock?: KhalaChatTimerClock
   readonly emit: ChatTurnEmitter
   readonly toolName: string
   readonly toolTranscript: KhalaCodeDesktopMessage
   readonly turnId: string
 }): LiveToolProgressCard {
   let pendingBody: string | null = null
-  let timer: ReturnType<typeof setTimeout> | null = null
+  let timer: KhalaChatTimerHandle | null = null
+  const clock = input.clock ?? { clearTimeout, setTimeout }
   const emitReplace = () => {
     if (pendingBody === null) return
     const body = pendingBody
@@ -1447,7 +1463,7 @@ function createLiveToolProgressCard(input: {
   }
   const flush = () => {
     if (timer !== null) {
-      clearTimeout(timer)
+      clock.clearTimeout(timer)
       timer = null
     }
     emitReplace()
@@ -1458,14 +1474,14 @@ function createLiveToolProgressCard(input: {
       if (body === null) return
       pendingBody = body
       if (timer !== null) return
-      timer = setTimeout(() => {
+      timer = clock.setTimeout(() => {
         timer = null
         emitReplace()
       }, 200)
-      timer.unref?.()
+      if (typeof timer === "object") timer.unref?.()
     },
     dispose: () => {
-      if (timer !== null) clearTimeout(timer)
+      if (timer !== null) clock.clearTimeout(timer)
       timer = null
       pendingBody = null
     },

--- a/clients/khala-code-desktop/src/bun/khala-codex-fleet-tools.ts
+++ b/clients/khala-code-desktop/src/bun/khala-codex-fleet-tools.ts
@@ -1422,6 +1422,7 @@ export class DefaultKhalaFleetRunSupervisorManager implements KhalaFleetRunSuper
           runner: this.runnerFor(runRef, pylonRef),
           capacity: this.capacityFor(),
           tickIntervalMs: DEFAULT_FLEET_RUN_TICK_INTERVAL_MS,
+          ...(this.options.sleep === undefined ? {} : { clock: { sleep: this.options.sleep } }),
           onLifecycle: event => {
             const existing = this.active.get(runRef)
             existing?.lifecycle.push(event)

--- a/clients/khala-code-desktop/src/ui/fleet-status.ts
+++ b/clients/khala-code-desktop/src/ui/fleet-status.ts
@@ -74,6 +74,10 @@ export type FleetPanelOptions = Readonly<{
   openExternal: (url: string) => Promise<boolean>
   lifecycleNdjson?: () => AsyncIterable<string | Uint8Array>
   lifecycleUpdateThrottleMs?: number
+  lifecycleUpdateClock?: {
+    readonly setTimeout?: (callback: () => void, ms: number) => number
+    readonly clearTimeout?: (handle: number) => void
+  }
   now?: () => Date
 }>
 
@@ -1645,6 +1649,12 @@ export const mountFleetPanel = (
       lifecycleFrames = update.frames
       paint()
     },
+    ...(options.lifecycleUpdateClock?.setTimeout === undefined
+      ? {}
+      : { setTimeout: options.lifecycleUpdateClock.setTimeout }),
+    ...(options.lifecycleUpdateClock?.clearTimeout === undefined
+      ? {}
+      : { clearTimeout: options.lifecycleUpdateClock.clearTimeout }),
   })
 
   const startLifecycleStream = (): void => {

--- a/clients/khala-code-desktop/tests/apple-fm-sidecar.test.ts
+++ b/clients/khala-code-desktop/tests/apple-fm-sidecar.test.ts
@@ -126,6 +126,7 @@ describe("Khala Desktop Apple FM sidecar host", () => {
   test("restarts a crashed packaged helper within the bounded supervision policy", async () => {
     const { resourcesDir } = createPackagedHelper()
     const exits: Array<(code: number) => void> = []
+    const restartCallbacks: Array<() => void> = []
     const spawned: Array<ReadonlyArray<string>> = []
     const host = createAppleFmSidecarHost({
       arch: "arm64",
@@ -139,6 +140,13 @@ describe("Khala Desktop Apple FM sidecar host", () => {
       platform: "darwin",
       resourcesDir,
       restartDelayMs: 0,
+      clock: {
+        setTimeout: (callback) => {
+          restartCallbacks.push(callback)
+          return restartCallbacks.length as unknown as ReturnType<typeof setTimeout>
+        },
+        clearTimeout: () => undefined,
+      },
       spawn: ((command: ReadonlyArray<string>) => {
         spawned.push([...command])
         const exited = new Promise<number>((resolve) => exits.push(resolve))
@@ -154,7 +162,8 @@ describe("Khala Desktop Apple FM sidecar host", () => {
       expect(spawned).toHaveLength(1)
 
       exits[0]?.(1)
-      await Bun.sleep(10)
+      await Promise.resolve()
+      restartCallbacks[0]?.()
 
       expect(spawned).toHaveLength(2)
     } finally {
@@ -166,6 +175,8 @@ describe("Khala Desktop Apple FM sidecar host", () => {
   test("stop cancels a pending Apple FM helper restart", async () => {
     const { resourcesDir } = createPackagedHelper()
     const exits: Array<(code: number) => void> = []
+    const restartCallbacks = new Map<number, () => void>()
+    let nextTimer = 0
     const spawned: Array<ReadonlyArray<string>> = []
     const host = createAppleFmSidecarHost({
       arch: "arm64",
@@ -178,6 +189,16 @@ describe("Khala Desktop Apple FM sidecar host", () => {
       platform: "darwin",
       resourcesDir,
       restartDelayMs: 25,
+      clock: {
+        setTimeout: (callback) => {
+          nextTimer += 1
+          restartCallbacks.set(nextTimer, callback)
+          return nextTimer as unknown as ReturnType<typeof setTimeout>
+        },
+        clearTimeout: handle => {
+          restartCallbacks.delete(handle as unknown as number)
+        },
+      },
       spawn: ((command: ReadonlyArray<string>) => {
         spawned.push([...command])
         const exited = new Promise<number>((resolve) => exits.push(resolve))
@@ -191,8 +212,9 @@ describe("Khala Desktop Apple FM sidecar host", () => {
     try {
       await host.readiness()
       exits[0]?.(1)
+      await Promise.resolve()
       host.stop()
-      await Bun.sleep(40)
+      for (const callback of restartCallbacks.values()) callback()
 
       expect(spawned).toHaveLength(1)
     } finally {

--- a/clients/khala-code-desktop/tests/claude-app-sdk-chat-runtime.test.ts
+++ b/clients/khala-code-desktop/tests/claude-app-sdk-chat-runtime.test.ts
@@ -322,7 +322,7 @@ describe("Claude Agent SDK chat runtime", () => {
       turnId: "turn-interrupt",
     })
     await started
-    await new Promise(resolve => setTimeout(resolve, 0))
+    await Promise.resolve()
     const interruptedResult = await runtime.interruptTurn({
       sessionId: "desktop-session-interrupt",
       turnId: "turn-interrupt",
@@ -369,7 +369,7 @@ describe("Claude Agent SDK chat runtime", () => {
       turnId: "turn-no-interrupt",
     })
     await started
-    await new Promise(resolve => setTimeout(resolve, 0))
+    await Promise.resolve()
     const interruptedResult = await runtime.interruptTurn({
       sessionId: "desktop-session-no-interrupt",
       turnId: "turn-no-interrupt",
@@ -402,6 +402,10 @@ describe("Claude Agent SDK chat runtime", () => {
     const approvalService = createClaudeApprovalService()
     const statePath = await tempPath("claude-approval-state.json")
     let decision: unknown
+    let approvalRequested!: () => void
+    const approvalReady = new Promise<void>(resolve => {
+      approvalRequested = resolve
+    })
     const runtime = createClaudeAppSdkChatRuntime({
       approvalService,
       query: input => ({
@@ -411,11 +415,13 @@ describe("Claude Agent SDK chat runtime", () => {
             toolInput: Record<string, unknown>,
             options: Record<string, unknown>,
           ) => Promise<unknown>
-          decision = await canUseTool("Bash", { command: "pwd" }, {
+          const decisionPromise = canUseTool("Bash", { command: "pwd" }, {
             signal: new AbortController().signal,
             suggestions: [{ toolName: "Bash", rule: "allow" }],
             title: "Claude wants to run pwd",
           })
+          approvalRequested()
+          decision = await decisionPromise
           yield { type: "result", subtype: "success", session_id: "claude-approval-session" }
         },
       }),
@@ -428,7 +434,7 @@ describe("Claude Agent SDK chat runtime", () => {
       sessionId: "desktop-approval",
       turnId: "turn-approval",
     })
-    while (approvalService.pending().length === 0) await new Promise(resolve => setTimeout(resolve, 0))
+    await approvalReady
     const pending = approvalService.pending()[0]
     expect(pending).toMatchObject({
       toolName: "Bash",

--- a/clients/khala-code-desktop/tests/codex-app-server-chat-runtime.test.ts
+++ b/clients/khala-code-desktop/tests/codex-app-server-chat-runtime.test.ts
@@ -1221,6 +1221,10 @@ describe("Codex app-server chat runtime", () => {
   test("interrupts the active Codex turn by desktop turn id", async () => {
     const fixture = await stateFixture()
     const records: RequestRecord[] = []
+    let turnStartedEmitted!: () => void
+    const turnStartedReady = new Promise<void>(resolve => {
+      turnStartedEmitted = resolve
+    })
     const host = createFakeHost({
       records,
       onRequest: (method, _params, subscribers) => {
@@ -1241,6 +1245,7 @@ describe("Codex app-server chat runtime", () => {
                 turn: { id: "turn-codex-1", status: "inProgress" },
               },
             })
+            turnStartedEmitted()
           })
           return { turn: { id: "turn-codex-1", status: "inProgress" } }
         }
@@ -1270,10 +1275,7 @@ describe("Codex app-server chat runtime", () => {
       sessionId: "desktop-session-1",
       turnId: "desktop-turn-1",
     })
-    for (let index = 0; index < 50 && !records.some(record => record.method === "turn/start"); index += 1) {
-      await Bun.sleep(1)
-    }
-    await Promise.resolve()
+    await turnStartedReady
 
     await expect(runtime.interruptTurn({
       sessionId: "desktop-session-1",

--- a/clients/khala-code-desktop/tests/fleet-run-supervisor.test.ts
+++ b/clients/khala-code-desktop/tests/fleet-run-supervisor.test.ts
@@ -500,6 +500,11 @@ describe("FleetRunSupervisor", () => {
     let tickCount = 0
     let scopeClosed = false
     const scope = Effect.runSync(Scope.make())
+    const sleepResolvers: Array<() => void> = []
+    let firstTickResolve: (() => void) | null = null
+    const firstTick = new Promise<void>(resolve => {
+      firstTickResolve = resolve
+    })
 
     const handle = await Effect.runPromise(Effect.provideService(
       startFleetRunSupervisor({
@@ -512,29 +517,26 @@ describe("FleetRunSupervisor", () => {
         tickIntervalMs: 1,
         clock: {
           now: () => fixedNow,
-          sleep: () => Promise.resolve(),
+          sleep: () => new Promise<void>(resolve => {
+            sleepResolvers.push(resolve)
+          }),
         },
         onLifecycle: event => {
-          if (event.kind === "tick" && !scopeClosed) tickCount += 1
+          if (event.kind !== "tick" || scopeClosed) return
+          tickCount += 1
+          firstTickResolve?.()
         },
       }),
       Scope.Scope,
       scope,
     ))
 
-    await new Promise<void>((resolve, reject) => {
-      const started = Date.now()
-      const poll = () => {
-        if (tickCount > 0) return resolve()
-        if (Date.now() - started > 1000) return reject(new Error("supervisor did not tick"))
-        setTimeout(poll, 1)
-      }
-      poll()
-    })
+    await firstTick
     await Effect.runPromise(Scope.close(scope, Exit.void))
     scopeClosed = true
     const ticksAtClose = tickCount
-    await new Promise(resolve => setTimeout(resolve, 5))
+    for (const resolve of sleepResolvers.splice(0)) resolve()
+    await Promise.resolve()
 
     expect(ticksAtClose).toBeGreaterThan(0)
     expect(tickCount).toBe(ticksAtClose)

--- a/clients/khala-code-desktop/tests/fleet-worker-cards.test.ts
+++ b/clients/khala-code-desktop/tests/fleet-worker-cards.test.ts
@@ -194,6 +194,7 @@ describe("Khala Fleet worker cards", () => {
 
     const requests: KhalaCodeDesktopFleetWorkerControlRequest[] = []
     const container = document.createElement("div")
+    const lifecycleUpdateCallbacks: Array<() => void> = []
     const lifecycleNdjson = async function* (): AsyncIterable<string> {
       yield `${assignmentEvent({
         elapsedMs: 3_000,
@@ -232,6 +233,13 @@ describe("Khala Fleet worker cards", () => {
         }
       },
       lifecycleNdjson,
+      lifecycleUpdateClock: {
+        setTimeout: callback => {
+          lifecycleUpdateCallbacks.push(callback)
+          return lifecycleUpdateCallbacks.length
+        },
+        clearTimeout: () => undefined,
+      },
       lifecycleUpdateThrottleMs: 0,
       loadGymDemoProof: async () => {
         throw new Error("not used")
@@ -247,10 +255,11 @@ describe("Khala Fleet worker cards", () => {
 
     try {
       panel.setVisible(true)
-      for (let index = 0; index < 20; index += 1) {
-        if (container.querySelector<HTMLElement>(".khala-fleet-worker-lifecycle")?.textContent?.includes("assignment_run.runtime_progress")) break
-        await new Promise(resolve => setTimeout(resolve, 10))
+      for (let index = 0; index < 50 && lifecycleUpdateCallbacks.length === 0; index += 1) {
+        await Promise.resolve()
       }
+      lifecycleUpdateCallbacks.splice(0).forEach(callback => callback())
+      await Promise.resolve()
       expect(container.innerHTML).toContain("khala-fleet-worker-card")
       const cardHtml = container.querySelector<HTMLElement>(".khala-fleet-worker-card")?.innerHTML ?? ""
       expect(cardHtml).not.toContain("assignment.public.worker-card")

--- a/clients/khala-code-desktop/tests/foldkit-embedding.test.ts
+++ b/clients/khala-code-desktop/tests/foldkit-embedding.test.ts
@@ -11,25 +11,62 @@ import { FoldkitDemoReceivedHostPort } from "../src/ui/foldkit/message"
 import { initialKhalaCodeFoldkitModel } from "../src/ui/foldkit/model"
 import { makeKhalaCodeFoldkitUpdate } from "../src/ui/foldkit/update"
 
-const installDom = (): Window => {
+const installDom = (): {
+  readonly flushAnimationFrame: () => void
+  readonly window: Window
+} => {
   const window = new Window({
     url: "https://khala-code-desktop.test/",
   })
-  const raf = (callback: FrameRequestCallback): number =>
-    Number(setTimeout(() => callback(performance.now()), 0))
-  const caf = (handle: number): void => clearTimeout(handle)
+  const animationFrames = new Map<number, FrameRequestCallback>()
+  let nextFrame = 0
+  const raf = (callback: FrameRequestCallback): number => {
+    nextFrame += 1
+    animationFrames.set(nextFrame, callback)
+    return nextFrame
+  }
+  const caf = (handle: number): void => {
+    animationFrames.delete(handle)
+  }
+  const defineGlobal = (key: keyof typeof globalThis, value: unknown): void => {
+    Object.defineProperty(globalThis, key, {
+      configurable: true,
+      value,
+      writable: true,
+    })
+  }
 
-  Object.assign(globalThis, {
-    cancelAnimationFrame: caf,
-    document: window.document,
-    location: window.location,
-    navigator: window.navigator,
-    requestAnimationFrame: raf,
+  defineGlobal("cancelAnimationFrame", caf)
+  defineGlobal("document", window.document)
+  defineGlobal("location", window.location)
+  defineGlobal("navigator", window.navigator)
+  defineGlobal("requestAnimationFrame", raf)
+  defineGlobal("window", window)
+  window.requestAnimationFrame = raf as unknown as typeof window.requestAnimationFrame
+  window.cancelAnimationFrame = caf as unknown as typeof window.cancelAnimationFrame
+
+  return {
+    flushAnimationFrame: () => {
+      const callbacks = [...animationFrames.values()]
+      animationFrames.clear()
+      for (const callback of callbacks) callback(performance.now())
+    },
     window,
-  })
-
-  return window
+  }
 }
+
+const flushDomWork = async (
+  dom: ReturnType<typeof installDom>,
+  count = 20,
+): Promise<void> => {
+  for (let index = 0; index < count; index += 1) {
+    dom.flushAnimationFrame()
+    await yieldTask()
+  }
+}
+
+const yieldTask = (): Promise<void> =>
+  new Promise(resolve => setTimeout(resolve, 0))
 
 describe("khala code Foldkit embedding skeleton", () => {
   test("keeps program update pure until returned commands run", async () => {
@@ -81,7 +118,7 @@ describe("khala code Foldkit embedding skeleton", () => {
   })
 
   test("mounts, round-trips ports, and unmounts from a designated container", async () => {
-    installDom()
+    const dom = installDom()
     const { embedKhalaCodeFoldkitProgram } = await import("../src/ui/foldkit/runtime")
     const container = document.createElement("section")
     container.id = "foldkit-demo-fixture"
@@ -94,7 +131,7 @@ describe("khala code Foldkit embedding skeleton", () => {
       mountId: "foldkit-demo-fixture-runtime",
       ports,
     })
-    await new Promise(resolve => setTimeout(resolve, 20))
+    await flushDomWork(dom)
 
     expect(container.querySelector("[data-foldkit-mount-id='foldkit-demo-fixture-runtime']")).not.toBeNull()
     expect(container.textContent ?? "").toContain("Foldkit skeleton")
@@ -104,7 +141,7 @@ describe("khala code Foldkit embedding skeleton", () => {
     })
 
     handle.send({ _tag: "HostPing", nonce: "host-fixture" })
-    await new Promise(resolve => setTimeout(resolve, 20))
+    await flushDomWork(dom)
 
     expect(container.textContent ?? "").toContain("Ping 1")
     expect(emitted).toContainEqual({

--- a/clients/khala-code-desktop/tests/forum-panel.test.ts
+++ b/clients/khala-code-desktop/tests/forum-panel.test.ts
@@ -26,9 +26,8 @@ const installDom = (): HTMLElement => {
 }
 
 const flushForumPanel = async (): Promise<void> => {
-  for (let index = 0; index < 4; index += 1) {
+  for (let index = 0; index < 50; index += 1) {
     await Promise.resolve()
-    await new Promise(resolve => setTimeout(resolve, 0))
   }
 }
 

--- a/clients/khala-code-desktop/tests/khala-chat-runtime.test.ts
+++ b/clients/khala-code-desktop/tests/khala-chat-runtime.test.ts
@@ -70,10 +70,6 @@ async function tempWorkspace(): Promise<string> {
   return dir
 }
 
-function sleep(ms: number): Promise<void> {
-  return new Promise(resolve => setTimeout(resolve, ms))
-}
-
 function jsonResponse(body: unknown, init?: ResponseInit): Response {
   return new Response(JSON.stringify(body), {
     ...init,
@@ -683,7 +679,6 @@ describe("Khala Code desktop chat runtime", () => {
               schema: "openagents.khala_code.codex_spawn_progress.v0.1",
               toolName: "codex_spawn",
             })
-            yield* Effect.promise(() => sleep(230))
             yield* context.emitProgress({
               events: [
                 { event: "assignment_run.runtime_started", phase: "runtime_starting" },
@@ -698,7 +693,6 @@ describe("Khala Code desktop chat runtime", () => {
               schema: "openagents.khala_code.codex_spawn_progress.v0.1",
               toolName: "codex_spawn",
             })
-            yield* Effect.promise(() => sleep(230))
             return khalaToolOk({
               modelText: "Codex spawn: accepted 1/1\n- slot 0: accepted",
               publicSummary: "Codex spawn accepted 1/1 request(s).",
@@ -729,6 +723,13 @@ describe("Khala Code desktop chat runtime", () => {
     const result = await runKhalaCodeDesktopChatTurn({
       env: { OPENAGENTS_AGENT_TOKEN: "agent-token" },
       fetchFn,
+      liveProgressClock: {
+        setTimeout: callback => {
+          callback()
+          return { unref() {} } as ReturnType<typeof setTimeout>
+        },
+        clearTimeout: () => undefined,
+      },
       onEvent: event => events.push(event),
       registry,
       request: {

--- a/clients/khala-code-desktop/tests/khala-codex-fleet-tools.test.ts
+++ b/clients/khala-code-desktop/tests/khala-codex-fleet-tools.test.ts
@@ -190,6 +190,7 @@ async function waitForFleetRunSnapshot(
   manager: DefaultKhalaFleetRunSupervisorManager,
   runRef: string,
   predicate: (snapshot: Awaited<ReturnType<DefaultKhalaFleetRunSupervisorManager["start"]>>) => boolean,
+  sleep: (ms: number) => Promise<void> = Bun.sleep,
 ): Promise<Awaited<ReturnType<DefaultKhalaFleetRunSupervisorManager["start"]>>> {
   // Array.isArray does not narrow readonly arrays out of a union, so use an
   // explicit guard for the single-snapshot shape.
@@ -202,7 +203,7 @@ async function waitForFleetRunSnapshot(
   for (let attempt = 0; attempt < 50; attempt += 1) {
     const snapshot = singleSnapshot(await manager.status({ runRef }))
     if (predicate(snapshot)) return snapshot
-    await Bun.sleep(10)
+    await sleep(10)
   }
   const snapshot = singleSnapshot(await manager.status({ runRef }))
   throw new Error(`fleet run ${runRef} did not reach expected state; last state=${snapshot.run.state} active=${snapshot.active}`)
@@ -425,7 +426,13 @@ describe("Khala Code Codex fleet tools", () => {
       }
       return failed(`unexpected command: ${joined}`)
     }
-    const manager = new DefaultKhalaFleetRunSupervisorManager({ env: fixture.env, runner })
+    const manager = new DefaultKhalaFleetRunSupervisorManager({
+      env: fixture.env,
+      runner,
+      sleep: async () => {
+        await new Promise(resolve => setTimeout(resolve, 0))
+      },
+    })
 
     await manager.start({
       fixtureCount: 1,
@@ -439,6 +446,9 @@ describe("Khala Code Codex fleet tools", () => {
       manager,
       "fleet_run.test.completed_one",
       snapshot => snapshot.run.state === "completed" && !snapshot.active,
+      async () => {
+        await new Promise(resolve => setTimeout(resolve, 0))
+      },
     )
     const second = await manager.start({
       fixtureCount: 1,
@@ -1661,6 +1671,11 @@ describe("Khala Code Codex fleet tools", () => {
     let inFlightRequests = 0
     let maxInFlightRequests = 0
     let requestCount = 0
+    let bothRequestsInFlight: (() => void) | null = null
+    const bothRequestsInFlightPromise = new Promise<void>(resolve => {
+      bothRequestsInFlight = resolve
+    })
+    const releaseRequests: Array<() => void> = []
     const runner = async (input: KhalaCodexFleetCommandInput): Promise<KhalaCodexFleetCommandResult> => {
       const args = pylonArgs(input)
       const joined = args.join(" ")
@@ -1716,7 +1731,10 @@ describe("Khala Code Codex fleet tools", () => {
         const slot = requestCount
         inFlightRequests += 1
         maxInFlightRequests = Math.max(maxInFlightRequests, inFlightRequests)
-        await new Promise(resolve => setTimeout(resolve, 25))
+        if (inFlightRequests === 2) bothRequestsInFlight?.()
+        await new Promise<void>(resolve => {
+          releaseRequests.push(resolve)
+        })
         inFlightRequests -= 1
         return ok({
           assignmentRef: `assignment.public.codex_agent_task.concurrent_${slot}`,
@@ -1729,7 +1747,7 @@ describe("Khala Code Codex fleet tools", () => {
       return failed(`unexpected command: ${joined}`)
     }
 
-    const result = await spawnCodexInstances({
+    const resultPromise = spawnCodexInstances({
       count: 2,
       noRun: true,
       prompt: "Run the public fixture.",
@@ -1737,6 +1755,9 @@ describe("Khala Code Codex fleet tools", () => {
       env: fixture.env,
       runner,
     })
+    await bothRequestsInFlightPromise
+    for (const release of releaseRequests.splice(0)) release()
+    const result = await resultPromise
 
     expect(result).toMatchObject({
       acceptedCount: 2,

--- a/clients/khala-code-desktop/tests/plans-panel.test.ts
+++ b/clients/khala-code-desktop/tests/plans-panel.test.ts
@@ -32,9 +32,8 @@ const installDom = (): HTMLElement => {
 }
 
 const flushPanel = async (): Promise<void> => {
-  for (let index = 0; index < 4; index += 1) {
+  for (let index = 0; index < 50; index += 1) {
     await Promise.resolve()
-    await new Promise(resolve => setTimeout(resolve, 0))
   }
 }
 

--- a/packages/khala-qa-harness/src/desktop-smoke-helpers.ts
+++ b/packages/khala-qa-harness/src/desktop-smoke-helpers.ts
@@ -11,6 +11,7 @@ export type KhalaQaStartViteServerOptions = Readonly<{
 export type KhalaQaWaitForHttpOptions = Readonly<{
   fetch?: typeof fetch
   intervalMs?: number
+  now?: () => number
   sleep?: (ms: number) => Promise<void>
   timeoutMs?: number
 }>
@@ -76,10 +77,11 @@ export const waitForKhalaQaHttp = async (
 ): Promise<void> => {
   const fetchLike = options.fetch ?? fetch
   const intervalMs = options.intervalMs ?? 250
+  const now = options.now ?? Date.now
   const sleep = options.sleep ?? Bun.sleep
-  const deadline = Date.now() + (options.timeoutMs ?? 30_000)
+  const deadline = now() + (options.timeoutMs ?? 30_000)
   let lastError: unknown = null
-  while (Date.now() < deadline) {
+  while (now() < deadline) {
     try {
       const response = await fetchLike(url)
       if (response.ok) return

--- a/packages/khala-qa-harness/src/scenario-runner.test.ts
+++ b/packages/khala-qa-harness/src/scenario-runner.test.ts
@@ -585,13 +585,17 @@ describe("Khala Code QA RPC driver and runner", () => {
 describe("desktop smoke helper extraction", () => {
   test("waitForKhalaQaHttp uses injectable fetch and sleep", async () => {
     let calls = 0
+    let now = 0
     await waitForKhalaQaHttp("http://fixture.local", {
       fetch: (() => {
         calls += 1
         return Promise.resolve(new Response("ok", { status: calls === 1 ? 503 : 200 }))
       }) as unknown as typeof fetch,
       intervalMs: 1,
-      sleep: () => Promise.resolve(),
+      now: () => now,
+      sleep: async ms => {
+        now += ms
+      },
       timeoutMs: 100,
     })
 


### PR DESCRIPTION
Closes #7899

## Summary
- Added injectable timer/clock seams for Khala chat live-progress debounce, Apple FM sidecar restart scheduling, fleet-run supervisor manager sleep, fleet worker lifecycle throttling, and QA HTTP polling.
- Replaced long real sleeps/polls in touched desktop tests with deterministic manual callbacks, explicit event promises, fake `now`/sleep control, or zero-delay task turns where the runtime needs a scheduler turn without elapsed wall-clock time.
- Preserved existing assertions around progress replacement ordering, sidecar restart/cancel behavior, supervisor scope shutdown, fleet concurrency, worker card privacy, approval/interrupt flow, and QA HTTP retry behavior.

## Suite Wall-Clock
- Before source edits: `time bun test tests/*.test.ts` could not complete in this cached checkout because `clients/khala-code-desktop/node_modules` pointed to a stale shared workspace cache; it failed during module resolution in `1.143s` wall-clock after loading 234 tests.
- After source edits, with local ignored workspace links repaired for verification: `time bun test tests/*.test.ts` passed 444 tests in `4.493s` wall-clock (`[4.48s]` Bun reported time).

## Verification
- `bun test tests/khala-chat-runtime.test.ts tests/apple-fm-sidecar.test.ts tests/fleet-run-supervisor.test.ts tests/khala-codex-fleet-tools.test.ts tests/foldkit-embedding.test.ts tests/fleet-worker-cards.test.ts tests/claude-app-sdk-chat-runtime.test.ts tests/forum-panel.test.ts tests/plans-panel.test.ts tests/codex-app-server-chat-runtime.test.ts`
- `bun run --cwd clients/khala-code-desktop verify`
- `bun run --cwd packages/khala-qa-harness typecheck`
- `bun test packages/khala-qa-harness/src/*.test.ts`
- Required pinned command `command.public.pylon_khala.verify.07cda6414807b7e4b2584e92`: `bun run --cwd clients/khala-code-desktop typecheck`