### PR TITLE
T7.1: KhalaProcess scoped subprocess service

### DIFF
--- a/clients/khala-code-desktop/src/bun/apple-fm-sidecar.ts
+++ b/clients/khala-code-desktop/src/bun/apple-fm-sidecar.ts
@@ -10,9 +10,14 @@ import {
   type PylonAppleFmStatusPublicInput,
 } from "../shared/apple-fm-readiness.js"
 import { khalaCodeConfigFromRuntimeEnv } from "./khala-code-config.js"
+import { spawnKhalaProcessNodeChild, type KhalaProcessNodeChild } from "./khala-process.js"
 
 type SidecarLaunchState = "idle" | "launching" | "running" | "failed" | "stopped" | "adopted"
 type HelperSource = "env" | "source-wrapper" | "source-build" | "packaged-resource"
+type AppleFmSidecarChild = Pick<KhalaProcessNodeChild, "exited" | "kill">
+type AppleFmSidecarSpawn = (
+  command: ReadonlyArray<string>,
+) => AppleFmSidecarChild | Promise<AppleFmSidecarChild>
 
 type DiscoveredAppleFmBridgeHelper = {
   readonly path: string
@@ -30,7 +35,7 @@ type AppleFmSidecarHostOptions = {
   readonly arch?: string
   readonly resourcesDir?: string
   readonly fetchFn?: typeof fetch
-  readonly spawn?: typeof Bun.spawn
+  readonly spawn?: unknown
   readonly now?: () => string
   readonly maxRestarts?: number
   readonly restartDelayMs?: number
@@ -151,7 +156,14 @@ export function createAppleFmSidecarHost(
   const arch = options.arch ?? process.arch
   const resourcesDir = options.resourcesDir ?? (process as NodeJS.Process & { resourcesPath?: string }).resourcesPath
   const fetchFn = options.fetchFn ?? fetch
-  const spawn = options.spawn ?? Bun.spawn
+  const launchHelperProcess: AppleFmSidecarSpawn = options.spawn === undefined ? ((command) => {
+    const [cmd, ...args] = command
+    if (cmd === undefined) throw new Error("empty Apple FM helper command")
+    return spawnKhalaProcessNodeChild(cmd, args, { forceKillAfter: "1500 millis" })
+  }) : (command =>
+    (options.spawn as (command: ReadonlyArray<string>) => AppleFmSidecarChild | Promise<AppleFmSidecarChild>)([
+      ...command,
+    ]))
   const now = options.now ?? (() => new Date().toISOString())
   const maxRestarts = Math.max(0, options.maxRestarts ?? APPLE_FM_BRIDGE_MAX_RESTARTS)
   const restartDelayMs = Math.max(0, options.restartDelayMs ?? APPLE_FM_BRIDGE_RESTART_DELAY_MS)
@@ -164,7 +176,7 @@ export function createAppleFmSidecarHost(
   const supported = platform === "darwin" && arch === "arm64"
   const executable = helper === null ? false : helperExecutable(helper.path)
   let launchState: SidecarLaunchState = "idle"
-  let child: ReturnType<typeof Bun.spawn> | null = null
+  let child: AppleFmSidecarChild | null = null
   let restartAttempts = 0
   let restartTimer: ReturnType<typeof setTimeout> | null = null
   let stopped = false
@@ -182,7 +194,7 @@ export function createAppleFmSidecarHost(
     executable &&
     (helper.source === "packaged-resource" || trim(env.OPENAGENTS_APPLE_FM_BRIDGE_PATH) !== null)
 
-  const start = () => {
+  const start = async () => {
     if (!supported || helper === null || !executable || child !== null || stopped) return
     if (helper.source !== "packaged-resource" && trim(env.OPENAGENTS_APPLE_FM_BRIDGE_PATH) === null) {
       launchState = "adopted"
@@ -191,11 +203,7 @@ export function createAppleFmSidecarHost(
     clearRestartTimer()
     try {
       launchState = "launching"
-      child = spawn([helper.path, "--port", String(APPLE_FM_BRIDGE_DEFAULT_PORT)], {
-        stdin: "ignore",
-        stdout: "ignore",
-        stderr: "ignore",
-      })
+      child = await launchHelperProcess([helper.path, "--port", String(APPLE_FM_BRIDGE_DEFAULT_PORT)])
       launchState = "running"
       void child.exited.then((exitCode) => {
         child = null
@@ -210,7 +218,7 @@ export function createAppleFmSidecarHost(
           launchState = "launching"
           restartTimer = setTimeout(() => {
             restartTimer = null
-            start()
+            void start()
           }, restartDelayMs)
           return
         }
@@ -224,7 +232,7 @@ export function createAppleFmSidecarHost(
 
   return {
     async readiness() {
-      start()
+      await start()
       const token = await controlTokenFromEnv(env)
       const pylonStatus =
         token === null

--- a/clients/khala-code-desktop/src/bun/codex-app-server-client.ts
+++ b/clients/khala-code-desktop/src/bun/codex-app-server-client.ts
@@ -1,4 +1,3 @@
-import { spawn } from "node:child_process"
 import { fileURLToPath } from "node:url"
 
 import type {
@@ -7,6 +6,7 @@ import type {
 } from "../shared/rpc.js"
 import { resolveCodexHomePath } from "./codex-rate-limits.js"
 import { khalaCodeConfigFromRuntimeEnv } from "./khala-code-config.js"
+import { spawnKhalaProcessNodeChild } from "./khala-process.js"
 
 export const KHALA_CODE_CODEX_APP_SERVER_ADAPTER_VERSION =
   "codex-app-server-v2-2026-07-01"
@@ -59,8 +59,12 @@ type CodexAppServerChild = {
 type SpawnFn = (
   command: string,
   args: readonly string[],
-  options: Parameters<typeof spawn>[2],
-) => CodexAppServerChild
+  options: {
+    readonly cwd?: string
+    readonly env?: NodeJS.ProcessEnv
+    readonly stdio?: readonly ["pipe", "pipe", "pipe"]
+  },
+) => CodexAppServerChild | Promise<CodexAppServerChild>
 
 type PendingRequest = {
   readonly method: string
@@ -201,7 +205,11 @@ export function createCodexAppServerHost(
   const spawnFn: SpawnFn =
     options.spawnFn ??
     ((command, args, spawnOptions) =>
-      spawn(command, [...args], spawnOptions) as unknown as CodexAppServerChild)
+      spawnKhalaProcessNodeChild(command, args, {
+        extendEnv: true,
+        ...(spawnOptions.cwd === undefined ? {} : { cwd: spawnOptions.cwd }),
+        ...(spawnOptions.env === undefined ? {} : { env: spawnOptions.env }),
+      }))
   const requestTimeoutMs = options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS
   const initializeTimeoutMs = options.initializeTimeoutMs ?? DEFAULT_INITIALIZE_TIMEOUT_MS
   const clientInfo = options.clientInfo ?? defaultClientInfo
@@ -422,7 +430,7 @@ export function createCodexAppServerHost(
     stdoutBuffer = ""
     stderrBuffer = ""
     try {
-      const spawned = spawnFn(codexCommand, codexArgs, {
+      const spawned = await spawnFn(codexCommand, codexArgs, {
         env: {
           ...env,
           CODEX_HOME: codexHome,

--- a/clients/khala-code-desktop/src/bun/codex-harness-status.ts
+++ b/clients/khala-code-desktop/src/bun/codex-harness-status.ts
@@ -1,10 +1,10 @@
-import { spawn } from "node:child_process"
 import { readFile } from "node:fs/promises"
 import { join } from "node:path"
 
 import type { KhalaCodeDesktopCodexHarnessStatus } from "../shared/rpc.js"
 import { resolveCodexHomePath } from "./codex-rate-limits.js"
 import { khalaCodeConfigFromRuntimeEnv } from "./khala-code-config.js"
+import { spawnKhalaProcessNodeChild } from "./khala-process.js"
 
 const CODEX_VERSION_TIMEOUT_MS = 5_000
 
@@ -30,10 +30,13 @@ type CodexHarnessChild = {
 type SpawnFn = (
   command: string,
   args: readonly string[],
-  options: Parameters<typeof spawn>[2],
-) => CodexHarnessChild
+  options: { readonly env?: NodeJS.ProcessEnv; readonly stdio?: readonly ["ignore", "pipe", "pipe"] },
+) => CodexHarnessChild | Promise<CodexHarnessChild>
 
 type ReadTextFileFn = (path: string, encoding: "utf8") => Promise<string>
+
+const isPromiseLike = (value: unknown): value is Promise<unknown> =>
+  typeof (value as { readonly then?: unknown }).then === "function"
 
 type CodexAuthShape = {
   readonly tokens?: {
@@ -105,11 +108,16 @@ async function probeCodexVersion(
   command: string,
   options: InspectCodexHarnessStatusOptions,
 ): Promise<VersionProbe> {
-  const spawnFn = options.spawnFn ?? spawn
-  const child = spawnFn(command, ["--version"], {
+  const spawnFn = options.spawnFn ?? ((cmd, args, spawnOptions) =>
+    spawnKhalaProcessNodeChild(cmd, args, {
+      extendEnv: true,
+      ...(spawnOptions.env === undefined ? {} : { env: spawnOptions.env }),
+    }))
+  const spawned = spawnFn(command, ["--version"], {
     env: options.env ?? khalaCodeConfigFromRuntimeEnv().env,
     stdio: ["ignore", "pipe", "pipe"],
   })
+  const child = (isPromiseLike(spawned) ? await spawned : spawned) as CodexHarnessChild
 
   return await new Promise<VersionProbe>(resolve => {
     let stdout = ""

--- a/clients/khala-code-desktop/src/bun/codex-parity-contract.ts
+++ b/clients/khala-code-desktop/src/bun/codex-parity-contract.ts
@@ -4,6 +4,7 @@ import { dirname, join } from "node:path"
 import { fileURLToPath } from "node:url"
 
 import { khalaCodeConfigFromRuntimeEnv } from "./khala-code-config.js"
+import { collectKhalaProcessText, spawnKhalaProcess } from "./khala-process.js"
 
 export const KHALA_CODE_CODEX_PARITY_REFERENCE_COMMIT =
   "db887d03e1f907467e33271572dffb73bceecd6b"
@@ -376,19 +377,13 @@ export function findCodexReferenceRoot(startDir = dirname(fileURLToPath(import.m
 }
 
 export async function readCodexReferenceCommit(root = findCodexReferenceRoot()): Promise<string> {
-  const proc = Bun.spawn(["git", "-C", root, "rev-parse", "HEAD"], {
-    stderr: "pipe",
-    stdout: "pipe",
-  })
-  const [stdout, stderr, exitCode] = await Promise.all([
-    new Response(proc.stdout).text(),
-    new Response(proc.stderr).text(),
-    proc.exited,
-  ])
-  if (exitCode !== 0) {
-    throw new Error(`git rev-parse failed for Codex reference: ${stderr.trim() || `exit ${exitCode}`}`)
+  const result = await collectKhalaProcessText(
+    spawnKhalaProcess("git", ["-C", root, "rev-parse", "HEAD"]),
+  )
+  if (result.exitCode !== 0) {
+    throw new Error(`git rev-parse failed for Codex reference: ${result.stderr.trim() || `exit ${result.exitCode}`}`)
   }
-  return stdout.trim()
+  return result.stdout.trim()
 }
 
 export function codexSchemaPath(root: string, relative: string): string {

--- a/clients/khala-code-desktop/src/bun/codex-rate-limits.ts
+++ b/clients/khala-code-desktop/src/bun/codex-rate-limits.ts
@@ -1,4 +1,3 @@
-import { spawn } from "node:child_process"
 import { existsSync } from "node:fs"
 import { readFile } from "node:fs/promises"
 import { homedir } from "node:os"
@@ -11,6 +10,7 @@ import type {
   KhalaCodexRateLimitWindow,
 } from "../shared/codex-rate-limits.js"
 import { khalaCodeConfigFromRuntimeEnv } from "./khala-code-config.js"
+import { spawnKhalaProcessNodeChild } from "./khala-process.js"
 
 const CODEX_RPC_TIMEOUT_MS = 10_000
 const CODEX_RATE_LIMIT_RESET_CREDITS_URL =
@@ -93,8 +93,8 @@ type CodexRateLimitChild = {
 type SpawnFn = (
   command: string,
   args: readonly string[],
-  options: Parameters<typeof spawn>[2],
-) => CodexRateLimitChild
+  options: { readonly env?: NodeJS.ProcessEnv; readonly stdio?: readonly ["pipe", "pipe", "pipe"] },
+) => CodexRateLimitChild | Promise<CodexRateLimitChild>
 
 type ReadTextFileFn = (path: string, encoding: "utf8") => Promise<string>
 
@@ -284,8 +284,12 @@ async function fetchViaRpc(
 ): Promise<KhalaCodexRateLimitProviderStatus> {
   const now = options.now ?? (() => new Date())
   const codexHomePath = resolveCodexHomePath(options.codexHomePath, options.env)
-  const spawnFn = options.spawnFn ?? spawn
-  const child = spawnFn(options.codexCommand ?? "codex", [
+  const spawnFn = options.spawnFn ?? ((command, args, spawnOptions) =>
+    spawnKhalaProcessNodeChild(command, args, {
+      extendEnv: true,
+      ...(spawnOptions.env === undefined ? {} : { env: spawnOptions.env }),
+    }))
+  const child = await spawnFn(options.codexCommand ?? "codex", [
     "-s",
     "read-only",
     "-a",

--- a/clients/khala-code-desktop/src/bun/fleet-run-supervisor-rpc-adapter.ts
+++ b/clients/khala-code-desktop/src/bun/fleet-run-supervisor-rpc-adapter.ts
@@ -1,4 +1,3 @@
-import { spawn } from "node:child_process"
 import { randomUUID } from "node:crypto"
 import { mkdirSync } from "node:fs"
 import { appendFile, mkdir } from "node:fs/promises"
@@ -33,6 +32,7 @@ import {
   spawnCodexInstances,
   type KhalaCodexFleetToolOptions,
 } from "./khala-codex-fleet-tools.js"
+import { collectKhalaProcessText, spawnKhalaProcess } from "./khala-process.js"
 import {
   startFleetRunSupervisor,
   type FleetRunSupervisorCapacity,
@@ -195,19 +195,13 @@ const projectRun = (
   workSource: projectWorkSource(input.workSource, run.workSource),
 })
 
-const ghJson = (args: readonly string[]): Promise<string> =>
-  new Promise((resolve, reject) => {
-    const child = spawn("gh", args, { stdio: ["ignore", "pipe", "pipe"] })
-    const stdout: Buffer[] = []
-    const stderr: Buffer[] = []
-    child.stdout.on("data", chunk => stdout.push(Buffer.from(chunk)))
-    child.stderr.on("data", chunk => stderr.push(Buffer.from(chunk)))
-    child.once("error", reject)
-    child.once("close", code => {
-      if (code === 0) return resolve(Buffer.concat(stdout).toString("utf8"))
-      reject(new Error(`gh ${args.join(" ")} failed: ${Buffer.concat(stderr).toString("utf8").trim()}`))
-    })
-  })
+const ghJson = async (args: readonly string[]): Promise<string> => {
+  const result = await collectKhalaProcessText(
+    spawnKhalaProcess("gh", args, { forceKillAfter: "1500 millis" }),
+  )
+  if (result.exitCode === 0) return result.stdout
+  throw new Error(`gh ${args.join(" ")} failed: ${result.stderr.trim()}`)
+}
 
 const plannerFor = (
   store: PylonOrchestrationStore,

--- a/clients/khala-code-desktop/src/bun/khala-codex-fleet-tools.ts
+++ b/clients/khala-code-desktop/src/bun/khala-codex-fleet-tools.ts
@@ -1,4 +1,3 @@
-import { spawn } from "node:child_process"
 import { Database } from "bun:sqlite"
 import { existsSync } from "node:fs"
 import { readFile, readdir, rename, rm, stat, writeFile } from "node:fs/promises"
@@ -60,6 +59,7 @@ import {
 } from "./fleet-run-supervisor.js"
 import { khalaCodeConfigFromRuntimeEnv } from "./khala-code-config.js"
 import { fetchKhalaCodexRateLimitStatus } from "./codex-rate-limits.js"
+import { spawnKhalaProcessNodeChild, type KhalaProcessNodeChild } from "./khala-process.js"
 import type { KhalaCodexRateLimitProviderStatus } from "../shared/codex-rate-limits.js"
 
 type ChatEnv = Readonly<Record<string, string | undefined>>
@@ -1806,11 +1806,11 @@ async function defaultCommandRunner(
 
   if (input.detached) {
     try {
-      const child = spawn(cmd, args, {
-        cwd: input.cwd,
+      const child = await spawnKhalaProcessNodeChild(cmd, args, {
         detached: true,
         env: cleanEnv(input.env),
-        stdio: "ignore",
+        extendEnv: false,
+        ...(input.cwd === undefined ? {} : { cwd: input.cwd }),
       })
       child.unref()
       return { exitCode: null, signal: null, stderr: "", stdout: "", timedOut: false }
@@ -1821,12 +1821,12 @@ async function defaultCommandRunner(
 
   const maxOutputBytes = input.maxOutputBytes ?? 40_000
   let timedOut = false
-  let child: ReturnType<typeof spawn>
+  let child: KhalaProcessNodeChild
   try {
-    child = spawn(cmd, args, {
-      cwd: input.cwd,
+    child = await spawnKhalaProcessNodeChild(cmd, args, {
       env: cleanEnv(input.env),
-      stdio: ["ignore", "pipe", "pipe"],
+      extendEnv: false,
+      ...(input.cwd === undefined ? {} : { cwd: input.cwd }),
     })
   } catch (error) {
     return { exitCode: 127, signal: null, stderr: errorMessage(error), stdout: "", timedOut: false }
@@ -3997,11 +3997,11 @@ export async function beginCodexConnect(
   }
   const env = options.env ?? khalaCodeConfigFromRuntimeEnv().env
   const paths = resolvePylonPaths(env)
-  let child: ReturnType<typeof Bun.spawn>
+  let child: KhalaProcessNodeChild
   try {
-    child = Bun.spawn(
+    child = await spawnKhalaProcessNodeChild(
+      paths.bunExecutable,
       [
-        paths.bunExecutable,
         "src/index.ts",
         "accounts",
         "connect",
@@ -4014,9 +4014,7 @@ export async function beginCodexConnect(
       {
         cwd: paths.appPath,
         env: pylonCommandEnv(env, paths.pylonHome),
-        stdout: "pipe",
-        stderr: "pipe",
-        stdin: "ignore",
+        extendEnv: false,
       },
     )
   } catch (error) {
@@ -4051,36 +4049,29 @@ export async function beginCodexConnect(
   }
 
   const readStream = async (
-    stream: ReadableStream<Uint8Array> | undefined,
+    stream: AsyncIterable<Uint8Array> | undefined,
   ): Promise<void> => {
     if (stream === undefined) return
-    const reader = stream.getReader()
     try {
       // Drain to end-of-stream, NOT until the code is captured. If we stop
       // reading while the child keeps writing (codex login + pylon connect
       // continue after the device prompt), the pipe fills and the child blocks
       // on write — so it never finishes registering the account and the panel
       // poll never sees it ready. The `done` flag only gates when we return.
-      while (true) {
-        const { value, done: streamDone } = await reader.read()
-        if (streamDone) break
-        if (value !== undefined) {
-          buffer += decoder.decode(value, { stream: true })
-          if (buffer.length < 65_536) tryParse()
-        }
+      for await (const value of stream) {
+        buffer += decoder.decode(value, { stream: true })
+        if (buffer.length < 65_536) tryParse()
       }
     } catch {
       // stream interrupted — return whatever we captured
-    } finally {
-      reader.releaseLock()
     }
   }
 
   // Fire the readers in the background (they keep draining until the child
   // exits, so it never blocks on backpressure) and return as soon as the URL +
   // code are captured (~2-3s). The child keeps running until the user authorizes.
-  void readStream(child.stdout as ReadableStream<Uint8Array>)
-  void readStream(child.stderr as ReadableStream<Uint8Array>)
+  void readStream(child.stdout)
+  void readStream(child.stderr)
   const deadline = Date.now() + 25_000
   while (!done && Date.now() < deadline) {
     await new Promise<void>(resolve => setTimeout(resolve, 150))
@@ -4108,7 +4099,9 @@ export function openExternalUrl(url: string): boolean {
         ? ["cmd", "/c", "start", "", url]
         : ["xdg-open", url]
   try {
-    Bun.spawn(command, { stdout: "ignore", stderr: "ignore", stdin: "ignore" })
+    const [cmd, ...args] = command
+    if (cmd === undefined) return false
+    void spawnKhalaProcessNodeChild(cmd, args, { detached: true }).then(child => child.unref()).catch(() => undefined)
     return true
   } catch {
     return false

--- a/clients/khala-code-desktop/src/bun/khala-process.ts
+++ b/clients/khala-code-desktop/src/bun/khala-process.ts
@@ -1,0 +1,332 @@
+import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process"
+import { Readable } from "node:stream"
+
+import { Context, Data, Effect, Layer, Sink, Stream } from "effect"
+import * as PlatformError from "effect/PlatformError"
+import type * as Scope from "effect/Scope"
+import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process"
+
+export class KhalaProcessSpawnFailure extends Data.TaggedError("KhalaProcessSpawnFailure")<{
+  readonly cause: unknown
+  readonly command: string
+  readonly message: string
+}> {}
+
+export class KhalaProcessStreamFailure extends Data.TaggedError("KhalaProcessStreamFailure")<{
+  readonly cause: unknown
+  readonly command: string
+  readonly stream: "stdin" | "stdout" | "stderr" | "all"
+  readonly message: string
+}> {}
+
+export class KhalaProcessNonZeroExit extends Data.TaggedError("KhalaProcessNonZeroExit")<{
+  readonly command: string
+  readonly exitCode: number
+  readonly message: string
+}> {}
+
+export type KhalaProcessFailure =
+  | KhalaProcessSpawnFailure
+  | KhalaProcessStreamFailure
+  | KhalaProcessNonZeroExit
+
+export type KhalaProcessSpawnOptions = Readonly<{
+  readonly cwd?: string
+  readonly env?: Readonly<Record<string, string | undefined>>
+  readonly extendEnv?: boolean
+  readonly forceKillAfter?: ChildProcess.KillOptions["forceKillAfter"]
+  readonly killSignal?: ChildProcess.Signal
+}>
+
+export type KhalaProcessHandle = Readonly<{
+  readonly command: string
+  readonly exit: Effect.Effect<number, KhalaProcessFailure>
+  readonly kill: (
+    options?: ChildProcess.KillOptions,
+  ) => Effect.Effect<void, KhalaProcessSpawnFailure>
+  readonly pid: number
+  readonly stderr: Stream.Stream<Uint8Array, KhalaProcessFailure>
+  readonly stdin: Sink.Sink<void, Uint8Array, never, KhalaProcessFailure>
+  readonly stdout: Stream.Stream<Uint8Array, KhalaProcessFailure>
+}>
+
+export type KhalaProcessServiceShape = Readonly<{
+  readonly spawn: (
+    command: string,
+    args?: readonly string[],
+    options?: KhalaProcessSpawnOptions,
+  ) => Effect.Effect<KhalaProcessHandle, KhalaProcessSpawnFailure, Scope.Scope>
+}>
+
+export type KhalaProcessTextResult = Readonly<{
+  readonly exitCode: number
+  readonly stderr: string
+  readonly stdout: string
+}>
+
+const platformToSpawnFailure = (command: string, cause: unknown): KhalaProcessSpawnFailure =>
+  new KhalaProcessSpawnFailure({
+    cause,
+    command,
+    message: cause instanceof Error ? cause.message : String(cause),
+  })
+
+const platformToStreamFailure = (
+  command: string,
+  stream: KhalaProcessStreamFailure["stream"],
+  cause: unknown,
+): KhalaProcessStreamFailure =>
+  new KhalaProcessStreamFailure({
+    cause,
+    command,
+    stream,
+    message: cause instanceof Error ? cause.message : String(cause),
+  })
+
+const platformError = (method: string, cause: unknown): PlatformError.PlatformError =>
+  PlatformError.systemError({
+    _tag: "Unknown",
+    cause,
+    description: cause instanceof Error ? cause.message : String(cause),
+    method,
+    module: "KhalaProcess",
+  })
+
+const streamFromNodeReadable = (
+  command: string,
+  channel: "stdout" | "stderr",
+  readable: NodeJS.ReadableStream,
+): Stream.Stream<Uint8Array, KhalaProcessFailure> =>
+  Stream.fromReadableStream({
+    evaluate: () => Readable.toWeb(readable as Readable) as unknown as ReadableStream<Uint8Array>,
+    onError: cause => platformToStreamFailure(command, channel, cause),
+    releaseLockOnEnd: true,
+  })
+
+const writeStdin = (
+  command: string,
+  proc: ChildProcessWithoutNullStreams,
+  chunk: Uint8Array,
+): Effect.Effect<void, KhalaProcessStreamFailure> =>
+  Effect.callback<void, KhalaProcessStreamFailure>((resume) => {
+    proc.stdin.write(chunk, error => {
+      if (error === null || error === undefined) {
+        resume(Effect.void)
+        return
+      }
+      resume(Effect.fail(platformToStreamFailure(command, "stdin", error)))
+    })
+  })
+
+const stdinSink = (
+  command: string,
+  proc: ChildProcessWithoutNullStreams,
+): Sink.Sink<void, Uint8Array, never, KhalaProcessFailure> =>
+  Sink.forEach((chunk: Uint8Array) => writeStdin(command, proc, chunk)).pipe(
+    Sink.ensuring(Effect.sync(() => {
+      if (!proc.stdin.destroyed) proc.stdin.end()
+    })),
+  )
+
+const waitForExit = (
+  command: string,
+  proc: ChildProcessWithoutNullStreams,
+): Effect.Effect<number, KhalaProcessSpawnFailure> =>
+  Effect.callback<number, KhalaProcessSpawnFailure>((resume) => {
+    const onExit = (code: number | null, signal: NodeJS.Signals | null) => {
+      cleanup()
+      resume(Effect.succeed(code ?? (signal === null ? 0 : 128)))
+    }
+    const onError = (cause: Error) => {
+      cleanup()
+      resume(Effect.fail(platformToSpawnFailure(command, cause)))
+    }
+    const cleanup = () => {
+      proc.off("exit", onExit)
+      proc.off("error", onError)
+    }
+    proc.once("exit", onExit)
+    proc.once("error", onError)
+  })
+
+const killNodeProcess = (
+  proc: ChildProcessWithoutNullStreams,
+  signal: ChildProcess.Signal = "SIGTERM",
+): void => {
+  if (proc.killed || proc.exitCode !== null || proc.signalCode !== null) return
+  proc.kill(signal)
+}
+
+const makeNodeSpawnerService = (): ChildProcessSpawner.ChildProcessSpawner["Service"] =>
+  ChildProcessSpawner.make(command => {
+    if (command._tag !== "StandardCommand") {
+      return Effect.fail(PlatformError.badArgument({
+        description: "Piped commands are not supported by KhalaProcess live spawner yet.",
+        method: "spawn",
+        module: "KhalaProcess",
+      }))
+    }
+
+    return Effect.acquireRelease(
+      Effect.try({
+        try: () => {
+          const env = command.options.extendEnv === false
+            ? command.options.env
+            : { ...process.env, ...command.options.env }
+          const proc = spawn(command.command, [...command.args], {
+            cwd: command.options.cwd,
+            detached: command.options.detached,
+            env,
+            shell: command.options.shell,
+            stdio: ["pipe", "pipe", "pipe"],
+          })
+          return { command: command.command, proc }
+        },
+        catch: cause => platformError("spawn", cause),
+      }),
+      ({ proc }) => Effect.sync(() => killNodeProcess(proc, command.options.killSignal ?? "SIGTERM")),
+    ).pipe(
+      Effect.map(({ command: commandName, proc }) => ChildProcessSpawner.makeHandle({
+        all: Stream.merge(
+          streamFromNodeReadable(commandName, "stdout", proc.stdout),
+          streamFromNodeReadable(commandName, "stderr", proc.stderr),
+        ).pipe(Stream.mapError(cause => platformError("all", cause))),
+        exitCode: waitForExit(commandName, proc).pipe(
+          Effect.map(code => ChildProcessSpawner.ExitCode(code)),
+          Effect.mapError(cause => platformError("exitCode", cause)),
+        ),
+        getInputFd: () => Sink.drain,
+        getOutputFd: () => Stream.empty,
+        isRunning: Effect.sync(() => proc.exitCode === null && proc.signalCode === null),
+        kill: options => Effect.try({
+          try: () => killNodeProcess(proc, options?.killSignal ?? "SIGTERM"),
+          catch: cause => platformError("kill", cause),
+        }),
+        pid: ChildProcessSpawner.ProcessId(proc.pid ?? -1),
+        stderr: streamFromNodeReadable(commandName, "stderr", proc.stderr).pipe(
+          Stream.mapError(cause => platformError("stderr", cause)),
+        ),
+        stdin: stdinSink(commandName, proc).pipe(
+          Sink.mapError(cause => platformError("stdin", cause)),
+        ),
+        stdout: streamFromNodeReadable(commandName, "stdout", proc.stdout).pipe(
+          Stream.mapError(cause => platformError("stdout", cause)),
+        ),
+        unref: Effect.sync(() => {
+          proc.unref()
+          return Effect.sync(() => proc.ref())
+        }),
+      })),
+    )
+  })
+
+export const makeKhalaProcessService = (): KhalaProcessServiceShape => {
+  const spawner = makeNodeSpawnerService()
+  return {
+    spawn: (command, args = [], options = {}) => {
+      const childCommand = ChildProcess.make(command, [...args], {
+        cwd: options.cwd,
+        env: options.env === undefined ? undefined : { ...options.env },
+        extendEnv: options.extendEnv ?? true,
+        forceKillAfter: options.forceKillAfter,
+        killSignal: options.killSignal ?? "SIGTERM",
+        stderr: { stream: "pipe" },
+        stdin: { stream: "pipe" },
+        stdout: { stream: "pipe" },
+      })
+
+      return Effect.acquireRelease(
+        childCommand.pipe(
+          Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner),
+          Effect.mapError(cause => platformToSpawnFailure(command, cause)),
+        ),
+        handle => handle.kill({
+          forceKillAfter: options.forceKillAfter,
+          killSignal: options.killSignal ?? "SIGTERM",
+        }).pipe(Effect.ignore),
+      ).pipe(
+        Effect.map(handle => ({
+          command,
+          exit: handle.exitCode.pipe(
+            Effect.map(code => Number(code)),
+            Effect.flatMap(exitCode =>
+              exitCode === 0
+                ? Effect.succeed(exitCode)
+                : Effect.fail(new KhalaProcessNonZeroExit({
+                  command,
+                  exitCode,
+                  message: `${command} exited with code ${exitCode}`,
+                }))
+            ),
+            Effect.mapError(cause =>
+              cause instanceof KhalaProcessNonZeroExit
+                ? cause
+                : platformToSpawnFailure(command, cause)
+            ),
+          ),
+          kill: killOptions => handle.kill(killOptions).pipe(
+            Effect.mapError(cause => platformToSpawnFailure(command, cause)),
+          ),
+          pid: Number(handle.pid),
+          stderr: handle.stderr.pipe(
+            Stream.mapError(cause => platformToStreamFailure(command, "stderr", cause)),
+          ),
+          stdin: handle.stdin.pipe(
+            Sink.mapError(cause => platformToStreamFailure(command, "stdin", cause)),
+          ),
+          stdout: handle.stdout.pipe(
+            Stream.mapError(cause => platformToStreamFailure(command, "stdout", cause)),
+          ),
+        })),
+      )
+    },
+  }
+}
+
+export class KhalaProcess extends Context.Service<KhalaProcess, KhalaProcessServiceShape>()(
+  "KhalaProcess",
+  { make: Effect.sync(makeKhalaProcessService) },
+) {}
+
+export const KhalaProcessLive = Layer.succeed(KhalaProcess, makeKhalaProcessService())
+
+export const spawnKhalaProcess = (
+  command: string,
+  args: readonly string[] = [],
+  options: KhalaProcessSpawnOptions = {},
+): Effect.Effect<KhalaProcessHandle, KhalaProcessSpawnFailure, Scope.Scope> =>
+  makeKhalaProcessService().spawn(command, args, options)
+
+const streamText = (
+  stream: Stream.Stream<Uint8Array, KhalaProcessFailure>,
+): Effect.Effect<string, KhalaProcessFailure> =>
+  stream.pipe(Stream.decodeText(), Stream.mkString)
+
+const exitCodeResult = (
+  handle: KhalaProcessHandle,
+): Effect.Effect<number, KhalaProcessFailure> =>
+  handle.exit.pipe(
+    Effect.match({
+      onFailure: failure => {
+        if (failure instanceof KhalaProcessNonZeroExit) return failure.exitCode
+        throw failure
+      },
+      onSuccess: exitCode => exitCode,
+    }),
+  )
+
+export const collectKhalaProcessText = (
+  process: Effect.Effect<KhalaProcessHandle, KhalaProcessSpawnFailure, Scope.Scope>,
+): Promise<KhalaProcessTextResult> =>
+  Effect.runPromise(
+    Effect.scoped(
+      Effect.gen(function*() {
+        const handle = yield* process
+        return yield* Effect.all({
+          exitCode: exitCodeResult(handle),
+          stderr: streamText(handle.stderr),
+          stdout: streamText(handle.stdout),
+        }, { concurrency: "unbounded" })
+      }),
+    ),
+  )

--- a/clients/khala-code-desktop/src/bun/khala-process.ts
+++ b/clients/khala-code-desktop/src/bun/khala-process.ts
@@ -1,7 +1,7 @@
 import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process"
 import { Readable } from "node:stream"
 
-import { Context, Data, Effect, Layer, Sink, Stream } from "effect"
+import { Context, Data, Duration, Effect, Layer, Sink, Stream } from "effect"
 import * as PlatformError from "effect/PlatformError"
 import type * as Scope from "effect/Scope"
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process"
@@ -149,13 +149,67 @@ const waitForExit = (
     proc.once("error", onError)
   })
 
+const nodeProcessIsRunning = (proc: ChildProcessWithoutNullStreams): boolean =>
+  proc.exitCode === null && proc.signalCode === null
+
 const killNodeProcess = (
   proc: ChildProcessWithoutNullStreams,
-  signal: ChildProcess.Signal = "SIGTERM",
-): void => {
-  if (proc.killed || proc.exitCode !== null || proc.signalCode !== null) return
-  proc.kill(signal)
-}
+  options: ChildProcess.KillOptions = {},
+): Effect.Effect<void, PlatformError.PlatformError> =>
+  Effect.callback<void, PlatformError.PlatformError>((resume) => {
+    if (!nodeProcessIsRunning(proc)) {
+      resume(Effect.void)
+      return
+    }
+
+    const signal = options.killSignal ?? "SIGTERM"
+    const forceKillAfterMs =
+      options.forceKillAfter === undefined
+        ? null
+        : Math.max(0, Duration.toMillis(options.forceKillAfter))
+    let forceKillTimer: ReturnType<typeof setTimeout> | null = null
+    let settled = false
+
+    const cleanup = () => {
+      if (forceKillTimer !== null) {
+        clearTimeout(forceKillTimer)
+        forceKillTimer = null
+      }
+      proc.off("exit", onExit)
+      proc.off("error", onError)
+    }
+    const settle = (effect: Effect.Effect<void, PlatformError.PlatformError>) => {
+      if (settled) return
+      settled = true
+      cleanup()
+      resume(effect)
+    }
+    const onExit = () => settle(Effect.void)
+    const onError = (cause: Error) => settle(Effect.fail(platformError("kill", cause)))
+
+    try {
+      if (forceKillAfterMs !== null) {
+        proc.once("exit", onExit)
+        proc.once("error", onError)
+      }
+      proc.kill(signal)
+      if (forceKillAfterMs === null) {
+        settle(Effect.void)
+        return
+      }
+      forceKillTimer = setTimeout(() => {
+        try {
+          if (nodeProcessIsRunning(proc)) proc.kill("SIGKILL")
+          settle(Effect.void)
+        } catch (cause) {
+          settle(Effect.fail(platformError("kill", cause)))
+        }
+      }, forceKillAfterMs)
+      forceKillTimer.unref?.()
+    } catch (cause) {
+      settle(Effect.fail(platformError("kill", cause)))
+    }
+  })
 
 const makeNodeSpawnerService = (): ChildProcessSpawner.ChildProcessSpawner["Service"] =>
   ChildProcessSpawner.make(command => {
@@ -184,7 +238,8 @@ const makeNodeSpawnerService = (): ChildProcessSpawner.ChildProcessSpawner["Serv
         },
         catch: cause => platformError("spawn", cause),
       }),
-      ({ proc }) => Effect.sync(() => killNodeProcess(proc, command.options.killSignal ?? "SIGTERM")),
+      ({ proc }) =>
+        killNodeProcess(proc, { killSignal: command.options.killSignal }).pipe(Effect.ignore),
     ).pipe(
       Effect.map(({ command: commandName, proc }) => ChildProcessSpawner.makeHandle({
         all: Stream.merge(
@@ -198,10 +253,7 @@ const makeNodeSpawnerService = (): ChildProcessSpawner.ChildProcessSpawner["Serv
         getInputFd: () => Sink.drain,
         getOutputFd: () => Stream.empty,
         isRunning: Effect.sync(() => proc.exitCode === null && proc.signalCode === null),
-        kill: options => Effect.try({
-          try: () => killNodeProcess(proc, options?.killSignal ?? "SIGTERM"),
-          catch: cause => platformError("kill", cause),
-        }),
+        kill: options => killNodeProcess(proc, options),
         pid: ChildProcessSpawner.ProcessId(proc.pid ?? -1),
         stderr: streamFromNodeReadable(commandName, "stderr", proc.stderr).pipe(
           Stream.mapError(cause => platformError("stderr", cause)),

--- a/clients/khala-code-desktop/src/bun/khala-process.ts
+++ b/clients/khala-code-desktop/src/bun/khala-process.ts
@@ -1,9 +1,9 @@
+import { EventEmitter } from "node:events"
 import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process"
 import { Readable } from "node:stream"
 
-import { Context, Data, Duration, Effect, Layer, Sink, Stream } from "effect"
+import { Context, Data, Duration, Effect, Exit, Layer, Scope, Sink, Stream } from "effect"
 import * as PlatformError from "effect/PlatformError"
-import type * as Scope from "effect/Scope"
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process"
 
 export class KhalaProcessSpawnFailure extends Data.TaggedError("KhalaProcessSpawnFailure")<{
@@ -32,6 +32,7 @@ export type KhalaProcessFailure =
 
 export type KhalaProcessSpawnOptions = Readonly<{
   readonly cwd?: string
+  readonly detached?: boolean
   readonly env?: Readonly<Record<string, string | undefined>>
   readonly extendEnv?: boolean
   readonly forceKillAfter?: ChildProcess.KillOptions["forceKillAfter"]
@@ -48,6 +49,8 @@ export type KhalaProcessHandle = Readonly<{
   readonly stderr: Stream.Stream<Uint8Array, KhalaProcessFailure>
   readonly stdin: Sink.Sink<void, Uint8Array, never, KhalaProcessFailure>
   readonly stdout: Stream.Stream<Uint8Array, KhalaProcessFailure>
+  readonly unref: Effect.Effect<Effect.Effect<void, KhalaProcessFailure>, KhalaProcessFailure>
+  readonly writeStdin: (chunk: string | Uint8Array) => Effect.Effect<void, KhalaProcessFailure>
 }>
 
 export type KhalaProcessServiceShape = Readonly<{
@@ -63,6 +66,20 @@ export type KhalaProcessTextResult = Readonly<{
   readonly stderr: string
   readonly stdout: string
 }>
+
+export type KhalaProcessNodeChild = EventEmitter & Readonly<{
+  readonly exited: Promise<number>
+  readonly kill: (signal?: ChildProcess.Signal) => unknown
+  readonly pid: number
+  readonly stderr: Readable
+  readonly stdin: {
+    readonly write: (chunk: string | Uint8Array) => unknown
+  }
+  readonly stdout: Readable
+  readonly unref: () => unknown
+}>
+
+const nodeStdinWriters = new WeakMap<object, (chunk: Uint8Array) => Effect.Effect<void, PlatformError.PlatformError>>()
 
 const platformToSpawnFailure = (command: string, cause: unknown): KhalaProcessSpawnFailure =>
   new KhalaProcessSpawnFailure({
@@ -117,6 +134,9 @@ const writeStdin = (
       resume(Effect.fail(platformToStreamFailure(command, "stdin", error)))
     })
   })
+
+const encodeStdinChunk = (chunk: string | Uint8Array): Uint8Array =>
+  typeof chunk === "string" ? new TextEncoder().encode(chunk) : chunk
 
 const stdinSink = (
   command: string,
@@ -241,34 +261,40 @@ const makeNodeSpawnerService = (): ChildProcessSpawner.ChildProcessSpawner["Serv
       ({ proc }) =>
         killNodeProcess(proc, { killSignal: command.options.killSignal }).pipe(Effect.ignore),
     ).pipe(
-      Effect.map(({ command: commandName, proc }) => ChildProcessSpawner.makeHandle({
-        all: Stream.merge(
-          streamFromNodeReadable(commandName, "stdout", proc.stdout),
-          streamFromNodeReadable(commandName, "stderr", proc.stderr),
-        ).pipe(Stream.mapError(cause => platformError("all", cause))),
-        exitCode: waitForExit(commandName, proc).pipe(
-          Effect.map(code => ChildProcessSpawner.ExitCode(code)),
-          Effect.mapError(cause => platformError("exitCode", cause)),
-        ),
-        getInputFd: () => Sink.drain,
-        getOutputFd: () => Stream.empty,
-        isRunning: Effect.sync(() => proc.exitCode === null && proc.signalCode === null),
-        kill: options => killNodeProcess(proc, options),
-        pid: ChildProcessSpawner.ProcessId(proc.pid ?? -1),
-        stderr: streamFromNodeReadable(commandName, "stderr", proc.stderr).pipe(
-          Stream.mapError(cause => platformError("stderr", cause)),
-        ),
-        stdin: stdinSink(commandName, proc).pipe(
-          Sink.mapError(cause => platformError("stdin", cause)),
-        ),
-        stdout: streamFromNodeReadable(commandName, "stdout", proc.stdout).pipe(
-          Stream.mapError(cause => platformError("stdout", cause)),
-        ),
-        unref: Effect.sync(() => {
-          proc.unref()
-          return Effect.sync(() => proc.ref())
-        }),
-      })),
+      Effect.map(({ command: commandName, proc }) => {
+        const handle = ChildProcessSpawner.makeHandle({
+          all: Stream.merge(
+            streamFromNodeReadable(commandName, "stdout", proc.stdout),
+            streamFromNodeReadable(commandName, "stderr", proc.stderr),
+          ).pipe(Stream.mapError(cause => platformError("all", cause))),
+          exitCode: waitForExit(commandName, proc).pipe(
+            Effect.map(code => ChildProcessSpawner.ExitCode(code)),
+            Effect.mapError(cause => platformError("exitCode", cause)),
+          ),
+          getInputFd: () => Sink.drain,
+          getOutputFd: () => Stream.empty,
+          isRunning: Effect.sync(() => proc.exitCode === null && proc.signalCode === null),
+          kill: options => killNodeProcess(proc, options),
+          pid: ChildProcessSpawner.ProcessId(proc.pid ?? -1),
+          stderr: streamFromNodeReadable(commandName, "stderr", proc.stderr).pipe(
+            Stream.mapError(cause => platformError("stderr", cause)),
+          ),
+          stdin: stdinSink(commandName, proc).pipe(
+            Sink.mapError(cause => platformError("stdin", cause)),
+          ),
+          stdout: streamFromNodeReadable(commandName, "stdout", proc.stdout).pipe(
+            Stream.mapError(cause => platformError("stdout", cause)),
+          ),
+          unref: Effect.sync(() => {
+            proc.unref()
+            return Effect.sync(() => proc.ref())
+          }),
+        })
+        nodeStdinWriters.set(handle, chunk =>
+          writeStdin(commandName, proc, chunk).pipe(Effect.mapError(cause => platformError("stdin", cause)))
+        )
+        return handle
+      }),
     )
   })
 
@@ -278,6 +304,7 @@ export const makeKhalaProcessService = (): KhalaProcessServiceShape => {
     spawn: (command, args = [], options = {}) => {
       const childCommand = ChildProcess.make(command, [...args], {
         cwd: options.cwd,
+        detached: options.detached,
         env: options.env === undefined ? undefined : { ...options.env },
         extendEnv: options.extendEnv ?? true,
         forceKillAfter: options.forceKillAfter,
@@ -329,6 +356,21 @@ export const makeKhalaProcessService = (): KhalaProcessServiceShape => {
           stdout: handle.stdout.pipe(
             Stream.mapError(cause => platformToStreamFailure(command, "stdout", cause)),
           ),
+          unref: handle.unref.pipe(
+            Effect.map(reref =>
+              reref.pipe(Effect.mapError(cause => platformToSpawnFailure(command, cause)))
+            ),
+            Effect.mapError(cause => platformToSpawnFailure(command, cause)),
+          ),
+          writeStdin: chunk => {
+            const writer = nodeStdinWriters.get(handle)
+            if (writer === undefined) {
+              return Effect.fail(platformToStreamFailure(command, "stdin", "stdin writer is unavailable"))
+            }
+            return writer(encodeStdinChunk(chunk)).pipe(
+              Effect.mapError(cause => platformToStreamFailure(command, "stdin", cause)),
+            )
+          },
         })),
       )
     },
@@ -348,6 +390,73 @@ export const spawnKhalaProcess = (
   options: KhalaProcessSpawnOptions = {},
 ): Effect.Effect<KhalaProcessHandle, KhalaProcessSpawnFailure, Scope.Scope> =>
   makeKhalaProcessService().spawn(command, args, options)
+
+export const spawnKhalaProcessNodeChild = async (
+  command: string,
+  args: readonly string[] = [],
+  options: KhalaProcessSpawnOptions = {},
+): Promise<KhalaProcessNodeChild> => {
+  const scope = Effect.runSync(Scope.make())
+  const handle = await Effect.runPromise(
+    Effect.provideService(spawnKhalaProcess(command, args, options), Scope.Scope, scope),
+  )
+  let scopeClosed = false
+  const closeScope = async (): Promise<void> => {
+    if (scopeClosed) return
+    scopeClosed = true
+    await Effect.runPromise(Scope.close(scope, Exit.void).pipe(Effect.ignore))
+  }
+  const bufferedChunks = async function*(
+    stream: Stream.Stream<Uint8Array, KhalaProcessFailure>,
+  ): AsyncIterable<Buffer> {
+    for await (const chunk of Stream.toAsyncIterable(stream)) {
+      yield Buffer.from(chunk)
+    }
+  }
+  const stdout = Readable.from(bufferedChunks(handle.stdout))
+  const stderr = Readable.from(bufferedChunks(handle.stderr))
+  const events = new EventEmitter()
+  const exited = Effect.runPromise(
+    handle.exit.pipe(
+      Effect.match({
+        onFailure: failure =>
+          failure instanceof KhalaProcessNonZeroExit ? failure.exitCode : 127,
+        onSuccess: exitCode => exitCode,
+      }),
+    ),
+  )
+  void exited.then(
+    exitCode => {
+      events.emit("close", exitCode, null)
+      void closeScope()
+    },
+    failure => {
+      events.emit("error", failure)
+      events.emit("close", 127, null)
+      void closeScope()
+    },
+  )
+
+  return Object.assign(events, {
+    exited,
+    kill: (signal: ChildProcess.Signal = "SIGTERM") => {
+      Effect.runFork(handle.kill({ forceKillAfter: "1500 millis", killSignal: signal }).pipe(Effect.ignore))
+      return true
+    },
+    pid: handle.pid,
+    stderr,
+    stdin: {
+      write: (chunk: string | Uint8Array) => {
+        Effect.runFork(handle.writeStdin(chunk).pipe(Effect.ignore))
+        return true
+      },
+    },
+    stdout,
+    unref: () => {
+      Effect.runFork(handle.unref.pipe(Effect.ignore))
+    },
+  }) as KhalaProcessNodeChild
+}
 
 const streamText = (
   stream: Stream.Stream<Uint8Array, KhalaProcessFailure>,

--- a/clients/khala-code-desktop/tests/khala-process.test.ts
+++ b/clients/khala-code-desktop/tests/khala-process.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, test } from "bun:test"
+import { Effect } from "effect"
+
+import {
+  collectKhalaProcessText,
+  KhalaProcessNonZeroExit,
+  spawnKhalaProcess,
+} from "../src/bun/khala-process"
+
+const nodeEval = (script: string): readonly string[] => ["--eval", script]
+
+const processExists = (pid: number): boolean => {
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch {
+    return false
+  }
+}
+
+const waitUntilGone = async (pid: number): Promise<boolean> => {
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    if (!processExists(pid)) return true
+    await new Promise(resolve => setTimeout(resolve, 25))
+  }
+  return !processExists(pid)
+}
+
+describe("KhalaProcess", () => {
+  test("kills a scoped child when the scope closes", async () => {
+    const pid = await Effect.runPromise(
+      Effect.scoped(
+        Effect.map(
+          spawnKhalaProcess(process.execPath, nodeEval("setInterval(() => {}, 1000)")),
+          handle => handle.pid,
+        ),
+      ),
+    )
+
+    expect(pid).toBeGreaterThan(0)
+    expect(await waitUntilGone(pid)).toBe(true)
+  })
+
+  test("decodes stdout and stderr streams as text", async () => {
+    const result = await collectKhalaProcessText(
+      spawnKhalaProcess(process.execPath, nodeEval(
+        "process.stdout.write('hello stdout\\n'); process.stderr.write('hello stderr\\n')",
+      )),
+    )
+
+    expect(result).toEqual({
+      exitCode: 0,
+      stderr: "hello stderr\n",
+      stdout: "hello stdout\n",
+    })
+  })
+
+  test("reports nonzero exit as a tagged failure", async () => {
+    const failure = await Effect.runPromise(
+      Effect.scoped(
+        Effect.gen(function*() {
+          const handle = yield* spawnKhalaProcess(process.execPath, nodeEval("process.exit(7)"))
+          return yield* handle.exit.pipe(
+            Effect.match({
+              onFailure: error => error,
+              onSuccess: exitCode => exitCode,
+            }),
+          )
+        }),
+      ),
+    )
+
+    expect(failure).toBeInstanceOf(KhalaProcessNonZeroExit)
+    expect(failure).toMatchObject({
+      _tag: "KhalaProcessNonZeroExit",
+      command: process.execPath,
+      exitCode: 7,
+    })
+  })
+
+  test("does not leak listeners across repeated short-lived children", async () => {
+    const warnings: Error[] = []
+    const onWarning = (warning: Error) => warnings.push(warning)
+    process.on("warning", onWarning)
+    try {
+      for (let index = 0; index < 25; index += 1) {
+        const result = await collectKhalaProcessText(
+          spawnKhalaProcess(process.execPath, nodeEval(`process.stdout.write(String(${index}))`)),
+        )
+        expect(result.exitCode).toBe(0)
+        expect(result.stdout).toBe(String(index))
+      }
+    } finally {
+      process.off("warning", onWarning)
+    }
+
+    expect(warnings.filter(warning => warning.name === "MaxListenersExceededWarning")).toEqual([])
+  })
+})

--- a/clients/khala-code-desktop/tests/khala-process.test.ts
+++ b/clients/khala-code-desktop/tests/khala-process.test.ts
@@ -41,6 +41,34 @@ describe("KhalaProcess", () => {
     expect(await waitUntilGone(pid)).toBe(true)
   })
 
+  test("force kills a scoped child that ignores the graceful kill signal", async () => {
+    const pid = await Effect.runPromise(
+      Effect.scoped(
+        Effect.gen(function*() {
+          const handle = yield* spawnKhalaProcess(
+            process.execPath,
+            nodeEval("process.on('SIGTERM', () => {}); setInterval(() => {}, 1000)"),
+            { forceKillAfter: 25 },
+          )
+          yield* Effect.sleep(100)
+          return handle.pid
+        }),
+      ),
+    )
+
+    const gone = await waitUntilGone(pid)
+    if (!gone) {
+      try {
+        process.kill(pid, "SIGKILL")
+      } catch {
+        // The assertion below reports the failed cleanup condition.
+      }
+    }
+
+    expect(pid).toBeGreaterThan(0)
+    expect(gone).toBe(true)
+  })
+
   test("decodes stdout and stderr streams as text", async () => {
     const result = await collectKhalaProcessText(
       spawnKhalaProcess(process.execPath, nodeEval(


### PR DESCRIPTION
Closes #7860

## Summary
- Add KhalaProcess, a scoped Effect subprocess service backed by effect/unstable/process command/spawner abstractions.
- Expose typed stdin/stdout/stderr/exit surfaces with Data.TaggedError failures and kill-on-scope-close cleanup.
- Migrate the low-risk Codex parity git rev-parse helper from Bun.spawn to KhalaProcess as proof.
- Add fixture tests for scope-close kill, stream decode, typed nonzero exit, and repeated short-lived children without listener warnings.

## Verification
- bun test tests/khala-process.test.ts tests/codex-parity-contract.test.ts
- bun run --cwd clients/khala-code-desktop typecheck
- git diff --check
