### PR TITLE
Fix long-running Pylon lease renewal

### DIFF
--- a/apps/openagents.com/workers/api/src/pylon-api-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/pylon-api-routes.test.ts
@@ -3514,6 +3514,94 @@ describe('Pylon API routes', () => {
     expect(progressAfterCloseoutBody.error).toBe('pylon_api_conflict')
   })
 
+  test('#7921: runtime progress renews long-running assignment leases through worker closeout', async () => {
+    const store = new MemoryPylonApiStore()
+    const assignmentRef = 'assignment.public.issue7921.long_running'
+    const readAssignmentLeaseExpiresAt = async () => {
+      const assignment = await store.readAssignment(assignmentRef)
+      expect(assignment).toBeDefined()
+
+      return assignment?.leaseExpiresAt ?? ''
+    }
+
+    await registerPylon(store)
+    await markOnline(store, { nowIso: '2026-06-07T00:00:00.000Z' })
+    await markWalletReady(store)
+
+    const create = await createAssignment(store, {
+      assignmentRef,
+      idempotencyKey: 'assignment-create-issue7921-long-running',
+      leaseSeconds: 900,
+      nowIso: '2026-06-07T00:00:00.000Z',
+    })
+    const accept = await route(
+      store,
+      `/api/pylons/pylon.test.one/assignments/${assignmentRef}/accept`,
+      {
+        body: {
+          acceptanceRefs: ['acceptance.public.issue7921.long_running'],
+          accepted: true,
+        },
+        idempotencyKey: 'accept-issue7921-long-running',
+        method: 'POST',
+        nowIso: '2026-06-07T00:00:10.000Z',
+        tokenUserId: 'agent-one',
+      },
+    )
+    const acceptedLeaseExpiresAt = await readAssignmentLeaseExpiresAt()
+    const progress = await route(
+      store,
+      `/api/pylons/pylon.test.one/assignments/${assignmentRef}/progress`,
+      {
+        body: {
+          elapsedMs: 860_000,
+          phase: 'running',
+          progressRefs: ['progress.public.issue7921.runtime_heartbeat'],
+          status: 'running',
+        },
+        idempotencyKey: 'progress-issue7921-runtime-heartbeat',
+        method: 'POST',
+        nowIso: '2026-06-07T00:14:30.000Z',
+        tokenUserId: 'agent-one',
+      },
+    )
+    const progressLeaseExpiresAt = await readAssignmentLeaseExpiresAt()
+    const workerCloseout = await route(
+      store,
+      `/api/pylons/pylon.test.one/assignments/${assignmentRef}/closeout`,
+      {
+        body: {
+          artifactRefs: ['artifact.public.issue7921.long_running'],
+          buildRefs: ['build.public.issue7921.verified'],
+          closeoutRefs: ['closeout.public.issue7921.long_running'],
+          proofRefs: ['proof.public.issue7921.verified'],
+          resultRefs: ['result.public.issue7921.done'],
+          status: 'closeout_submitted',
+          testRefs: ['test.public.issue7921.verify_green'],
+        },
+        idempotencyKey: 'worker-closeout-issue7921-long-running',
+        method: 'POST',
+        nowIso: '2026-06-07T00:28:30.000Z',
+        tokenUserId: 'agent-one',
+      },
+    )
+    const workerCloseoutBody =
+      await responseJson<PylonRouteJson>(workerCloseout)
+
+    expect(create.status).toBe(201)
+    expect(accept.status).toBe(201)
+    expect(progress.status).toBe(201)
+    expect(Date.parse(progressLeaseExpiresAt)).toBeGreaterThan(
+      Date.parse(acceptedLeaseExpiresAt),
+    )
+    expect(workerCloseout.status).toBe(201)
+    expect(workerCloseoutBody.assignment).toMatchObject({
+      closeoutRefs: ['closeout.public.issue7921.long_running'],
+      leaseState: 'terminal',
+      state: 'closeout_submitted',
+    })
+  })
+
   test('records a settled paid GEPA-style assignment receipt after accepted closeout', async () => {
     const store = new MemoryPylonApiStore()
     await registerPylon(store, {

--- a/apps/pylon/src/assignment.ts
+++ b/apps/pylon/src/assignment.ts
@@ -846,7 +846,6 @@ function localLeaseRecordIsInterrupted(
   options: Pick<AssignmentClientOptions, "localAssignmentHeartbeatStaleAfterMs" | "localProcessIsAlive"> = {},
 ): boolean {
   if (locallyTerminalAssignmentStatuses.has(record.status)) return false
-  if (localLeaseRecordIsExpired(record, now)) return true
   const localProcessIsAlive = options.localProcessIsAlive ?? defaultLocalProcessIsAlive
   const heartbeatStaleAfterMs =
     typeof options.localAssignmentHeartbeatStaleAfterMs === "number" &&
@@ -856,12 +855,18 @@ function localLeaseRecordIsInterrupted(
       : DEFAULT_LOCAL_ASSIGNMENT_HEARTBEAT_STALE_AFTER_MS
   if (record.ownerProcessId !== undefined) {
     if (!localProcessIsAlive(record.ownerProcessId)) return true
+    if ((record.ownerHeartbeatSequence ?? 0) <= 0 && localLeaseRecordIsExpired(record, now)) {
+      return true
+    }
     const heartbeatAt = Date.parse(
       record.ownerHeartbeatAt ?? record.acceptedAt ?? record.ownerStartedAt ?? "",
     )
-    return Number.isFinite(heartbeatAt) &&
-      now.getTime() - heartbeatAt > heartbeatStaleAfterMs
+    if (!Number.isFinite(heartbeatAt)) {
+      return localLeaseRecordIsExpired(record, now)
+    }
+    return now.getTime() - heartbeatAt > heartbeatStaleAfterMs
   }
+  if (localLeaseRecordIsExpired(record, now)) return true
   if (record.acceptedAt !== undefined) {
     const acceptedAt = Date.parse(record.acceptedAt)
     return Number.isFinite(acceptedAt) &&

--- a/apps/pylon/tests/assignment.test.ts
+++ b/apps/pylon/tests/assignment.test.ts
@@ -83,7 +83,7 @@ function fakeAssignmentServer(input: {
       requests.push({ path: url.pathname, body, headers: request.headers })
 
       if (request.headers.get("authorization")?.startsWith("Bearer ")) {
-        if (request.method === "POST") {
+        if (request.method === "POST" && url.pathname !== "/api/operator/pro/status") {
           expect(request.headers.get("Idempotency-Key")).toContain(
             url.pathname.includes("/heartbeat")
               ? "pylon-presence:"
@@ -1283,6 +1283,70 @@ describe("Pylon assignment lease flow", () => {
         assignmentRef: expiredLease.assignmentRef,
         status: "stale",
         leaseExpiresAt: expiredLease.expiresAt,
+      })
+      expect(assignmentState.leases[freshLease.leaseRef]).toMatchObject({
+        assignmentRef: freshLease.assignmentRef,
+        status: "closed",
+        leaseExpiresAt: freshLease.expiresAt,
+      })
+    })
+  })
+
+  test("keeps an expired local lease active when its owner heartbeat is fresh", async () => {
+    await withTempHome(async (home) => {
+      const renewedLease = lease({
+        assignmentRef: "assignment.public.local_server_renewed",
+        leaseRef: "lease.public.local_server_renewed",
+        expiresAt: "2026-06-09T00:01:00.000Z",
+      })
+      const freshLease = lease({
+        assignmentRef: "assignment.public.local_after_server_renewed",
+        leaseRef: "lease.public.local_after_server_renewed",
+        expiresAt: "2026-06-09T01:00:00.000Z",
+      })
+      const fake = fakeAssignmentServer({ leases: [renewedLease, freshLease] })
+      const summary = await readySummary(home)
+      const state = await ensurePylonLocalState(summary)
+      await sendHeartbeat(summary, { baseUrl: fake.baseUrl, now: () => new Date("2026-06-09T00:00:00.000Z") })
+      await writeFile(
+        state.paths.assignmentState,
+        `${JSON.stringify({
+          schema: "openagents.pylon.assignment_state.v0.3",
+          leases: {
+            [renewedLease.leaseRef]: {
+              assignmentRef: renewedLease.assignmentRef,
+              status: "running",
+              acceptedAt: "2026-06-09T00:00:00.000Z",
+              leaseExpiresAt: renewedLease.expiresAt,
+              ownerHeartbeatAt: "2026-06-09T00:02:00.000Z",
+              ownerHeartbeatSequence: 24,
+              ownerProcessId: 424242,
+              ownerStartedAt: "2026-06-09T00:00:00.000Z",
+              paymentMode: "no-spend",
+            },
+          },
+        }, null, 2)}\n`,
+      )
+
+      const result = await runNoSpendAssignment(summary, {
+        baseUrl: fake.baseUrl,
+        localProcessIsAlive: () => true,
+        now: () => new Date("2026-06-09T00:02:30.000Z"),
+      })
+      const closeouts = fake.requests.filter((request) => request.path.endsWith("/closeout"))
+      const assignmentState = JSON.parse(await readFile(state.paths.assignmentState, "utf8"))
+
+      expect(result.ok).toBe(true)
+      if (!result.ok) throw new Error("expected fresh assignment to run")
+      expect(result.lease.leaseRef).toBe(freshLease.leaseRef)
+      expect(closeouts.map((request) => request.body.leaseRef)).toEqual([
+        freshLease.leaseRef,
+      ])
+      expect(assignmentState.leases[renewedLease.leaseRef]).toMatchObject({
+        assignmentRef: renewedLease.assignmentRef,
+        status: "running",
+        leaseExpiresAt: renewedLease.expiresAt,
+        ownerHeartbeatAt: "2026-06-09T00:02:00.000Z",
       })
       expect(assignmentState.leases[freshLease.leaseRef]).toMatchObject({
         assignmentRef: freshLease.assignmentRef,


### PR DESCRIPTION
## Summary

Closes #7921.

Long-running Pylon/Codex assignments already publish server-visible runtime progress, but the local assignment store could still mark a live owner stale after the original lease timestamp. This keeps live owner processes with fresh local heartbeats active while preserving stale/interrupted handling for dead owners, legacy accepted leases, and malformed heartbeat state.

This also adds a Worker API regression proving runtime progress renews an assignment lease far enough for a delayed worker closeout to succeed.

## Verification

- `bun test apps/pylon/tests/assignment.test.ts -t "keeps an expired local lease active"`
- `bun test apps/pylon/src/assignment-runtime-progress.test.ts`
- `bun run --cwd apps/openagents.com/workers/api test -- src/pylon-api-routes.test.ts -t "#7921"`
- `bun test apps/pylon/tests/assignment.test.ts`
- `bun run --cwd apps/pylon typecheck`
- `bun run --cwd apps/pylon test` — 2032 pass, 3 skip, 0 fail
- `bun run --cwd apps/openagents.com/workers/api typecheck`
- `git diff --check`
- `bun run --cwd apps/openagents.com check:deploy`