### PR TITLE
T4.4: generalize fleet worker kind

### DIFF
--- a/apps/pylon/src/index.ts
+++ b/apps/pylon/src/index.ts
@@ -212,9 +212,11 @@ import {
   completePylonLink,
   codexAccountCapacityRefs,
   codexBusyByAccount,
+  claudeBusyByAccount,
   codingServiceCapacityFromRuntime,
   codingServiceCapacityRefs,
   DEFAULT_CODEX_PER_ACCOUNT_CONCURRENCY,
+  localClaudeAccountCapacities,
   localCodexAccountCapacities,
   localCodingServiceReadyCounts,
   presenceClientOptionsFromEnv,
@@ -329,6 +331,7 @@ import {
   buildPylonKhalaSpawnPlan,
   repeatedKhalaSpawnObjectives,
   runPylonKhalaSpawnPlan,
+  type PylonKhalaSpawnWorkflow,
 } from "./khala-spawn.js"
 import {
   pylonKhalaMcpConfig,
@@ -2333,6 +2336,20 @@ async function availableCodexAssignments(
   return codingCapacity.find((item) => item.service === "codex")?.available ?? 0
 }
 
+async function availableClaudeAssignments(
+  summary: BootstrapSummary,
+  state: PylonLocalState,
+  options?: AssignmentLeaseNetworkOptions,
+  env: NodeJS.ProcessEnv = Bun.env,
+): Promise<number> {
+  const claudeAccounts = await localClaudeDispatchAccounts(summary, state, env, options)
+  if (claudeAccounts.length > 0) {
+    return claudeAccounts.reduce((sum, account) => sum + account.available, 0)
+  }
+  const codingCapacity = await codingCapacityForDispatch(summary, state, options, env)
+  return codingCapacity.find((item) => item.service === "claude")?.available ?? 0
+}
+
 async function localCodexDispatchAccounts(
   summary: BootstrapSummary,
   state: PylonLocalState,
@@ -2344,6 +2361,22 @@ async function localCodexDispatchAccounts(
     summary,
     env,
     codexBusyByAccount(
+      await codingAccountBusyCountsForDispatch(summary, state, options),
+    ),
+  )
+}
+
+async function localClaudeDispatchAccounts(
+  summary: BootstrapSummary,
+  state: PylonLocalState,
+  env: NodeJS.ProcessEnv = Bun.env,
+  options?: AssignmentLeaseNetworkOptions,
+) {
+  return localClaudeAccountCapacities(
+    state,
+    summary,
+    env,
+    claudeBusyByAccount(
       await codingAccountBusyCountsForDispatch(summary, state, options),
     ),
   )
@@ -2374,6 +2407,34 @@ function khalaCodexCapacityAdvertisementEnv(
     OPENAGENTS_PYLON_CODEX_BUSY: "0",
     OPENAGENTS_PYLON_CODEX_CONCURRENCY: String(pooledTarget),
     OPENAGENTS_PYLON_CODEX_QUEUED: "0",
+  }
+}
+
+function khalaClaudeCapacityAdvertisementEnv(
+  env: NodeJS.ProcessEnv,
+  requestedSlots: number,
+): NodeJS.ProcessEnv {
+  const requestedFloor = Math.max(
+    1,
+    Number.isSafeInteger(requestedSlots) && requestedSlots > 0
+      ? Math.floor(requestedSlots)
+      : 1,
+  )
+  const inheritedPooledConcurrency =
+    positiveIntegerEnv(env.OPENAGENTS_PYLON_CLAUDE_CONCURRENCY) ??
+    1
+  const explicitPerAccountConcurrency =
+    positiveIntegerEnv(env.OPENAGENTS_PYLON_CLAUDE_ACCOUNT_CONCURRENCY)
+  const perAccountTarget =
+    explicitPerAccountConcurrency ??
+    Math.max(inheritedPooledConcurrency, requestedFloor)
+  const pooledTarget = Math.max(inheritedPooledConcurrency, requestedFloor)
+  return {
+    ...env,
+    OPENAGENTS_PYLON_CLAUDE_ACCOUNT_CONCURRENCY: String(perAccountTarget),
+    OPENAGENTS_PYLON_CLAUDE_BUSY: "0",
+    OPENAGENTS_PYLON_CLAUDE_CONCURRENCY: String(pooledTarget),
+    OPENAGENTS_PYLON_CLAUDE_QUEUED: "0",
   }
 }
 
@@ -4223,8 +4284,15 @@ async function main() {
           optionString(options, "prompt") ??
           (args[2] !== undefined && !args[2].startsWith("--") ? args[2] : undefined)
         if (!objective) {
-          throw new Error("usage: pylon khala spawn --count <n> --objective <text> [--fixture | --commit <sha> --repo owner/repo --verify <argv>] [--pylon-ref <pylonRef>] [--account <ref>] [--max-parallel n] [--execute] [--lifecycle-ndjson] [--json]")
+          throw new Error("usage: pylon khala spawn --count <n> --objective <text> [--workflow claude_agent_task|codex_agent_task] [--fixture | --commit <sha> --repo owner/repo --verify <argv>] [--pylon-ref <pylonRef>] [--account <ref>] [--max-parallel n] [--execute] [--lifecycle-ndjson] [--json]")
         }
+        const workflow = optionString(options, "workflow") ?? "codex_agent_task"
+        if (workflow !== "claude_agent_task" && workflow !== "codex_agent_task") {
+          throw new Error("khala spawn --workflow must be claude_agent_task or codex_agent_task")
+        }
+        const spawnWorkflow = workflow as PylonKhalaSpawnWorkflow
+        const accountProvider = spawnWorkflow === "claude_agent_task" ? "claude_agent" : "codex"
+        const workerKind = spawnWorkflow === "claude_agent_task" ? "Claude" : "Codex"
         const count = positiveIntegerOption(options, "count", "khala spawn --count") ?? 1
         const maxParallel = positiveIntegerOption(options, "max-parallel", "khala spawn --max-parallel")
         const commit = optionString(options, "commit")
@@ -4254,7 +4322,9 @@ async function main() {
           optionString(options, "pylon-ref") ??
           optionString(options, "target-pylon-ref") ??
           localPylonTargetRef(state)
-        const capacityEnv = khalaCodexCapacityAdvertisementEnv(Bun.env, Math.max(count, maxParallel ?? 0))
+        const capacityEnv = spawnWorkflow === "claude_agent_task"
+          ? khalaClaudeCapacityAdvertisementEnv(Bun.env, Math.max(count, maxParallel ?? 0))
+          : khalaCodexCapacityAdvertisementEnv(Bun.env, Math.max(count, maxParallel ?? 0))
         if (optionFlag(options, "execute")) {
           try {
             await sendHeartbeat(summary, {
@@ -4278,7 +4348,7 @@ async function main() {
             : {
                 ...allAccounts,
                 accounts: allAccounts.accounts.filter((account) =>
-                  account.provider === "codex" &&
+                  account.provider === accountProvider &&
                   (
                     account.accountRef === accountSelector ||
                     account.accountRefHash === accountSelector ||
@@ -4287,12 +4357,16 @@ async function main() {
                 ),
               }
         if (accountSelector !== undefined && accounts.accounts.length === 0) {
-          throw new Error(`khala spawn account ${accountSelector} is not a connected Codex account`)
+          throw new Error(`khala spawn account ${accountSelector} is not a connected ${workerKind} account`)
         }
-        const advertisedCodexAccounts = await localCodexDispatchAccounts(summary, state, capacityEnv, networkOptions)
+        const advertisedCodexAccounts = spawnWorkflow === "claude_agent_task"
+          ? await localClaudeDispatchAccounts(summary, state, capacityEnv, networkOptions)
+          : await localCodexDispatchAccounts(summary, state, capacityEnv, networkOptions)
         const advertisedCodexAvailability = advertisedCodexAccounts.length > 0
           ? advertisedCodexAccounts.reduce((sum, account) => sum + account.available, 0)
-          : await availableCodexAssignments(summary, state, networkOptions, capacityEnv)
+          : spawnWorkflow === "claude_agent_task"
+            ? await availableClaudeAssignments(summary, state, networkOptions, capacityEnv)
+            : await availableCodexAssignments(summary, state, networkOptions, capacityEnv)
         const workspace = explicitFixture
           ? undefined
           : buildPylonKhalaGitCheckoutWorkspace({
@@ -4314,6 +4388,7 @@ async function main() {
           repository,
           targetPylonRef,
           ...(verificationCommand === undefined ? {} : { verificationCommand }),
+          workflow: spawnWorkflow,
           ...(workspace === undefined ? {} : { workspace }),
         })
         if (!optionFlag(options, "execute")) {

--- a/apps/pylon/src/khala-burndown.test.ts
+++ b/apps/pylon/src/khala-burndown.test.ts
@@ -28,6 +28,29 @@ const accounts: PylonAccountsListProjection = {
   schema: "openagents.pylon.accounts_list.v0.3",
 }
 
+const claudeAccounts: PylonAccountsListProjection = {
+  ...accounts,
+  accounts: [
+    {
+      accountRef: "claude-a",
+      accountRefHash: "account.pylon.claude.a",
+      blockerRefs: [],
+      homeRef: "home.pylon.claude.a",
+      homeState: "present",
+      provider: "claude_agent",
+      readiness: {
+        blockerRefs: [],
+        capabilityRefs: ["capability.pylon.local_claude"],
+        credentialSourceRef: "credential.source.claude_agent.setup_token",
+        enabled: true,
+        schema: "openagents.pylon.claude_agent_readiness.v0.3",
+        state: "ready",
+      },
+      selector: "registry_ref",
+    },
+  ],
+}
+
 describe("Khala burndown plan", () => {
   test("keeps requested issue count visible when capacity is unavailable", () => {
     const plan = buildPylonKhalaBurndownPlan({
@@ -109,5 +132,37 @@ describe("Khala burndown plan", () => {
       "account.pylon.codex.b",
       "account.pylon.codex.a",
     ])
+  })
+
+  test("uses claude_agent_task when worker kind is Claude", () => {
+    const plan = buildPylonKhalaBurndownPlan({
+      accounts: claudeAccounts,
+      advertisedCodexAccounts: [
+        {
+          accountKey: "claude-a",
+          accountRefHash: "account.pylon.claude.a",
+          available: 2,
+          busy: 0,
+          queued: 0,
+          ready: 2,
+        },
+      ],
+      baseUrl: "https://openagents.example",
+      commit: "2e5937497ec2d7a6b5256e7265042b0e78cd294f",
+      issueNumbers: [6323, 6311],
+      maxParallel: 2,
+      repository: "OpenAgentsInc/openagents",
+      targetPylonRef: "pylon.33afd48282a649047e3a",
+      verificationCommand: "bun test apps/pylon/src/khala-burndown.test.ts",
+      workerKind: "claude",
+    })
+
+    expect(plan.workerKind).toBe("claude")
+    expect(plan.workflow).toBe("claude_agent_task")
+    expect(plan.readyWorkerAccountCount).toBe(1)
+    expect(plan.slots).toHaveLength(2)
+    expect(plan.slots[0]?.requestInput.workflow).toBe("claude_agent_task")
+    expect(plan.slots[0]?.commands.request).toContain("--workflow claude_agent_task")
+    expect(plan.slots.map((slot) => slot.account.accountRef)).toEqual(["claude-a", "claude-a"])
   })
 })

--- a/apps/pylon/src/khala-burndown.ts
+++ b/apps/pylon/src/khala-burndown.ts
@@ -20,17 +20,20 @@ import type { PylonAccountsListProjection } from "./account-usage.js"
 import {
   PYLON_KHALA_SPAWN_PLAN_SCHEMA,
   readPublicKhalaTokensServed,
-  readyCodexAccounts,
+  pylonKhalaSpawnWorkflowForWorkerKind,
+  readyKhalaSpawnAccounts,
   runPylonKhalaSpawnPlan,
   weightedKhalaAccountPool,
   type PylonKhalaSpawnAdvertisedCodexAccount,
   type PylonKhalaSpawnProofProjection,
+  type PylonKhalaSpawnWorkerKind,
 } from "./khala-spawn.js"
 
 export { readPublicKhalaTokensServed } from "./khala-spawn.js"
 
 export const PYLON_KHALA_BURNDOWN_PLAN_SCHEMA = "openagents.pylon.khala_burndown_plan.v0.1"
 export const PYLON_KHALA_BURNDOWN_RUN_SCHEMA = "openagents.pylon.khala_burndown_run.v0.1"
+export type PylonKhalaBurndownWorkerKind = PylonKhalaSpawnWorkerKind
 
 export type PylonKhalaBurndownIssue = {
   issueNumber: number
@@ -67,11 +70,15 @@ export type PylonKhalaBurndownPlan = {
   targetPylonRef: string
   advertisedCodexAccounts: readonly PylonKhalaSpawnAdvertisedCodexAccount[]
   advertisedCodexAvailability: number
+  advertisedWorkerAvailability: number
   readyCodexAccountCount: number
+  readyWorkerAccountCount: number
   issueCount: number
   slots: PylonKhalaBurndownSlot[]
   mergePolicy: "operator_review_required"
   blockerRefs: string[]
+  workerKind: PylonKhalaBurndownWorkerKind
+  workflow: "claude_agent_task" | "codex_agent_task"
 }
 
 export type PylonKhalaBurndownSlotResult = {
@@ -181,6 +188,14 @@ const accountCommandArgs = (account: PylonKhalaBurndownAccount): string =>
 const requestAccountArgs = (account: PylonKhalaBurndownAccount): string[] =>
   account.accountRef === null ? [] : [`--account-ref ${quoteArg(account.accountRef)}`]
 
+const burndownBlocker = (
+  workerKind: PylonKhalaBurndownWorkerKind,
+  suffix: "no_advertised_availability" | "no_ready_account_slots" | "no_ready_accounts",
+): string => {
+  const kind = workerKind === "claude" ? "claude" : "codex"
+  return `blocker.khala_burndown.${suffix.replace("_account", `_${kind}_account`).replace("_advertised_", `_advertised_${kind}_`)}`
+}
+
 export function buildKhalaBurndownObjective(issueNumber: number): string {
   return [
     `Implement OpenAgents issue #${issueNumber} from the Khala roadmap.`,
@@ -202,8 +217,11 @@ export function buildPylonKhalaBurndownPlan(input: {
   repository: string
   targetPylonRef: string
   verificationCommand: string
+  workerKind?: PylonKhalaBurndownWorkerKind
 }): PylonKhalaBurndownPlan {
-  const readyAccounts = readyCodexAccounts(input.accounts)
+  const workerKind = input.workerKind ?? "codex"
+  const workflow = pylonKhalaSpawnWorkflowForWorkerKind(workerKind)
+  const readyAccounts = readyKhalaSpawnAccounts(input.accounts, workflow)
   const advertisedCodexAccounts = (input.advertisedCodexAccounts ?? [])
     .map(account => ({
       accountKey: account.accountKey,
@@ -239,11 +257,11 @@ export function buildPylonKhalaBurndownPlan(input: {
   const requestedIssueNumbers = uniqueIssueNumbers(input.issueNumbers)
   const issueNumbers = requestedIssueNumbers.slice(0, selectedParallel * iterations)
   const blockerRefs = [
-    ...(readyAccounts.length === 0 ? ["blocker.khala_burndown.no_ready_codex_accounts"] : []),
+    ...(readyAccounts.length === 0 ? [burndownBlocker(workerKind, "no_ready_accounts")] : []),
     ...(readyAccounts.length > 0 && accounts.length === 0
-      ? ["blocker.khala_burndown.no_ready_codex_account_slots"]
+      ? [burndownBlocker(workerKind, "no_ready_account_slots")]
       : []),
-    ...(advertisedCodexAvailability === 0 ? ["blocker.khala_burndown.no_advertised_codex_availability"] : []),
+    ...(advertisedCodexAvailability === 0 ? [burndownBlocker(workerKind, "no_advertised_availability")] : []),
     ...(requestedIssueNumbers.length === 0 ? ["blocker.khala_burndown.no_issue_numbers"] : []),
   ]
   const slots: PylonKhalaBurndownSlot[] = selectedParallel === 0
@@ -264,12 +282,12 @@ export function buildPylonKhalaBurndownPlan(input: {
           prompt: objective,
           targetAccountRefHash: account.accountRefHash,
           targetPylonRef: input.targetPylonRef,
-          workflow: "codex_agent_task",
+          workflow,
           workspace,
         }
         const requestCommand = [
           "pylon khala request",
-          "--workflow codex_agent_task",
+          `--workflow ${workflow}`,
           `--pylon-ref ${quoteArg(input.targetPylonRef)}`,
           ...requestAccountArgs(account),
           `--repo ${quoteArg(input.repository)}`,
@@ -306,11 +324,15 @@ export function buildPylonKhalaBurndownPlan(input: {
     targetPylonRef: input.targetPylonRef,
     advertisedCodexAccounts,
     advertisedCodexAvailability,
+    advertisedWorkerAvailability: advertisedCodexAvailability,
     readyCodexAccountCount: readyAccounts.length,
+    readyWorkerAccountCount: readyAccounts.length,
     issueCount: requestedIssueNumbers.length,
     slots,
     mergePolicy: "operator_review_required",
     blockerRefs,
+    workerKind,
+    workflow,
   }
   assertPublicProjectionSafe(plan)
   return plan
@@ -335,14 +357,18 @@ export async function runPylonKhalaBurndownPlan(input: {
       schema: PYLON_KHALA_SPAWN_PLAN_SCHEMA,
       advertisedCodexAccounts: input.plan.advertisedCodexAccounts,
       advertisedCodexAvailability: input.plan.advertisedCodexAvailability,
+      advertisedWorkerAvailability: input.plan.advertisedWorkerAvailability,
       baseUrl: input.plan.baseUrl,
       blockerRefs: input.plan.blockerRefs,
       maxParallel: input.plan.maxParallel,
       objectiveCount: input.plan.issueCount,
       readyCodexAccountCount: input.plan.readyCodexAccountCount,
+      readyWorkerAccountCount: input.plan.readyWorkerAccountCount,
       requestedCount: input.plan.issueCount,
       slots: input.plan.slots,
       targetPylonRef: input.plan.targetPylonRef,
+      workerKind: input.plan.workerKind,
+      workflow: input.plan.workflow,
     },
     summary: input.summary,
   })

--- a/apps/pylon/src/khala-requester.ts
+++ b/apps/pylon/src/khala-requester.ts
@@ -10,6 +10,30 @@ export type PylonKhalaWorkflow =
   | "cloud_coding_session"
   | "codex_agent_task"
 
+export type PylonKhalaOwnCapacityTokenModel =
+  | "openagents/pylon-claude"
+  | "openagents/pylon-codex"
+
+export type PylonKhalaOwnCapacityTokenProvider =
+  | "pylon-claude-own-capacity"
+  | "pylon-codex-own-capacity"
+
+export function isPylonKhalaExactOwnCapacityTokenUsage(input: {
+  demandKind: "own_capacity"
+  demandSource: "khala_coding_delegation"
+  model: PylonKhalaOwnCapacityTokenModel
+  provider: PylonKhalaOwnCapacityTokenProvider
+  usageTruth: "exact"
+}): boolean {
+  const providerMatchesModel =
+    (input.provider === "pylon-codex-own-capacity" && input.model === "openagents/pylon-codex") ||
+    (input.provider === "pylon-claude-own-capacity" && input.model === "openagents/pylon-claude")
+  return providerMatchesModel &&
+    input.usageTruth === "exact" &&
+    input.demandKind === "own_capacity" &&
+    input.demandSource === "khala_coding_delegation"
+}
+
 export type PylonKhalaRequestInput = {
   prompt: string
   objectiveSummary?: string
@@ -173,9 +197,9 @@ export type PylonKhalaAssignmentTraceStatusResult = {
     demandKind: "own_capacity"
     demandSource: "khala_coding_delegation"
     inputTokens: number
-    model: "openagents/pylon-codex"
+    model: PylonKhalaOwnCapacityTokenModel
     outputTokens: number
-    provider: "pylon-codex-own-capacity"
+    provider: PylonKhalaOwnCapacityTokenProvider
     reasoningTokens: number
     refs: string[]
     rowCount: number
@@ -217,9 +241,9 @@ export type PylonKhalaProofResult = {
     demandKind: "own_capacity"
     demandSource: "khala_coding_delegation"
     inputTokens: number
-    model: "openagents/pylon-codex"
+    model: PylonKhalaOwnCapacityTokenModel
     outputTokens: number
-    provider: "pylon-codex-own-capacity"
+    provider: PylonKhalaOwnCapacityTokenProvider
     reasoningTokens: number
     refs: string[]
     rowCount: number
@@ -485,11 +509,7 @@ export function evaluatePylonKhalaProofChecklist(
     ),
     checklistItem(
       "check.khala_proof.token_usage.exact_own_capacity",
-      proof.tokenUsage.provider === "pylon-codex-own-capacity" &&
-        proof.tokenUsage.model === "openagents/pylon-codex" &&
-        proof.tokenUsage.usageTruth === "exact" &&
-        proof.tokenUsage.demandKind === "own_capacity" &&
-        proof.tokenUsage.demandSource === "khala_coding_delegation",
+      isPylonKhalaExactOwnCapacityTokenUsage(proof.tokenUsage),
     ),
     checklistItem(
       "check.khala_proof.token_usage.rows_and_tokens_present",

--- a/apps/pylon/src/khala-spawn.test.ts
+++ b/apps/pylon/src/khala-spawn.test.ts
@@ -11,6 +11,7 @@ import type { PylonKhalaProofResult, PylonKhalaRequestResult } from "./khala-req
 
 const accountHashA = "account.pylon.codex.aaaaaaaaaaaa"
 const accountHashB = "account.pylon.codex.bbbbbbbbbbbb"
+const claudeAccountHash = "account.pylon.claude.aaaaaaaaaaaa"
 
 const plan: PylonKhalaSpawnPlan = {
   schema: PYLON_KHALA_SPAWN_PLAN_SCHEMA,
@@ -25,11 +26,13 @@ const plan: PylonKhalaSpawnPlan = {
     },
   ],
   advertisedCodexAvailability: 1,
+  advertisedWorkerAvailability: 1,
   baseUrl: "https://openagents.example",
   blockerRefs: [],
   maxParallel: 1,
   objectiveCount: 1,
   readyCodexAccountCount: 1,
+  readyWorkerAccountCount: 1,
   requestedCount: 1,
   slots: [
     {
@@ -57,6 +60,8 @@ const plan: PylonKhalaSpawnPlan = {
     },
   ],
   targetPylonRef: "pylon.owner.codex",
+  workerKind: "codex",
+  workflow: "codex_agent_task",
 }
 
 describe("Khala spawn per-account planning", () => {
@@ -231,6 +236,57 @@ describe("Khala spawn per-account planning", () => {
     expect(requestInput?.objectiveSummary?.endsWith("...")).toBe(true)
   })
 
+  test("plans claude_agent_task slots against ready Claude accounts", () => {
+    const result = buildPylonKhalaSpawnPlan({
+      accounts: {
+        accounts: [
+          {
+            accountRef: "codex-a",
+            accountRefHash: accountHashA,
+            blockerRefs: [],
+            homeState: "present",
+            provider: "codex",
+            readiness: { state: "ready" },
+          },
+          {
+            accountRef: "claude-a",
+            accountRefHash: claudeAccountHash,
+            blockerRefs: [],
+            homeState: "present",
+            provider: "claude_agent",
+            readiness: { state: "ready" },
+          },
+        ],
+      } as never,
+      advertisedCodexAccounts: [
+        {
+          accountKey: "claudeaaaaaaaaaaaa",
+          accountRefHash: claudeAccountHash,
+          available: 2,
+          busy: 0,
+          queued: 0,
+          ready: 2,
+        },
+      ],
+      baseUrl: "https://openagents.example",
+      fixture: true,
+      objectives: repeatedKhalaSpawnObjectives({
+        count: 2,
+        objective: "Run the bounded fixture.",
+      }),
+      targetPylonRef: "pylon.owner.codex",
+      workflow: "claude_agent_task",
+    })
+
+    expect(result.workerKind).toBe("claude")
+    expect(result.workflow).toBe("claude_agent_task")
+    expect(result.readyWorkerAccountCount).toBe(1)
+    expect(result.slots.map(slot => slot.account.accountRef)).toEqual(["claude-a", "claude-a"])
+    expect(result.slots[0]?.requestInput.workflow).toBe("claude_agent_task")
+    expect(result.slots[0]?.commands.request).toContain("--workflow claude_agent_task")
+    expect(result.slots[0]?.commands.request).toContain('--account-ref "claude-a"')
+  })
+
   test("blocks batches that request more slots than advertised free capacity", () => {
     const result = buildPylonKhalaSpawnPlan({
       accounts: {
@@ -285,7 +341,7 @@ describe("Khala spawn per-account planning", () => {
     expect(result.maxParallel).toBe(0)
     expect(result.slots).toEqual([])
     expect(result.blockerRefs).toContain(
-      "blocker.khala_spawn.requested_count_exceeds_advertised_availability",
+      "blocker.khala_spawn.requested_count_exceeds_advertised_codex_availability",
     )
   })
 })
@@ -305,6 +361,13 @@ const requestResult: PylonKhalaRequestResult = {
   streamUpToDate: true,
   text: "",
   workflow: "codex_agent_task",
+}
+
+const claudeRequestResult: PylonKhalaRequestResult = {
+  ...requestResult,
+  assignmentRef: "assignment.public.khala_claude.test",
+  durableRequestId: "durable.claude.test",
+  workflow: "claude_agent_task",
 }
 
 const exactProof: PylonKhalaProofResult = {
@@ -352,6 +415,19 @@ const exactProof: PylonKhalaProofResult = {
   },
 }
 
+const claudeExactProof: PylonKhalaProofResult = {
+  ...exactProof,
+  assignmentRef: "assignment.public.khala_claude.test",
+  pylonRef: "pylon.owner.claude",
+  tokenUsage: {
+    ...exactProof.tokenUsage,
+    model: "openagents/pylon-claude",
+    provider: "pylon-claude-own-capacity",
+    refs: ["event.inference.served-tokens.pylon-claude.owner"],
+    totalTokens: 18,
+  },
+}
+
 describe("Khala spawn proof gate", () => {
   test("accepts exact own-capacity Pylon/Codex proof rows", async () => {
     const tokenCounts = [1000, 1016]
@@ -376,6 +452,54 @@ describe("Khala spawn proof gate", () => {
     expect(result.ok).toBe(true)
     expect(result.aggregate.acceptedCount).toBe(1)
     expect(result.aggregate.totalVerifiedTokens).toBe(16)
+    expect(result.blockerRefs).toEqual([])
+  })
+
+  test("accepts exact own-capacity Pylon/Claude proof rows", async () => {
+    const tokenCounts = [1000, 1018]
+    const claudePlan = buildPylonKhalaSpawnPlan({
+      accounts: {
+        accounts: [
+          {
+            accountRef: "claude-a",
+            accountRefHash: claudeAccountHash,
+            blockerRefs: [],
+            homeState: "present",
+            provider: "claude_agent",
+            readiness: { state: "ready" },
+          },
+        ],
+      } as never,
+      advertisedCodexAvailability: 1,
+      baseUrl: "https://openagents.example",
+      fixture: true,
+      objectives: repeatedKhalaSpawnObjectives({ count: 1, objective: "Run Claude fixture." }),
+      targetPylonRef: "pylon.owner.claude",
+      workflow: "claude_agent_task",
+    })
+
+    const result = await runPylonKhalaSpawnPlan({
+      deps: {
+        readProof: async () => claudeExactProof,
+        readTokensServed: async () => tokenCounts.shift() ?? 1018,
+        requestAssignment: async () => claudeRequestResult,
+        runAssignment: async () => ({
+          closeout: { status: "accepted" },
+          ok: true,
+        }),
+      },
+      network: {
+        agentToken: "agent.public.test",
+        baseUrl: "https://openagents.example",
+      },
+      plan: claudePlan,
+      summary: {} as never,
+    })
+
+    expect(result.ok).toBe(true)
+    expect(result.plan.workflow).toBe("claude_agent_task")
+    expect(result.aggregate.acceptedCount).toBe(1)
+    expect(result.aggregate.totalVerifiedTokens).toBe(18)
     expect(result.blockerRefs).toEqual([])
   })
 

--- a/apps/pylon/src/khala-spawn.ts
+++ b/apps/pylon/src/khala-spawn.ts
@@ -11,11 +11,13 @@ import type { PylonAccountsListProjection } from "./account-usage.js"
 import type { TipsNetworkOptions } from "./tips.js"
 import {
   issuePylonKhalaRequest,
+  isPylonKhalaExactOwnCapacityTokenUsage,
   readPylonKhalaProof,
   type PylonKhalaGitCheckoutWorkspace,
   type PylonKhalaProofResult,
   type PylonKhalaRequestInput,
   type PylonKhalaRequestResult,
+  type PylonKhalaWorkflow,
 } from "./khala-requester.js"
 import { assertPublicProjectionSafe } from "./state.js"
 
@@ -36,6 +38,9 @@ export type PylonKhalaSpawnAdvertisedCodexAccount = {
   queued: number
   ready: number
 }
+
+export type PylonKhalaSpawnWorkflow = Extract<PylonKhalaWorkflow, "claude_agent_task" | "codex_agent_task">
+export type PylonKhalaSpawnWorkerKind = "claude" | "codex"
 
 export type PylonKhalaSpawnObjective = {
   objective: string
@@ -66,14 +71,18 @@ export type PylonKhalaSpawnPlan = {
   schema: typeof PYLON_KHALA_SPAWN_PLAN_SCHEMA
   advertisedCodexAccounts: readonly PylonKhalaSpawnAdvertisedCodexAccount[]
   advertisedCodexAvailability: number
+  advertisedWorkerAvailability: number
   baseUrl: string
   blockerRefs: string[]
   maxParallel: number
   objectiveCount: number
   readyCodexAccountCount: number
+  readyWorkerAccountCount: number
   requestedCount: number
   slots: readonly PylonKhalaSpawnSlot[]
   targetPylonRef: string
+  workerKind: PylonKhalaSpawnWorkerKind
+  workflow: PylonKhalaSpawnWorkflow
 }
 
 export type PylonKhalaSpawnPlanLike<Slot extends PylonKhalaSpawnSlotLike = PylonKhalaSpawnSlot> =
@@ -209,9 +218,17 @@ function nonNegativeInteger(value: number | undefined, fallback: number): number
 export function readyCodexAccounts(
   accounts: PylonAccountsListProjection,
 ): PylonKhalaSpawnAccount[] {
+  return readyKhalaSpawnAccounts(accounts, "codex_agent_task")
+}
+
+export function readyKhalaSpawnAccounts(
+  accounts: PylonAccountsListProjection,
+  workflow: PylonKhalaSpawnWorkflow = "codex_agent_task",
+): PylonKhalaSpawnAccount[] {
+  const provider = pylonKhalaSpawnAccountProviderForWorkflow(workflow)
   return accounts.accounts
     .filter((account) =>
-      account.provider === "codex" &&
+      account.provider === provider &&
       account.homeState === "present" &&
       account.readiness.state === "ready" &&
       account.blockerRefs.length === 0
@@ -220,6 +237,37 @@ export function readyCodexAccounts(
       accountRef: account.accountRef,
       accountRefHash: account.accountRefHash,
     }))
+}
+
+export function pylonKhalaSpawnWorkflowForWorkerKind(
+  workerKind: PylonKhalaSpawnWorkerKind,
+): PylonKhalaSpawnWorkflow {
+  return workerKind === "claude" ? "claude_agent_task" : "codex_agent_task"
+}
+
+export function pylonKhalaSpawnWorkerKindForWorkflow(
+  workflow: PylonKhalaSpawnWorkflow,
+): PylonKhalaSpawnWorkerKind {
+  return workflow === "claude_agent_task" ? "claude" : "codex"
+}
+
+function pylonKhalaSpawnAccountProviderForWorkflow(
+  workflow: PylonKhalaSpawnWorkflow,
+): "claude_agent" | "codex" {
+  return workflow === "claude_agent_task" ? "claude_agent" : "codex"
+}
+
+function pylonKhalaSpawnWorkerBlocker(
+  workerKind: PylonKhalaSpawnWorkerKind,
+  suffix: "no_advertised_availability" | "no_ready_account_slots" | "no_ready_accounts" | "requested_count_exceeds_advertised_availability",
+): string {
+  const kind = workerKind === "claude" ? "claude" : "codex"
+  return blocker(
+    "khala_spawn",
+    suffix
+      .replace("_account", `_${kind}_account`)
+      .replace("_advertised_", `_advertised_${kind}_`),
+  )
 }
 
 export function repeatedKhalaSpawnObjectives(input: {
@@ -258,9 +306,12 @@ export function buildPylonKhalaSpawnPlan(input: {
   repository?: string
   targetPylonRef: string
   verificationCommand?: string
+  workflow?: PylonKhalaSpawnWorkflow
   workspace?: PylonKhalaGitCheckoutWorkspace
 }): PylonKhalaSpawnPlan {
-  const readyAccounts = readyCodexAccounts(input.accounts)
+  const workflow = input.workflow ?? "codex_agent_task"
+  const workerKind = pylonKhalaSpawnWorkerKindForWorkflow(workflow)
+  const readyAccounts = readyKhalaSpawnAccounts(input.accounts, workflow)
   const advertisedCodexAccounts = (input.advertisedCodexAccounts ?? [])
     .map((account) => ({
       accountKey: account.accountKey,
@@ -308,13 +359,15 @@ export function buildPylonKhalaSpawnPlan(input: {
     Math.min(accounts.length, Math.max(1, selectedParallel)),
   )
   const blockerRefs = [
-    ...(readyAccounts.length === 0 ? [blocker("khala_spawn", "no_ready_codex_accounts")] : []),
+    ...(readyAccounts.length === 0 ? [pylonKhalaSpawnWorkerBlocker(workerKind, "no_ready_accounts")] : []),
     ...(readyAccounts.length > 0 && accounts.length === 0
-      ? [blocker("khala_spawn", "no_ready_codex_account_slots")]
+      ? [pylonKhalaSpawnWorkerBlocker(workerKind, "no_ready_account_slots")]
       : []),
-    ...(advertisedCodexAvailability === 0 ? [blocker("khala_spawn", "no_advertised_codex_availability")] : []),
+    ...(advertisedCodexAvailability === 0
+      ? [pylonKhalaSpawnWorkerBlocker(workerKind, "no_advertised_availability")]
+      : []),
     ...(requestedExceedsAdvertisedAvailability
-      ? [blocker("khala_spawn", "requested_count_exceeds_advertised_availability")]
+      ? [pylonKhalaSpawnWorkerBlocker(workerKind, "requested_count_exceeds_advertised_availability")]
       : []),
     ...(requestedCount === 0 ? [blocker("khala_spawn", "no_objectives")] : []),
   ]
@@ -328,7 +381,7 @@ export function buildPylonKhalaSpawnPlan(input: {
           prompt: objective.objective,
           targetAccountRefHash: account.accountRefHash,
           targetPylonRef: input.targetPylonRef,
-          workflow: "codex_agent_task",
+          workflow,
           ...(input.workspace === undefined ? {} : { workspace: input.workspace }),
         }
         const workspaceArgs = input.workspace === undefined || input.fixture === true
@@ -345,7 +398,7 @@ export function buildPylonKhalaSpawnPlan(input: {
             proof: "pylon khala proof --assignment-ref <assignmentRef> --json",
             request: [
               "pylon khala request",
-              "--workflow codex_agent_task",
+              `--workflow ${workflow}`,
               `--pylon-ref ${quoteArg(input.targetPylonRef)}`,
               ...requestAccountArgs(account),
               `--prompt ${quoteArg(objective.objective)}`,
@@ -364,14 +417,18 @@ export function buildPylonKhalaSpawnPlan(input: {
     schema: PYLON_KHALA_SPAWN_PLAN_SCHEMA,
     advertisedCodexAccounts,
     advertisedCodexAvailability,
+    advertisedWorkerAvailability: advertisedCodexAvailability,
     baseUrl: input.baseUrl,
     blockerRefs,
     maxParallel: selectedParallel,
     objectiveCount: requestedCount,
     readyCodexAccountCount: readyAccounts.length,
+    readyWorkerAccountCount: readyAccounts.length,
     requestedCount,
     slots,
     targetPylonRef: input.targetPylonRef,
+    workerKind,
+    workflow,
   }
   assertPublicProjectionSafe(plan)
   return plan
@@ -434,12 +491,7 @@ function proofBlockerRefs(
   proof: PylonKhalaSpawnProofProjection,
   namespace: string,
 ): string[] {
-  const exactOwnCapacity =
-    proof.provider === "pylon-codex-own-capacity" &&
-    proof.model === "openagents/pylon-codex" &&
-    proof.usageTruth === "exact" &&
-    proof.demandKind === "own_capacity" &&
-    proof.demandSource === "khala_coding_delegation"
+  const exactOwnCapacity = isPylonKhalaExactOwnCapacityTokenUsage(proof)
   return [
     ...(!exactOwnCapacity ? [blocker(namespace, "proof_not_exact_own_capacity")] : []),
     ...(proof.tokenRows <= 0 || proof.totalTokens <= 0 ? [blocker(namespace, "proof_token_rows_missing")] : []),

--- a/apps/pylon/tests/khala-burndown.test.ts
+++ b/apps/pylon/tests/khala-burndown.test.ts
@@ -37,6 +37,27 @@ const readyCodexAccount = (
   selector: "registry_ref",
 })
 
+const readyClaudeAccount = (
+  accountRef: string,
+  accountRefHash: string,
+): PylonAccountsListProjection["accounts"][number] => ({
+  accountRef,
+  accountRefHash,
+  blockerRefs: [],
+  homeRef: `home.public.${accountRefHash}`,
+  homeState: "present",
+  provider: "claude_agent",
+  readiness: {
+    blockerRefs: [],
+    capabilityRefs: ["capability.pylon.local_claude"],
+    credentialSourceRef: "credential.public.claude_setup_token",
+    enabled: true,
+    schema: "openagents.pylon.claude_agent_readiness.v0.3",
+    state: "ready",
+  },
+  selector: "registry_ref",
+})
+
 const accountsProjection = (): PylonAccountsListProjection => ({
   accounts: [
     readyCodexAccount("account.public.codex.one", "accthash_one"),
@@ -160,6 +181,38 @@ describe("pylon khala burndown planner", () => {
     expect(plan.slots[0]?.commands.request).toContain("pylon khala request")
     expect(plan.slots[0]?.commands.runNoSpend).toContain("assignment run-no-spend")
     expect(plan.slots[0]?.commands.proof).toContain("pylon khala proof")
+  })
+
+  test("maps ready Claude accounts to claude_agent_task issue slots", () => {
+    const plan = buildPylonKhalaBurndownPlan({
+      accounts: {
+        ...accountsProjection(),
+        accounts: [
+          readyCodexAccount("account.public.codex.one", "accthash_codex"),
+          readyClaudeAccount("account.public.claude.one", "accthash_claude"),
+        ],
+      },
+      advertisedCodexAvailability: 2,
+      baseUrl: "https://openagents.test",
+      commit,
+      issueNumbers: [6355, 6356],
+      maxParallel: 2,
+      repository: "OpenAgentsInc/openagents",
+      targetPylonRef: "pylon.public.local",
+      verificationCommand,
+      workerKind: "claude",
+    })
+
+    expect(plan.workerKind).toBe("claude")
+    expect(plan.workflow).toBe("claude_agent_task")
+    expect(plan.readyWorkerAccountCount).toBe(1)
+    expect(plan.slots).toHaveLength(2)
+    expect(plan.slots.map((slot) => slot.account.accountRefHash)).toEqual([
+      "accthash_claude",
+      "accthash_claude",
+    ])
+    expect(plan.slots[0]?.requestInput.workflow).toBe("claude_agent_task")
+    expect(plan.slots[0]?.commands.request).toContain("--workflow claude_agent_task")
   })
 })
 

--- a/apps/pylon/tests/khala-spawn.test.ts
+++ b/apps/pylon/tests/khala-spawn.test.ts
@@ -33,6 +33,27 @@ const readyCodexAccount = (
   selector: "registry_ref",
 })
 
+const readyClaudeAccount = (
+  accountRef: string,
+  accountRefHash: string,
+): PylonAccountsListProjection["accounts"][number] => ({
+  accountRef,
+  accountRefHash,
+  blockerRefs: [],
+  homeRef: `home.public.${accountRefHash}`,
+  homeState: "present",
+  provider: "claude_agent",
+  readiness: {
+    blockerRefs: [],
+    capabilityRefs: ["capability.pylon.local_claude"],
+    credentialSourceRef: "credential.public.claude_setup_token",
+    enabled: true,
+    schema: "openagents.pylon.claude_agent_readiness.v0.3",
+    state: "ready",
+  },
+  selector: "registry_ref",
+})
+
 const accountsProjection = (): PylonAccountsListProjection => ({
   accounts: [
     readyCodexAccount("account.public.codex.one", "accthash_one"),
@@ -158,6 +179,37 @@ describe("pylon khala spawn planner", () => {
       "accthash_one",
       "accthash_two",
     ])
+  })
+
+  test("routes claude_agent_task slots to Claude accounts", () => {
+    const plan = buildPylonKhalaSpawnPlan({
+      accounts: {
+        ...accountsProjection(),
+        accounts: [
+          readyCodexAccount("account.public.codex.one", "accthash_codex"),
+          readyClaudeAccount("account.public.claude.one", "accthash_claude"),
+        ],
+      },
+      advertisedCodexAvailability: 2,
+      baseUrl: "https://openagents.test",
+      maxParallel: 2,
+      objectives: repeatedKhalaSpawnObjectives({
+        count: 2,
+        objective: "run a Claude-backed fixture assignment",
+      }),
+      targetPylonRef: "pylon.public.local",
+      workflow: "claude_agent_task",
+    })
+
+    expect(plan.workerKind).toBe("claude")
+    expect(plan.workflow).toBe("claude_agent_task")
+    expect(plan.readyWorkerAccountCount).toBe(1)
+    expect(plan.slots.map((slot) => slot.account.accountRefHash)).toEqual([
+      "accthash_claude",
+      "accthash_claude",
+    ])
+    expect(plan.slots[0]?.commands.request).toContain("--workflow claude_agent_task")
+    expect(plan.slots[0]?.requestInput.workflow).toBe("claude_agent_task")
   })
 })
 

--- a/clients/khala-code-desktop/scripts/part2-delegation-smoke.ts
+++ b/clients/khala-code-desktop/scripts/part2-delegation-smoke.ts
@@ -7,7 +7,7 @@ import {
   spawnCodexInstances,
   type KhalaCodexFleetCommandInput,
   type KhalaCodexFleetCommandResult,
-} from "../src/bun/khala-codex-fleet-tools"
+} from "../src/bun/khala-fleet-tools"
 
 const MATRIX_ACCOUNT_KEY = "4db4cc18ebc55f39fb4da894"
 const MATRIX_ACCOUNT_REF_HASH = `account.pylon.codex.${MATRIX_ACCOUNT_KEY}`

--- a/clients/khala-code-desktop/src/bun/fleet-run-supervisor-rpc-adapter.ts
+++ b/clients/khala-code-desktop/src/bun/fleet-run-supervisor-rpc-adapter.ts
@@ -31,7 +31,7 @@ import {
   resolvePylonHome,
   spawnCodexInstances,
   type KhalaCodexFleetToolOptions,
-} from "./khala-codex-fleet-tools.js"
+} from "./khala-fleet-tools.js"
 import { collectKhalaProcessText, spawnKhalaProcess } from "./khala-process.js"
 import {
   startFleetRunSupervisor,
@@ -191,7 +191,7 @@ const projectRun = (
   state: run.state,
   targetConcurrency: run.targetConcurrency,
   updatedAt: run.updatedAt,
-  workerKind: "codex",
+  workerKind: run.workerKind,
   workSource: projectWorkSource(input.workSource, run.workSource),
 })
 
@@ -217,14 +217,18 @@ const plannerFor = (
 })
 
 const capacityFor = (options: KhalaCodexFleetToolOptions | undefined): FleetRunSupervisorCapacity => ({
-  accounts: async () => {
+  accounts: async ({ run }) => {
     const status = await inspectCodexFleet({
       includeProcesses: false,
       includeRateLimits: false,
       startPylon: true,
+      workerKind: run.workerKind,
     }, options)
     return status.accounts
-      .filter(account => account.provider === "codex" && !account.paused)
+      .filter(account => !account.paused && (
+        run.workerKind === "auto" ||
+        account.provider === (run.workerKind === "claude" ? "claude_agent" : "codex")
+      ))
       .map(account => ({
         accountRef: account.accountRef,
         advertisedCapacity: Math.max(0, Math.trunc(
@@ -252,6 +256,7 @@ const runnerFor = (input: {
       pylonRef: input.pylonRef ?? undefined,
       repo: dispatch.workUnit.repo,
       verify: fixture ? undefined : DEFAULT_VERIFY,
+      workerKind: dispatch.run.workerKind,
     }, input.toolOptions)
     const slot = result.results[0]
     return {
@@ -490,7 +495,7 @@ export function createKhalaCodeDesktopFleetRunSupervisorRpcAdapter(
         ...(refillPolicy === undefined ? {} : { refillPolicy }),
         state: "running",
         targetConcurrency: request.targetConcurrency,
-        workerKind: "codex",
+        workerKind: request.workerKind ?? "codex",
         workSource: workSourceKind(workSource),
       })
       sources.set(run.runRef, workSource)

--- a/clients/khala-code-desktop/src/bun/khala-chat-runtime.ts
+++ b/clients/khala-code-desktop/src/bun/khala-chat-runtime.ts
@@ -42,7 +42,7 @@ import {
   type KhalaCodeDesktopToolCatalogResponse,
   type KhalaCodeDesktopUsage,
 } from "../shared/rpc.js"
-import { createKhalaCodexFleetTools } from "./khala-codex-fleet-tools.js"
+import { createKhalaCodexFleetTools } from "./khala-fleet-tools.js"
 import { createPlaywrightKhalaBrowserService } from "./khala-browser-service.js"
 import { createDuckDuckGoKhalaWebSearchService } from "./khala-web-search-service.js"
 
@@ -55,7 +55,7 @@ const KHALA_CODE_SYSTEM_PROMPT = [
   "Work in short, active updates: usually one or two sentences, then use tools. Say what we are checking or changing now; avoid long front-loaded plans.",
   "Use local tools whenever helpful. Never claim a tool ran unless the host returned a tool result.",
   "For tool-list or capability questions, answer from the tool catalog without calling tools.",
-  "For Codex instance launch or monitoring, use only these Pylon/Codex fleet tools: pylon_ensure, codex_fleet_status, codex_spawn, fleet_run_start, fleet_run_status, fleet_run_control. Do not call or invent codex_terminate or other Codex fleet tools.",
+  "For worker launch or monitoring, use only these Pylon fleet tools: pylon_ensure, codex_fleet_status, codex_spawn, fleet_run_start, fleet_run_status, fleet_run_control. Do not call or invent codex_terminate or other fleet tools.",
   "When the owner asks us to delegate, spawn, hand off, dispatch, or have a Codex worker / agent / instance do one bounded task — analysis, audit, coding, review, summary, anything — dispatch it with codex_spawn. Use fleet_run_start only for an owner-approved sustained run, then fleet_run_status/fleet_run_control for monitoring and pause/resume/drain/stop. Do NOT do delegated worker tasks ourselves with local read or search tools.",
   "Our local read/search/edit tools operate in the owner's workspace directory, not the Khala Code app's own source. Do not analyze or report on the Khala Code Desktop app's own files unless the owner explicitly asks about this app.",
   "After codex_spawn, summarize only the returned assignment, auto-run, and closeout status unless a tool explicitly returns a real local output path.",

--- a/clients/khala-code-desktop/src/bun/khala-codex-live-smoke.ts
+++ b/clients/khala-code-desktop/src/bun/khala-codex-live-smoke.ts
@@ -3,7 +3,7 @@ import {
   spawnVerifiedTokenTotal,
   type KhalaCodexFleetProgressPayload,
   type KhalaCodexFleetToolOptions,
-} from "./khala-codex-fleet-tools.js"
+} from "./khala-fleet-tools.js"
 import { khalaCodeConfigFromRuntimeEnv } from "./khala-code-config.js"
 
 export const TWO_CODEX_READONLY_SMOKE_COUNT = 2

--- a/clients/khala-code-desktop/src/bun/khala-fleet-mcp-server.ts
+++ b/clients/khala-code-desktop/src/bun/khala-fleet-mcp-server.ts
@@ -7,7 +7,7 @@ import {
 import {
   createKhalaCodexFleetTools,
   type KhalaCodexFleetToolOptions,
-} from "./khala-codex-fleet-tools.js"
+} from "./khala-fleet-tools.js"
 
 export const KHALA_CODE_DESKTOP_FLEET_MCP_SERVER_NAME = "khala_fleet" as const
 export const KHALA_CODE_DESKTOP_FLEET_MCP_SERVER_VERSION = "0.1.0" as const

--- a/clients/khala-code-desktop/src/bun/khala-fleet-tools.ts
+++ b/clients/khala-code-desktop/src/bun/khala-fleet-tools.ts
@@ -11,6 +11,7 @@ import {
   type PylonLifecycleWireEvent,
 } from "@openagentsinc/agent-runtime-schema"
 import {
+  decodeKhalaFleetDelegationParameterSet,
   KhalaFleetDelegateModuleError,
   khalaFleetDelegationParametersFromEnv,
   khalaFleetDelegationPerAccountConcurrency,
@@ -24,8 +25,10 @@ import {
   type KhalaFleetDelegateAccount,
   type KhalaFleetDelegateBlockerCode,
   type KhalaFleetDelegateCapacity,
+  type KhalaFleetDelegateConcreteWorkerKind,
   type KhalaFleetDelegateProgramResult,
   type KhalaFleetDelegateStep,
+  type KhalaFleetDelegateWorkerKind,
   type KhalaFleetDelegateWork,
   type KhalaFleetDelegationParameterSet,
   type KhalaToolDefinition,
@@ -179,7 +182,7 @@ type AccountRow = {
   readonly capacity: AccountCapacityRow | null
   readonly home: string | null
   readonly paused: boolean
-  readonly provider: "codex"
+  readonly provider: "claude_agent" | "codex"
   readonly quotaState: string | null
   readonly rateLimits?: KhalaCodexRateLimitProviderStatus | undefined
   readonly readiness: string
@@ -270,6 +273,7 @@ type SpawnCodexInstancesInput = {
   readonly repo?: string | undefined
   readonly timeoutMs?: number | undefined
   readonly verify?: string | undefined
+  readonly workerKind?: FleetRunWorkerKind | undefined
 }
 
 type NormalizedSpawnInput = {
@@ -287,6 +291,7 @@ type NormalizedSpawnInput = {
   readonly repo?: string | undefined
   readonly timeoutMs: number
   readonly verify?: string | undefined
+  readonly workerKind: FleetRunWorkerKind
 }
 
 type SpawnCodexInstancesResult = {
@@ -345,6 +350,41 @@ const DEFAULT_OPENAGENTS_BASE_URL = "https://openagents.com"
 const MAX_MODEL_OUTPUT_BYTES = 4_000
 const MAX_STREAMED_LIFECYCLE_EVENTS = 200
 
+type AccountProvider = AccountRow["provider"]
+
+function concreteWorkflowForWorkerKind(
+  workerKind: KhalaFleetDelegateConcreteWorkerKind,
+): "claude_agent_task" | "codex_agent_task" {
+  return workerKind === "claude" ? "claude_agent_task" : "codex_agent_task"
+}
+
+function accountProviderForWorkerKind(
+  workerKind: KhalaFleetDelegateConcreteWorkerKind,
+): AccountProvider {
+  return workerKind === "claude" ? "claude_agent" : "codex"
+}
+
+function accountProvidersForRequestedWorkerKind(
+  workerKind: KhalaFleetDelegateWorkerKind,
+): readonly AccountProvider[] {
+  if (workerKind === "auto") return ["codex", "claude_agent"]
+  return [accountProviderForWorkerKind(workerKind)]
+}
+
+function workerKindForAccountProvider(provider: AccountProvider): KhalaFleetDelegateConcreteWorkerKind {
+  return provider === "claude_agent" ? "claude" : "codex"
+}
+
+function workerLabel(workerKind: KhalaFleetDelegateConcreteWorkerKind): string {
+  return workerKind === "claude" ? "Claude" : "Codex"
+}
+
+function noAvailableCapacityBlockerForWorkerKind(
+  workerKind: KhalaFleetDelegateConcreteWorkerKind,
+): "no_available_claude_capacity" | "no_available_codex_capacity" {
+  return workerKind === "claude" ? "no_available_claude_capacity" : "no_available_codex_capacity"
+}
+
 const pylonEnsureToolDefinition: KhalaToolDefinition = {
   authority: "owner_full_access",
   availability: ["owner_local_full", "coding"],
@@ -401,7 +441,7 @@ const codexFleetStatusToolDefinition: KhalaToolDefinition = {
   authority: "owner_full_access",
   availability: ["owner_local_full", "coding"],
   description:
-    "Inspect local Pylon-backed Codex fleet accounts, assignment markers, and local Pylon/Codex processes.",
+    "Inspect local Pylon-backed fleet accounts, assignment markers, and local worker processes.",
   executionMode: "local",
   inputSchema: {
     additionalProperties: false,
@@ -425,7 +465,7 @@ const codexFleetStatusToolDefinition: KhalaToolDefinition = {
     type: "object",
   },
   internalId: "khala.desktop.codex_fleet.status",
-  label: "Codex Fleet Status",
+  label: "Fleet Status",
   name: "codex_fleet_status",
   outputSchema: {
     additionalProperties: false,
@@ -442,7 +482,7 @@ const codexFleetStatusToolDefinition: KhalaToolDefinition = {
   },
   permissionMode: "allow",
   prompt:
-    "Use when the user asks to monitor Codex instances, fleet capacity, linked accounts, or local Pylon health.",
+    "Use when the user asks to monitor worker instances, fleet capacity, linked accounts, or local Pylon health.",
   promptGuidelines: [
     "Report no ready accounts plainly; do not run device login from this tool.",
     "Summarize account readiness and assignment counts without exposing local credential paths.",
@@ -455,13 +495,13 @@ const codexSpawnToolDefinition: KhalaToolDefinition = {
   authority: "owner_full_access",
   availability: ["owner_local_full", "coding"],
   description:
-    "Delegate one or more Codex-backed assignments from the main Khala Code session to isolated Pylon worker homes.",
+    "Delegate one or more assignments from the main Khala Code session to isolated Pylon worker homes.",
   executionMode: "local",
   inputSchema: {
     additionalProperties: false,
     properties: {
       account_ref: {
-        description: "Optional linked Pylon Codex account ref to use. If omitted, a ready account is selected.",
+        description: "Optional linked Pylon worker account ref to use. If omitted, a ready account is selected.",
         type: "string",
       },
       base_url: {
@@ -482,7 +522,7 @@ const codexSpawnToolDefinition: KhalaToolDefinition = {
       },
       count: {
         default: 1,
-        description: `Number of Codex assignments to dispatch, capped at ${MAX_SPAWN_COUNT}.`,
+        description: `Number of worker assignments to dispatch, capped at ${MAX_SPAWN_COUNT}.`,
         minimum: 1,
         type: "integer",
       },
@@ -503,7 +543,7 @@ const codexSpawnToolDefinition: KhalaToolDefinition = {
         type: "integer",
       },
       prompt: {
-        description: "Public-safe assignment objective for Codex.",
+        description: "Public-safe assignment objective for the delegated worker.",
         type: "string",
       },
       pylon_ref: {
@@ -523,12 +563,18 @@ const codexSpawnToolDefinition: KhalaToolDefinition = {
         description: "Verification command for real repository work, paired with repo and commit.",
         type: "string",
       },
+      worker_kind: {
+        default: "codex",
+        description: "Worker target for delegated assignments.",
+        enum: ["codex", "claude", "auto"],
+        type: "string",
+      },
     },
     required: ["prompt"],
     type: "object",
   },
   internalId: "khala.desktop.codex_fleet.spawn",
-  label: "Spawn Codex",
+  label: "Spawn Worker",
   name: "codex_spawn",
   outputSchema: {
     additionalProperties: false,
@@ -546,14 +592,14 @@ const codexSpawnToolDefinition: KhalaToolDefinition = {
   },
   permissionMode: "allow",
   prompt:
-    "Use when the user asks Khala to fan out or delegate the current Codex-backed task to swarm worker sessions through Desktop.",
+    "Use when the user asks Khala to fan out or delegate the current task to swarm worker sessions through Desktop.",
   promptGuidelines: [
     "The primary local chat loop remains the Codex harness; this tool only delegates bounded worker assignments around it.",
     "When the user asks for a smoke test or omits repo pins, call this without repo pins; the tool will use the public fixture.",
     "Require complete repo, branch, verify, and claim_ref pins only for real repository work; Desktop resolves or validates the live commit pin before dispatch.",
-    "Do not run Codex login. If no ready Pylon Codex account exists, tell the user to connect one first.",
+    "Do not run Codex or Claude login. If no ready Pylon account exists for the requested worker kind, tell the user to connect one first.",
     "Omit account_ref unless the user names a specific non-default account; Desktop prefers named ready accounts over the display-only default account.",
-    "This MVP exposes only pylon_ensure, codex_fleet_status, and codex_spawn for Codex fleet control. Do not invent codex_terminate or other Codex fleet tools.",
+    "This MVP exposes only pylon_ensure, codex_fleet_status, and codex_spawn for fleet control. Do not invent codex_terminate or other fleet tools.",
     "After codex_spawn, summarize the returned assignment, auto-run, and closeout status; do not read guessed local output files.",
     "Keep count small; this MVP caps fan-out at five assignments.",
   ],
@@ -874,6 +920,7 @@ export async function inspectCodexFleet(
     readonly includeProcesses?: boolean | undefined
     readonly includeRateLimits?: boolean | undefined
     readonly startPylon?: boolean | undefined
+    readonly workerKind?: KhalaFleetDelegateWorkerKind | undefined
   } = {},
   options: KhalaCodexFleetToolOptions = {},
 ): Promise<FleetStatusResult> {
@@ -881,19 +928,26 @@ export async function inspectCodexFleet(
   const paths = resolvePylonPaths(env)
   const ensure = await ensureLocalPylon({ start: input.startPylon ?? false }, { ...options, env })
   const baseUrl = resolveOpenAgentsBaseUrl(env)
-  const [listResult, statusResult, apmResult, processes, rawActiveAssignments] = await Promise.all([
-    runPylonCommand(["codex", "accounts", "list", "--json"], {
+  const workerKind = input.workerKind ?? "codex"
+  const accountProviders = accountProvidersForRequestedWorkerKind(workerKind)
+  const listCommand = accountProviders.length === 1 && accountProviders[0] === "codex"
+    ? ["codex", "accounts", "list", "--json"]
+    : ["accounts", "list", "--json"]
+  const [listResult, statusResults, apmResult, processes, rawActiveAssignments] = await Promise.all([
+    runPylonCommand(listCommand, {
       env,
       paths,
       runner: options.runner,
       timeoutMs: DEFAULT_COMMAND_TIMEOUT_MS,
     }).catch(errorResult),
-    runPylonCommand(["accounts", "status", "--provider", "codex", "--json"], {
-      env,
-      paths,
-      runner: options.runner,
-      timeoutMs: DEFAULT_COMMAND_TIMEOUT_MS,
-    }).catch(errorResult),
+    Promise.all(accountProviders.map(provider =>
+      runPylonCommand(["accounts", "status", "--provider", provider, "--json"], {
+        env,
+        paths,
+        runner: options.runner,
+        timeoutMs: DEFAULT_COMMAND_TIMEOUT_MS,
+      }).catch(errorResult)
+    )),
     runPylonCommand(["khala", "apm", "--base-url", baseUrl, "--json"], {
       env,
       paths,
@@ -907,13 +961,14 @@ export async function inspectCodexFleet(
   ])
 
   const listProjection = parseJsonObject(listResult.stdout)
-  const statusProjection = parseJsonObject(statusResult.stdout)
+  const statusProjection = mergeAccountStatusProjections(statusResults.map(result => parseJsonObject(result.stdout)))
   const apm = fleetTokenRateProjectionFromApm(apmResult, rawActiveAssignments.length)
-  const accountConfig = await readCodexAccountConfig(paths.pylonHome)
+  const accountConfig = await readAccountConfig(paths.pylonHome, accountProviders)
   const accountsWithConfig = withAccountConfig(
     withAccountCapacity(
-      mergeAccountRows(listProjection, statusProjection),
+      mergeAccountRows(listProjection, statusProjection, accountProviders),
       [ensure.providerProjection, statusProjection, listProjection],
+      workerKind,
     ),
     accountConfig,
   )
@@ -924,7 +979,7 @@ export async function inspectCodexFleet(
     rawActiveAssignments,
     apm.serverAssignments,
   )
-  const provider = providerCapacity(listProjection, statusProjection, ensure)
+  const provider = providerCapacity(listProjection, statusProjection, ensure, workerKind)
   return {
     accounts,
     activeAssignments,
@@ -943,10 +998,11 @@ export async function spawnCodexInstances(
   options: KhalaCodexFleetToolOptions = {},
 ): Promise<SpawnCodexInstancesResult> {
   const baseEnv = options.env ?? khalaCodeConfigFromRuntimeEnv().env
-  const delegationParameters = options.delegationParameters ??
+  const baseDelegationParameters = options.delegationParameters ??
     khalaFleetDelegationParametersFromEnv(baseEnv)
-  const input = decodeSpawnInput(raw, delegationParameters)
-  const env = withCodexCapacityAdvertisementEnv(baseEnv, input.count, delegationParameters)
+  const input = decodeSpawnInput(raw, baseDelegationParameters)
+  const delegationParameters = delegationParametersWithWorkerKind(baseDelegationParameters, input.workerKind)
+  const env = withWorkerCapacityAdvertisementEnv(baseEnv, input.count, delegationParameters, input.workerKind)
   const paths = resolvePylonPaths(env)
   const baseUrl = resolveOpenAgentsBaseUrl(env, input.baseUrl)
   const preparedInput = await resolveRealWorkCommitPin(input, {
@@ -973,7 +1029,7 @@ export async function spawnCodexInstances(
     if (heartbeat.exitCode !== 0) {
       throw new KhalaFleetDelegateModuleError({
         blockerCode: reason === "stale_heartbeat" ? "stale_heartbeat" : "capacity_probe_failed",
-        message: `Pylon heartbeat failed before Codex spawn: ${safeFailureReason(heartbeat)}`,
+        message: `Pylon heartbeat failed before fleet spawn: ${safeFailureReason(heartbeat)}`,
         module: "advertise_capacity",
         refs: [`blocker.public.khala_fleet_delegate.${reason === "stale_heartbeat" ? "stale_heartbeat" : "capacity_probe_failed"}`],
       })
@@ -982,9 +1038,9 @@ export async function spawnCodexInstances(
     const freshHeartbeatPylonRef = stringField(heartbeatJson, "pylonRef")
     if (freshHeartbeatPylonRef !== null) heartbeatPylonRef = freshHeartbeatPylonRef
     else if (pylonRef !== undefined) heartbeatPylonRef = pylonRef
-    fleetStatus = await inspectCodexFleet({ includeProcesses: false, startPylon: false }, { ...options, env })
+    fleetStatus = await inspectCodexFleet({ includeProcesses: false, startPylon: false, workerKind: input.workerKind }, { ...options, env })
     providerProjection = await readProviderProjection(env, paths, options.runner)
-    accountAvailability = codexAccountAvailabilityByRef(fleetStatus.accounts, providerProjection)
+    accountAvailability = accountAvailabilityByRef(fleetStatus.accounts, providerProjection, input.workerKind)
     const heartbeatRef = stringField(heartbeatJson, "heartbeatRef")
     return {
       capacity: khalaDelegateCapacityFromFleetStatus(
@@ -1029,7 +1085,7 @@ export async function spawnCodexInstances(
       }),
     advertiseCapacity: ({ pylonRef, reason }) =>
       Effect.promise(() => refreshFleetProjection(pylonRef, reason)),
-    dispatch: ({ capacity, work }) =>
+    dispatch: ({ capacity, work, workerKind }) =>
       Effect.promise(async () => {
         const planned = planDelegatedSpawnAccounts(
           input,
@@ -1037,6 +1093,7 @@ export async function spawnCodexInstances(
           fleetStatus,
           accountAvailability,
           delegationParameters,
+          workerKind,
         )
         if (planned.status === "blocked") return planned.dispatch
         const targetPylonRef = input.pylonRef ?? heartbeatPylonRef ?? ""
@@ -1050,6 +1107,7 @@ export async function spawnCodexInstances(
               parameters: delegationParameters,
               runner: options.runner,
               targetPylonRef,
+              workerKind,
             })
           : await runDelegatedBatchSpawn({
               baseUrl,
@@ -1061,6 +1119,7 @@ export async function spawnCodexInstances(
               parameters: delegationParameters,
               runner: options.runner,
               targetPylonRef,
+              workerKind,
               work,
             })
         const firstAssignmentRef = firstSpawnAssignmentRef(dispatchedResult)
@@ -1068,10 +1127,10 @@ export async function spawnCodexInstances(
           return { assignmentRef: firstAssignmentRef, ok: true }
         }
         return {
-          blockerCode: classifySpawnDispatchBlocker(dispatchedResult),
+          blockerCode: classifySpawnDispatchBlocker(dispatchedResult, workerKind),
           message: renderSpawnResult(dispatchedResult),
           ok: false,
-          refs: spawnDispatchBlockerRefs(dispatchedResult),
+          refs: spawnDispatchBlockerRefs(dispatchedResult, workerKind),
         }
       }),
     verifyCloseout: () =>
@@ -1162,7 +1221,7 @@ function executeCodexFleetStatusTool(
       return khalaToolOk({
         modelText: renderFleetStatus(result),
         publicSafety: "private",
-        publicSummary: `Codex fleet status: ${result.accounts.length} account(s), ${readyAccountCount(result.accounts)} ready.`,
+        publicSummary: `Fleet status: ${result.accounts.length} account(s), ${readyAccountCount(result.accounts)} ready.`,
         ui: {
           accounts: result.accounts,
           activeAssignments: result.activeAssignments,
@@ -1208,12 +1267,13 @@ function executeCodexSpawnTool(
         repo: optionalString(input.repo),
         timeoutMs: optionalInteger(input.timeout_ms),
         verify: optionalString(input.verify),
+        workerKind: optionalWorkerKind(input.worker_kind),
       }, options)
       const tokensVerified = spawnVerifiedTokenTotal(result)
       const toolResult = khalaToolOk({
         modelText: renderSpawnResult(result),
         publicSafety: "private",
-        publicSummary: `Codex spawn accepted ${result.acceptedCount}/${result.requestedCount} request(s); ${tokensVerified} Khala tokens generated.`,
+        publicSummary: `Fleet spawn accepted ${result.acceptedCount}/${result.requestedCount} request(s); ${tokensVerified} Khala tokens generated.`,
         ui: {
           acceptedCount: result.acceptedCount,
           delegateSignature: result.delegateSignature ?? null,
@@ -1363,9 +1423,6 @@ export class DefaultKhalaFleetRunSupervisorManager implements KhalaFleetRunSuper
     if (this.store.getFleetRun(runRef) !== null) throw new Error(`fleet run already exists: ${runRef}`)
     const workSource = input.workSource ?? "fixture"
     const workerKind = input.workerKind ?? "codex"
-    if (workerKind !== "codex") {
-      throw new Error(`fleet_run_start currently wires codex workers only; received ${workerKind}`)
-    }
     const targetConcurrency = boundedPositiveInteger(input.targetConcurrency, 1, 1, MAX_SPAWN_COUNT)
     const fixtureCount = boundedPositiveInteger(
       input.fixtureCount,
@@ -1420,7 +1477,7 @@ export class DefaultKhalaFleetRunSupervisorManager implements KhalaFleetRunSuper
           runRef,
           planner: this.plannerFor(runRef),
           runner: this.runnerFor(runRef, pylonRef),
-          capacity: this.capacityFor(),
+          capacity: this.capacityFor(runRef),
           tickIntervalMs: DEFAULT_FLEET_RUN_TICK_INTERVAL_MS,
           ...(this.options.sleep === undefined ? {} : { clock: { sleep: this.options.sleep } }),
           onLifecycle: event => {
@@ -1540,6 +1597,7 @@ export class DefaultKhalaFleetRunSupervisorManager implements KhalaFleetRunSuper
           repo: fixture ? undefined : config.repo,
           timeoutMs: config.timeoutMs,
           verify: fixture ? undefined : config.verify,
+          workerKind: run.workerKind,
         }, this.options)
         const first = result.results[0]
         const accepted = result.acceptedCount >= 1 && first?.status === "accepted"
@@ -1550,7 +1608,7 @@ export class DefaultKhalaFleetRunSupervisorManager implements KhalaFleetRunSuper
           lifecycle: [{
             assignmentRef: first?.assignmentRef ?? null,
             event: completed ? "assignment.completed" : accepted ? "assignment.accepted" : "assignment.failed",
-            phase: "codex_spawn",
+            phase: run.workerKind === "claude" ? "claude_spawn" : "codex_spawn",
             status,
           }],
           status,
@@ -1560,13 +1618,15 @@ export class DefaultKhalaFleetRunSupervisorManager implements KhalaFleetRunSuper
     }
   }
 
-  private capacityFor(): FleetRunSupervisorCapacity {
+  private capacityFor(runRef: string): FleetRunSupervisorCapacity {
     return {
       accounts: async () => {
+        const run = this.store.getFleetRun(runRef)
         const status = await inspectCodexFleet({
           includeProcesses: false,
           includeRateLimits: false,
           startPylon: true,
+          workerKind: run?.workerKind ?? "codex",
         }, this.options)
         return status.accounts
           .filter(account => account.readiness === "ready" && !account.paused)
@@ -1931,7 +1991,7 @@ function parseJsonObject(raw: string): Record<string, unknown> | null {
   }
 }
 
-type CodexAccountConfigEntry = Readonly<{
+type AccountConfigEntry = Readonly<{
   home: string
   paused: boolean
 }>
@@ -1940,21 +2000,24 @@ function pylonConfigPath(pylonHome: string): string {
   return join(pylonHome, "config.json")
 }
 
-async function readCodexAccountConfig(
+async function readAccountConfig(
   pylonHome: string,
-): Promise<ReadonlyMap<string, CodexAccountConfigEntry>> {
+  providers: readonly AccountProvider[],
+): Promise<ReadonlyMap<string, AccountConfigEntry>> {
   try {
     const parsed = JSON.parse(await readFile(pylonConfigPath(pylonHome), "utf8")) as {
       dev?: { accounts?: readonly Record<string, unknown>[] }
     }
-    const out = new Map<string, CodexAccountConfigEntry>()
+    const allowed = new Set(providers)
+    const out = new Map<string, AccountConfigEntry>()
     for (const account of parsed.dev?.accounts ?? []) {
       if (
-        account.provider === "codex" &&
+        (account.provider === "codex" || account.provider === "claude_agent") &&
+        allowed.has(account.provider) &&
         typeof account.ref === "string" &&
         typeof account.home === "string"
       ) {
-        out.set(account.ref, {
+        out.set(accountConfigKey(account.provider, account.ref), {
           home: account.home,
           paused: account.paused === true,
         })
@@ -1969,17 +2032,19 @@ async function readCodexAccountConfig(
 function mergeAccountRows(
   listProjection: Record<string, unknown> | null,
   statusProjection: Record<string, unknown> | null,
+  providers: readonly AccountProvider[] = ["codex"],
 ): readonly AccountRow[] {
   const rows = new Map<string, AccountRow>()
   for (const account of arrayField(listProjection, "accounts")) {
-    const row = accountRowFrom(account)
-    if (row !== null) rows.set(row.accountRef, row)
+    const row = accountRowFrom(account, providers)
+    if (row !== null) rows.set(accountConfigKey(row.provider, row.accountRef), row)
   }
   for (const account of arrayField(statusProjection, "accounts")) {
-    const row = accountRowFrom(account)
+    const row = accountRowFrom(account, providers)
     if (row !== null) {
-      const previous = rows.get(row.accountRef)
-      rows.set(row.accountRef, {
+      const key = accountConfigKey(row.provider, row.accountRef)
+      const previous = rows.get(key)
+      rows.set(key, {
         ...row,
         accountKey: row.accountKey ?? previous?.accountKey ?? null,
         accountRefHash: row.accountRefHash ?? previous?.accountRefHash ?? null,
@@ -1994,11 +2059,19 @@ function mergeAccountRows(
   return [...rows.values()].sort((left, right) => left.accountRef.localeCompare(right.accountRef))
 }
 
-function accountRowFrom(value: unknown): AccountRow | null {
+function mergeAccountStatusProjections(
+  projections: readonly (Record<string, unknown> | null)[],
+): Record<string, unknown> | null {
+  const accounts = projections.flatMap(projection => arrayField(projection, "accounts"))
+  return accounts.length === 0 ? null : { accounts }
+}
+
+function accountRowFrom(value: unknown, providers: readonly AccountProvider[] = ["codex"]): AccountRow | null {
   const account = record(value)
   if (account === null) return null
   const provider = stringField(account, "provider")
-  if (provider !== "codex") return null
+  if (provider !== "codex" && provider !== "claude_agent") return null
+  if (!providers.includes(provider)) return null
   const accountRef =
     stringField(account, "accountRef") ??
     stringField(account, "ref") ??
@@ -2018,7 +2091,7 @@ function accountRowFrom(value: unknown): AccountRow | null {
     capacity: null,
     home: null,
     paused: false,
-    provider: "codex",
+    provider,
     quotaState: stringField(quota, "state"),
     readiness,
   }
@@ -2026,13 +2099,21 @@ function accountRowFrom(value: unknown): AccountRow | null {
 
 function withAccountConfig(
   accounts: readonly AccountRow[],
-  config: ReadonlyMap<string, CodexAccountConfigEntry>,
+  config: ReadonlyMap<string, AccountConfigEntry>,
 ): readonly AccountRow[] {
   return accounts.map(account => {
-    const entry = config.get(account.accountRef)
+    const entry = config.get(accountConfigKey(account.provider, account.accountRef))
     if (entry === undefined) return account
     return { ...account, home: entry.home, paused: entry.paused }
   })
+}
+
+function accountConfigKey(provider: AccountProvider, accountRef: string): string {
+  return `${provider}:${accountRef}`
+}
+
+function accountAvailabilityKey(account: AccountRow): string {
+  return accountConfigKey(account.provider, account.accountRef)
 }
 
 async function withAccountRateLimits(
@@ -2040,7 +2121,7 @@ async function withAccountRateLimits(
   env: ChatEnv,
 ): Promise<readonly AccountRow[]> {
   return Promise.all(accounts.map(async account => {
-    if (account.home === null) return account
+    if (account.home === null || account.provider !== "codex") return account
     const rateLimits = await fetchKhalaCodexRateLimitStatus({
       codexHomePath: account.home,
       env: cleanEnv(env),
@@ -2058,7 +2139,9 @@ function providerCapacity(
   listProjection: Record<string, unknown> | null,
   statusProjection: Record<string, unknown> | null,
   ensure: KhalaPylonEnsureResult,
+  workerKind: KhalaFleetDelegateWorkerKind,
 ): { available: number | null; max: number | null } {
+  if (workerKind !== "codex") return { available: null, max: null }
   for (const projection of [statusProjection, listProjection]) {
     const dispatch = recordField(projection, "ownCapacityDispatch")
     const available = numberField(dispatch, "availableCodexAssignments") ??
@@ -2078,7 +2161,9 @@ function providerCapacity(
 
 function capacityFromProviderProjection(
   projection: Record<string, unknown> | null,
+  workerKind: KhalaFleetDelegateWorkerKind = "codex",
 ): { available: number | null; max: number | null } {
+  if (workerKind !== "codex") return { available: null, max: null }
   const dispatch = recordField(projection, "ownCapacityDispatch")
   return {
     available: numberField(dispatch, "availableCodexAssignments") ??
@@ -2088,23 +2173,31 @@ function capacityFromProviderProjection(
   }
 }
 
-function codexAccountAvailabilityByRef(
+function accountAvailabilityByRef(
   accounts: readonly AccountRow[],
   projection: Record<string, unknown> | null,
+  workerKind: KhalaFleetDelegateWorkerKind,
 ): ReadonlyMap<string, number> {
   const ownCapacity = recordField(projection, "ownCapacityDispatch")
+  const capacityFields = workerKind === "auto"
+    ? ["codexAccounts", "claudeAccounts"]
+    : workerKind === "claude"
+      ? ["claudeAccounts"]
+      : ["codexAccounts"]
   const accountRefByKey = new Map<string, string>()
   for (const account of accounts) {
-    if (account.accountKey !== null) accountRefByKey.set(account.accountKey, account.accountRef)
+    if (account.accountKey !== null) accountRefByKey.set(account.accountKey, accountAvailabilityKey(account))
   }
   const out = new Map<string, number>()
-  for (const capacity of arrayField(ownCapacity, "codexAccounts")) {
-    const row = record(capacity)
-    if (row === null) continue
-    const accountKey = stringField(row, "accountKey")
-    const accountRef = accountKey === null ? null : accountRefByKey.get(accountKey) ?? null
-    const available = numberField(row, "available")
-    if (accountRef !== null && available !== null) out.set(accountRef, available)
+  for (const field of capacityFields) {
+    for (const capacity of arrayField(ownCapacity, field)) {
+      const row = record(capacity)
+      if (row === null) continue
+      const accountKey = stringField(row, "accountKey")
+      const accountRef = accountKey === null ? null : accountRefByKey.get(accountKey) ?? null
+      const available = numberField(row, "available")
+      if (accountRef !== null && available !== null) out.set(accountRef, available)
+    }
   }
   return out
 }
@@ -2112,19 +2205,27 @@ function codexAccountAvailabilityByRef(
 function withAccountCapacity(
   accounts: readonly AccountRow[],
   projections: readonly (Record<string, unknown> | null)[],
+  workerKind: KhalaFleetDelegateWorkerKind = "codex",
 ): readonly AccountRow[] {
   const capacityByKey = new Map<string, AccountCapacityRow>()
   const capacityByRef = new Map<string, AccountCapacityRow>()
+  const capacityFields = workerKind === "auto"
+    ? ["codexAccounts", "claudeAccounts"]
+    : workerKind === "claude"
+      ? ["claudeAccounts"]
+      : ["codexAccounts"]
   for (const projection of projections) {
     const ownCapacity = recordField(projection, "ownCapacityDispatch")
-    for (const item of arrayField(ownCapacity, "codexAccounts")) {
-      const row = record(item)
-      if (row === null) continue
-      const capacity = accountCapacityRowFrom(row)
-      const accountKey = stringField(row, "accountKey")
-      const accountRef = stringField(row, "accountRef")
-      if (accountKey !== null) capacityByKey.set(accountKey, capacity)
-      if (accountRef !== null) capacityByRef.set(accountRef, capacity)
+    for (const field of capacityFields) {
+      for (const item of arrayField(ownCapacity, field)) {
+        const row = record(item)
+        if (row === null) continue
+        const capacity = accountCapacityRowFrom(row)
+        const accountKey = stringField(row, "accountKey")
+        const accountRef = stringField(row, "accountRef")
+        if (accountKey !== null) capacityByKey.set(accountKey, capacity)
+        if (accountRef !== null) capacityByRef.set(accountRef, capacity)
+      }
     }
   }
   if (capacityByKey.size === 0 && capacityByRef.size === 0) return accounts
@@ -2428,7 +2529,7 @@ function isCodexExecAgentProcess(command: string): boolean {
   if (/\bdurable-runner-pool\.sh\b/iu.test(command)) return false
   if (/\b(?:grep|rg|ripgrep)\b.*\bcodex\s+exec\b/iu.test(command)) return false
   if (/\bps\s+-axo\b/iu.test(command)) return false
-  if (/\bkhala-codex-fleet-tools\b/iu.test(command)) return false
+  if (/\bkhala-(?:codex-)?fleet-tools\b/iu.test(command)) return false
   return true
 }
 
@@ -2450,6 +2551,7 @@ function decodeSpawnInput(
   const verify = raw.verify ?? (!fixture && (raw.repo !== undefined || raw.commit !== undefined)
     ? delegationParameters.verifyCriteria?.defaultVerify
     : undefined)
+  const workerKind = raw.workerKind ?? delegationParameters.delegationTarget?.workerKind ?? "codex"
   const missingPins = [
     raw.repo === undefined ? "repo" : null,
     verify === undefined ? "verify" : null,
@@ -2473,7 +2575,31 @@ function decodeSpawnInput(
     prompt,
     timeoutMs,
     verify,
+    workerKind,
   }
+}
+
+function delegationParametersWithWorkerKind(
+  parameters: KhalaFleetDelegationParameterSet,
+  workerKind: KhalaFleetDelegateWorkerKind,
+): KhalaFleetDelegationParameterSet {
+  const raw: Record<string, unknown> = {
+    delegationTarget: {
+      ...(parameters.delegationTarget ?? {}),
+      workerKind,
+    },
+    parameterSetRef: parameters.parameterSetRef,
+    schemaVersion: parameters.schemaVersion,
+    source: parameters.source,
+  }
+  if (parameters.accountRanking !== undefined) raw.accountRanking = parameters.accountRanking
+  if (parameters.actionSubmissionRef !== undefined) raw.actionSubmissionRef = parameters.actionSubmissionRef
+  if (parameters.advertiseCapacity !== undefined) raw.advertiseCapacity = parameters.advertiseCapacity
+  if (parameters.candidateRef !== undefined) raw.candidateRef = parameters.candidateRef
+  if (parameters.objectiveTemplate !== undefined) raw.objectiveTemplate = parameters.objectiveTemplate
+  if (parameters.retryBackoff !== undefined) raw.retryBackoff = parameters.retryBackoff
+  if (parameters.verifyCriteria !== undefined) raw.verifyCriteria = parameters.verifyCriteria
+  return decodeKhalaFleetDelegationParameterSet(raw)
 }
 
 async function resolveRealWorkCommitPin(
@@ -2594,14 +2720,14 @@ function renderEnsureResult(result: KhalaPylonEnsureResult): string {
 function renderFleetStatus(result: FleetStatusResult): string {
   const lines = [
     `Pylon: ${result.ensure.ok ? result.ensure.status : "unavailable"}${result.ensure.pylonRef ? ` (${result.ensure.pylonRef})` : ""}`,
-    `Codex capacity: ${capacityLabel(result.availableCodexAssignments, result.maxCodexAssignments)}`,
-    `Codex accounts: ${result.accounts.length} total, ${readyAccountCount(result.accounts)} ready`,
+    `Worker capacity: ${capacityLabel(result.availableCodexAssignments, result.maxCodexAssignments)}`,
+    `Worker accounts: ${result.accounts.length} total, ${readyAccountCount(result.accounts)} ready`,
     renderFleetTokenRate(result.tokenRate),
   ]
   if (result.accounts.length > 0) {
     lines.push(...result.accounts.map(renderAccountStatusLine))
   } else {
-    lines.push("- no Pylon Codex accounts found")
+    lines.push("- no Pylon worker accounts found")
   }
   lines.push(`Active assignment markers: ${result.activeAssignments.length}`)
   if (result.activeAssignments.length > 0) {
@@ -2611,10 +2737,10 @@ function renderFleetStatus(result: FleetStatusResult): string {
     lines.push(`Server assignment token rows: ${result.serverAssignments.length}`)
     lines.push(...result.serverAssignments.slice(0, 8).map(renderServerAssignmentTokenLine))
   }
-  lines.push(`Active Codex exec processes: ${result.processes.length}`)
+  lines.push(`Active local worker processes: ${result.processes.length}`)
   if (result.activeAssignments.length !== result.processes.length) {
     lines.push(
-      `Assignment/process reconciliation: ${result.activeAssignments.length} marker(s), ${result.processes.length} codex exec process(es)`,
+      `Assignment/process reconciliation: ${result.activeAssignments.length} marker(s), ${result.processes.length} local worker process(es)`,
     )
   }
   if (result.processes.length > 0) {
@@ -2649,7 +2775,7 @@ function renderAccountStatusLine(account: AccountRow): string {
   const capacityText = capacity === null
     ? ""
     : `, slots ${capacityLabel(capacity.available, capacity.ready)}${capacity.busy === null ? "" : `, busy ${capacity.busy}`}${capacity.queued === null ? "" : `, queued ${capacity.queued}`}`
-  return `- ${account.accountRef}: ${account.readiness}${capacityText}${account.quotaState ? `, quota ${account.quotaState}` : ""}`
+  return `- ${workerKindForAccountProvider(account.provider)}:${account.accountRef}: ${account.readiness}${capacityText}${account.quotaState ? `, quota ${account.quotaState}` : ""}`
 }
 
 function renderActiveAssignmentLine(marker: ActiveAssignmentMarker): string {
@@ -2768,13 +2894,60 @@ function withCodexCapacityAdvertisementEnv(
   }
 }
 
+function withClaudeCapacityAdvertisementEnv(
+  env: ChatEnv,
+  requestedCount: number,
+  parameters: KhalaFleetDelegationParameterSet,
+): ChatEnv {
+  const fallbackTarget = Math.max(
+    1,
+    requestedCount,
+    positiveIntegerEnv(env.OPENAGENTS_PYLON_CLAUDE_ACCOUNT_CONCURRENCY) ?? 0,
+    positiveIntegerEnv(env.OPENAGENTS_PYLON_CLAUDE_CONCURRENCY) ?? 0,
+  )
+  const admittedTarget = khalaFleetDelegationPerAccountConcurrency(parameters, fallbackTarget)
+  const target = Math.max(
+    admittedTarget,
+    requestedCount,
+    positiveIntegerEnv(env.OPENAGENTS_PYLON_CLAUDE_ACCOUNT_CONCURRENCY) ?? 0,
+    positiveIntegerEnv(env.OPENAGENTS_PYLON_CLAUDE_CONCURRENCY) ?? 0,
+  )
+  return {
+    ...env,
+    OPENAGENTS_PYLON_CLAUDE_ACCOUNT_CONCURRENCY: String(target),
+    OPENAGENTS_PYLON_CLAUDE_BUSY: "0",
+    OPENAGENTS_PYLON_CLAUDE_CONCURRENCY: String(target),
+    OPENAGENTS_PYLON_CLAUDE_QUEUED: "0",
+  }
+}
+
+function withWorkerCapacityAdvertisementEnv(
+  env: ChatEnv,
+  requestedCount: number,
+  parameters: KhalaFleetDelegationParameterSet,
+  workerKind: KhalaFleetDelegateWorkerKind,
+): ChatEnv {
+  if (workerKind === "claude") {
+    return withClaudeCapacityAdvertisementEnv(env, requestedCount, parameters)
+  }
+  if (workerKind === "auto") {
+    return withClaudeCapacityAdvertisementEnv(
+      withCodexCapacityAdvertisementEnv(env, requestedCount, parameters),
+      requestedCount,
+      parameters,
+    )
+  }
+  return withCodexCapacityAdvertisementEnv(env, requestedCount, parameters)
+}
+
 function khalaDelegateCapacityFromFleetStatus(
   status: FleetStatusResult,
   projection: Record<string, unknown> | null,
   availability: ReadonlyMap<string, number>,
   parameters: KhalaFleetDelegationParameterSet = resolveKhalaFleetDelegationParameters(undefined),
 ): KhalaFleetDelegateCapacity {
-  const capacity = capacityFromProviderProjection(projection)
+  const workerKind = resolveKhalaFleetDelegationParameters(parameters).delegationTarget?.workerKind ?? "codex"
+  const capacity = capacityFromProviderProjection(projection, workerKind)
   const accounts = preferredSpawnAccounts(status.accounts, availability, parameters)
     .filter(account => !account.paused)
     .map(account => khalaDelegateAccountFromRow(account, availability))
@@ -2782,8 +2955,10 @@ function khalaDelegateCapacityFromFleetStatus(
   const accountAvailable = availability.size === 0
     ? readyCount
     : accounts.reduce((sum, account) => sum + Math.max(0, account.availableSlots ?? 0), 0)
-  const available = capacity.available ?? status.availableCodexAssignments ?? accountAvailable
-  const max = capacity.max ?? status.maxCodexAssignments ?? Math.max(available, readyCount)
+  const legacyCodexAvailable = workerKind === "codex" ? status.availableCodexAssignments : null
+  const legacyCodexMax = workerKind === "codex" ? status.maxCodexAssignments : null
+  const available = capacity.available ?? legacyCodexAvailable ?? accountAvailable
+  const max = capacity.max ?? legacyCodexMax ?? Math.max(available, readyCount)
   return {
     accounts,
     available: Math.max(0, Math.floor(available)),
@@ -2795,12 +2970,13 @@ function khalaDelegateAccountFromRow(
   account: AccountRow,
   availability: ReadonlyMap<string, number>,
 ): KhalaFleetDelegateAccount {
-  const availableSlots = availability.get(account.accountRef)
+  const availableSlots = availability.get(accountAvailabilityKey(account))
   return {
     accountRef: account.accountRef,
     ...(availableSlots === undefined ? {} : { availableSlots }),
     isDefault: isDefaultAccountRef(account.accountRef),
     readiness: khalaDelegateReadiness(account),
+    workerKind: workerKindForAccountProvider(account.provider),
   }
 }
 
@@ -2817,6 +2993,7 @@ function planDelegatedSpawnAccounts(
   status: FleetStatusResult | null,
   availability: ReadonlyMap<string, number>,
   parameters: KhalaFleetDelegationParameterSet,
+  workerKind: KhalaFleetDelegateConcreteWorkerKind,
 ):
   | Readonly<{ accounts: readonly AccountRow[]; status: "planned" }>
   | Readonly<{ dispatch: { blockerCode: KhalaFleetDelegateBlockerCode; message: string; ok: false; refs: readonly string[] }; status: "blocked" }> {
@@ -2824,7 +3001,7 @@ function planDelegatedSpawnAccounts(
     return {
       dispatch: {
         blockerCode: "capacity_probe_failed",
-        message: "Codex fleet projection was not available after capacity advertisement.",
+        message: `${workerLabel(workerKind)} fleet projection was not available after capacity advertisement.`,
         ok: false,
         refs: ["blocker.public.khala_fleet_delegate.capacity_probe_failed"],
       },
@@ -2832,7 +3009,11 @@ function planDelegatedSpawnAccounts(
     }
   }
   const readyAccounts = preferredSpawnAccounts(
-    status.accounts.filter(account => isReadyAccount(account) && !account.paused),
+    status.accounts.filter(account =>
+      isReadyAccount(account) &&
+      !account.paused &&
+      workerKindForAccountProvider(account.provider) === workerKind
+    ),
     availability,
     parameters,
   )
@@ -2841,7 +3022,7 @@ function planDelegatedSpawnAccounts(
       dispatch: {
         blockerCode: "connect_account_required",
         message:
-          "No ready Pylon Codex account is connected. Connect one first with `khala fleet connect` or `pylon auth codex --account codex`; this Desktop tool will not run Codex device login.",
+          `No ready Pylon ${workerLabel(workerKind)} account is connected. Connect one first; this Desktop tool will not run device login.`,
         ok: false,
         refs: ["blocker.public.khala_fleet_delegate.connect_account_required"],
       },
@@ -2850,7 +3031,14 @@ function planDelegatedSpawnAccounts(
   }
   let selectedAccounts: readonly AccountRow[]
   try {
-    selectedAccounts = resolveSpawnAccounts(input.accountRef, readyAccounts, status.accounts, availability, parameters)
+    selectedAccounts = resolveSpawnAccounts(
+      input.accountRef,
+      readyAccounts,
+      status.accounts.filter(account => workerKindForAccountProvider(account.provider) === workerKind),
+      availability,
+      parameters,
+      workerKind,
+    )
   } catch (error) {
     const message = errorMessage(error)
     const blockerCode: KhalaFleetDelegateBlockerCode = /not found|not connected/iu.test(message)
@@ -2869,24 +3057,26 @@ function planDelegatedSpawnAccounts(
     }
   }
   if (selectedAccounts.length === 0 || capacity.available <= 0) {
+    const blockerCode = noAvailableCapacityBlockerForWorkerKind(workerKind)
     return {
       dispatch: {
-        blockerCode: "no_available_codex_capacity",
-        message: `No Pylon Codex assignment capacity is available right now (${capacityLabel(capacity.available, capacity.max)}).`,
+        blockerCode,
+        message: `No Pylon ${workerLabel(workerKind)} assignment capacity is available right now (${capacityLabel(capacity.available, capacity.max)}).`,
         ok: false,
-        refs: ["blocker.public.pylon_dispatch.no_available_codex_capacity"],
+        refs: [`blocker.public.pylon_dispatch.${blockerCode}`],
       },
       status: "blocked",
     }
   }
   const plannedAccounts = planSpawnAccounts(input.count, selectedAccounts, availability)
   if (plannedAccounts.length < input.count) {
+    const blockerCode = noAvailableCapacityBlockerForWorkerKind(workerKind)
     return {
       dispatch: {
-        blockerCode: "no_available_codex_capacity",
-        message: `Only ${plannedAccounts.length}/${input.count} advertised Pylon Codex account slot(s) are free right now.`,
+        blockerCode,
+        message: `Only ${plannedAccounts.length}/${input.count} advertised Pylon ${workerLabel(workerKind)} account slot(s) are free right now.`,
         ok: false,
-        refs: ["blocker.public.pylon_dispatch.no_available_codex_capacity"],
+        refs: [`blocker.public.pylon_dispatch.${blockerCode}`],
       },
       status: "blocked",
     }
@@ -2904,6 +3094,7 @@ async function runDelegatedBatchSpawn(input: {
   readonly plannedAccounts: readonly AccountRow[]
   readonly runner?: KhalaCodexFleetCommandRunner | undefined
   readonly targetPylonRef: string
+  readonly workerKind: KhalaFleetDelegateConcreteWorkerKind
   readonly work: KhalaFleetDelegateWork
 }): Promise<SpawnCodexInstancesResult> {
   const selectedCommandAccount =
@@ -2939,6 +3130,8 @@ async function runDelegatedBatchSpawn(input: {
     String(input.input.count),
     "--max-parallel",
     String(input.input.count),
+    "--workflow",
+    concreteWorkflowForWorkerKind(input.workerKind),
     "--objective",
     objective,
     "--pylon-ref",
@@ -2980,6 +3173,7 @@ async function runDelegatedNoRunRequests(input: {
   readonly plannedAccounts: readonly AccountRow[]
   readonly runner?: KhalaCodexFleetCommandRunner | undefined
   readonly targetPylonRef: string
+  readonly workerKind: KhalaFleetDelegateConcreteWorkerKind
 }): Promise<SpawnCodexInstancesResult> {
   const objective = renderKhalaFleetDelegationObjective({
     branch: input.input.fixture ? undefined : input.input.branch,
@@ -2996,7 +3190,7 @@ async function runDelegatedNoRunRequests(input: {
       "khala",
       "request",
       "--workflow",
-      "codex_agent_task",
+      concreteWorkflowForWorkerKind(input.workerKind),
       "--prompt",
       objective,
       "--pylon-ref",
@@ -3049,26 +3243,34 @@ function firstSpawnAssignmentRef(result: SpawnCodexInstancesResult): string | nu
   return result.results.find(slot => slot.assignmentRef !== null)?.assignmentRef ?? null
 }
 
-function classifySpawnDispatchBlocker(result: SpawnCodexInstancesResult): KhalaFleetDelegateBlockerCode {
+function classifySpawnDispatchBlocker(
+  result: SpawnCodexInstancesResult,
+  workerKind: KhalaFleetDelegateConcreteWorkerKind = "codex",
+): KhalaFleetDelegateBlockerCode {
   const text = renderSpawnResult(result)
   if (/duplicate_active_assignment|duplicate active assignment/iu.test(text)) return "duplicate_active_assignment"
   if (/stale_heartbeat|stale heartbeat|presence\.stale_heartbeat/iu.test(text)) return "stale_heartbeat"
-  if (/no_available_codex_capacity|no .*capacity|0\/\d+ available|rate.?limit|429|409/iu.test(text)) {
-    return "no_available_codex_capacity"
+  if (/no_available_(?:claude|codex)_capacity|no .*capacity|0\/\d+ available|rate.?limit|429|409/iu.test(text)) {
+    return noAvailableCapacityBlockerForWorkerKind(workerKind)
   }
   return "dispatch_failed"
 }
 
-function spawnDispatchBlockerRefs(result: SpawnCodexInstancesResult): readonly string[] {
+function spawnDispatchBlockerRefs(
+  result: SpawnCodexInstancesResult,
+  workerKind: KhalaFleetDelegateConcreteWorkerKind = "codex",
+): readonly string[] {
   const refs = result.results
     .flatMap(slot => slot.summary.match(/blocker(?: refs)?: ([^\n]+)/iu)?.[1]?.split(",") ?? [])
     .map(ref => ref.trim())
     .filter(ref => ref.length > 0 && ref !== "none")
   if (refs.length > 0) return [...new Set(refs)]
-  const blocker = classifySpawnDispatchBlocker(result)
+  const blocker = classifySpawnDispatchBlocker(result, workerKind)
   if (blocker === "duplicate_active_assignment") return ["blocker.public.pylon_dispatch.duplicate_active_assignment"]
   if (blocker === "stale_heartbeat") return ["blocker.public.pylon_dispatch.stale_heartbeat"]
-  if (blocker === "no_available_codex_capacity") return ["blocker.public.pylon_dispatch.no_available_codex_capacity"]
+  if (blocker === "no_available_codex_capacity" || blocker === "no_available_claude_capacity") {
+    return [`blocker.public.pylon_dispatch.${blocker}`]
+  }
   return ["blocker.public.khala_fleet_delegate.dispatch_failed"]
 }
 
@@ -3111,7 +3313,7 @@ function renderSpawnResult(result: SpawnCodexInstancesResult): string {
   const tokensVerified = spawnVerifiedTokenTotal(result)
   return [
     ...renderDelegateTraceLines(result),
-    `Codex spawn: accepted ${result.acceptedCount}/${result.requestedCount}${result.pylonRef ? ` via ${result.pylonRef}` : ""}`,
+    `Fleet spawn: accepted ${result.acceptedCount}/${result.requestedCount}${result.pylonRef ? ` via ${result.pylonRef}` : ""}`,
     ...(tokensVerified > 0
       ? [`Khala tokens generated: ${tokensVerified} verified (exact)`]
       : []),
@@ -3326,8 +3528,8 @@ function preferredSpawnAccounts(
     const rightReady = isReadyAccount(right)
     if (leftReady !== rightReady) return leftReady ? -1 : 1
     if (heuristic === "lexicographic_ready") return left.accountRef.localeCompare(right.accountRef)
-    const leftSlots = availability.get(left.accountRef) ?? 1
-    const rightSlots = availability.get(right.accountRef) ?? 1
+    const leftSlots = availability.get(accountAvailabilityKey(left)) ?? 1
+    const rightSlots = availability.get(accountAvailabilityKey(right)) ?? 1
     if (leftSlots !== rightSlots) return rightSlots - leftSlots
     const leftDefault = isDefaultAccountRef(left.accountRef)
     const rightDefault = isDefaultAccountRef(right.accountRef)
@@ -3346,6 +3548,7 @@ function resolveSpawnAccounts(
   allAccounts: readonly AccountRow[],
   availability: ReadonlyMap<string, number>,
   parameters: KhalaFleetDelegationParameterSet,
+  workerKind: KhalaFleetDelegateConcreteWorkerKind = "codex",
 ): readonly AccountRow[] {
   if (requestedAccountRef === undefined) return dispatchableSpawnAccounts(readyAccounts, availability)
   if (isDefaultAccountRef(requestedAccountRef)) {
@@ -3361,17 +3564,17 @@ function resolveSpawnAccounts(
   }
   const selected = allAccounts.find(account => account.accountRef === requestedAccountRef)
   if (selected === undefined) {
-    throw new Error(`Pylon Codex account ${requestedAccountRef} was not found.`)
+    throw new Error(`Pylon ${workerLabel(workerKind)} account ${requestedAccountRef} was not found.`)
   }
   if (!isReadyAccount(selected)) {
-    throw new Error(`Pylon Codex account ${requestedAccountRef} is not ready (${selected.readiness}).`)
+    throw new Error(`Pylon ${workerLabel(workerKind)} account ${requestedAccountRef} is not ready (${selected.readiness}).`)
   }
   if (selected.paused) {
-    throw new Error(`Pylon Codex account ${requestedAccountRef} is paused for planning.`)
+    throw new Error(`Pylon ${workerLabel(workerKind)} account ${requestedAccountRef} is paused for planning.`)
   }
-  const slots = availability.get(selected.accountRef)
+  const slots = availability.get(accountAvailabilityKey(selected))
   if (slots !== undefined && slots <= 0) {
-    throw new Error(`Pylon Codex account ${requestedAccountRef} has no advertised available slots right now.`)
+    throw new Error(`Pylon ${workerLabel(workerKind)} account ${requestedAccountRef} has no advertised available slots right now.`)
   }
   return [selected]
 }
@@ -3382,9 +3585,9 @@ function dispatchableSpawnAccounts(
 ): readonly AccountRow[] {
   accounts = accounts.filter(account => !account.paused)
   if (availability.size === 0) return accounts
-  const positive = accounts.filter(account => (availability.get(account.accountRef) ?? 0) > 0)
+  const positive = accounts.filter(account => (availability.get(accountAvailabilityKey(account)) ?? 0) > 0)
   if (positive.length > 0) return positive
-  return accounts.filter(account => availability.get(account.accountRef) === undefined)
+  return accounts.filter(account => availability.get(accountAvailabilityKey(account)) === undefined)
 }
 
 function planSpawnAccounts(
@@ -3398,7 +3601,7 @@ function planSpawnAccounts(
   }
   const planned: AccountRow[] = []
   for (const account of accounts) {
-    const available = availability.get(account.accountRef)
+    const available = availability.get(accountAvailabilityKey(account))
     if (available === undefined) {
       planned.push(account)
       continue

--- a/clients/khala-code-desktop/src/bun/rpc-handlers.ts
+++ b/clients/khala-code-desktop/src/bun/rpc-handlers.ts
@@ -142,7 +142,7 @@ import {
   openExternalUrl,
   removeCodexAccount,
   setCodexAccountPaused,
-} from "./khala-codex-fleet-tools.js"
+} from "./khala-fleet-tools.js"
 
 type ChatEnv = Readonly<Record<string, string | undefined>>
 type MaybePromise<T> = T | Promise<T>

--- a/clients/khala-code-desktop/src/shared/rpc.ts
+++ b/clients/khala-code-desktop/src/shared/rpc.ts
@@ -1302,6 +1302,8 @@ const RpcFleetCapacity = S.Struct({
   queued: RpcNumberNull,
   ready: RpcNumberNull,
 })
+const RpcFleetAccountProvider = S.Literals(["claude_agent", "codex"])
+const RpcFleetRunWorkerKind = S.Literals(["codex", "claude", "auto"])
 const RpcFleetTokenMeasurementStatus = S.Literals(["exact", "estimated", "not_measured", "pending"])
 const RpcFleetSessionRole = S.Literals(["main_local_codex_session", "swarm_worker_codex_session"])
 const RpcFleetHomeRole = S.Literals(["main_user_codex_home_display_only", "pylon_isolated_worker_codex_home"])
@@ -1321,7 +1323,7 @@ const RpcFleetSessionLayer = S.Struct({
 })
 const RpcFleetAccount = S.Struct({
   accountRef: S.String,
-  provider: S.Literal("codex"),
+  provider: RpcFleetAccountProvider,
   readiness: S.String,
   quotaState: RpcStringNull,
   accountKey: RpcStringNull,
@@ -1544,7 +1546,7 @@ const RpcFleetRunStartRequest = S.Struct({
   runRef: S.optional(S.String),
   targetConcurrency: S.Number,
   workSource: RpcFleetRunWorkSource,
-  workerKind: S.optional(S.Literal("codex")),
+  workerKind: S.optional(RpcFleetRunWorkerKind),
   refillPolicy: S.optional(RpcFleetRunRefillPolicyPatch),
   tickImmediately: S.optional(S.Boolean),
 })
@@ -1560,7 +1562,7 @@ const RpcFleetRunProjection = S.Struct({
   state: RpcFleetRunState,
   targetConcurrency: S.Number,
   updatedAt: S.String,
-  workerKind: S.Literal("codex"),
+  workerKind: RpcFleetRunWorkerKind,
   workSource: RpcFleetRunWorkSource,
 })
 const RpcFleetRunStartResult = S.Struct({

--- a/clients/khala-code-desktop/src/ui/fleet-status.ts
+++ b/clients/khala-code-desktop/src/ui/fleet-status.ts
@@ -148,6 +148,13 @@ type FleetRunPreviewSlot = Readonly<{
   workerKind: FleetRunFormState["workerKind"]
 }>
 
+const fleetRunAccountMatchesWorkerKind = (
+  account: KhalaCodeDesktopFleetAccount,
+  workerKind: FleetRunFormState["workerKind"],
+): boolean =>
+  workerKind === "auto" ||
+  account.provider === (workerKind === "claude" ? "claude_agent" : "codex")
+
 type FleetRunView =
   | { readonly phase: "idle" }
   | { readonly phase: "preview"; readonly slots: readonly FleetRunPreviewSlot[] }
@@ -1565,7 +1572,10 @@ export const mountFleetPanel = (
     }
     if (lastData === null) return "Fleet status must load before previewing a run."
     const accounts = lastData.accounts.filter(
-      account => accountReadinessState(account.readiness) === "ready" && account.paused !== true,
+      account =>
+        accountReadinessState(account.readiness) === "ready" &&
+        account.paused !== true &&
+        fleetRunAccountMatchesWorkerKind(account, fleetRunForm.workerKind),
     )
     if (accounts.length === 0) return "No ready worker accounts are available for the first wave."
     const slots: FleetRunPreviewSlot[] = []
@@ -1594,13 +1604,10 @@ export const mountFleetPanel = (
     if (!Number.isInteger(targetConcurrency) || targetConcurrency < 1) {
       return "Fleet run target concurrency must be a positive integer."
     }
-    if (fleetRunForm.workerKind !== "codex") {
-      return `${titleize(fleetRunForm.workerKind)} FleetRun starts are accepted by the form but only Codex is wired in this build.`
-    }
     return {
       objective,
       targetConcurrency,
-      workerKind: "codex",
+      workerKind: fleetRunForm.workerKind,
       workSource: {
         kind: fleetRunForm.workSource,
       },

--- a/clients/khala-code-desktop/tests/app-shell.test.ts
+++ b/clients/khala-code-desktop/tests/app-shell.test.ts
@@ -1729,8 +1729,8 @@ describe("khala code desktop app shell", () => {
       status: "running",
       toolName: "codex_spawn",
     })
-    expect(parseToolTranscript("codex_spawn: ok\n\nCodex spawn: accepted 0/1\n- slot 1: failed\n  command timed out")).toEqual({
-      output: "Codex spawn: accepted 0/1\n- slot 1: failed\n  command timed out",
+    expect(parseToolTranscript("codex_spawn: ok\n\nFleet spawn: accepted 0/1\n- slot 1: failed\n  command timed out")).toEqual({
+      output: "Fleet spawn: accepted 0/1\n- slot 1: failed\n  command timed out",
       status: "failed",
       toolName: "codex_spawn",
     })

--- a/clients/khala-code-desktop/tests/codex-fleet-mcp-bridge.test.ts
+++ b/clients/khala-code-desktop/tests/codex-fleet-mcp-bridge.test.ts
@@ -19,7 +19,7 @@ import type {
   KhalaFleetRunStartInput,
   KhalaFleetRunStatusInput,
   KhalaFleetRunSupervisorManager,
-} from "../src/bun/khala-codex-fleet-tools"
+} from "../src/bun/khala-fleet-tools"
 import { createCodexAppServerHost } from "../src/bun/codex-app-server-client"
 import { handleKhalaMcpRequest } from "@openagentsinc/khala-tools"
 

--- a/clients/khala-code-desktop/tests/fleet-run-supervisor-rpc-adapter.test.ts
+++ b/clients/khala-code-desktop/tests/fleet-run-supervisor-rpc-adapter.test.ts
@@ -20,6 +20,7 @@ const acceptingRunner: FleetRunSupervisorRunner = {
 let fixtureOrdinal = 0
 
 const adapterFixture = (input: {
+  readonly accountRef?: string
   readonly advertisedCapacity?: number
   readonly env?: Record<string, string>
   readonly runner?: FleetRunSupervisorRunner
@@ -29,7 +30,7 @@ const adapterFixture = (input: {
   const pylonRef = `pylon.test.${fixtureOrdinal}`
   const adapter = createKhalaCodeDesktopFleetRunSupervisorRpcAdapter({
     capacity: {
-      accounts: async () => [{ accountRef: "codex", advertisedCapacity: input.advertisedCapacity ?? 0 }],
+      accounts: async () => [{ accountRef: input.accountRef ?? "codex", advertisedCapacity: input.advertisedCapacity ?? 0 }],
     },
     env: input.env ?? { PYLON_HOME: "/tmp/khala-code-fleet-run-rpc-adapter-test" },
     pylonRef,
@@ -76,6 +77,41 @@ describe("Khala Code fleet run supervisor RPC adapter", () => {
       },
     })
     expect(result.run).not.toHaveProperty("objective")
+  })
+
+  test("starts Claude worker-kind runs without storing or dispatching them as Codex", async () => {
+    const dispatched: Array<{ readonly accountRef: string; readonly workerKind: string }> = []
+    const { adapter, store } = adapterFixture({
+      accountRef: "claude-a",
+      advertisedCapacity: 1,
+      runner: {
+        dispatch: async input => {
+          dispatched.push({
+            accountRef: input.accountRef,
+            workerKind: input.run.workerKind,
+          })
+          return {
+            assignmentRef: "assignment.claude",
+            lifecycle: [],
+            status: "accepted",
+            summary: null,
+          }
+        },
+      },
+    })
+
+    const result = await adapter.start({
+      objective: "Run Claude fixture target.",
+      runRef: "fleet_run.adapter.claude",
+      targetConcurrency: 1,
+      tickImmediately: true,
+      workerKind: "claude",
+      workSource: { kind: "fixture", count: 1 },
+    })
+
+    expect(result.run.workerKind).toBe("claude")
+    expect(store.getFleetRun("fleet_run.adapter.claude")?.workerKind).toBe("claude")
+    expect(dispatched).toEqual([{ accountRef: "claude-a", workerKind: "claude" }])
   })
 
   test("accepts target_reached stop conditions in projections", async () => {

--- a/clients/khala-code-desktop/tests/fleet-status.test.ts
+++ b/clients/khala-code-desktop/tests/fleet-status.test.ts
@@ -94,6 +94,21 @@ const status = (): KhalaCodeDesktopFleetStatus => ({
       quotaState: "available",
       readiness: "ready",
     },
+    {
+      accountKey: null,
+      accountRef: "claude-a",
+      capacity: {
+        available: 1,
+        busy: 0,
+        queued: 0,
+        ready: 1,
+      },
+      email: "operator-claude@example.com",
+      paused: false,
+      provider: "claude_agent",
+      quotaState: "available",
+      readiness: "ready",
+    },
   ],
   activeAssignments: [],
   processes: [],
@@ -135,6 +150,7 @@ const runStartResult = (
   ok: true,
   run: fleetRunProjection({
     targetConcurrency: request.targetConcurrency,
+    workerKind: request.workerKind ?? "codex",
     workSource: request.workSource,
   }),
   supervisorStarted: true,
@@ -439,7 +455,7 @@ describe("Fleet status panel", () => {
       {
         objective: "Burn down public fixture tasks.",
         targetConcurrency: 3,
-                workerKind: "codex",
+        workerKind: "codex",
         workSource: { kind: "fixture" },
       },
     ])
@@ -452,6 +468,78 @@ describe("Fleet status panel", () => {
     expect(root.textContent).toContain("claimed2")
     expect(root.textContent).toContain("done4")
     expect(root.textContent).toContain("elapsed30s")
+  })
+
+  test("starts Claude FleetRuns from the form without falling back to Codex", async () => {
+    const root = document.createElement("div")
+    const requests: KhalaCodeDesktopFleetRunStartRequest[] = []
+    const panel = mountFleetPanel(root, {
+      connectAccount: async () => ({
+        ok: false,
+        accountRef: "codex-test",
+        error: "disabled",
+        output: "",
+        userCode: null,
+        verificationUrl: null,
+      }),
+      delegateRun: async () => {
+        throw new Error("delegate runner should not be called")
+      },
+      fetch: async () => status(),
+      fleetRunControl: async () => {
+        throw new Error("fleet run control should not be called")
+      },
+      fleetRunList: async () => ({ ok: true, runs: [] }),
+      fleetRunStart: async request => {
+        requests.push(request)
+        return runStartResult(request)
+      },
+      fleetWorkerControl: async () => {
+        throw new Error("fleet worker control should not be called")
+      },
+      loadGymDemoProof: () => {
+        throw new Error("gym proof should not be called")
+      },
+      openExternal: async () => false,
+      removeAccount: async () => ({ ok: true }),
+      setAccountPaused: async () => ({ ok: true }),
+      consumeResetCredit: async () => ({ ok: true }),
+      startDelegationOptimization: async () => {
+        throw new Error("optimization should not be called")
+      },
+    })
+
+    await panel.refresh()
+
+    const form = root.querySelector<HTMLFormElement>('form[aria-label="Start fleet run"]')
+    expect(form).not.toBeNull()
+    changeInput(form!.elements.namedItem("objective") as HTMLTextAreaElement, "Burn down Claude fixture tasks.")
+    changeInput(form!.elements.namedItem("targetConcurrency") as HTMLInputElement, "1")
+    changeInput(form!.elements.namedItem("workSource") as HTMLSelectElement, "fixture")
+    changeInput(form!.elements.namedItem("workerKind") as HTMLSelectElement, "claude")
+
+    const previewButton = [...root.querySelectorAll<HTMLButtonElement>("button")]
+      .find(button => button.textContent?.includes("Preview first wave"))
+    expect(previewButton).not.toBeUndefined()
+    previewButton!.click()
+
+    const previewRows = [...root.querySelectorAll<HTMLElement>(".khala-fleet-run-preview-slot")]
+      .map(row => row.textContent ?? "")
+    expect(previewRows).toHaveLength(1)
+    expect(previewRows[0]).toContain("claude-a")
+    expect(previewRows[0]).toContain("workerclaude")
+
+    form!.dispatchEvent(new window.Event("submit", { bubbles: true, cancelable: true }))
+    await flushPanelWork()
+
+    expect(requests).toEqual([
+      {
+        objective: "Burn down Claude fixture tasks.",
+        targetConcurrency: 1,
+        workerKind: "claude",
+        workSource: { kind: "fixture" },
+      },
+    ])
   })
 
   test("renders the active FleetRun header from fleetRunList without fabricated objective text", async () => {

--- a/clients/khala-code-desktop/tests/khala-chat-runtime.test.ts
+++ b/clients/khala-code-desktop/tests/khala-chat-runtime.test.ts
@@ -221,7 +221,7 @@ describe("Khala Code desktop chat runtime", () => {
     expect(requestMessages[0]?.content).toContain("We are Khala. How can we help?")
     expect(requestMessages[0]?.content).toContain("usually one or two sentences, then use tools")
     expect(requestMessages[0]?.content).toContain("avoid long front-loaded plans")
-    expect(requestMessages[0]?.content).toContain("Pylon/Codex fleet tools")
+    expect(requestMessages[0]?.content).toContain("Pylon fleet tools")
     expect(requestMessages[0]?.content).toContain("Do not call or invent codex_terminate")
     expect(requestMessages[0]?.content).toContain("summarize only the returned assignment")
     expect(requestMessages[0]?.content).toContain("Never end a turn with only tool output")
@@ -694,8 +694,8 @@ describe("Khala Code desktop chat runtime", () => {
               toolName: "codex_spawn",
             })
             return khalaToolOk({
-              modelText: "Codex spawn: accepted 1/1\n- slot 0: accepted",
-              publicSummary: "Codex spawn accepted 1/1 request(s).",
+              modelText: "Fleet spawn: accepted 1/1\n- slot 0: accepted",
+              publicSummary: "Fleet spawn accepted 1/1 request(s).",
             })
           }),
       },
@@ -763,7 +763,7 @@ describe("Khala Code desktop chat runtime", () => {
     const finalIndex = toolReplacements.findIndex(event =>
       event.type === "message_replace" &&
       event.message.body.includes("codex_spawn: ok") &&
-      event.message.body.includes("Codex spawn: accepted 1/1")
+      event.message.body.includes("Fleet spawn: accepted 1/1")
     )
 
     expect(result.ok).toBe(true)

--- a/clients/khala-code-desktop/tests/khala-codex-live-smoke.test.ts
+++ b/clients/khala-code-desktop/tests/khala-codex-live-smoke.test.ts
@@ -12,7 +12,7 @@ import {
   type KhalaCodexFleetCommandInput,
   type KhalaCodexFleetCommandResult,
   type KhalaCodexFleetProgressPayload,
-} from "../src/bun/khala-codex-fleet-tools"
+} from "../src/bun/khala-fleet-tools"
 
 const tempDirs: string[] = []
 

--- a/clients/khala-code-desktop/tests/khala-fleet-tools.test.ts
+++ b/clients/khala-code-desktop/tests/khala-fleet-tools.test.ts
@@ -19,7 +19,7 @@ import {
   type KhalaCodexFleetCommandInput,
   type KhalaCodexFleetCommandResult,
   type KhalaCodexFleetProgressPayload,
-} from "../src/bun/khala-codex-fleet-tools"
+} from "../src/bun/khala-fleet-tools"
 
 const tempDirs: string[] = []
 
@@ -209,7 +209,7 @@ async function waitForFleetRunSnapshot(
   throw new Error(`fleet run ${runRef} did not reach expected state; last state=${snapshot.run.state} active=${snapshot.active}`)
 }
 
-describe("Khala Code Codex fleet tools", () => {
+describe("Khala Code fleet tools", () => {
   test("parsePylonLifecycleNdjsonLine accepts public lifecycle schemas and drops malformed lines", () => {
     expect(parsePylonLifecycleNdjsonLine("not json")).toBeNull()
     expect(parsePylonLifecycleNdjsonLine(JSON.stringify({
@@ -633,9 +633,9 @@ describe("Khala Code Codex fleet tools", () => {
     const toolResult = await Effect.runPromise(tool!.execute!({}, {} as never))
 
     expect(toolResult.modelOutput.text).toContain("Active assignment markers: 2")
-    expect(toolResult.modelOutput.text).toContain("Active Codex exec processes: 1")
+    expect(toolResult.modelOutput.text).toContain("Active local worker processes: 1")
     expect(toolResult.modelOutput.text)
-      .toContain("Assignment/process reconciliation: 2 marker(s), 1 codex exec process(es)")
+      .toContain("Assignment/process reconciliation: 2 marker(s), 1 local worker process(es)")
     expect(toolResult.modelOutput.text).toContain("- 200 parent=199 elapsed=00:02:03 codex_exec")
     expect(toolResult.modelOutput.text).not.toContain("Local Pylon/Codex processes")
     expect(toolResult.modelOutput.text).not.toContain("Codex.app")
@@ -765,7 +765,7 @@ describe("Khala Code Codex fleet tools", () => {
       .find(item => item.definition.name === "codex_fleet_status")
     const toolResult = await Effect.runPromise(tool!.execute!({ include_processes: false }, {} as never))
 
-    expect(toolResult.modelOutput.text).toContain("- codex-2: ready, slots 4/5 available, busy 1, queued 0")
+    expect(toolResult.modelOutput.text).toContain("- codex:codex-2: ready, slots 4/5 available, busy 1, queued 0")
     expect(toolResult.modelOutput.text).toContain("Token rate: exact 42 tokens/min completed window across 3 exact row(s)")
     expect(toolResult.modelOutput.text).toContain("assignment.public.one")
     expect(toolResult.modelOutput.text).toContain("tokens=exact 600, 300 tokens/min, kind=exact")
@@ -963,6 +963,89 @@ describe("Khala Code Codex fleet tools", () => {
     expect(result.results[0]?.summary).toContain("assignment run: no result returned")
     expect(result.results[0]?.summary).toContain("no local output path was returned")
     expect(calls.some(call => pylonArgs(call)[0] === "khala" && pylonArgs(call)[1] === "request")).toBe(true)
+  })
+
+  test("spawnCodexInstances routes Claude worker kind through claude_agent_task", async () => {
+    const fixture = await tempPylonFixture()
+    const calls: KhalaCodexFleetCommandInput[] = []
+    const runner = async (input: KhalaCodexFleetCommandInput): Promise<KhalaCodexFleetCommandResult> => {
+      calls.push(input)
+      const args = pylonArgs(input)
+      const joined = args.join(" ")
+      if (joined === "provider go-online --json") {
+        return ok({ ok: true, pylonRef: "pylon.local.test" })
+      }
+      if (joined === "accounts list --json") {
+        return ok({
+          accounts: [
+            {
+              accountRef: "claude",
+              homeState: "present",
+              provider: "claude_agent",
+            },
+          ],
+          schema: "openagents.pylon.accounts_list.v0.3",
+        })
+      }
+      if (joined === "accounts status --provider claude_agent --json") {
+        return ok({
+          accounts: [
+            {
+              accountRef: "claude",
+              provider: "claude_agent",
+              quota: { state: "available" },
+              readiness: { state: "ready" },
+            },
+          ],
+          schema: "openagents.pylon.accounts_status.v0.1",
+        })
+      }
+      if (joined === "presence heartbeat --base-url https://openagents.com --json") {
+        return ok({
+          heartbeatRef: "heartbeat.pylon.local.test.1",
+          pylonRef: "pylon.local.test",
+        })
+      }
+      if (args[0] === "khala" && args[1] === "request") {
+        expect(args).toContain("--workflow")
+        expect(args).toContain("claude_agent_task")
+        expect(args).toContain("--fixture")
+        expect(args).toContain("--account-ref")
+        expect(args).toContain("claude")
+        expect(input.env?.OPENAGENTS_PYLON_CLAUDE_ACCOUNT_CONCURRENCY).toBeDefined()
+        return ok({
+          assignmentRef: "assignment.public.claude_agent_task.test",
+          autoRun: {
+            attempted: false,
+            reason: "disabled_by_no_run",
+          },
+        })
+      }
+      return failed(`unexpected command: ${joined}`)
+    }
+
+    const result = await spawnCodexInstances({
+      count: 1,
+      noRun: true,
+      prompt: "Run the public fixture.",
+      workerKind: "claude",
+    }, {
+      env: fixture.env,
+      runner,
+    })
+
+    expect(result).toMatchObject({
+      acceptedCount: 1,
+      pylonRef: "pylon.local.test",
+      requestedCount: 1,
+    })
+    expect(result.results[0]).toMatchObject({
+      accountRef: "claude",
+      assignmentRef: "assignment.public.claude_agent_task.test",
+      status: "accepted",
+    })
+    expect(calls.some(call => pylonArgs(call).join(" ") === "accounts status --provider claude_agent --json")).toBe(true)
+    expect(calls.every(call => pylonArgs(call).join(" ") !== "codex accounts list --json")).toBe(true)
   })
 
   test("spawnCodexInstances resolves live commit pins and renders claim-aware real-work prompts", async () => {
@@ -2319,7 +2402,7 @@ describe("Khala Code Codex fleet tools", () => {
     }, {} as never))
 
     expect(result.status).toBe("failed")
-    expect(result.modelOutput.text).toContain("Codex spawn: accepted 0/1")
+    expect(result.modelOutput.text).toContain("Fleet spawn: accepted 0/1")
     expect(result.modelOutput.text).toContain("assignment run: failed")
     expect(result.modelOutput.text).toContain("blocker refs: blocker.assignment.timeout")
     expect(result.modelOutput.text).toContain("assignment_run.completed")
@@ -2393,7 +2476,7 @@ describe("Khala Code Codex fleet tools", () => {
     }, {} as never))
 
     expect(result.status).toBe("failed")
-    expect(result.modelOutput.text).toContain("Codex spawn: accepted 0/1")
+    expect(result.modelOutput.text).toContain("Fleet spawn: accepted 0/1")
     expect(result.modelOutput.text).toContain("command timed out")
     expect(result.modelOutput.text).toContain("assignment_run.runtime_started")
     expect(result.modelOutput.text).not.toContain("phase=runtime_active")

--- a/clients/khala-code-desktop/tests/rpc-handlers.test.ts
+++ b/clients/khala-code-desktop/tests/rpc-handlers.test.ts
@@ -13,13 +13,14 @@ import type {
 import type {
   KhalaCodexFleetCommandInput,
   KhalaCodexFleetCommandResult,
-} from "../src/bun/khala-codex-fleet-tools"
+} from "../src/bun/khala-fleet-tools"
 import type {
   KhalaCodeDesktopChatTurnResponse,
   KhalaCodeDesktopCodexAppServerControlResult,
   KhalaCodeDesktopCodexAppServerStatus,
   KhalaCodeDesktopCodexHarnessStatus,
   KhalaCodeDesktopFleetRunProjection,
+  KhalaCodeDesktopFleetRunStartRequest,
 } from "../src/shared/rpc"
 
 const tempDirs: string[] = []
@@ -264,7 +265,7 @@ function throwingClaudeChatRuntime(
 
 describe("Khala Code desktop RPC handlers", () => {
   test("starts fleet runs through the supervisor RPC port", async () => {
-    const calls: unknown[] = []
+    const calls: KhalaCodeDesktopFleetRunStartRequest[] = []
     const run = fleetRunProjection()
     const handlers = createKhalaCodeDesktopRpcRequestHandlers({
       appleFmReadiness: () => {
@@ -295,6 +296,7 @@ describe("Khala Code desktop RPC handlers", () => {
     await expect(handlers.fleetRunStart({
       objective: "Burn down public issue backlog.",
       targetConcurrency: 25,
+      workerKind: "claude",
       workSource: {
         kind: "issue_list",
         repo: "OpenAgentsInc/openagents",
@@ -306,6 +308,7 @@ describe("Khala Code desktop RPC handlers", () => {
       supervisorStarted: true,
     })
     expect(calls).toHaveLength(1)
+    expect(calls[0]?.workerKind).toBe("claude")
   })
 
   test("reads fleet run status through a public-safe projection", async () => {

--- a/packages/khala-qa-harness/src/real-app-fetch.ts
+++ b/packages/khala-qa-harness/src/real-app-fetch.ts
@@ -9,7 +9,7 @@ import { buildKhalaAppleFmReadiness } from "../../../clients/khala-code-desktop/
 import type {
   KhalaCodexFleetCommandInput,
   KhalaCodexFleetCommandResult,
-} from "../../../clients/khala-code-desktop/src/bun/khala-codex-fleet-tools.js"
+} from "../../../clients/khala-code-desktop/src/bun/khala-fleet-tools.js"
 import type {
   KhalaCodeDesktopCodexHarnessStatus,
   KhalaCodeDesktopFleetRunProjection,

--- a/packages/khala-tools/src/fleet-delegate-program.test.ts
+++ b/packages/khala-tools/src/fleet-delegate-program.test.ts
@@ -314,6 +314,27 @@ describe("khala.fleet.delegate deterministic program", () => {
       })
     })
 
+    test("fixture trace refs are keyed by selected worker kind", async () => {
+      const result = await Effect.runPromise(runKhalaFleetDelegateProgram({
+        objective: "Run Claude fixture.",
+      }, completedModules({
+        advertiseCapacity: () => Effect.succeed(advertised(1, [
+          readyAccount({ accountRef: "claude", availableSlots: 1, workerKind: "claude" }),
+        ])),
+      }), {
+        parameters: admittedParameters({
+          delegationTarget: { workerKind: "claude" },
+        }),
+      }))
+
+      expect(result.status).toBe("completed")
+      expect(result.trace.find(step => step.module === "prepare_work")?.refs)
+        .toEqual(["fixture:claude_agent_task"])
+      if (result.status === "completed") {
+        expect(result.workerKind).toBe("claude")
+      }
+    })
+
     test("switching retry budget changes duplicate-assignment recovery behavior", async () => {
       let oneAttemptDispatchCalls = 0
       const oneAttempt = await Effect.runPromise(runKhalaFleetDelegateProgram({

--- a/packages/khala-tools/src/fleet-delegate-program.ts
+++ b/packages/khala-tools/src/fleet-delegate-program.ts
@@ -533,7 +533,7 @@ export const runKhalaFleetDelegateProgram = (
       message: prepared.kind === "fixture" ? "Prepared fixture work." : `Prepared ${prepared.repo}@${prepared.commit}.`,
       module: "prepare_work",
       precondition: "work_prepared",
-      refs: prepared.kind === "fixture" ? ["fixture:codex_agent_task"] : [`repo:${prepared.repo}`, `commit:${prepared.commit}`],
+      refs: prepared.kind === "fixture" ? [`fixture:${selected.workerKind}_agent_task`] : [`repo:${prepared.repo}`, `commit:${prepared.commit}`],
       status: prepared.kind === "fixture" ? "recovered" : "satisfied",
     })
 


### PR DESCRIPTION
## Summary

Closes #7837.

- threads `workerKind` through the desktop fleet tools, `khala.fleet.delegate`, Pylon spawn/burndown planning, FleetRun RPC start/projection, and supervised FleetRun dispatch
- routes Claude worker runs to `claude_agent_task` / `claude_agent` capacity while preserving Codex defaults and `auto` worker-kind handling
- renames the shared desktop fleet tooling module from `khala-codex-fleet-tools.ts` to `khala-fleet-tools.ts` and neutralizes Fleet status/spawn wording where the surface is no longer Codex-only
- extends exact own-capacity proof validation to the Pylon/Claude token provider/model pair

## Verification

- `bun run --cwd clients/khala-code-desktop typecheck`
- `bun run --cwd clients/khala-code-desktop test` — 463 pass, 0 fail
- `bun run --cwd packages/khala-qa-harness typecheck`
- `bun run --cwd packages/khala-tools typecheck && bun run --cwd packages/khala-tools test` — 192 pass, 0 fail
- `bun run --cwd apps/pylon typecheck && bun run --cwd apps/pylon test` — 2037 pass, 3 skip, 0 fail
- `bun run --cwd apps/openagents.com check:deploy`
- `git diff --check origin/main...HEAD`
