### PR TITLE
[codex] Implement fleet run live smokes

### DIFF
--- a/apps/pylon/README.md
+++ b/apps/pylon/README.md
@@ -489,6 +489,30 @@ token-counter evidence. The command reports `mergePolicy:
 "operator_review_required"`; review, commit, push, and close each issue after
 proof. See `docs/khala-burndown-runbook.md`.
 
+The FleetRun live smoke scripts are skip-safe by default and exist for owner
+or release-operator proof runs, not CI. `bun run --cwd apps/pylon
+smoke:fleet-run-live` runs only when `PYLON_FLEET_RUN_LIVE_ARM=1` is present
+with `PYLON_FLEET_RUN_LIVE_PYLON_REF`, exactly two distinct
+`PYLON_FLEET_RUN_LIVE_ISSUES`, `PYLON_FLEET_RUN_LIVE_REPO`,
+`PYLON_FLEET_RUN_LIVE_COMMIT` (40-character SHA),
+`PYLON_FLEET_RUN_LIVE_VERIFY`, and `OPENAGENTS_AGENT_TOKEN`. Armed execution
+starts a supervised issue-list FleetRun at target concurrency 2, then fails
+closed unless both assignment refs close out with green `pylon khala closeout`
+checklists, positive exact `token_usage_events` rows, zero duplicate work-unit
+claims, and a public `/api/public/khala-tokens-served` delta at least as large
+as the exact closeout total. Counter movement alone is never accepted.
+
+`bun run --cwd apps/pylon smoke:fleet-run-sustained` uses the same evidence
+chain behind `PYLON_FLEET_RUN_SUSTAINED_ARM=1`. Defaults are target 5,
+duration 30 minutes, minimum 2 refills, and at least 7 distinct issue numbers
+(`target + minRefills`). Optional knobs are
+`PYLON_FLEET_RUN_SUSTAINED_TARGET`,
+`PYLON_FLEET_RUN_SUSTAINED_DURATION_MINUTES`,
+`PYLON_FLEET_RUN_SUSTAINED_MIN_REFILLS`,
+`PYLON_FLEET_RUN_SUSTAINED_POLL_MS`, and
+`PYLON_FLEET_RUN_SUSTAINED_TIMEOUT_MS`; the script rejects values below the
+documented minimums before dispatching real work.
+
 ### Local multi-session proof runs
 
 For owner-directed local orchestration, `scripts/multi-session-run.ts` runs a

--- a/apps/pylon/package.json
+++ b/apps/pylon/package.json
@@ -53,6 +53,7 @@
     "smoke:default-start": "rm -f /tmp/pylon-default-start.log; perl -e 'alarm 3; $ENV{PYLON_DISABLE_OPENCODE_STARTUP}=1; exec @ARGV' bun src/index.ts > /tmp/pylon-default-start.log 2>&1; code=$?; if [ \"$code\" -ne 142 ] && [ \"$code\" -ne 0 ]; then cat /tmp/pylon-default-start.log; exit \"$code\"; fi; if rg -n 'TypeError|Effect\\.(fork|catchAll)|is not a function|\\[ERROR\\]' /tmp/pylon-default-start.log; then exit 1; fi; printf 'default startup reached persistent mode without startup API errors\\n'",
     "smoke:live-worker-loop": "bun scripts/live-worker-loop-smoke.ts",
     "smoke:fleet-run-live": "bun scripts/fleet-run-live-smoke.ts",
+    "smoke:fleet-run-sustained": "bun scripts/fleet-run-sustained-smoke.ts",
     "smoke:nip90-provider": "bun scripts/nip90-provider-loop-smoke.ts",
     "provider:serve": "bun scripts/nip90-provider-serve.ts",
     "smoke:stranger-probe": "bun scripts/stranger-probe-smoke.ts",

--- a/apps/pylon/scripts/fleet-run-sustained-smoke.ts
+++ b/apps/pylon/scripts/fleet-run-sustained-smoke.ts
@@ -7,7 +7,7 @@ import {
   type FleetRunSmokePlan,
 } from "../src/fleet-run-live-smoke"
 
-const result = await runFleetRunSmokeFromEnv("live", {
+const result = await runFleetRunSmokeFromEnv("sustained", {
   createManager: async (env: FleetRunSmokeEnv, _plan: FleetRunSmokePlan) => {
     const module = await import("../../../clients/khala-code-desktop/src/bun/khala-fleet-tools.ts")
     return new module.DefaultKhalaFleetRunSupervisorManager({ env })

--- a/apps/pylon/src/fleet-run-live-smoke.ts
+++ b/apps/pylon/src/fleet-run-live-smoke.ts
@@ -1,0 +1,928 @@
+import { dirname, resolve } from "node:path"
+import { fileURLToPath } from "node:url"
+
+export type FleetRunSmokeKind = "live" | "sustained"
+export type FleetRunSmokeName = "smoke:fleet-run-live" | "smoke:fleet-run-sustained"
+
+export type FleetRunSmokeEnv = Readonly<Record<string, string | undefined>>
+
+type FleetRunSmokeConfig = {
+  readonly armEnv: string
+  readonly defaultPollIntervalMs: number
+  readonly defaultTargetWorkers: number
+  readonly defaultTimeoutMs: number
+  readonly envPrefix: string
+  readonly exactIssueCount?: number
+  readonly kind: FleetRunSmokeKind
+  readonly minDurationMinutes: number | null
+  readonly minRefills: number
+  readonly minTargetWorkers: number
+  readonly smoke: FleetRunSmokeName
+}
+
+export type FleetRunSmokePlan = {
+  readonly armed: boolean
+  readonly armingEnv: string
+  readonly baseUrl: string
+  readonly branch: string
+  readonly commit: string | null
+  readonly expectedCloseout: readonly string[]
+  readonly failures: readonly string[]
+  readonly issues: readonly number[]
+  readonly kind: FleetRunSmokeKind
+  readonly managerEnv: FleetRunSmokeEnv
+  readonly message: string
+  readonly minDurationMs: number | null
+  readonly minDurationMinutes: number | null
+  readonly minRefills: number
+  readonly pollIntervalMs: number
+  readonly repo: string | null
+  readonly requiredCloseouts: number
+  readonly runRef: string
+  readonly smoke: FleetRunSmokeName
+  readonly targetWorkers: number
+  readonly timeoutMs: number
+  readonly verify: string | null
+  readonly workerKind: "codex"
+}
+
+export type FleetRunSmokeRun = {
+  readonly counters: {
+    readonly activeAssignments: number
+    readonly blockedAssignments: number
+    readonly completedAssignments: number
+    readonly failedAssignments: number
+    readonly workUnitsTotal: number
+  }
+  readonly runRef: string
+  readonly state: string
+  readonly targetConcurrency: number
+  readonly workerKind: string
+  readonly workSource: string
+}
+
+export type FleetRunSmokeLifecycleEvent = Readonly<Record<string, unknown>>
+
+export type FleetRunSmokeSnapshot = {
+  readonly active: boolean
+  readonly lifecycle: readonly FleetRunSmokeLifecycleEvent[]
+  readonly pylonRef: string | null
+  readonly run: FleetRunSmokeRun
+}
+
+export type FleetRunSmokeManager = {
+  readonly control?: ((input: { readonly runRef: string; readonly verb: "stop" }) => Promise<unknown>) | undefined
+  readonly start: (input: FleetRunSmokeManagerStartInput) => Promise<FleetRunSmokeSnapshot>
+  readonly status: (input: { readonly runRef: string }) => Promise<FleetRunSmokeSnapshot | readonly FleetRunSmokeSnapshot[]>
+}
+
+export type FleetRunSmokeManagerStartInput = {
+  readonly baseUrl: string
+  readonly branch: string
+  readonly commit: string
+  readonly issues: readonly number[]
+  readonly objective: string
+  readonly pylonRef: string
+  readonly repo: string
+  readonly runRef: string
+  readonly targetConcurrency: number
+  readonly timeoutMs: number
+  readonly verify: string
+  readonly workerKind: "codex"
+  readonly workSource: "issue_list"
+}
+
+export type FleetRunSmokeCloseoutEvidence = {
+  readonly assignmentRef: string
+  readonly blockerRefs: readonly string[]
+  readonly closeoutChecklistOk: boolean
+  readonly demandSource: string | null
+  readonly ok: boolean
+  readonly proofChecklistOk: boolean
+  readonly rawEventCount: number
+  readonly statusState: string | null
+  readonly tokenRefs: readonly string[]
+  readonly tokenRows: number
+  readonly totalTokens: number
+  readonly traceCount: number
+  readonly usageTruth: string | null
+}
+
+export type FleetRunSmokeCounterReconciliation =
+  | {
+      readonly afterTokensServed: number
+      readonly beforeTokensServed: number
+      readonly delta: number
+      readonly expectedMinimumDelta: number
+      readonly ok: boolean
+      readonly state: "checked"
+      readonly url: string
+    }
+  | {
+      readonly ok: false
+      readonly reason: string
+      readonly state: "unavailable"
+      readonly url: string
+    }
+
+export type FleetRunSmokeEvidence = {
+  readonly assignmentRefs: readonly string[]
+  readonly closeouts: readonly FleetRunSmokeCloseoutEvidence[]
+  readonly completedAt: string | null
+  readonly duplicateWorkUnitRefs: readonly string[]
+  readonly publicCounterReconciliation: FleetRunSmokeCounterReconciliation
+  readonly pylonRef: string | null
+  readonly refillsObserved: number
+  readonly run: FleetRunSmokeRun | null
+  readonly runObservedDurationMs: number
+  readonly startedAt: string
+  readonly tokenRows: number
+  readonly totalTokens: number
+  readonly workUnitRefs: readonly string[]
+}
+
+export type FleetRunSmokeResult = {
+  readonly ok: boolean
+  readonly skipped: boolean
+  readonly smoke: FleetRunSmokeName
+  readonly armingEnv: string
+  readonly targetWorkers: number
+  readonly minDurationMinutes?: number | undefined
+  readonly minRefills?: number | undefined
+  readonly repo?: string | undefined
+  readonly branch?: string | undefined
+  readonly commit?: string | undefined
+  readonly pylonRef?: string | undefined
+  readonly issues?: readonly number[] | undefined
+  readonly verify?: string | undefined
+  readonly runRef?: string | undefined
+  readonly expectedCloseout: readonly string[]
+  readonly evidence?: FleetRunSmokeEvidence | undefined
+  readonly failures: readonly string[]
+  readonly message: string
+}
+
+export type FleetRunSmokeRunOptions = {
+  readonly closeoutReader?: ((assignmentRef: string, plan: FleetRunSmokePlan) => Promise<FleetRunSmokeCloseoutEvidence>) | undefined
+  readonly createManager?: ((env: FleetRunSmokeEnv, plan: FleetRunSmokePlan) => FleetRunSmokeManager | Promise<FleetRunSmokeManager>) | undefined
+  readonly env?: FleetRunSmokeEnv | undefined
+  readonly fetch?: typeof fetch | undefined
+  readonly manager?: FleetRunSmokeManager | undefined
+  readonly now?: (() => Date) | undefined
+  readonly sleep?: ((ms: number) => Promise<void>) | undefined
+}
+
+const DEFAULT_BASE_URL = "https://openagents.com"
+const LIVE_TIMEOUT_MS = 2 * 60 * 60 * 1000
+const SUSTAINED_TIMEOUT_MS = 4 * 60 * 60 * 1000
+
+const smokeConfigs: Record<FleetRunSmokeKind, FleetRunSmokeConfig> = {
+  live: {
+    armEnv: "PYLON_FLEET_RUN_LIVE_ARM",
+    defaultPollIntervalMs: 10_000,
+    defaultTargetWorkers: 2,
+    defaultTimeoutMs: LIVE_TIMEOUT_MS,
+    envPrefix: "PYLON_FLEET_RUN_LIVE",
+    exactIssueCount: 2,
+    kind: "live",
+    minDurationMinutes: null,
+    minRefills: 0,
+    minTargetWorkers: 2,
+    smoke: "smoke:fleet-run-live",
+  },
+  sustained: {
+    armEnv: "PYLON_FLEET_RUN_SUSTAINED_ARM",
+    defaultPollIntervalMs: 30_000,
+    defaultTargetWorkers: 5,
+    defaultTimeoutMs: SUSTAINED_TIMEOUT_MS,
+    envPrefix: "PYLON_FLEET_RUN_SUSTAINED",
+    kind: "sustained",
+    minDurationMinutes: 30,
+    minRefills: 2,
+    minTargetWorkers: 5,
+    smoke: "smoke:fleet-run-sustained",
+  },
+}
+
+export function buildFleetRunSmokePlan(
+  kind: FleetRunSmokeKind,
+  env: FleetRunSmokeEnv = process.env,
+  now: Date = new Date(),
+): FleetRunSmokePlan {
+  const config = smokeConfigs[kind]
+  const armed = env[config.armEnv]?.trim() === "1"
+  const armingEnv = `${config.armEnv}=1`
+  const failures: string[] = []
+  const targetWorkers = parseOptionalInteger(
+    env[`${config.envPrefix}_TARGET`],
+    config.defaultTargetWorkers,
+    `${config.envPrefix}_TARGET`,
+    failures,
+  )
+  const minRefills = parseOptionalInteger(
+    env[`${config.envPrefix}_MIN_REFILLS`],
+    config.minRefills,
+    `${config.envPrefix}_MIN_REFILLS`,
+    failures,
+  )
+  const minDurationMinutes = config.minDurationMinutes === null
+    ? null
+    : parseOptionalInteger(
+        env[`${config.envPrefix}_DURATION_MINUTES`],
+        config.minDurationMinutes,
+        `${config.envPrefix}_DURATION_MINUTES`,
+        failures,
+      )
+  const minDurationMs = minDurationMinutes === null ? null : minDurationMinutes * 60_000
+  const requiredCloseouts = Math.max(targetWorkers, config.minTargetWorkers) +
+    Math.max(minRefills, config.minRefills)
+  const pollIntervalMs = parseOptionalInteger(
+    env[`${config.envPrefix}_POLL_MS`],
+    config.defaultPollIntervalMs,
+    `${config.envPrefix}_POLL_MS`,
+    failures,
+  )
+  const timeoutMs = parseOptionalInteger(
+    env[`${config.envPrefix}_TIMEOUT_MS`],
+    config.defaultTimeoutMs,
+    `${config.envPrefix}_TIMEOUT_MS`,
+    failures,
+  )
+  const baseUrl = firstTrimmed([
+    env[`${config.envPrefix}_BASE_URL`],
+    env.PYLON_OPENAGENTS_BASE_URL,
+    env.OPENAGENTS_BASE_URL,
+    DEFAULT_BASE_URL,
+  ])
+  const branch = firstTrimmed([env[`${config.envPrefix}_BRANCH`], "main"])
+  const runRef = firstTrimmed([
+    env[`${config.envPrefix}_RUN_REF`],
+    `fleet_run.${kind}_smoke.${compactTimestamp(now)}`,
+  ])
+  const workerKindRaw = firstTrimmed([env[`${config.envPrefix}_WORKER_KIND`], "codex"])
+
+  let pylonRef: string | null = null
+  let repo: string | null = null
+  let commit: string | null = null
+  let verify: string | null = null
+  let issues: readonly number[] = []
+
+  if (armed) {
+    pylonRef = requireTrimmed(env, `${config.envPrefix}_PYLON_REF`, config.armEnv, failures)
+    repo = requireTrimmed(env, `${config.envPrefix}_REPO`, config.armEnv, failures)
+    commit = requireTrimmed(env, `${config.envPrefix}_COMMIT`, config.armEnv, failures)
+    verify = requireTrimmed(env, `${config.envPrefix}_VERIFY`, config.armEnv, failures)
+    requireTrimmed(env, "OPENAGENTS_AGENT_TOKEN", config.armEnv, failures)
+    issues = parseIssues(
+      requireTrimmed(env, `${config.envPrefix}_ISSUES`, config.armEnv, failures),
+      `${config.envPrefix}_ISSUES`,
+      failures,
+    )
+  }
+
+  if (armed && commit !== null && !/^[0-9a-f]{40}$/iu.test(commit)) {
+    failures.push(`${config.envPrefix}_COMMIT must be a pinned 40-character commit SHA`)
+  }
+  if (armed && targetWorkers < config.minTargetWorkers) {
+    failures.push(`${config.envPrefix}_TARGET must be at least ${config.minTargetWorkers}`)
+  }
+  if (armed && config.exactIssueCount !== undefined && targetWorkers !== config.defaultTargetWorkers) {
+    failures.push(`${config.envPrefix}_TARGET must be exactly ${config.defaultTargetWorkers}`)
+  }
+  if (armed && minRefills < config.minRefills) {
+    failures.push(`${config.envPrefix}_MIN_REFILLS must be at least ${config.minRefills}`)
+  }
+  if (armed && minDurationMinutes !== null && minDurationMinutes < config.minDurationMinutes!) {
+    failures.push(`${config.envPrefix}_DURATION_MINUTES must be at least ${config.minDurationMinutes}`)
+  }
+  if (armed && pollIntervalMs < 100) {
+    failures.push(`${config.envPrefix}_POLL_MS must be at least 100`)
+  }
+  if (armed && timeoutMs <= 0) {
+    failures.push(`${config.envPrefix}_TIMEOUT_MS must be positive`)
+  }
+  if (armed && minDurationMs !== null && timeoutMs <= minDurationMs) {
+    failures.push(`${config.envPrefix}_TIMEOUT_MS must be greater than ${config.envPrefix}_DURATION_MINUTES`)
+  }
+  if (armed && workerKindRaw !== "codex") {
+    failures.push(`${config.envPrefix}_WORKER_KIND must be codex; this smoke proves exact rows through pylon khala closeout`)
+  }
+  if (armed && config.exactIssueCount !== undefined && issues.length !== config.exactIssueCount) {
+    failures.push(`${config.envPrefix}_ISSUES must contain exactly ${config.exactIssueCount} positive issue numbers`)
+  }
+  if (armed && config.exactIssueCount === undefined && issues.length < requiredCloseouts) {
+    failures.push(`${config.envPrefix}_ISSUES must contain at least ${requiredCloseouts} distinct issue numbers`)
+  }
+
+  return {
+    armed,
+    armingEnv,
+    baseUrl,
+    branch,
+    commit: commit === null ? null : commit.toLowerCase(),
+    expectedCloseout: expectedCloseoutFor(config, targetWorkers, minDurationMinutes, minRefills),
+    failures,
+    issues,
+    kind,
+    managerEnv: {
+      ...env,
+      PYLON_OPENAGENTS_BASE_URL: baseUrl,
+    },
+    message: armed
+      ? failures.length === 0
+        ? `${config.smoke} armed; starting a real supervised FleetRun and proving closeout/token evidence.`
+        : `${config.smoke} is armed but its inputs are invalid.`
+      : `Skipped by default. Arm with ${armingEnv} plus ${requiredEnvList(config).join(", ")}.`,
+    minDurationMs,
+    minDurationMinutes,
+    minRefills,
+    pollIntervalMs,
+    repo,
+    requiredCloseouts,
+    runRef,
+    smoke: config.smoke,
+    targetWorkers,
+    timeoutMs,
+    verify,
+    workerKind: "codex",
+  }
+}
+
+export async function runFleetRunSmokeFromEnv(
+  kind: FleetRunSmokeKind,
+  options: FleetRunSmokeRunOptions = {},
+): Promise<FleetRunSmokeResult> {
+  const env = options.env ?? process.env
+  const plan = buildFleetRunSmokePlan(kind, env, options.now?.() ?? new Date())
+  if (!plan.armed) return skippedResult(plan)
+  if (plan.failures.length > 0) return failedResult(plan, plan.failures)
+  return executeFleetRunSmoke(plan, options)
+}
+
+export async function executeFleetRunSmoke(
+  plan: FleetRunSmokePlan,
+  options: FleetRunSmokeRunOptions = {},
+): Promise<FleetRunSmokeResult> {
+  const closeoutReader = options.closeoutReader ?? readPylonKhalaCloseoutEvidence
+  const manager = options.manager ?? await options.createManager?.(plan.managerEnv, plan)
+  if (manager === undefined) {
+    return failedResult(plan, ["a FleetRun smoke manager is required for armed execution"])
+  }
+  if (plan.repo === null || plan.commit === null || plan.verify === null) {
+    return failedResult(plan, ["armed smoke plan is missing repo, commit, or verify"])
+  }
+  const pylonRef = firstTrimmed([plan.managerEnv[`${smokeConfigs[plan.kind].envPrefix}_PYLON_REF`], ""])
+  if (pylonRef === "") return failedResult(plan, ["armed smoke plan is missing pylon ref"])
+
+  const now = options.now ?? (() => new Date())
+  const sleep = options.sleep ?? Bun.sleep
+  const startedAt = now()
+  const counterUrl = publicCounterUrl(plan.baseUrl)
+  const beforeCounter = await fetchPublicKhalaTokensServed(counterUrl, options.fetch)
+  let snapshot: FleetRunSmokeSnapshot | null = null
+  let completedAt: Date | null = null
+  let timedOut = false
+  let terminalFailure: string | null = null
+
+  try {
+    snapshot = await manager.start({
+      baseUrl: plan.baseUrl,
+      branch: plan.branch,
+      commit: plan.commit,
+      issues: plan.issues,
+      objective: objectiveFor(plan),
+      pylonRef,
+      repo: plan.repo,
+      runRef: plan.runRef,
+      targetConcurrency: plan.targetWorkers,
+      timeoutMs: plan.timeoutMs,
+      verify: plan.verify,
+      workerKind: "codex",
+      workSource: "issue_list",
+    })
+
+    while (true) {
+      const observedNow = now()
+      if (snapshot.run.state === "completed") {
+        completedAt = observedNow
+        break
+      }
+      if (snapshot.run.state === "stopped") {
+        terminalFailure = "fleet run stopped before completion"
+        completedAt = observedNow
+        break
+      }
+      if (observedNow.getTime() - startedAt.getTime() >= plan.timeoutMs) {
+        timedOut = true
+        terminalFailure = `timed out after ${plan.timeoutMs}ms waiting for ${plan.smoke}`
+        break
+      }
+      await sleep(plan.pollIntervalMs)
+      snapshot = singleSnapshot(await manager.status({ runRef: plan.runRef }))
+    }
+  } catch (error) {
+    return failedResult(plan, [errorMessage(error)])
+  } finally {
+    if (timedOut && manager.control !== undefined) {
+      await manager.control({ runRef: plan.runRef, verb: "stop" }).catch(() => undefined)
+    }
+  }
+
+  const observedAt = completedAt ?? now()
+  const preCloseoutEvidence = evidenceFromSnapshot({
+    completedAt: completedAt?.toISOString() ?? null,
+    plan,
+    snapshot,
+    startedAt: startedAt.toISOString(),
+    observedAt,
+  })
+  const preCloseoutFailures = [
+    ...(terminalFailure === null ? [] : [terminalFailure]),
+    ...preCloseoutEvidenceFailures(plan, preCloseoutEvidence),
+  ]
+
+  const closeoutRefs = preCloseoutEvidence.assignmentRefs
+  const closeouts = await Promise.all(
+    closeoutRefs.map(assignmentRef =>
+      closeoutReader(assignmentRef, plan).catch(error => ({
+        assignmentRef,
+        blockerRefs: [`blocker.${plan.kind}_smoke.closeout_read_failed`],
+        closeoutChecklistOk: false,
+        demandSource: null,
+        ok: false,
+        proofChecklistOk: false,
+        rawEventCount: 0,
+        statusState: null,
+        tokenRefs: [],
+        tokenRows: 0,
+        totalTokens: 0,
+        traceCount: 0,
+        usageTruth: null,
+        failure: redactSmokeText(errorMessage(error)),
+      }) as FleetRunSmokeCloseoutEvidence),
+    ),
+  )
+  const tokenRows = closeouts.reduce((sum, closeout) => sum + closeout.tokenRows, 0)
+  const totalTokens = closeouts.reduce((sum, closeout) => sum + closeout.totalTokens, 0)
+  const afterCounter = await fetchPublicKhalaTokensServed(counterUrl, options.fetch)
+  const evidence: FleetRunSmokeEvidence = {
+    ...preCloseoutEvidence,
+    closeouts,
+    publicCounterReconciliation: reconcilePublicCounter(counterUrl, beforeCounter, afterCounter, totalTokens),
+    tokenRows,
+    totalTokens,
+  }
+  const failures = [
+    ...preCloseoutFailures,
+    ...closeoutEvidenceFailures(plan, evidence),
+  ]
+
+  return {
+    ok: failures.length === 0,
+    skipped: false,
+    smoke: plan.smoke,
+    armingEnv: plan.armingEnv,
+    targetWorkers: plan.targetWorkers,
+    ...(plan.minDurationMinutes === null ? {} : { minDurationMinutes: plan.minDurationMinutes }),
+    ...(plan.minRefills === 0 ? {} : { minRefills: plan.minRefills }),
+    repo: plan.repo ?? undefined,
+    branch: plan.branch,
+    commit: plan.commit ?? undefined,
+    pylonRef,
+    issues: plan.issues,
+    verify: plan.verify ?? undefined,
+    runRef: plan.runRef,
+    expectedCloseout: plan.expectedCloseout,
+    evidence,
+    failures,
+    message: failures.length === 0
+      ? `${plan.smoke} passed with ${evidence.closeouts.length} closeout(s), ${evidence.tokenRows} exact token row(s), and ${evidence.refillsObserved} refill(s).`
+      : `${plan.smoke} failed: ${failures.join("; ")}`,
+  }
+}
+
+export async function readPylonKhalaCloseoutEvidence(
+  assignmentRef: string,
+  plan: FleetRunSmokePlan,
+): Promise<FleetRunSmokeCloseoutEvidence> {
+  const env = cleanEnv(plan.managerEnv)
+  const proc = Bun.spawn([
+    resolveBunExecutable(plan.managerEnv),
+    "src/index.ts",
+    "khala",
+    "closeout",
+    assignmentRef,
+    "--base-url",
+    plan.baseUrl,
+    "--json",
+  ], {
+    cwd: pylonAppDir(),
+    env,
+    stderr: "pipe",
+    stdout: "pipe",
+  })
+  const closeoutTimeoutMs = Math.min(Math.max(plan.pollIntervalMs * 4, 30_000), 120_000)
+  const timeout = setTimeout(() => proc.kill("SIGTERM"), closeoutTimeoutMs)
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]).finally(() => clearTimeout(timeout))
+  if (exitCode !== 0) {
+    throw new Error(redactSmokeText(stderr.trim() || stdout.trim() || `pylon khala closeout exited ${exitCode}`))
+  }
+  const parsed = JSON.parse(stdout) as unknown
+  return closeoutEvidenceFromPayload(assignmentRef, parsed)
+}
+
+export function closeoutEvidenceFromPayload(
+  assignmentRef: string,
+  payload: unknown,
+): FleetRunSmokeCloseoutEvidence {
+  const root = record(payload)
+  const closeoutChecklist = recordField(root, "closeoutChecklist")
+  const proof = recordField(root, "proof")
+  const proofChecklist = recordField(proof, "proofChecklist")
+  const status = recordField(root, "status")
+  const progress = recordField(status, "progress")
+  const tokenUsage = recordField(proof, "tokenUsage")
+  const rawEvents = recordField(proof, "rawEvents")
+  const traces = recordField(proof, "traces")
+  const blockerRefs = dedupe([
+    ...stringArrayField(closeoutChecklist, "blockerRefs"),
+    ...stringArrayField(proofChecklist, "blockerRefs"),
+  ])
+  return {
+    assignmentRef,
+    blockerRefs,
+    closeoutChecklistOk: booleanField(closeoutChecklist, "ok") === true,
+    demandSource: stringField(tokenUsage, "demandSource"),
+    ok: booleanField(root, "ok") === true,
+    proofChecklistOk: booleanField(proofChecklist, "ok") === true,
+    rawEventCount: numberField(rawEvents, "eventCount") ?? numberField(rawEvents, "count") ?? 0,
+    statusState: stringField(progress, "state"),
+    tokenRefs: stringArrayField(tokenUsage, "refs"),
+    tokenRows: numberField(tokenUsage, "rowCount") ?? 0,
+    totalTokens: numberField(tokenUsage, "totalTokens") ?? 0,
+    traceCount: numberField(traces, "count") ?? 0,
+    usageTruth: stringField(tokenUsage, "usageTruth"),
+  }
+}
+
+export function writeFleetRunSmokeResult(result: FleetRunSmokeResult): void {
+  process.stdout.write(`${JSON.stringify(result, null, 2)}\n`)
+}
+
+function skippedResult(plan: FleetRunSmokePlan): FleetRunSmokeResult {
+  return {
+    ok: true,
+    skipped: true,
+    smoke: plan.smoke,
+    armingEnv: plan.armingEnv,
+    targetWorkers: plan.targetWorkers,
+    ...(plan.minDurationMinutes === null ? {} : { minDurationMinutes: plan.minDurationMinutes }),
+    ...(plan.minRefills === 0 ? {} : { minRefills: plan.minRefills }),
+    expectedCloseout: plan.expectedCloseout,
+    failures: [],
+    message: plan.message,
+  }
+}
+
+function failedResult(plan: FleetRunSmokePlan, failures: readonly string[]): FleetRunSmokeResult {
+  return {
+    ok: false,
+    skipped: false,
+    smoke: plan.smoke,
+    armingEnv: plan.armingEnv,
+    targetWorkers: plan.targetWorkers,
+    ...(plan.minDurationMinutes === null ? {} : { minDurationMinutes: plan.minDurationMinutes }),
+    ...(plan.minRefills === 0 ? {} : { minRefills: plan.minRefills }),
+    repo: plan.repo ?? undefined,
+    branch: plan.branch,
+    commit: plan.commit ?? undefined,
+    pylonRef: plan.managerEnv[`${smokeConfigs[plan.kind].envPrefix}_PYLON_REF`],
+    issues: plan.issues.length === 0 ? undefined : plan.issues,
+    verify: plan.verify ?? undefined,
+    runRef: plan.runRef,
+    expectedCloseout: plan.expectedCloseout,
+    failures,
+    message: failures.join("; "),
+  }
+}
+
+function evidenceFromSnapshot(input: {
+  readonly completedAt: string | null
+  readonly observedAt: Date
+  readonly plan: FleetRunSmokePlan
+  readonly snapshot: FleetRunSmokeSnapshot | null
+  readonly startedAt: string
+}): Omit<FleetRunSmokeEvidence, "closeouts" | "publicCounterReconciliation" | "tokenRows" | "totalTokens"> {
+  const lifecycle = input.snapshot?.lifecycle ?? []
+  const assignmentRefs = dedupe(lifecycle.flatMap(assignmentRefsFromLifecycleEvent))
+  const workUnitRefs = lifecycle.flatMap(workUnitRefsFromLifecycleEvent)
+  const duplicateWorkUnitRefs = duplicateRefs(workUnitRefs)
+  return {
+    assignmentRefs,
+    completedAt: input.completedAt,
+    duplicateWorkUnitRefs,
+    pylonRef: input.snapshot?.pylonRef ?? null,
+    refillsObserved: Math.max(0, assignmentRefs.length - input.plan.targetWorkers),
+    run: input.snapshot?.run ?? null,
+    runObservedDurationMs: Math.max(0, input.observedAt.getTime() - Date.parse(input.startedAt)),
+    startedAt: input.startedAt,
+    workUnitRefs: dedupe(workUnitRefs),
+  }
+}
+
+function preCloseoutEvidenceFailures(
+  plan: FleetRunSmokePlan,
+  evidence: Omit<FleetRunSmokeEvidence, "closeouts" | "publicCounterReconciliation" | "tokenRows" | "totalTokens">,
+): readonly string[] {
+  const failures: string[] = []
+  const run = evidence.run
+  if (run === null) {
+    failures.push("fleet run snapshot was not observed")
+    return failures
+  }
+  if (run.state !== "completed") failures.push(`expected completed fleet run, got ${run.state}`)
+  if (run.targetConcurrency < plan.targetWorkers) {
+    failures.push(`expected target concurrency ${plan.targetWorkers}, got ${run.targetConcurrency}`)
+  }
+  if (run.counters.completedAssignments < plan.requiredCloseouts) {
+    failures.push(`expected at least ${plan.requiredCloseouts} completed assignments, got ${run.counters.completedAssignments}`)
+  }
+  if (run.counters.failedAssignments !== 0) {
+    failures.push(`expected zero failed assignments, got ${run.counters.failedAssignments}`)
+  }
+  if (run.counters.blockedAssignments !== 0) {
+    failures.push(`expected zero blocked assignments, got ${run.counters.blockedAssignments}`)
+  }
+  if (evidence.assignmentRefs.length < plan.requiredCloseouts) {
+    failures.push(`expected at least ${plan.requiredCloseouts} assignment refs, got ${evidence.assignmentRefs.length}`)
+  }
+  if (evidence.duplicateWorkUnitRefs.length > 0) {
+    failures.push(`expected zero duplicate work-unit claims, saw ${evidence.duplicateWorkUnitRefs.join(", ")}`)
+  }
+  if (plan.minDurationMs !== null && evidence.runObservedDurationMs < plan.minDurationMs) {
+    failures.push(`expected sustained run duration >= ${plan.minDurationMs}ms, got ${evidence.runObservedDurationMs}ms`)
+  }
+  if (plan.minRefills > 0 && evidence.refillsObserved < plan.minRefills) {
+    failures.push(`expected at least ${plan.minRefills} refill(s), got ${evidence.refillsObserved}`)
+  }
+  return failures
+}
+
+function closeoutEvidenceFailures(plan: FleetRunSmokePlan, evidence: FleetRunSmokeEvidence): readonly string[] {
+  const failures: string[] = []
+  if (evidence.closeouts.length < plan.requiredCloseouts) {
+    failures.push(`expected at least ${plan.requiredCloseouts} closeout(s), got ${evidence.closeouts.length}`)
+  }
+  for (const closeout of evidence.closeouts) {
+    if (!closeout.ok || !closeout.closeoutChecklistOk || !closeout.proofChecklistOk) {
+      failures.push(`closeout checklist failed for ${closeout.assignmentRef}`)
+    }
+    if (closeout.statusState !== "closed_out") {
+      failures.push(`expected ${closeout.assignmentRef} to be closed_out, got ${closeout.statusState ?? "unknown"}`)
+    }
+    if (closeout.usageTruth !== "exact") {
+      failures.push(`expected exact token rows for ${closeout.assignmentRef}, got ${closeout.usageTruth ?? "unknown"}`)
+    }
+    if (closeout.demandSource !== "khala_coding_delegation") {
+      failures.push(`expected khala_coding_delegation demand source for ${closeout.assignmentRef}`)
+    }
+    if (closeout.tokenRows <= 0 || closeout.totalTokens <= 0 || closeout.tokenRefs.length < Math.min(closeout.tokenRows, 100)) {
+      failures.push(`expected positive exact token row evidence for ${closeout.assignmentRef}`)
+    }
+    if (closeout.traceCount <= 0 || closeout.rawEventCount <= 0) {
+      failures.push(`expected owner trace and raw-event evidence for ${closeout.assignmentRef}`)
+    }
+    for (const blocker of closeout.blockerRefs) failures.push(`${closeout.assignmentRef}: ${blocker}`)
+  }
+  if (evidence.tokenRows <= 0 || evidence.totalTokens <= 0) {
+    failures.push("expected aggregate exact token rows and verified tokens to be positive")
+  }
+  if (evidence.publicCounterReconciliation.state !== "checked") {
+    failures.push(`public counter reconciliation unavailable: ${evidence.publicCounterReconciliation.reason}`)
+  } else if (!evidence.publicCounterReconciliation.ok) {
+    failures.push(
+      `expected public counter delta >= ${evidence.publicCounterReconciliation.expectedMinimumDelta}, got ${evidence.publicCounterReconciliation.delta}`,
+    )
+  }
+  return failures
+}
+
+function assignmentRefsFromLifecycleEvent(event: FleetRunSmokeLifecycleEvent): readonly string[] {
+  if (event.kind === "dispatch" && typeof event.assignmentRef === "string") return [event.assignmentRef]
+  const nested = recordField(event, "event")
+  const assignmentRef = stringField(nested, "assignmentRef")
+  return assignmentRef === null ? [] : [assignmentRef]
+}
+
+function workUnitRefsFromLifecycleEvent(event: FleetRunSmokeLifecycleEvent): readonly string[] {
+  if (event.kind !== "dispatch") return []
+  const workUnitRef = stringField(event, "workUnitRef")
+  const status = stringField(event, "status")
+  return workUnitRef === null || status === "failed" ? [] : [workUnitRef]
+}
+
+function singleSnapshot(value: FleetRunSmokeSnapshot | readonly FleetRunSmokeSnapshot[]): FleetRunSmokeSnapshot {
+  if (Array.isArray(value)) throw new Error("expected one fleet run snapshot")
+  return value as FleetRunSmokeSnapshot
+}
+
+function objectiveFor(plan: FleetRunSmokePlan): string {
+  return [
+    `${plan.smoke}: supervised live FleetRun evidence run.`,
+    `Work source: ${plan.repo ?? "unknown repo"} issue_list.`,
+    `Pinned base: ${plan.branch}@${plan.commit ?? "unknown commit"}.`,
+    `Verify command: ${plan.verify ?? "unknown verify"}.`,
+    "Each worker must open exactly one PR for its assigned issue and include verify-green evidence.",
+    "Do not claim work outside the assigned issue; respect the FleetRun claim ref and close out with exact token accounting.",
+  ].join("\n")
+}
+
+function expectedCloseoutFor(
+  config: FleetRunSmokeConfig,
+  targetWorkers: number,
+  minDurationMinutes: number | null,
+  minRefills: number,
+): readonly string[] {
+  if (config.kind === "live") {
+    return [
+      "two real workers accepted by the supervised FleetRun",
+      "two distinct assignment refs close out successfully",
+      "each closeout checklist proves exact token_usage_events rows",
+      "public /api/public/khala-tokens-served delta reconciles to the exact closeout total",
+      "zero duplicate live work-unit claims",
+    ]
+  }
+  return [
+    `${targetWorkers} or more real workers accepted by the supervised FleetRun`,
+    `run remains active long enough to prove at least ${minDurationMinutes} minutes of sustained execution`,
+    `${minRefills} or more refill assignments close out after the first target wave`,
+    "each closeout checklist proves exact token_usage_events rows",
+    "public /api/public/khala-tokens-served delta reconciles to the exact closeout total",
+    "zero duplicate live work-unit claims",
+  ]
+}
+
+function requiredEnvList(config: FleetRunSmokeConfig): readonly string[] {
+  return [
+    `${config.envPrefix}_PYLON_REF`,
+    `${config.envPrefix}_ISSUES`,
+    `${config.envPrefix}_REPO`,
+    `${config.envPrefix}_COMMIT`,
+    `${config.envPrefix}_VERIFY`,
+    "OPENAGENTS_AGENT_TOKEN",
+  ]
+}
+
+function parseIssues(value: string | null, key: string, failures: string[]): readonly number[] {
+  if (value === null) return []
+  const issues = value.split(",").map(part => Number(part.trim()))
+  if (issues.length === 0 || issues.some(issue => !Number.isInteger(issue) || issue <= 0)) {
+    failures.push(`${key} must contain positive issue numbers`)
+    return []
+  }
+  if (new Set(issues).size !== issues.length) {
+    failures.push(`${key} must name distinct issues`)
+  }
+  return issues
+}
+
+function requireTrimmed(env: FleetRunSmokeEnv, key: string, armEnv: string, failures: string[]): string | null {
+  const value = env[key]?.trim()
+  if (value === undefined || value === "") {
+    failures.push(`${key} is required when ${armEnv}=1`)
+    return null
+  }
+  return value
+}
+
+function parseOptionalInteger(value: string | undefined, fallback: number, key: string, failures: string[]): number {
+  if (value === undefined || value.trim() === "") return fallback
+  const parsed = Number(value.trim())
+  if (!Number.isInteger(parsed)) {
+    failures.push(`${key} must be an integer`)
+    return fallback
+  }
+  return parsed
+}
+
+function firstTrimmed(values: readonly (string | undefined)[]): string {
+  for (const value of values) {
+    const trimmed = value?.trim()
+    if (trimmed !== undefined && trimmed !== "") return trimmed
+  }
+  return ""
+}
+
+function compactTimestamp(now: Date): string {
+  return now.toISOString().replace(/[^0-9]/gu, "").slice(0, 14)
+}
+
+function publicCounterUrl(baseUrl: string): string {
+  return new URL("/api/public/khala-tokens-served", baseUrl).toString()
+}
+
+async function fetchPublicKhalaTokensServed(
+  url: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<number | Error> {
+  try {
+    const response = await fetchImpl(url, { headers: { accept: "application/json" } })
+    if (!response.ok) return new Error(`counter query failed (${response.status})`)
+    const payload = await response.json() as Record<string, unknown>
+    const value = payload.tokensServed
+    return typeof value === "number" && Number.isFinite(value)
+      ? Math.max(0, Math.trunc(value))
+      : new Error("counter payload missing numeric tokensServed")
+  } catch (error) {
+    return error instanceof Error ? error : new Error(String(error))
+  }
+}
+
+function reconcilePublicCounter(
+  url: string,
+  before: number | Error,
+  after: number | Error,
+  expectedMinimumDelta: number,
+): FleetRunSmokeCounterReconciliation {
+  if (before instanceof Error) return { ok: false, reason: before.message, state: "unavailable", url }
+  if (after instanceof Error) return { ok: false, reason: after.message, state: "unavailable", url }
+  const delta = Math.max(0, after - before)
+  return {
+    afterTokensServed: after,
+    beforeTokensServed: before,
+    delta,
+    expectedMinimumDelta,
+    ok: delta >= expectedMinimumDelta,
+    state: "checked",
+    url,
+  }
+}
+
+function resolveBunExecutable(env: FleetRunSmokeEnv): string {
+  return firstTrimmed([env.OPENAGENTS_BUN_PATH, process.execPath, "bun"])
+}
+
+function pylonAppDir(): string {
+  return resolve(dirname(fileURLToPath(import.meta.url)), "..")
+}
+
+function cleanEnv(env: FleetRunSmokeEnv): Record<string, string> {
+  const out: Record<string, string> = {}
+  for (const [key, value] of Object.entries({ ...process.env, ...env })) {
+    if (value !== undefined) out[key] = value
+  }
+  return out
+}
+
+export function redactSmokeText(text: string): string {
+  return text
+    .replace(/Bearer\s+[A-Za-z0-9._~+/-]+/gu, "Bearer <redacted>")
+    .replace(/oa_agent_[A-Za-z0-9._~+/-]+/gu, "oa_agent_<redacted>")
+    .replace(/(OPENAGENTS_AGENT_TOKEN=)[^\s]+/gu, "$1<redacted>")
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}
+
+function duplicateRefs(values: readonly string[]): readonly string[] {
+  const counts = new Map<string, number>()
+  for (const value of values) counts.set(value, (counts.get(value) ?? 0) + 1)
+  return [...counts.entries()].flatMap(([value, count]) => count > 1 ? [value] : [])
+}
+
+function dedupe(values: readonly string[]): readonly string[] {
+  return [...new Set(values.filter(value => value.trim() !== ""))]
+}
+
+function record(value: unknown): Record<string, unknown> | null {
+  return typeof value === "object" && value !== null ? value as Record<string, unknown> : null
+}
+
+function recordField(source: Record<string, unknown> | null, field: string): Record<string, unknown> | null {
+  return record(source?.[field])
+}
+
+function stringField(source: Record<string, unknown> | null, field: string): string | null {
+  const value = source?.[field]
+  return typeof value === "string" ? value : null
+}
+
+function numberField(source: Record<string, unknown> | null, field: string): number | null {
+  const value = source?.[field]
+  return typeof value === "number" && Number.isFinite(value) ? value : null
+}
+
+function booleanField(source: Record<string, unknown> | null, field: string): boolean | null {
+  const value = source?.[field]
+  return typeof value === "boolean" ? value : null
+}
+
+function stringArrayField(source: Record<string, unknown> | null, field: string): readonly string[] {
+  const value = source?.[field]
+  return Array.isArray(value) ? value.filter((item): item is string => typeof item === "string") : []
+}

--- a/apps/pylon/tests/fleet-run-live-smoke.test.ts
+++ b/apps/pylon/tests/fleet-run-live-smoke.test.ts
@@ -1,0 +1,292 @@
+import { describe, expect, test } from "bun:test"
+import {
+  buildFleetRunSmokePlan,
+  closeoutEvidenceFromPayload,
+  runFleetRunSmokeFromEnv,
+  type FleetRunSmokeCloseoutEvidence,
+  type FleetRunSmokeManager,
+  type FleetRunSmokeSnapshot,
+} from "../src/fleet-run-live-smoke"
+
+const commit = "0123456789abcdef0123456789abcdef01234567"
+
+const liveEnv = {
+  OPENAGENTS_AGENT_TOKEN: "oa_agent_secret",
+  PYLON_FLEET_RUN_LIVE_ARM: "1",
+  PYLON_FLEET_RUN_LIVE_COMMIT: commit,
+  PYLON_FLEET_RUN_LIVE_ISSUES: "7854,7900",
+  PYLON_FLEET_RUN_LIVE_POLL_MS: "100",
+  PYLON_FLEET_RUN_LIVE_PYLON_REF: "pylon.local.test",
+  PYLON_FLEET_RUN_LIVE_REPO: "OpenAgentsInc/openagents",
+  PYLON_FLEET_RUN_LIVE_VERIFY: "bun test apps/pylon/tests/fleet-run-live-smoke.test.ts",
+}
+
+const sustainedEnv = {
+  OPENAGENTS_AGENT_TOKEN: "oa_agent_secret",
+  PYLON_FLEET_RUN_SUSTAINED_ARM: "1",
+  PYLON_FLEET_RUN_SUSTAINED_COMMIT: commit,
+  PYLON_FLEET_RUN_SUSTAINED_ISSUES: "7854,7900,7901,7902,7904,7905,7906",
+  PYLON_FLEET_RUN_SUSTAINED_POLL_MS: "100",
+  PYLON_FLEET_RUN_SUSTAINED_PYLON_REF: "pylon.local.test",
+  PYLON_FLEET_RUN_SUSTAINED_REPO: "OpenAgentsInc/openagents",
+  PYLON_FLEET_RUN_SUSTAINED_VERIFY: "bun test apps/pylon/tests/fleet-run-live-smoke.test.ts",
+}
+
+const snapshot = (input: {
+  readonly assignmentRefs?: readonly string[]
+  readonly completedAssignments?: number
+  readonly state?: string
+  readonly targetConcurrency?: number
+  readonly workUnitRefs?: readonly string[]
+}): FleetRunSmokeSnapshot => ({
+  active: input.state !== "completed",
+  lifecycle: (input.assignmentRefs ?? []).map((assignmentRef, index) => ({
+    assignmentRef,
+    claimRef: `claim.test.${index}`,
+    kind: "dispatch",
+    status: "completed",
+    workUnitRef: input.workUnitRefs?.[index] ?? `github.issue.${index}`,
+  })),
+  pylonRef: "pylon.local.test",
+  run: {
+    counters: {
+      activeAssignments: 0,
+      blockedAssignments: 0,
+      completedAssignments: input.completedAssignments ?? input.assignmentRefs?.length ?? 0,
+      failedAssignments: 0,
+      workUnitsTotal: input.assignmentRefs?.length ?? 0,
+    },
+    runRef: "fleet_run.test",
+    state: input.state ?? "completed",
+    targetConcurrency: input.targetConcurrency ?? 2,
+    workerKind: "codex",
+    workSource: "issue_list",
+  },
+})
+
+const managerReturning = (snapshots: readonly FleetRunSmokeSnapshot[]): FleetRunSmokeManager => {
+  let index = 0
+  return {
+    start: async () => snapshots[0] ?? snapshot({}),
+    status: async () => {
+      index = Math.min(index + 1, snapshots.length - 1)
+      return snapshots[index] ?? snapshots[0] ?? snapshot({})
+    },
+  }
+}
+
+const closeout = (
+  assignmentRef: string,
+  overrides: Partial<FleetRunSmokeCloseoutEvidence> = {},
+): FleetRunSmokeCloseoutEvidence => ({
+  assignmentRef,
+  blockerRefs: [],
+  closeoutChecklistOk: true,
+  demandSource: "khala_coding_delegation",
+  ok: true,
+  proofChecklistOk: true,
+  rawEventCount: 1,
+  statusState: "closed_out",
+  tokenRefs: [`d1:token_usage_events:${assignmentRef}`],
+  tokenRows: 1,
+  totalTokens: 100,
+  traceCount: 1,
+  usageTruth: "exact",
+  ...overrides,
+})
+
+const counterFetch = (values: number[]): typeof fetch => async () =>
+  new Response(JSON.stringify({ tokensServed: values.shift() ?? values.at(-1) ?? 0 }), {
+    headers: { "Content-Type": "application/json" },
+  })
+
+describe("fleet run live smoke", () => {
+  test("skips by default without constructing a live supervisor", async () => {
+    const result = await runFleetRunSmokeFromEnv("live", {
+      createManager: () => {
+        throw new Error("manager should not be constructed for an unarmed smoke")
+      },
+      env: {},
+    })
+
+    expect(result.ok).toBe(true)
+    expect(result.skipped).toBe(true)
+    expect(result.message).toContain("Skipped by default")
+  })
+
+  test("validates live pins and issue cardinality before dispatch", async () => {
+    const result = await runFleetRunSmokeFromEnv("live", {
+      env: {
+        ...liveEnv,
+        PYLON_FLEET_RUN_LIVE_COMMIT: "not-a-sha",
+        PYLON_FLEET_RUN_LIVE_ISSUES: "7854,7854,7900",
+        PYLON_FLEET_RUN_LIVE_TARGET: "3",
+      },
+    })
+
+    expect(result.ok).toBe(false)
+    expect(result.failures).toContain("PYLON_FLEET_RUN_LIVE_COMMIT must be a pinned 40-character commit SHA")
+    expect(result.failures).toContain("PYLON_FLEET_RUN_LIVE_ISSUES must name distinct issues")
+    expect(result.failures).toContain("PYLON_FLEET_RUN_LIVE_ISSUES must contain exactly 2 positive issue numbers")
+    expect(result.failures).toContain("PYLON_FLEET_RUN_LIVE_TARGET must be exactly 2")
+  })
+
+  test("passes live smoke only with exact closeouts and public counter reconciliation", async () => {
+    const result = await runFleetRunSmokeFromEnv("live", {
+      closeoutReader: async assignmentRef => closeout(assignmentRef),
+      env: liveEnv,
+      fetch: counterFetch([1_000, 1_250]),
+      manager: managerReturning([
+        snapshot({
+          assignmentRefs: ["assignment.public.one", "assignment.public.two"],
+          completedAssignments: 2,
+          targetConcurrency: 2,
+          workUnitRefs: ["issue.7854", "issue.7900"],
+        }),
+      ]),
+    })
+
+    expect(result.ok).toBe(true)
+    expect(result.skipped).toBe(false)
+    expect(result.evidence?.closeouts).toHaveLength(2)
+    expect(result.evidence?.tokenRows).toBe(2)
+    expect(result.evidence?.totalTokens).toBe(200)
+    expect(result.evidence?.publicCounterReconciliation).toMatchObject({
+      delta: 250,
+      expectedMinimumDelta: 200,
+      ok: true,
+      state: "checked",
+    })
+  })
+
+  test("fails when duplicate work-unit claims are observed", async () => {
+    const result = await runFleetRunSmokeFromEnv("live", {
+      closeoutReader: async assignmentRef => closeout(assignmentRef),
+      env: liveEnv,
+      fetch: counterFetch([1_000, 1_300]),
+      manager: managerReturning([
+        snapshot({
+          assignmentRefs: ["assignment.public.one", "assignment.public.two"],
+          completedAssignments: 2,
+          workUnitRefs: ["issue.7854", "issue.7854"],
+        }),
+      ]),
+    })
+
+    expect(result.ok).toBe(false)
+    expect(result.failures.join("\n")).toContain("expected zero duplicate work-unit claims")
+  })
+
+  test("does not accept public counter movement without exact closeout rows", async () => {
+    const result = await runFleetRunSmokeFromEnv("live", {
+      closeoutReader: async assignmentRef => closeout(assignmentRef, {
+        tokenRefs: [],
+        tokenRows: 0,
+        totalTokens: 0,
+      }),
+      env: liveEnv,
+      fetch: counterFetch([1_000, 2_000]),
+      manager: managerReturning([
+        snapshot({
+          assignmentRefs: ["assignment.public.one", "assignment.public.two"],
+          completedAssignments: 2,
+        }),
+      ]),
+    })
+
+    expect(result.ok).toBe(false)
+    expect(result.failures.join("\n")).toContain("expected positive exact token row evidence")
+    expect(result.failures.join("\n")).toContain("expected aggregate exact token rows and verified tokens to be positive")
+  })
+
+  test("enforces sustained thresholds before dispatch", async () => {
+    const result = await runFleetRunSmokeFromEnv("sustained", {
+      env: {
+        ...sustainedEnv,
+        PYLON_FLEET_RUN_SUSTAINED_DURATION_MINUTES: "29",
+        PYLON_FLEET_RUN_SUSTAINED_ISSUES: "7854,7900,7901,7902,7904,7905",
+        PYLON_FLEET_RUN_SUSTAINED_MIN_REFILLS: "1",
+        PYLON_FLEET_RUN_SUSTAINED_TARGET: "4",
+      },
+    })
+
+    expect(result.ok).toBe(false)
+    expect(result.failures).toContain("PYLON_FLEET_RUN_SUSTAINED_TARGET must be at least 5")
+    expect(result.failures).toContain("PYLON_FLEET_RUN_SUSTAINED_MIN_REFILLS must be at least 2")
+    expect(result.failures).toContain("PYLON_FLEET_RUN_SUSTAINED_DURATION_MINUTES must be at least 30")
+    expect(result.failures).toContain("PYLON_FLEET_RUN_SUSTAINED_ISSUES must contain at least 7 distinct issue numbers")
+  })
+
+  test("passes sustained smoke after duration, refill, closeout, and counter evidence", async () => {
+    let current = new Date("2026-07-02T00:00:00.000Z")
+    const refs = Array.from({ length: 7 }, (_, index) => `assignment.public.${index + 1}`)
+    const result = await runFleetRunSmokeFromEnv("sustained", {
+      closeoutReader: async assignmentRef => closeout(assignmentRef),
+      env: sustainedEnv,
+      fetch: counterFetch([10_000, 10_900]),
+      manager: managerReturning([
+        snapshot({
+          assignmentRefs: refs.slice(0, 5),
+          completedAssignments: 5,
+          state: "running",
+          targetConcurrency: 5,
+        }),
+        snapshot({
+          assignmentRefs: refs,
+          completedAssignments: 7,
+          state: "completed",
+          targetConcurrency: 5,
+        }),
+      ]),
+      now: () => current,
+      sleep: async () => {
+        current = new Date(current.getTime() + 30 * 60 * 1000)
+      },
+    })
+
+    expect(result.ok).toBe(true)
+    expect(result.evidence?.refillsObserved).toBe(2)
+    expect(result.evidence?.runObservedDurationMs).toBe(30 * 60 * 1000)
+    expect(result.evidence?.closeouts).toHaveLength(7)
+  })
+
+  test("parses closeout checklist evidence from pylon khala closeout output", () => {
+    const evidence = closeoutEvidenceFromPayload("assignment.public.one", {
+      closeoutChecklist: { blockerRefs: [], ok: true },
+      ok: true,
+      proof: {
+        proofChecklist: { blockerRefs: [], ok: true },
+        rawEvents: { eventCount: 1 },
+        tokenUsage: {
+          demandSource: "khala_coding_delegation",
+          refs: ["d1:token_usage_events:one"],
+          rowCount: 1,
+          totalTokens: 123,
+          usageTruth: "exact",
+        },
+        traces: { count: 1 },
+      },
+      status: { progress: { state: "closed_out" } },
+    })
+
+    expect(evidence).toMatchObject({
+      assignmentRef: "assignment.public.one",
+      closeoutChecklistOk: true,
+      demandSource: "khala_coding_delegation",
+      statusState: "closed_out",
+      tokenRows: 1,
+      totalTokens: 123,
+      usageTruth: "exact",
+    })
+  })
+
+  test("builds sustained plan with the documented defaults", () => {
+    const plan = buildFleetRunSmokePlan("sustained", {}, new Date("2026-07-02T00:00:00.000Z"))
+
+    expect(plan.armed).toBe(false)
+    expect(plan.targetWorkers).toBe(5)
+    expect(plan.minDurationMinutes).toBe(30)
+    expect(plan.minRefills).toBe(2)
+    expect(plan.requiredCloseouts).toBe(7)
+  })
+})

--- a/clients/khala-code-desktop/src/bun/khala-fleet-tools.ts
+++ b/clients/khala-code-desktop/src/bun/khala-fleet-tools.ts
@@ -1411,6 +1411,8 @@ export class DefaultKhalaFleetRunSupervisorManager implements KhalaFleetRunSuper
   private readonly store: PylonOrchestrationStore
   private readonly active = new Map<string, ActiveFleetRun>()
   private readonly planConfigs = new Map<string, FleetRunPlanConfig>()
+  private readonly retainedLifecycle = new Map<string, readonly FleetRunSupervisorObservedEvent[]>()
+  private readonly retainedPylonRefs = new Map<string, string>()
 
   constructor(private readonly options: KhalaCodexFleetToolOptions) {
     this.store = createPylonOrchestrationStore(new Database(":memory:"))
@@ -1545,6 +1547,8 @@ export class DefaultKhalaFleetRunSupervisorManager implements KhalaFleetRunSuper
   private async releaseActive(runRef: string, knownActive?: ActiveFleetRun): Promise<void> {
     const active = knownActive ?? this.active.get(runRef)
     if (active === undefined) return
+    this.retainedLifecycle.set(runRef, [...active.lifecycle])
+    this.retainedPylonRefs.set(runRef, active.pylonRef)
     this.active.delete(runRef)
     await Effect.runPromise(Effect.exit(active.handle.stop()))
     await Effect.runPromise(Scope.close(active.scope, Exit.void))
@@ -1650,8 +1654,8 @@ export class DefaultKhalaFleetRunSupervisorManager implements KhalaFleetRunSuper
     return {
       active: active !== undefined,
       lastTick: active?.lastTick ?? null,
-      lifecycle: [...(active?.lifecycle ?? [])],
-      pylonRef: active?.pylonRef ?? null,
+      lifecycle: [...(active?.lifecycle ?? this.retainedLifecycle.get(runRef) ?? [])],
+      pylonRef: active?.pylonRef ?? this.retainedPylonRefs.get(runRef) ?? null,
       run,
     }
   }

--- a/clients/khala-code-desktop/tests/khala-fleet-tools.test.ts
+++ b/clients/khala-code-desktop/tests/khala-fleet-tools.test.ts
@@ -378,8 +378,9 @@ describe("Khala Code fleet tools", () => {
 
   test("DefaultKhalaFleetRunSupervisorManager releases a Pylon slot after natural completion", async () => {
     const fixture = await tempPylonFixture()
+    const firstAssignmentRef = "assignment.public.codex_agent_task.completed_one"
     const spawnRefs = [
-      "assignment.public.codex_agent_task.completed_one",
+      firstAssignmentRef,
       "assignment.public.codex_agent_task.completed_two",
     ]
     const runner = async (input: KhalaCodexFleetCommandInput): Promise<KhalaCodexFleetCommandResult> => {
@@ -461,6 +462,7 @@ describe("Khala Code fleet tools", () => {
 
     expect(first.run.state).toBe("completed")
     expect(first.active).toBe(false)
+    expect(first.lifecycle.some(event => event.kind === "dispatch" && event.assignmentRef === firstAssignmentRef)).toBe(true)
     expect(second.run.state).toBe("completed")
     expect(second.active).toBe(false)
   })


### PR DESCRIPTION
Closes #7854.

## What changed

- Replaced the placeholder live FleetRun smoke with an env-armed runner that starts a supervised issue-list FleetRun and fails closed unless real assignment closeouts prove exact token rows, owner trace/raw-event evidence, zero duplicate work-unit claims, and public counter reconciliation.
- Added `smoke:fleet-run-sustained` with the same proof chain plus target 5, 30 minute minimum duration, at least 2 refills, and at least 7 distinct issue numbers.
- Retained completed FleetRun lifecycle/pylon refs after supervisor release so terminal snapshots still expose dispatch evidence for smoke verification.
- Documented the operator-only, skip-safe smoke contract in `apps/pylon/README.md`.

## Validation

- `git diff --check`
- `bun run --cwd apps/pylon typecheck`
- `bun run --cwd clients/khala-code-desktop typecheck`
- `bun test apps/pylon/tests/fleet-run-live-smoke.test.ts clients/khala-code-desktop/tests/khala-fleet-tools.test.ts` — 40 pass, 0 fail
- `bun run --cwd apps/pylon smoke:fleet-run-live` — skip-safe by default
- `bun run --cwd apps/pylon smoke:fleet-run-sustained` — skip-safe by default
- `bun run --cwd apps/pylon test` — 2046 pass, 3 skip, 0 fail
- `bun run --cwd apps/openagents.com check:deploy` — passed
