### PR TITLE
Implement Codex app-server Effect service

### DIFF
--- a/clients/khala-code-desktop/src/bun/codex-app-server-service.ts
+++ b/clients/khala-code-desktop/src/bun/codex-app-server-service.ts
@@ -1,0 +1,315 @@
+import { Context, Effect, Layer, Queue, Schema as S, Scope, Stream } from "effect"
+
+import {
+  createCodexAppServerHost,
+  type CodexAppServerHost,
+  type CodexAppServerNotification,
+  type CreateCodexAppServerHostOptions,
+} from "./codex-app-server-client.js"
+
+type JsonRpcId = number | string
+
+type CodexAppServerRequestOutcome<Result> =
+  | { readonly ok: true; readonly value: Result }
+  | {
+      readonly error: CodexAppServerUnavailable | CodexAppServerRpcFailure | CodexAppServerRpcTimeout
+      readonly ok: false
+    }
+
+export const CodexAppServerRpcIdSchema = S.Union([S.Number, S.String])
+export type CodexAppServerRpcId = typeof CodexAppServerRpcIdSchema.Type
+
+export const CodexAppServerNotificationSchema = S.Struct({
+  id: S.optional(CodexAppServerRpcIdSchema),
+  method: S.String,
+  params: S.Unknown,
+  receivedAt: S.String,
+})
+export type CodexAppServerDecodedNotification = typeof CodexAppServerNotificationSchema.Type
+
+export class CodexAppServerUnavailable extends S.TaggedErrorClass<CodexAppServerUnavailable>()(
+  "CodexAppServerUnavailable",
+  {
+    message: S.String,
+  },
+) {}
+
+export class CodexAppServerRpcFailure extends S.TaggedErrorClass<CodexAppServerRpcFailure>()(
+  "CodexAppServerRpcFailure",
+  {
+    message: S.String,
+    method: S.String,
+  },
+) {}
+
+export class CodexAppServerRpcTimeout extends S.TaggedErrorClass<CodexAppServerRpcTimeout>()(
+  "CodexAppServerRpcTimeout",
+  {
+    interruptAttempted: S.Boolean,
+    interruptOk: S.Boolean,
+    message: S.String,
+    method: S.String,
+    timeoutMs: S.Number,
+  },
+) {}
+
+export class CodexAppServerDecodeFailure extends S.TaggedErrorClass<CodexAppServerDecodeFailure>()(
+  "CodexAppServerDecodeFailure",
+  {
+    boundary: S.Literals(["response", "notification"]),
+    message: S.String,
+    method: S.String,
+  },
+) {}
+
+export class CodexAppServerControlFailure extends S.TaggedErrorClass<CodexAppServerControlFailure>()(
+  "CodexAppServerControlFailure",
+  {
+    action: S.Literals(["start", "stop", "restart"]),
+    message: S.String,
+  },
+) {}
+
+export type CodexAppServerFailure =
+  | CodexAppServerUnavailable
+  | CodexAppServerRpcFailure
+  | CodexAppServerRpcTimeout
+  | CodexAppServerDecodeFailure
+  | CodexAppServerControlFailure
+
+export type CodexAppServerInterruptOnTimeout = Readonly<{
+  readonly threadId: string
+  readonly turnId?: string
+}>
+
+export type CodexAppServerRequestOptions = Readonly<{
+  readonly interruptOnTimeout?: CodexAppServerInterruptOnTimeout
+  readonly interruptTimeoutMs?: number
+  readonly timeoutMs?: number
+}>
+
+export type CodexAppServerServiceShape = Readonly<{
+  readonly dispose: Effect.Effect<void>
+  readonly notifications: () => Stream.Stream<CodexAppServerDecodedNotification, CodexAppServerDecodeFailure>
+  readonly request: <Result = unknown>(
+    method: string,
+    params?: unknown,
+    options?: CodexAppServerRequestOptions,
+  ) => Effect.Effect<Result, CodexAppServerUnavailable | CodexAppServerRpcFailure | CodexAppServerRpcTimeout>
+  readonly requestDecoded: <Result>(
+    schema: S.Decoder<Result>,
+    method: string,
+    params?: unknown,
+    options?: CodexAppServerRequestOptions,
+  ) => Effect.Effect<Result, CodexAppServerUnavailable | CodexAppServerRpcFailure | CodexAppServerRpcTimeout | CodexAppServerDecodeFailure>
+  readonly respondToServerRequest: (
+    id: JsonRpcId,
+    result: unknown,
+  ) => Effect.Effect<void, CodexAppServerUnavailable | CodexAppServerRpcFailure>
+  readonly restart: Effect.Effect<void, CodexAppServerControlFailure>
+  readonly start: Effect.Effect<void, CodexAppServerControlFailure>
+  readonly status: CodexAppServerHost["status"]
+  readonly stop: Effect.Effect<void, CodexAppServerControlFailure>
+}>
+
+const errorMessage = (cause: unknown): string =>
+  cause instanceof Error ? cause.message : String(cause)
+
+const isTimeout = (method: string, cause: unknown): boolean =>
+  errorMessage(cause).includes(`Codex app-server request timed out: ${method}`)
+
+const controlFailure = (
+  action: "start" | "stop" | "restart",
+  message: string,
+): CodexAppServerControlFailure =>
+  new CodexAppServerControlFailure({ action, message })
+
+const decodeFailure = (
+  boundary: "response" | "notification",
+  method: string,
+  cause: unknown,
+): CodexAppServerDecodeFailure =>
+  new CodexAppServerDecodeFailure({
+    boundary,
+    message: errorMessage(cause),
+    method,
+  })
+
+const interruptParams = (
+  input: CodexAppServerInterruptOnTimeout,
+): Record<string, string> => ({
+  threadId: input.threadId,
+  ...(input.turnId === undefined ? {} : { turnId: input.turnId }),
+})
+
+const mapRequestFailure = (
+  method: string,
+  cause: unknown,
+): CodexAppServerUnavailable | CodexAppServerRpcFailure => {
+  const message = errorMessage(cause)
+  return message === "Codex app-server is not running"
+    ? new CodexAppServerUnavailable({ message })
+    : new CodexAppServerRpcFailure({ message, method })
+}
+
+const decodeNotification = (
+  notification: CodexAppServerNotification,
+): Effect.Effect<CodexAppServerDecodedNotification, CodexAppServerDecodeFailure> =>
+  S.decodeUnknownEffect(CodexAppServerNotificationSchema)(notification).pipe(
+    Effect.mapError(cause => decodeFailure("notification", notification.method, cause)),
+  )
+
+const requestEffect = <Result>(
+  host: CodexAppServerHost,
+  method: string,
+  params: unknown,
+  options: CodexAppServerRequestOptions,
+): Effect.Effect<Result, CodexAppServerUnavailable | CodexAppServerRpcFailure | CodexAppServerRpcTimeout> =>
+  Effect.promise(async (): Promise<CodexAppServerRequestOutcome<Result>> => {
+    try {
+      return {
+        ok: true as const,
+        value: await host.request<Result>(
+          method,
+          params,
+          options.timeoutMs === undefined ? {} : { timeoutMs: options.timeoutMs },
+        ),
+      }
+    } catch (cause) {
+      const error = mapRequestFailure(method, cause)
+      if (!(error instanceof CodexAppServerRpcFailure) || !isTimeout(method, error.message)) {
+        return { error, ok: false as const }
+      }
+      const interruptOnTimeout = options.interruptOnTimeout
+      if (interruptOnTimeout === undefined) {
+        return {
+          error: new CodexAppServerRpcTimeout({
+            interruptAttempted: false,
+            interruptOk: false,
+            message: error.message,
+            method,
+            timeoutMs: options.timeoutMs ?? 0,
+          }),
+          ok: false as const,
+        }
+      }
+      const interruptOk = await host.request(
+        "turn/interrupt",
+        interruptParams(interruptOnTimeout),
+        { timeoutMs: options.interruptTimeoutMs ?? 5_000 },
+      ).then(
+        () => true,
+        () => false,
+      )
+      return {
+        error: new CodexAppServerRpcTimeout({
+          interruptAttempted: true,
+          interruptOk,
+          message: error.message,
+          method,
+          timeoutMs: options.timeoutMs ?? 0,
+        }),
+        ok: false as const,
+      }
+    }
+  }).pipe(
+    Effect.flatMap(result =>
+      result.ok
+        ? Effect.succeed(result.value)
+        : Effect.fail(result.error)
+    ),
+  )
+
+export const makeCodexAppServerServiceFromHost = (
+  host: CodexAppServerHost,
+): CodexAppServerServiceShape => {
+  const request: CodexAppServerServiceShape["request"] = <Result = unknown>(
+    method: string,
+    params: unknown = {},
+    options: CodexAppServerRequestOptions = {},
+  ) => requestEffect<Result>(host, method, params, options)
+
+  const requestDecoded: CodexAppServerServiceShape["requestDecoded"] = <Result>(
+    schema: S.Decoder<Result>,
+    method: string,
+    params: unknown = {},
+    options: CodexAppServerRequestOptions = {},
+  ) =>
+    request<unknown>(method, params, options).pipe(
+      Effect.flatMap(value =>
+        S.decodeUnknownEffect(schema)(value).pipe(
+          Effect.mapError(cause => decodeFailure("response", method, cause)),
+        )
+      ),
+    )
+
+  const notifications = (): Stream.Stream<CodexAppServerDecodedNotification, CodexAppServerDecodeFailure> =>
+    Stream.unwrap(
+      Effect.map(Queue.unbounded<CodexAppServerNotification>(), queue => {
+        const unsubscribe = host.subscribe(notification => {
+          Queue.offerUnsafe(queue, notification)
+        })
+        return Stream.fromQueue(queue).pipe(
+          Stream.mapEffect(decodeNotification),
+          Stream.ensuring(Effect.all([
+            Effect.sync(unsubscribe),
+            Queue.shutdown(queue),
+          ], { discard: true })),
+        )
+      }),
+    )
+
+  const control = (
+    action: "start" | "stop" | "restart",
+    run: () => Promise<{ readonly ok: boolean; readonly error?: string | undefined }>,
+  ): Effect.Effect<void, CodexAppServerControlFailure> =>
+    Effect.tryPromise({
+      catch: cause => controlFailure(action, errorMessage(cause)),
+      try: run,
+    }).pipe(
+      Effect.flatMap(result =>
+        result.ok
+          ? Effect.void
+          : Effect.fail(controlFailure(action, result.error ?? `Codex app-server ${action} failed`))
+      ),
+    )
+
+  return {
+    dispose: Effect.sync(() => host.dispose()),
+    notifications,
+    request,
+    requestDecoded,
+    respondToServerRequest: (id, result) =>
+      Effect.try({
+        catch: cause => mapRequestFailure("respondToServerRequest", cause),
+        try: () => host.respondToServerRequest(id, result),
+      }),
+    restart: control("restart", host.restart),
+    start: control("start", host.start),
+    status: host.status,
+    stop: control("stop", host.stop),
+  }
+}
+
+export const makeCodexAppServerService = (
+  options: CreateCodexAppServerHostOptions = {},
+): CodexAppServerServiceShape =>
+  makeCodexAppServerServiceFromHost(createCodexAppServerHost(options))
+
+export const makeCodexAppServerScoped = (
+  options: CreateCodexAppServerHostOptions = {},
+): Effect.Effect<CodexAppServerServiceShape, never, Scope.Scope> =>
+  Effect.acquireRelease(
+    Effect.sync(() => makeCodexAppServerService(options)),
+    service => service.dispose,
+  )
+
+export class CodexAppServer extends Context.Service<CodexAppServer, CodexAppServerServiceShape>()(
+  "CodexAppServer",
+  { make: Effect.sync(makeCodexAppServerService) },
+) {}
+
+export const CodexAppServerLive = (
+  options: CreateCodexAppServerHostOptions = {},
+) =>
+  Layer.effect(CodexAppServer, makeCodexAppServerScoped(options))

--- a/clients/khala-code-desktop/src/bun/codex-parity-contract.ts
+++ b/clients/khala-code-desktop/src/bun/codex-parity-contract.ts
@@ -58,6 +58,17 @@ export const KHALA_CODE_CODEX_PARITY_COVERAGE: readonly KhalaCodeCodexParityCove
     ],
   },
   {
+    id: "app-server-effect-service",
+    harness: "codex_wrapper_fixture",
+    testFile: "clients/khala-code-desktop/tests/codex-app-server-service.test.ts",
+    covers: [
+      "CodexAppServer Context.Service wrapper",
+      "Schema-decoded response and notification boundaries",
+      "notification Stream subscriber isolation",
+      "timeout interrupt policy and scoped disposal",
+    ],
+  },
+  {
     id: "slash-commands",
     harness: "codex_wrapper_fixture",
     testFile: "clients/khala-code-desktop/tests/codex-slash-commands.test.ts",

--- a/clients/khala-code-desktop/tests/codex-app-server-service.test.ts
+++ b/clients/khala-code-desktop/tests/codex-app-server-service.test.ts
@@ -1,0 +1,231 @@
+import { EventEmitter } from "node:events"
+import { describe, expect, test } from "bun:test"
+import { Cause, Effect, Exit, Option, Schema as S, Stream } from "effect"
+
+import {
+  CodexAppServer,
+  CodexAppServerLive,
+  CodexAppServerDecodeFailure,
+  CodexAppServerRpcTimeout,
+  CodexAppServerUnavailable,
+  makeCodexAppServerService,
+} from "../src/bun/codex-app-server-service"
+
+type FakeChild = EventEmitter & {
+  readonly pid: number
+  readonly stdout: EventEmitter
+  readonly stderr: EventEmitter
+  readonly stdin: { readonly write: (line: string) => void }
+  readonly kill: () => void
+  killed: boolean
+}
+
+type WireMessage = {
+  readonly id?: number | string
+  readonly method?: string
+  readonly params?: unknown
+  readonly result?: unknown
+}
+
+const makeChild = (
+  onWrite: (message: WireMessage, child: FakeChild) => void,
+  pid = 4321,
+): FakeChild => {
+  const child = new EventEmitter() as FakeChild
+  Object.assign(child, {
+    killed: false,
+    pid,
+    stderr: new EventEmitter(),
+    stdin: {
+      write: (line: string) => {
+        const message = JSON.parse(line) as WireMessage
+        queueMicrotask(() => onWrite(message, child))
+      },
+    },
+    stdout: new EventEmitter(),
+    kill: () => {
+      child.killed = true
+      queueMicrotask(() => child.emit("close", 0, null))
+    },
+  })
+  return child
+}
+
+const respond = (child: FakeChild, id: number | string | undefined, result: unknown): void => {
+  if (id === undefined) return
+  child.stdout.emit("data", Buffer.from(`${JSON.stringify({ id, result })}\n`))
+}
+
+const notify = (
+  child: FakeChild,
+  method: string,
+  params: unknown = {},
+  id?: number | string,
+): void => {
+  child.stdout.emit("data", Buffer.from(`${JSON.stringify({
+    ...(id === undefined ? {} : { id }),
+    method,
+    params,
+  })}\n`))
+}
+
+const typedFailure = <E>(exit: Exit.Exit<unknown, E>): E => {
+  expect(Exit.isFailure(exit)).toBe(true)
+  const failure = Exit.isFailure(exit)
+    ? Cause.findErrorOption(exit.cause)
+    : Option.none()
+  if (Option.isNone(failure)) {
+    throw new Error("expected a typed Effect failure")
+  }
+  return failure.value
+}
+
+describe("CodexAppServer Effect service", () => {
+  test("decodes app-server responses through caller-provided schemas", async () => {
+    const service = makeCodexAppServerService({
+      spawnFn: () => makeChild((message, child) => {
+        if (message.method === "initialize") {
+          respond(child, message.id, {})
+          return
+        }
+        if (message.method === "model/list") {
+          respond(child, message.id, { models: [{ id: "gpt-5.1-codex" }] })
+        }
+      }),
+    })
+    const ModelList = S.Struct({
+      models: S.Array(S.Struct({ id: S.String })),
+    })
+
+    await Effect.runPromise(service.start)
+    const result = await Effect.runPromise(service.requestDecoded(ModelList, "model/list"))
+
+    expect(result.models[0]?.id).toBe("gpt-5.1-codex")
+    await Effect.runPromise(service.dispose)
+  })
+
+  test("surfaces schema decode failures as tagged service errors", async () => {
+    const service = makeCodexAppServerService({
+      spawnFn: () => makeChild((message, child) => {
+        if (message.method === "initialize") {
+          respond(child, message.id, {})
+          return
+        }
+        if (message.method === "model/list") {
+          respond(child, message.id, { models: [{ id: 123 }] })
+        }
+      }),
+    })
+    const ModelList = S.Struct({
+      models: S.Array(S.Struct({ id: S.String })),
+    })
+
+    await Effect.runPromise(service.start)
+    const exit = await Effect.runPromiseExit(service.requestDecoded(ModelList, "model/list"))
+
+    const failure = typedFailure(exit)
+    expect(failure).toBeInstanceOf(CodexAppServerDecodeFailure)
+    expect(failure).toMatchObject({
+      boundary: "response",
+      method: "model/list",
+    })
+    await Effect.runPromise(service.dispose)
+  })
+
+  test("delivers notifications as isolated decoded streams", async () => {
+    const service = makeCodexAppServerService({
+      spawnFn: () => makeChild((message, child) => {
+        if (message.method === "initialize") {
+          respond(child, message.id, {})
+          queueMicrotask(() => notify(child, "thread/status/changed", { threadId: "thread-1" }))
+        }
+      }),
+    })
+    const failingConsumer = Effect.runPromiseExit(
+      service.notifications().pipe(
+        Stream.runForEach(() => Effect.fail("subscriber failed")),
+      ),
+    )
+    const succeedingConsumer = Effect.runPromise(
+      service.notifications().pipe(Stream.runHead),
+    )
+
+    await Effect.runPromise(service.start)
+    const [failed, notification] = await Promise.all([failingConsumer, succeedingConsumer])
+
+    expect(Exit.isFailure(failed)).toBe(true)
+    expect(notification._tag).toBe("Some")
+    if (notification._tag === "Some") {
+      expect(notification.value.method).toBe("thread/status/changed")
+    }
+    await Effect.runPromise(service.dispose)
+  })
+
+  test("fires turn/interrupt when a request times out with an active turn", async () => {
+    const writes: WireMessage[] = []
+    const service = makeCodexAppServerService({
+      requestTimeoutMs: 5,
+      spawnFn: () => makeChild((message, child) => {
+        writes.push(message)
+        if (message.method === "initialize") {
+          respond(child, message.id, {})
+          return
+        }
+        if (message.method === "turn/interrupt") {
+          expect(message.params).toEqual({
+            threadId: "thread-1",
+            turnId: "turn-1",
+          })
+          respond(child, message.id, {})
+        }
+      }),
+    })
+
+    await Effect.runPromise(service.start)
+    const exit = await Effect.runPromiseExit(service.request("turn/start", {
+      threadId: "thread-1",
+    }, {
+      interruptOnTimeout: { threadId: "thread-1", turnId: "turn-1" },
+      timeoutMs: 5,
+    }))
+
+    expect(writes.map(write => write.method)).toContain("turn/interrupt")
+    const failure = typedFailure(exit)
+    expect(failure).toBeInstanceOf(CodexAppServerRpcTimeout)
+    expect(failure).toMatchObject({
+      interruptAttempted: true,
+      interruptOk: true,
+      method: "turn/start",
+    })
+    await Effect.runPromise(service.dispose)
+  })
+
+  test("scoped service disposal kills the supervised app-server child", async () => {
+    let child: FakeChild | null = null
+    await Effect.runPromise(
+      Effect.scoped(
+        Effect.gen(function*() {
+          const service = yield* CodexAppServer
+          yield* service.start
+        }).pipe(
+          Effect.provide(CodexAppServerLive({
+            spawnFn: () => makeChild((message, rpcChild) => {
+              child = rpcChild
+              if (message.method === "initialize") respond(rpcChild, message.id, {})
+            }),
+          })),
+        ),
+      ),
+    )
+
+    expect(child).not.toBeNull()
+    expect((child as unknown as FakeChild).killed).toBe(true)
+  })
+
+  test("reports unavailable app-server requests as typed errors", async () => {
+    const service = makeCodexAppServerService()
+    const exit = await Effect.runPromiseExit(service.request("thread/list"))
+
+    expect(typedFailure(exit)).toBeInstanceOf(CodexAppServerUnavailable)
+  })
+})

--- a/docs/fable/2026-07-01-khala-code-effect-integration-audit.md
+++ b/docs/fable/2026-07-01-khala-code-effect-integration-audit.md
@@ -295,6 +295,15 @@ migration they de-risk.
    (start/restart/dispose) as scoped acquire/release. The chat runtime's
    deferred-promise/turn assembly collapses into `Effect.gen` over that
    service.
+
+   **T7.2 update (2026-07-02):** the first desktop seam now lives at
+   `clients/khala-code-desktop/src/bun/codex-app-server-service.ts`. It
+   wraps the legacy stdio host as a `Context.Service`, exposes tagged
+   Effect errors, caller-provided Schema-decoded responses, decoded
+   notification streams with per-subscriber isolation, timeout-triggered
+   `turn/interrupt`, and a scoped live layer. The legacy host remains the
+   transport compatibility wrapper until the chat runtime migration consumes
+   this service directly.
 7. **A typed `PylonService`.** `request`, `runAssignment`,
    `lifecycle: Stream<AssignmentRunLifecycleEvent>` — backed by the
    subprocess service and the shared schema from phase 1, replacing


### PR DESCRIPTION
Closes #7861.

## Summary
- Add `CodexAppServer` as an Effect `Context.Service` wrapper around the existing app-server host, with tagged errors, decoded response and notification boundaries, notification streams, timeout-triggered `turn/interrupt`, and scoped disposal.
- Add fixture tests for decode failures, stream subscriber isolation, timeout interrupt behavior, scoped process cleanup, and unavailable-request errors.
- Register the service in the Codex parity coverage ledger and update the fable Effect audit with the T7.2 landing note.

## Verification
- `git diff --check`
- `bun run --cwd clients/khala-code-desktop typecheck`
- `bun test clients/khala-code-desktop/tests/codex-app-server-client.test.ts clients/khala-code-desktop/tests/codex-app-server-service.test.ts clients/khala-code-desktop/tests/codex-parity-contract.test.ts` (20 pass, 0 fail)
- `bun run --cwd clients/khala-code-desktop test` (469 pass, 0 fail)
- `bun run --cwd clients/khala-code-desktop verify` (typecheck, 469 tests, Vite build, Bun host bundle)
- `bun run --cwd apps/openagents.com check:deploy`
