### PR TITLE
T7.3: Typed PylonService

### DIFF
--- a/clients/khala-code-desktop/src/bun/fleet-run-supervisor-rpc-adapter.ts
+++ b/clients/khala-code-desktop/src/bun/fleet-run-supervisor-rpc-adapter.ts
@@ -29,10 +29,10 @@ import type { KhalaCodeDesktopFleetRunSupervisorRpc } from "./rpc-handlers.js"
 import {
   inspectCodexFleet,
   resolvePylonHome,
-  spawnCodexInstances,
   type KhalaCodexFleetToolOptions,
 } from "./khala-fleet-tools.js"
 import { collectKhalaProcessText, spawnKhalaProcess } from "./khala-process.js"
+import { makePylonService, type PylonServiceShape } from "./pylon-service.js"
 import {
   startFleetRunSupervisor,
   type FleetRunSupervisorCapacity,
@@ -70,6 +70,7 @@ export type KhalaCodeDesktopFleetRunSupervisorRpcAdapterOptions = {
   readonly capacity?: FleetRunSupervisorCapacity
   readonly env?: ChatEnv
   readonly onLifecycleNdjson?: (line: string) => void | Promise<void>
+  readonly pylonService?: PylonServiceShape | undefined
   readonly pylonRef?: string | null
   readonly runner?: FleetRunSupervisorRunner
   readonly store?: PylonOrchestrationStore
@@ -241,30 +242,26 @@ const capacityFor = (options: KhalaCodexFleetToolOptions | undefined): FleetRunS
 })
 
 const runnerFor = (input: {
+  readonly env?: ChatEnv | undefined
   readonly pylonRef: string | null
+  readonly pylonService?: PylonServiceShape | undefined
   readonly toolOptions?: KhalaCodexFleetToolOptions
 }): FleetRunSupervisorRunner => ({
   dispatch: async dispatch => {
     const fixture = dispatch.workUnit.kind === "fixture"
-    const result = await spawnCodexInstances({
+    const service = input.pylonService ?? input.toolOptions?.pylonService ?? makePylonService({
+      env: input.env ?? input.toolOptions?.env,
+      runner: input.toolOptions?.runner,
+    })
+    return await Effect.runPromise(service.runAssignment({
       accountRef: dispatch.accountRef,
-      claimRef: fixture ? undefined : dispatch.claim.claimRef,
-      count: 1,
       fixture,
-      issue: dispatch.workUnit.number,
-      prompt: dispatch.run.objective,
+      objective: dispatch.run.objective,
       pylonRef: input.pylonRef ?? undefined,
       repo: dispatch.workUnit.repo,
       verify: fixture ? undefined : DEFAULT_VERIFY,
       workerKind: dispatch.run.workerKind,
-    }, input.toolOptions)
-    const slot = result.results[0]
-    return {
-      assignmentRef: slot?.assignmentRef ?? null,
-      lifecycle: [],
-      status: result.acceptedCount > 0 ? "accepted" : "failed",
-      summary: slot?.summary ?? null,
-    }
+    }))
   },
 })
 
@@ -281,14 +278,7 @@ const inboxRefFor = (request: KhalaCodeDesktopFleetWorkerControlRequest, observe
   `inbox.assignment.${request.workerRefHash}.${request.verb}.${observedAt.replace(/[^0-9TZ]/g, "")}`
 
 const lifecycleEventLine = (event: FleetRunSupervisorLifecycleEvent): string =>
-  `${JSON.stringify({
-    schema: "openagents.pylon.assignment_run_lifecycle_event.v0.1",
-    event: event.event,
-    observedAt: new Date().toISOString(),
-    ...(event.assignmentRef === undefined || event.assignmentRef === null ? {} : { assignmentRef: event.assignmentRef }),
-    ...(event.phase === undefined || event.phase === null ? {} : { phase: event.phase }),
-    ...(event.status === undefined || event.status === null ? {} : { status: event.status }),
-  })}\n`
+  `${JSON.stringify(event)}\n`
 
 export function createKhalaCodeDesktopFleetRunSupervisorRpcAdapter(
   options: KhalaCodeDesktopFleetRunSupervisorRpcAdapterOptions = {},
@@ -334,7 +324,7 @@ export function createKhalaCodeDesktopFleetRunSupervisorRpcAdapter(
           planner: plannerFor(store, sources),
           pylonRef: pylonRef ?? "local-pylon",
           runRef,
-          runner: options.runner ?? runnerFor({ pylonRef, toolOptions }),
+          runner: options.runner ?? runnerFor({ env, pylonRef, pylonService: options.pylonService, toolOptions }),
           store,
           onLifecycle: publishLifecycle,
           ...(options.tickIntervalMs === undefined ? {} : { tickIntervalMs: options.tickIntervalMs }),

--- a/clients/khala-code-desktop/src/bun/fleet-run-supervisor.ts
+++ b/clients/khala-code-desktop/src/bun/fleet-run-supervisor.ts
@@ -1,4 +1,5 @@
 import { Effect, Scope } from "effect"
+import type { PylonAssignmentRunLifecycleEvent } from "@openagentsinc/agent-runtime-schema"
 
 import type {
   FleetRun,
@@ -21,12 +22,7 @@ export type FleetRunSupervisorAccount = {
   readonly paused?: boolean
 }
 
-export type FleetRunSupervisorLifecycleEvent = {
-  readonly assignmentRef?: string | null
-  readonly event: string
-  readonly phase?: string | null
-  readonly status?: string | null
-}
+export type FleetRunSupervisorLifecycleEvent = PylonAssignmentRunLifecycleEvent
 
 export type FleetRunSupervisorDispatchInput = {
   readonly accountRef: string
@@ -162,12 +158,20 @@ const terminalStatusForDispatch = (
   if (result.status === "completed") return "completed"
   if (result.status === "failed") return "failed"
   if (result.status === "blocked") return "blocked"
-  const terminal = [...result.lifecycle].reverse().find(event =>
-    event.status === "completed" || event.status === "failed" || event.status === "blocked"
-  )
-  if (terminal?.status === "completed") return "completed"
-  if (terminal?.status === "failed") return "failed"
-  if (terminal?.status === "blocked") return "blocked"
+  const terminal = [...result.lifecycle].reverse().find(event => {
+    if (event.event === "assignment_run.completed" || event.event === "assignment_run.runtime_failed") return true
+    return event.status === "cancelled" || event.status === "rejected" || event.status === "stale" ||
+      event.status === "timed-out" || event.status === "closed"
+  })
+  if (terminal?.event === "assignment_run.completed") return "completed"
+  if (terminal?.event === "assignment_run.runtime_failed") return "failed"
+  if (terminal?.status === "closed") return "completed"
+  if (
+    terminal?.status === "cancelled" ||
+    terminal?.status === "rejected" ||
+    terminal?.status === "stale" ||
+    terminal?.status === "timed-out"
+  ) return "failed"
   return null
 }
 

--- a/clients/khala-code-desktop/src/bun/khala-fleet-tools.ts
+++ b/clients/khala-code-desktop/src/bun/khala-fleet-tools.ts
@@ -63,6 +63,7 @@ import {
 import { khalaCodeConfigFromRuntimeEnv } from "./khala-code-config.js"
 import { fetchKhalaCodexRateLimitStatus } from "./codex-rate-limits.js"
 import { spawnKhalaProcessNodeChild, type KhalaProcessNodeChild } from "./khala-process.js"
+import { makePylonService, type PylonServiceShape } from "./pylon-service.js"
 import type { KhalaCodexRateLimitProviderStatus } from "../shared/codex-rate-limits.js"
 
 type ChatEnv = Readonly<Record<string, string | undefined>>
@@ -94,6 +95,7 @@ export type KhalaCodexFleetToolOptions = {
   readonly env?: ChatEnv | undefined
   readonly fleetRunSupervisor?: KhalaFleetRunSupervisorManager | undefined
   readonly onProgress?: KhalaCodexFleetProgressSink | undefined
+  readonly pylonService?: PylonServiceShape | undefined
   readonly runner?: KhalaCodexFleetCommandRunner | undefined
   readonly sleep?: ((ms: number) => Promise<void>) | undefined
 }
@@ -1411,11 +1413,16 @@ export class DefaultKhalaFleetRunSupervisorManager implements KhalaFleetRunSuper
   private readonly store: PylonOrchestrationStore
   private readonly active = new Map<string, ActiveFleetRun>()
   private readonly planConfigs = new Map<string, FleetRunPlanConfig>()
+  private readonly pylonService: PylonServiceShape
   private readonly retainedLifecycle = new Map<string, readonly FleetRunSupervisorObservedEvent[]>()
   private readonly retainedPylonRefs = new Map<string, string>()
 
   constructor(private readonly options: KhalaCodexFleetToolOptions) {
     this.store = createPylonOrchestrationStore(new Database(":memory:"))
+    this.pylonService = options.pylonService ?? makePylonService({
+      env: options.env,
+      runner: options.runner,
+    })
   }
 
   async start(input: KhalaFleetRunStartInput): Promise<KhalaFleetRunSnapshot> {
@@ -1589,35 +1596,19 @@ export class DefaultKhalaFleetRunSupervisorManager implements KhalaFleetRunSuper
         const config = this.planConfigs.get(runRef)
         if (config === undefined) throw new Error(`missing fleet run plan config: ${runRef}`)
         const fixture = run.workSource === "fixture"
-        const result = await spawnCodexInstances({
+        return await Effect.runPromise(this.pylonService.runAssignment({
           accountRef,
           baseUrl: config.baseUrl,
           branch: config.branch,
           commit: fixture ? undefined : config.commit,
-          count: 1,
           fixture,
-          prompt: renderFleetRunDispatchPrompt(run, workUnit),
+          objective: renderFleetRunDispatchPrompt(run, workUnit),
           pylonRef,
           repo: fixture ? undefined : config.repo,
           timeoutMs: config.timeoutMs,
           verify: fixture ? undefined : config.verify,
           workerKind: run.workerKind,
-        }, this.options)
-        const first = result.results[0]
-        const accepted = result.acceptedCount >= 1 && first?.status === "accepted"
-        const completed = accepted && (first?.autoRunOk === true || first.closeoutStatus === "accepted")
-        const status = completed ? "completed" : accepted ? "accepted" : "failed"
-        return {
-          assignmentRef: first?.assignmentRef ?? null,
-          lifecycle: [{
-            assignmentRef: first?.assignmentRef ?? null,
-            event: completed ? "assignment.completed" : accepted ? "assignment.accepted" : "assignment.failed",
-            phase: run.workerKind === "claude" ? "claude_spawn" : "codex_spawn",
-            status,
-          }],
-          status,
-          summary: first?.summary ?? renderSpawnResult(result),
-        }
+        }))
       },
     }
   }

--- a/clients/khala-code-desktop/src/bun/pylon-service.ts
+++ b/clients/khala-code-desktop/src/bun/pylon-service.ts
@@ -1,0 +1,681 @@
+import { existsSync } from "node:fs"
+import { homedir } from "node:os"
+import { dirname, join, resolve } from "node:path"
+
+import { Context, Effect, Layer, Queue, Schema as S, Stream } from "effect"
+import {
+  decodePylonLifecycleWireEvent,
+  decodePylonLifecycleWireEventJson,
+  type PylonAssignmentRunLifecycleEvent,
+  type PylonLifecycleWireEvent,
+} from "@openagentsinc/agent-runtime-schema"
+
+import { khalaCodeConfigFromRuntimeEnv } from "./khala-code-config.js"
+import {
+  KhalaProcess,
+  KhalaProcessLive,
+  KhalaProcessNonZeroExit,
+  makeKhalaProcessService,
+  type KhalaProcessFailure,
+  type KhalaProcessServiceShape,
+} from "./khala-process.js"
+
+type ChatEnv = Readonly<Record<string, string | undefined>>
+
+type PylonPaths = {
+  readonly appPath: string
+  readonly bunExecutable: string
+  readonly pylonHome: string
+}
+
+export type PylonServiceCommandInput = {
+  readonly args: readonly string[]
+  readonly env?: ChatEnv | undefined
+  readonly maxOutputBytes?: number | undefined
+  readonly timeoutMs?: number | undefined
+}
+
+export type PylonServiceCommandResult = {
+  readonly exitCode: number | null
+  readonly lifecycle: readonly PylonAssignmentRunLifecycleEvent[]
+  readonly stderr: string
+  readonly stdout: string
+  readonly timedOut: boolean
+}
+
+export type PylonServiceAssignmentInput = {
+  readonly accountRef?: string | undefined
+  readonly baseUrl?: string | undefined
+  readonly branch?: string | undefined
+  readonly commit?: string | undefined
+  readonly fixture?: boolean | undefined
+  readonly objective: string
+  readonly pylonRef?: string | undefined
+  readonly repo?: string | undefined
+  readonly timeoutMs?: number | undefined
+  readonly verify?: string | undefined
+  readonly workerKind?: "auto" | "claude" | "codex" | undefined
+}
+
+export type PylonServiceAssignmentResult = {
+  readonly assignmentRef: string | null
+  readonly lifecycle: readonly PylonAssignmentRunLifecycleEvent[]
+  readonly status: "accepted" | "blocked" | "failed" | "completed"
+  readonly summary: string
+}
+
+export class PylonServiceCommandFailure extends S.TaggedErrorClass<PylonServiceCommandFailure>()(
+  "PylonServiceCommandFailure",
+  {
+    message: S.String,
+  },
+) {}
+
+export class PylonServiceDecodeFailure extends S.TaggedErrorClass<PylonServiceDecodeFailure>()(
+  "PylonServiceDecodeFailure",
+  {
+    boundary: S.Literals(["response", "lifecycle"]),
+    message: S.String,
+  },
+) {}
+
+export type PylonServiceFailure = PylonServiceCommandFailure | PylonServiceDecodeFailure
+
+export type PylonServiceShape = {
+  readonly lifecycle: Stream.Stream<PylonAssignmentRunLifecycleEvent, PylonServiceDecodeFailure>
+  readonly request: (
+    input: PylonServiceCommandInput,
+  ) => Effect.Effect<PylonServiceCommandResult, PylonServiceFailure>
+  readonly requestDecoded: <Result>(
+    schema: S.Decoder<Result>,
+    input: PylonServiceCommandInput,
+  ) => Effect.Effect<Result, PylonServiceFailure>
+  readonly runAssignment: (
+    input: PylonServiceAssignmentInput,
+  ) => Effect.Effect<PylonServiceAssignmentResult, PylonServiceFailure>
+}
+
+type PylonServiceOptions = {
+  readonly env?: ChatEnv | undefined
+  readonly process?: KhalaProcessServiceShape | undefined
+  readonly runner?: PylonServiceCommandRunner | undefined
+}
+
+export type PylonServiceCommandRunnerInput = {
+  readonly cmd: readonly string[]
+  readonly cwd?: string | undefined
+  readonly env?: ChatEnv | undefined
+  readonly maxOutputBytes?: number | undefined
+  readonly onStderrLine?: ((line: string) => void | Promise<void>) | undefined
+  readonly timeoutMs: number
+}
+
+export type PylonServiceCommandRunnerResult = {
+  readonly exitCode: number | null
+  readonly signal?: NodeJS.Signals | null | undefined
+  readonly stderr: string
+  readonly stdout: string
+  readonly timedOut: boolean
+}
+
+export type PylonServiceCommandRunner = (
+  input: PylonServiceCommandRunnerInput,
+) => Promise<PylonServiceCommandRunnerResult>
+
+type PylonServiceStubOptions = {
+  readonly assignments?: readonly PylonServiceAssignmentResult[] | undefined
+  readonly requests?: readonly PylonServiceCommandResult[] | undefined
+}
+
+const DEFAULT_COMMAND_TIMEOUT_MS = 45_000
+const DEFAULT_ASSIGNMENT_TIMEOUT_MS = 1_800_000
+const DEFAULT_MAX_OUTPUT_BYTES = 80_000
+const DEFAULT_ASSIGNMENT_MAX_OUTPUT_BYTES = 5_000_000
+const DEFAULT_OPENAGENTS_BASE_URL = "https://openagents.com"
+
+const errorMessage = (cause: unknown): string =>
+  cause instanceof Error ? cause.message : String(cause)
+
+const commandFailure = (cause: unknown): PylonServiceCommandFailure =>
+  new PylonServiceCommandFailure({ message: errorMessage(cause) })
+
+const decodeFailure = (
+  boundary: "response" | "lifecycle",
+  cause: unknown,
+): PylonServiceDecodeFailure =>
+  new PylonServiceDecodeFailure({ boundary, message: errorMessage(cause) })
+
+const cleanEnv = (env: ChatEnv): NodeJS.ProcessEnv => {
+  const clean: NodeJS.ProcessEnv = {}
+  for (const [key, value] of Object.entries(env)) {
+    if (value !== undefined) clean[key] = value
+  }
+  return clean
+}
+
+const dedupe = (values: readonly string[]): readonly string[] =>
+  [...new Set(values.map(value => resolve(value)))]
+
+const pathCandidates = (env: ChatEnv): readonly string[] => [
+  env.PATH ?? "",
+  join(homedir(), ".bun", "bin"),
+  "/opt/homebrew/bin",
+  "/usr/local/bin",
+  "/usr/bin",
+  "/bin",
+]
+
+const pylonHomeCandidates = (env: ChatEnv): readonly string[] => {
+  const home = homedir()
+  return dedupe([
+    ...(env.PYLON_HOME === undefined ? [] : [env.PYLON_HOME]),
+    join(home, ".openagents", "pylon"),
+    join(home, ".pylon"),
+    ...(env.PYLON_FABLE_HOME === undefined ? [] : [env.PYLON_FABLE_HOME]),
+    join(home, ".pylon-fable"),
+  ])
+}
+
+export function resolvePylonServiceHome(env: ChatEnv = khalaCodeConfigFromRuntimeEnv().env): string {
+  const explicit = env.PYLON_HOME?.trim()
+  if (explicit !== undefined && explicit.length > 0) return resolve(explicit)
+  const candidates = pylonHomeCandidates(env)
+  const withState = candidates.find(candidate =>
+    existsSync(join(candidate, "identity.json")) || existsSync(join(candidate, "config.json")),
+  )
+  return withState ?? candidates[0] ?? join(homedir(), ".openagents", "pylon")
+}
+
+const ancestorPylonCandidates = (anchor: string): readonly string[] => {
+  const candidates: string[] = []
+  let current = resolve(anchor)
+  for (let index = 0; index < 12; index += 1) {
+    candidates.push(resolve(current, "apps/pylon"))
+    candidates.push(resolve(current, "../../apps/pylon"))
+    const parent = dirname(current)
+    if (parent === current) break
+    current = parent
+  }
+  return candidates
+}
+
+const resolvePylonAppPath = (env: ChatEnv): string => {
+  const candidates = dedupe([
+    ...(env.OPENAGENTS_PYLON_APP_PATH === undefined ? [] : [env.OPENAGENTS_PYLON_APP_PATH]),
+    ...(env.OPENAGENTS_REPO_ROOT === undefined ? [] : [resolve(env.OPENAGENTS_REPO_ROOT, "apps/pylon")]),
+    ...(env.INIT_CWD === undefined ? [] : ancestorPylonCandidates(env.INIT_CWD)),
+    ...(env.PWD === undefined ? [] : ancestorPylonCandidates(env.PWD)),
+    ...ancestorPylonCandidates(process.cwd()),
+    join(homedir(), "work", "openagents", "apps", "pylon"),
+    resolve(process.cwd(), "../../apps/pylon"),
+    resolve(process.cwd(), "apps/pylon"),
+  ])
+  return candidates.find(candidate => existsSync(join(candidate, "package.json"))) ??
+    candidates[0] ??
+    resolve(process.cwd(), "../../apps/pylon")
+}
+
+const resolveBunExecutable = (env: ChatEnv): string => {
+  const candidates = [
+    ...(env.OPENAGENTS_BUN_PATH === undefined ? [] : [env.OPENAGENTS_BUN_PATH]),
+    process.execPath,
+    join(homedir(), ".bun", "bin", "bun"),
+    "/opt/homebrew/bin/bun",
+    "/usr/local/bin/bun",
+    "/usr/bin/bun",
+  ]
+  return candidates.find(candidate => candidate.length > 0 && existsSync(candidate)) ?? "bun"
+}
+
+const resolvePylonPaths = (env: ChatEnv): PylonPaths => ({
+  appPath: resolvePylonAppPath(env),
+  bunExecutable: resolveBunExecutable(env),
+  pylonHome: resolvePylonServiceHome(env),
+})
+
+const configuredOpenAgentsBaseUrl = (env: ChatEnv): string | undefined =>
+  [env.PYLON_OPENAGENTS_BASE_URL, env.OPENAGENTS_BASE_URL]
+    .map(value => value?.trim())
+    .find((value): value is string => value !== undefined && value.length > 0)
+
+const pylonCommandEnv = (env: ChatEnv, pylonHome: string): ChatEnv => {
+  const mergedEnv = { ...khalaCodeConfigFromRuntimeEnv().env, ...env }
+  const configuredBaseUrl = configuredOpenAgentsBaseUrl(mergedEnv)
+  return {
+    ...mergedEnv,
+    PATH: pathCandidates(mergedEnv).filter(path => path.length > 0).join(":"),
+    ...(configuredBaseUrl === undefined ? {} : { PYLON_OPENAGENTS_BASE_URL: configuredBaseUrl }),
+    PYLON_HOME: pylonHome,
+  }
+}
+
+const commandEnvForArgs = (
+  env: ChatEnv,
+  paths: PylonPaths,
+  args: readonly string[],
+): ChatEnv => {
+  const commandEnv = pylonCommandEnv(env, paths.pylonHome)
+  if (!args.includes("--base-url")) return commandEnv
+  return Object.fromEntries(
+    Object.entries(commandEnv).filter(([key]) =>
+      key !== "PYLON_OPENAGENTS_BASE_URL" && key !== "OPENAGENTS_BASE_URL"
+    ),
+  )
+}
+
+const tailByBytes = (text: string, maxBytes: number): string => {
+  const bytes = Buffer.from(text, "utf8")
+  if (bytes.byteLength <= maxBytes) return text
+  return bytes.subarray(Math.max(0, bytes.byteLength - maxBytes)).toString("utf8")
+}
+
+const assignmentLifecycleEventFromLine = (
+  line: string,
+): PylonAssignmentRunLifecycleEvent | null => {
+  const trimmed = line.trim()
+  if (!trimmed.startsWith("{") || !trimmed.endsWith("}")) return null
+  try {
+    const event = decodePylonLifecycleWireEventJson(trimmed)
+    return event.schema === "openagents.pylon.assignment_run_lifecycle_event.v0.1"
+      ? event
+      : null
+  } catch {
+    return null
+  }
+}
+
+const assignmentLifecycleEventsFromUnknown = (
+  value: unknown,
+): readonly PylonAssignmentRunLifecycleEvent[] => {
+  if (!Array.isArray(value)) return []
+  return value.flatMap(item => {
+    try {
+      const event: PylonLifecycleWireEvent = decodePylonLifecycleWireEvent(item)
+      return event.schema === "openagents.pylon.assignment_run_lifecycle_event.v0.1"
+        ? [event]
+        : []
+    } catch {
+      return []
+    }
+  })
+}
+
+const collectText = (
+  stream: Stream.Stream<Uint8Array, KhalaProcessFailure>,
+  input: {
+    readonly maxOutputBytes: number
+    readonly onLine?: ((line: string) => Effect.Effect<void>) | undefined
+  },
+): Effect.Effect<string> =>
+  Effect.gen(function* () {
+    let text = ""
+    yield* stream.pipe(
+      Stream.decodeText(),
+      Stream.splitLines,
+      Stream.runForEach(line =>
+        Effect.gen(function* () {
+          text = tailByBytes(`${text}${line}\n`, input.maxOutputBytes)
+          if (input.onLine !== undefined) yield* input.onLine(line)
+        })
+      ),
+      Effect.catch(() => Effect.void),
+    )
+    return text
+  })
+
+const parseJsonObject = (value: string): Record<string, unknown> | null => {
+  try {
+    const parsed: unknown = JSON.parse(value)
+    return typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)
+      ? parsed as Record<string, unknown>
+      : null
+  } catch {
+    return null
+  }
+}
+
+const stringField = (source: Record<string, unknown> | null, field: string): string | null => {
+  const value = source?.[field]
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : null
+}
+
+const booleanField = (source: Record<string, unknown> | null, field: string): boolean | null => {
+  const value = source?.[field]
+  return typeof value === "boolean" ? value : null
+}
+
+const recordField = (source: Record<string, unknown> | null, field: string): Record<string, unknown> | null => {
+  const value = source?.[field]
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null
+}
+
+const lifecycleSummaryLines = (
+  events: readonly PylonAssignmentRunLifecycleEvent[],
+): readonly string[] => {
+  if (events.length === 0) return []
+  return [
+    "lifecycle:",
+    ...events.slice(-8).map(event => {
+      const details = [
+        event.phase === undefined ? null : `phase=${event.phase}`,
+        event.status === undefined ? null : `status=${event.status}`,
+      ].filter((value): value is string => value !== null)
+      return details.length === 0
+        ? `  - ${event.event}`
+        : `  - ${event.event} (${details.join(", ")})`
+    }),
+  ]
+}
+
+const safeFailureSummary = (result: PylonServiceCommandResult): string => {
+  const nonLifecycle = `${result.stdout}\n${result.stderr}`
+    .split(/\r?\n/u)
+    .filter(line => assignmentLifecycleEventFromLine(line) === null)
+    .map(line => line.replace(/\s+/gu, " ").trimEnd())
+    .filter(line => line.trim().length > 0)
+    .join("\n")
+  const headline = result.timedOut
+    ? "command timed out"
+    : nonLifecycle.length === 0
+      ? `command exited ${result.exitCode ?? "without status"}`
+      : nonLifecycle
+  return tailByBytes([headline, ...lifecycleSummaryLines(result.lifecycle)].join("\n"), 4_000)
+}
+
+const resolveOpenAgentsBaseUrl = (env: ChatEnv, explicit?: string | undefined): string =>
+  (
+    [explicit, env.PYLON_OPENAGENTS_BASE_URL, env.OPENAGENTS_BASE_URL, DEFAULT_OPENAGENTS_BASE_URL]
+      .map(value => value?.trim())
+      .find((value): value is string => value !== undefined && value.length > 0) ?? DEFAULT_OPENAGENTS_BASE_URL
+  ).replace(/\/+$/u, "")
+
+const workflowForWorkerKind = (
+  workerKind: PylonServiceAssignmentInput["workerKind"],
+): "claude_agent_task" | "codex_agent_task" =>
+  workerKind === "claude" ? "claude_agent_task" : "codex_agent_task"
+
+const assignmentArgs = (
+  input: PylonServiceAssignmentInput,
+  env: ChatEnv,
+): readonly string[] => {
+  const fixture = input.fixture === true
+  return [
+    "khala",
+    "request",
+    "--workflow",
+    workflowForWorkerKind(input.workerKind),
+    "--prompt",
+    input.objective,
+    ...(input.pylonRef === undefined ? [] : ["--pylon-ref", input.pylonRef]),
+    ...(input.accountRef === undefined ? [] : ["--account-ref", input.accountRef]),
+    ...(fixture
+      ? ["--fixture"]
+      : [
+          ...(input.repo === undefined ? [] : ["--repo", input.repo]),
+          ...(input.branch === undefined ? [] : ["--branch", input.branch]),
+          ...(input.commit === undefined ? [] : ["--commit", input.commit]),
+          ...(input.verify === undefined ? [] : ["--verify", input.verify]),
+        ]),
+    "--base-url",
+    resolveOpenAgentsBaseUrl(env, input.baseUrl),
+    "--lifecycle-ndjson",
+    "--json",
+  ]
+}
+
+const assignmentResultFromCommand = (
+  command: PylonServiceCommandResult,
+): PylonServiceAssignmentResult => {
+  const payload = parseJsonObject(command.stdout)
+  const assignmentRef = stringField(payload, "assignmentRef")
+  const autoRun = recordField(payload, "autoRun")
+  const assignmentRun = recordField(payload, "assignmentRun")
+  const closeout = recordField(assignmentRun, "closeout")
+  const autoRunOk = booleanField(autoRun, "ok")
+  const runOk = booleanField(assignmentRun, "ok")
+  const closeoutStatus = stringField(closeout, "status") ?? stringField(payload, "closeoutStatus")
+  const payloadLifecycle = assignmentLifecycleEventsFromUnknown(payload?.assignmentLifecycleEvents)
+  const lifecycle = command.lifecycle.length > 0 ? command.lifecycle : payloadLifecycle
+  const accepted = command.exitCode === 0 && assignmentRef !== null && autoRunOk !== false
+  const completed = accepted && (autoRunOk === true || runOk === true || closeoutStatus === "accepted")
+  const status: PylonServiceAssignmentResult["status"] =
+    completed ? "completed" : accepted ? "accepted" : "failed"
+  const summary = accepted
+    ? [
+        `assignment: ${assignmentRef}`,
+        autoRunOk === null ? "auto-run: unknown" : `auto-run: ${autoRunOk ? "completed" : "failed"}`,
+        runOk === null ? null : `assignment run: ${runOk ? "completed" : "failed"}`,
+        closeoutStatus === null ? null : `closeout: ${closeoutStatus}`,
+        ...lifecycleSummaryLines(lifecycle),
+        "next: summarize this status; no local output path was returned",
+      ].filter((line): line is string => line !== null).join("\n")
+    : safeFailureSummary(command)
+  return {
+    assignmentRef,
+    lifecycle,
+    status,
+    summary,
+  }
+}
+
+const makeLifecycleStream = (
+  subscribers: Set<(event: PylonAssignmentRunLifecycleEvent) => void>,
+): Stream.Stream<PylonAssignmentRunLifecycleEvent, PylonServiceDecodeFailure> =>
+  Stream.unwrap(
+    Effect.map(Queue.unbounded<PylonAssignmentRunLifecycleEvent>(), queue => {
+      const subscriber = (event: PylonAssignmentRunLifecycleEvent): void => {
+        Queue.offerUnsafe(queue, event)
+      }
+      subscribers.add(subscriber)
+      return Stream.fromQueue(queue).pipe(
+        Stream.ensuring(Effect.all([
+          Effect.sync(() => subscribers.delete(subscriber)),
+          Queue.shutdown(queue),
+        ], { discard: true })),
+      )
+    }),
+  )
+
+const makeRequest = (
+  process: KhalaProcessServiceShape,
+  options: PylonServiceOptions,
+  subscribers: Set<(event: PylonAssignmentRunLifecycleEvent) => void>,
+): PylonServiceShape["request"] =>
+  input => {
+    if (options.runner !== undefined) {
+      return Effect.tryPromise({
+        try: async () => {
+          const env = { ...(options.env ?? khalaCodeConfigFromRuntimeEnv().env), ...(input.env ?? {}) }
+          const paths = resolvePylonPaths(env)
+          const lifecycleEvents: PylonAssignmentRunLifecycleEvent[] = []
+          const publishLine = async (line: string): Promise<void> => {
+            const event = assignmentLifecycleEventFromLine(line)
+            if (event === null) return
+            lifecycleEvents.push(event)
+            for (const subscriber of subscribers) subscriber(event)
+          }
+          const result = await options.runner?.({
+            cmd: [paths.bunExecutable, "src/index.ts", ...input.args],
+            cwd: paths.appPath,
+            env: commandEnvForArgs(env, paths, input.args),
+            maxOutputBytes: input.maxOutputBytes ?? DEFAULT_MAX_OUTPUT_BYTES,
+            onStderrLine: publishLine,
+            timeoutMs: Math.max(1, Math.trunc(input.timeoutMs ?? DEFAULT_COMMAND_TIMEOUT_MS)),
+          })
+          if (result === undefined) throw new Error("Pylon service runner is unavailable")
+          return {
+            exitCode: result.exitCode,
+            lifecycle: lifecycleEvents,
+            stderr: result.stderr,
+            stdout: result.stdout,
+            timedOut: result.timedOut,
+          }
+        },
+        catch: commandFailure,
+      })
+    }
+    return (
+    Effect.scoped(
+      Effect.gen(function* () {
+        const env = { ...(options.env ?? khalaCodeConfigFromRuntimeEnv().env), ...(input.env ?? {}) }
+        const paths = resolvePylonPaths(env)
+        const args = ["src/index.ts", ...input.args]
+        const timeoutMs = Math.max(1, Math.trunc(input.timeoutMs ?? DEFAULT_COMMAND_TIMEOUT_MS))
+        const maxOutputBytes = Math.max(1, Math.trunc(input.maxOutputBytes ?? DEFAULT_MAX_OUTPUT_BYTES))
+        const lifecycleEvents: PylonAssignmentRunLifecycleEvent[] = []
+        let timedOut = false
+        const handle = yield* process.spawn(paths.bunExecutable, args, {
+          cwd: paths.appPath,
+          env: cleanEnv(commandEnvForArgs(env, paths, input.args)),
+          extendEnv: false,
+          forceKillAfter: "1500 millis",
+        }).pipe(Effect.mapError(commandFailure))
+        yield* Effect.forkScoped(
+          Effect.sleep(`${timeoutMs} millis`).pipe(
+            Effect.tap(() => Effect.sync(() => {
+              timedOut = true
+            })),
+            Effect.flatMap(() => handle.kill({ forceKillAfter: "1500 millis" }).pipe(Effect.ignore)),
+          ),
+        )
+        const lineSink = (line: string): Effect.Effect<void> =>
+          Effect.sync(() => {
+            const event = assignmentLifecycleEventFromLine(line)
+            if (event === null) return
+            lifecycleEvents.push(event)
+            for (const subscriber of subscribers) subscriber(event)
+          })
+        const exitCode = handle.exit.pipe(
+          Effect.match({
+            onFailure: failure =>
+              failure instanceof KhalaProcessNonZeroExit ? failure.exitCode : 127,
+            onSuccess: code => code,
+          }),
+        )
+        const output = yield* Effect.all({
+          exitCode,
+          stderr: collectText(handle.stderr, { maxOutputBytes, onLine: lineSink }),
+          stdout: collectText(handle.stdout, { maxOutputBytes }),
+        }, { concurrency: "unbounded" }).pipe(
+          Effect.mapError(commandFailure),
+        )
+        return {
+          ...output,
+          lifecycle: lifecycleEvents,
+          timedOut,
+        }
+      }),
+    )
+    )
+  }
+
+export const makePylonService = (
+  options: PylonServiceOptions = {},
+): PylonServiceShape => {
+  const process = options.process ?? makeKhalaProcessService()
+  const subscribers = new Set<(event: PylonAssignmentRunLifecycleEvent) => void>()
+  const request = makeRequest(process, options, subscribers)
+  return {
+    lifecycle: makeLifecycleStream(subscribers),
+    request,
+    requestDecoded: (schema, input) =>
+      request(input).pipe(
+        Effect.flatMap(result =>
+          S.decodeUnknownEffect(schema)(parseJsonObject(result.stdout)).pipe(
+            Effect.mapError(cause => decodeFailure("response", cause)),
+          )
+        ),
+      ),
+    runAssignment: input => {
+      const env = { ...(options.env ?? khalaCodeConfigFromRuntimeEnv().env) }
+      return request({
+        args: assignmentArgs(input, env),
+        maxOutputBytes: DEFAULT_ASSIGNMENT_MAX_OUTPUT_BYTES,
+        timeoutMs: input.timeoutMs ?? DEFAULT_ASSIGNMENT_TIMEOUT_MS,
+      }).pipe(
+        Effect.map(assignmentResultFromCommand),
+      )
+    },
+  }
+}
+
+export const makePylonServiceLayer = (
+  options: Omit<PylonServiceOptions, "process"> = {},
+): Layer.Layer<PylonService, never, KhalaProcess> =>
+  Layer.effect(
+    PylonService,
+    Effect.map(KhalaProcess, process => makePylonService({ ...options, process })),
+  )
+
+export const makePylonServiceStub = (
+  options: PylonServiceStubOptions = {},
+): PylonServiceShape => {
+  const subscribers = new Set<(event: PylonAssignmentRunLifecycleEvent) => void>()
+  const assignments = [...(options.assignments ?? [])]
+  const requests = [...(options.requests ?? [])]
+  const publish = (events: readonly PylonAssignmentRunLifecycleEvent[]): void => {
+    for (const event of events) {
+      for (const subscriber of subscribers) subscriber(event)
+    }
+  }
+  const defaultAssignment = (input: PylonServiceAssignmentInput): PylonServiceAssignmentResult => {
+    const observedAt = new Date(0).toISOString()
+    const assignmentRef = `assignment.fixture.${input.workerKind ?? "codex"}`
+    return {
+      assignmentRef,
+      lifecycle: [{
+        schema: "openagents.pylon.assignment_run_lifecycle_event.v0.1",
+        assignmentRef,
+        event: "assignment_run.completed",
+        observedAt,
+        status: "closeout-submitted",
+      }],
+      status: "completed",
+      summary: `assignment: ${assignmentRef}`,
+    }
+  }
+  const request: PylonServiceShape["request"] = () =>
+    Effect.sync(() => {
+      const result = requests.shift() ?? {
+        exitCode: 0,
+        lifecycle: [],
+        stderr: "",
+        stdout: "{}",
+        timedOut: false,
+      }
+      publish(result.lifecycle)
+      return result
+    })
+  return {
+    lifecycle: makeLifecycleStream(subscribers),
+    request,
+    requestDecoded: (schema, input) =>
+      request(input).pipe(
+        Effect.flatMap(result =>
+          S.decodeUnknownEffect(schema)(parseJsonObject(result.stdout)).pipe(
+            Effect.mapError(cause => decodeFailure("response", cause)),
+          )
+        ),
+      ),
+    runAssignment: input =>
+      Effect.sync(() => {
+        const result = assignments.shift() ?? defaultAssignment(input)
+        publish(result.lifecycle)
+        return result
+      }),
+  }
+}
+
+export const PylonServiceStub = (
+  options: PylonServiceStubOptions = {},
+): Layer.Layer<PylonService> =>
+  Layer.succeed(PylonService, makePylonServiceStub(options))
+
+export class PylonService extends Context.Service<PylonService, PylonServiceShape>()(
+  "PylonService",
+  { make: Effect.sync(makePylonService) },
+) {}
+
+export const PylonServiceLive = makePylonServiceLayer().pipe(Layer.provide(KhalaProcessLive))

--- a/clients/khala-code-desktop/tests/fleet-run-supervisor-rpc-adapter.test.ts
+++ b/clients/khala-code-desktop/tests/fleet-run-supervisor-rpc-adapter.test.ts
@@ -261,7 +261,9 @@ describe("Khala Code fleet run supervisor RPC adapter", () => {
               lifecycle: [{
                 assignmentRef: "assignment.lifecycle",
                 event: "assignment_run.runtime_progress",
+                observedAt: "2026-07-01T12:00:00.000Z",
                 phase: "runtime_active",
+                schema: "openagents.pylon.assignment_run_lifecycle_event.v0.1",
                 status: "running",
               }],
               status: "accepted",

--- a/clients/khala-code-desktop/tests/fleet-run-supervisor.test.ts
+++ b/clients/khala-code-desktop/tests/fleet-run-supervisor.test.ts
@@ -4,6 +4,7 @@ import { join } from "node:path"
 import { describe, expect, test } from "bun:test"
 import { Database } from "bun:sqlite"
 import { Effect, Exit, Scope } from "effect"
+import type { PylonAssignmentRunLifecycleEvent } from "@openagentsinc/agent-runtime-schema"
 
 import {
   createPylonOrchestrationStore,
@@ -23,6 +24,20 @@ import {
 } from "../src/bun/fleet-run-supervisor.js"
 
 const fixedNow = new Date("2026-07-01T12:00:00.000Z")
+
+const lifecycleEvent = (
+  event: PylonAssignmentRunLifecycleEvent["event"],
+  input: {
+    readonly assignmentRef?: string | undefined
+    readonly status?: PylonAssignmentRunLifecycleEvent["status"] | undefined
+  } = {},
+): PylonAssignmentRunLifecycleEvent => ({
+  schema: "openagents.pylon.assignment_run_lifecycle_event.v0.1",
+  event,
+  observedAt: fixedNow.toISOString(),
+  ...(input.assignmentRef === undefined ? {} : { assignmentRef: input.assignmentRef }),
+  ...(input.status === undefined ? {} : { status: input.status }),
+})
 
 function createStoreWithRun(input: {
   readonly runRef?: string
@@ -69,7 +84,7 @@ const acceptingRunner = (dispatched: string[] = []): FleetRunSupervisorRunner =>
     dispatched.push(input.workUnit.workUnitRef)
     return {
       assignmentRef: `assignment.${input.claim.claimRef}`,
-      lifecycle: [{ event: "assignment.accepted", status: "accepted" }],
+      lifecycle: [lifecycleEvent("assignment_run.accepted", { status: "accepted" })],
       status: "accepted",
     }
   },
@@ -87,7 +102,7 @@ function drainingRunner(input: {
       input.dispatched?.push(assignment.workUnit.workUnitRef)
       return {
         assignmentRef: `assignment.${assignment.claim.claimRef}`,
-        lifecycle: [{ event: "assignment.accepted", status: "accepted" }],
+        lifecycle: [lifecycleEvent("assignment_run.accepted", { status: "accepted" })],
         status: "accepted",
       }
     },
@@ -97,7 +112,7 @@ function drainingRunner(input: {
       if (peakActive < (input.completeAfterPeak ?? 1)) return []
       return activeAssignments.slice(0, input.completePerTick).map(assignment => ({
         assignmentRef: `assignment.${assignment.claim.claimRef}`,
-        lifecycle: [{ event: "assignment.closeout", status: "completed" }],
+        lifecycle: [lifecycleEvent("assignment_run.completed", { status: "closed" })],
         status: "completed" as const,
         summary: "fixture assignment completed",
         taskId: assignment.taskId,
@@ -377,7 +392,7 @@ describe("FleetRunSupervisor", () => {
           dispatched.push(input.workUnit.workUnitRef)
           return {
             assignmentRef: `assignment.${input.claim.claimRef}`,
-            lifecycle: [{ event: "assignment.completed", status: "completed" }],
+            lifecycle: [lifecycleEvent("assignment_run.completed", { status: "closed" })],
             status: "completed" as const,
           }
         },
@@ -416,8 +431,8 @@ describe("FleetRunSupervisor", () => {
         dispatch: async (input: FleetRunSupervisorDispatchInput) => ({
           assignmentRef: `assignment.${input.claim.claimRef}`,
           lifecycle: [
-            { event: "assignment.accepted", status: "accepted" },
-            { event: "assignment.closeout", status: "completed" },
+            lifecycleEvent("assignment_run.accepted", { status: "accepted" }),
+            lifecycleEvent("assignment_run.completed", { status: "closed" }),
           ],
           status: "completed",
           summary: "fixture completed",
@@ -466,7 +481,7 @@ describe("FleetRunSupervisor", () => {
           dispatched.push(input.workUnit.workUnitRef)
           return {
             assignmentRef: `assignment.${input.claim.claimRef}`,
-            lifecycle: [{ event: "assignment.closeout", status: "completed" }],
+            lifecycle: [lifecycleEvent("assignment_run.completed", { status: "closed" })],
             status: "completed" as const,
           }
         },
@@ -501,7 +516,7 @@ describe("FleetRunSupervisor", () => {
           dispatched.push(input.workUnit.workUnitRef)
           return {
             assignmentRef: `assignment.${input.claim.claimRef}`,
-            lifecycle: [{ event: "assignment.closeout", status: "completed" }],
+            lifecycle: [lifecycleEvent("assignment_run.completed", { status: "closed" })],
             status: "completed" as const,
           }
         },
@@ -534,7 +549,7 @@ describe("FleetRunSupervisor", () => {
           if (calls === 1) throw new Error("dispatch exploded")
           return {
             assignmentRef: `assignment.${input.claim.claimRef}`,
-            lifecycle: [{ event: "assignment.closeout", status: "completed" }],
+            lifecycle: [lifecycleEvent("assignment_run.completed", { status: "closed" })],
             status: "completed" as const,
           }
         },

--- a/clients/khala-code-desktop/tests/khala-fleet-tools.test.ts
+++ b/clients/khala-code-desktop/tests/khala-fleet-tools.test.ts
@@ -151,38 +151,36 @@ function matrixBatchSpawnBlocker(
   }
 }
 
-function matrixBatchSpawnInFlight(
-  assignmentRef: string,
-  accountRef = "codex-2",
-): Record<string, unknown> {
+function matrixKhalaRequestCompleted(assignmentRef: string): Record<string, unknown> {
   return {
-    aggregate: {
-      acceptedCount: 1,
-      assignmentRefs: [assignmentRef],
-      durableRequestIds: [`durable.${assignmentRef.split(".").at(-1) ?? "matrix"}`],
-      ownerOnlyRawEventCount: 0,
-      ownerOnlyTraceCount: 0,
-      totalTokenRows: 0,
-      totalVerifiedTokens: 0,
-    },
-    blockerRefs: [],
-    ok: true,
-    plan: {
-      requestedCount: 1,
-      slots: [{ account: { accountRef }, slotIndex: 0 }],
-      targetPylonRef: "pylon.local.test",
-    },
-    results: [{
+    assignmentRef,
+    assignmentLifecycleEvents: [{
       assignmentRef,
-      blockerRefs: [],
-      closeoutStatus: null,
-      ok: true,
-      proof: null,
-      runAccepted: null,
-      slotIndex: 0,
-      state: "accepted",
+      event: "assignment_run.completed",
+      observedAt: "2026-07-01T12:00:00.000Z",
+      schema: "openagents.pylon.assignment_run_lifecycle_event.v0.1",
+      status: "closed",
     }],
-    schema: "openagents.pylon.khala_spawn_run.v0.1",
+    assignmentRun: {
+      closeout: { status: "accepted" },
+      ok: true,
+    },
+    autoRun: { ok: true },
+  }
+}
+
+function matrixKhalaRequestInFlight(assignmentRef: string): Record<string, unknown> {
+  return {
+    assignmentRef,
+    assignmentLifecycleEvents: [{
+      assignmentRef,
+      event: "assignment_run.accepted",
+      observedAt: "2026-07-01T12:00:00.000Z",
+      schema: "openagents.pylon.assignment_run_lifecycle_event.v0.1",
+      status: "accepted",
+    }],
+    assignmentRun: null,
+    autoRun: { attempted: true },
   }
 }
 
@@ -422,8 +420,8 @@ describe("Khala Code fleet tools", () => {
       if (joined === "presence heartbeat --base-url https://openagents.com --json") {
         return ok({ heartbeatRef: "heartbeat.pylon.local.test.completed", pylonRef: "pylon.local.test" })
       }
-      if (args[0] === "khala" && args[1] === "spawn") {
-        return ok(matrixBatchSpawnSuccess(spawnRefs.shift() ?? "assignment.public.codex_agent_task.completed_extra"))
+      if (args[0] === "khala" && args[1] === "request") {
+        return ok(matrixKhalaRequestCompleted(spawnRefs.shift() ?? "assignment.public.codex_agent_task.completed_extra"))
       }
       return failed(`unexpected command: ${joined}`)
     }
@@ -508,8 +506,8 @@ describe("Khala Code fleet tools", () => {
       if (joined === "presence heartbeat --base-url https://openagents.com --json") {
         return ok({ heartbeatRef: "heartbeat.pylon.local.test.inflight", pylonRef: "pylon.local.test" })
       }
-      if (args[0] === "khala" && args[1] === "spawn") {
-        return ok(matrixBatchSpawnInFlight("assignment.public.codex_agent_task.inflight"))
+      if (args[0] === "khala" && args[1] === "request") {
+        return ok(matrixKhalaRequestInFlight("assignment.public.codex_agent_task.inflight"))
       }
       return failed(`unexpected command: ${joined}`)
     }

--- a/clients/khala-code-desktop/tests/pylon-service.test.ts
+++ b/clients/khala-code-desktop/tests/pylon-service.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, test } from "bun:test"
+import { Effect, Stream } from "effect"
+import type { PylonAssignmentRunLifecycleEvent } from "@openagentsinc/agent-runtime-schema"
+
+import {
+  makePylonService,
+  PylonService,
+  PylonServiceStub,
+  type PylonServiceCommandRunnerInput,
+} from "../src/bun/pylon-service"
+
+const lifecycleEvent = (
+  event: PylonAssignmentRunLifecycleEvent["event"] = "assignment_run.runtime_progress",
+): PylonAssignmentRunLifecycleEvent => ({
+  schema: "openagents.pylon.assignment_run_lifecycle_event.v0.1",
+  assignmentRef: "assignment.test",
+  event,
+  observedAt: "2026-07-01T12:00:00.000Z",
+  phase: "runtime_active",
+  status: "running",
+})
+
+describe("PylonService", () => {
+  test("decodes command lifecycle NDJSON into isolated streams", async () => {
+    const event = lifecycleEvent()
+    const service = makePylonService({
+      runner: async (input) => {
+        await input.onStderrLine?.(JSON.stringify(event))
+        return {
+          exitCode: 0,
+          stderr: "",
+          stdout: "{}",
+          timedOut: false,
+        }
+      },
+    })
+    const first = Effect.runPromise(service.lifecycle.pipe(Stream.runHead))
+    const second = Effect.runPromise(service.lifecycle.pipe(Stream.runHead))
+
+    const result = await Effect.runPromise(service.request({ args: ["khala", "request", "--json"] }))
+    const [firstEvent, secondEvent] = await Promise.all([first, second])
+
+    expect(result.lifecycle).toEqual([event])
+    expect(firstEvent._tag).toBe("Some")
+    expect(secondEvent._tag).toBe("Some")
+    if (firstEvent._tag === "Some") expect(firstEvent.value).toEqual(event)
+    if (secondEvent._tag === "Some") expect(secondEvent.value).toEqual(event)
+  })
+
+  test("runs one assignment through pylon khala request and maps closeout result", async () => {
+    const event = lifecycleEvent("assignment_run.completed")
+    const captured: PylonServiceCommandRunnerInput[] = []
+    const service = makePylonService({
+      env: { OPENAGENTS_PYLON_APP_PATH: "/tmp/pylon-app", PYLON_HOME: "/tmp/pylon-home" },
+      runner: async (input) => {
+        captured.push(input)
+        await input.onStderrLine?.(JSON.stringify(event))
+        return {
+          exitCode: 0,
+          stderr: "",
+          stdout: JSON.stringify({
+            assignmentRef: "assignment.test",
+            assignmentLifecycleEvents: [event],
+            assignmentRun: {
+              closeout: { status: "accepted" },
+              ok: true,
+            },
+            autoRun: {
+              ok: true,
+            },
+          }),
+          timedOut: false,
+        }
+      },
+    })
+
+    const result = await Effect.runPromise(service.runAssignment({
+      accountRef: "codex-2",
+      baseUrl: "https://openagents.test",
+      fixture: true,
+      objective: "Run the fixture assignment.",
+      pylonRef: "pylon.owner",
+      workerKind: "codex",
+    }))
+
+    const command = captured[0]
+    expect(command).toBeDefined()
+    expect(command?.cmd).toContain("src/index.ts")
+    expect(command?.cmd).toContain("khala")
+    expect(command?.cmd).toContain("request")
+    expect(command?.cmd).toContain("--account-ref")
+    expect(command?.cmd).toContain("codex-2")
+    expect(command?.cmd).toContain("--lifecycle-ndjson")
+    expect(command?.env?.PYLON_HOME).toBe("/tmp/pylon-home")
+    expect(result).toMatchObject({
+      assignmentRef: "assignment.test",
+      status: "completed",
+    })
+    expect(result.lifecycle).toEqual([event])
+  })
+
+  test("provides a fixture stub layer for supervisor tests", async () => {
+    const service = await Effect.runPromise(PylonService.pipe(Effect.provide(PylonServiceStub())))
+    const eventPromise = Effect.runPromise(service.lifecycle.pipe(Stream.runHead))
+    const assignment = await Effect.runPromise(service.runAssignment({
+      fixture: true,
+      objective: "Run a stub assignment.",
+    }))
+    const event = await eventPromise
+
+    expect(assignment.status).toBe("completed")
+    expect(event._tag).toBe("Some")
+    if (event._tag === "Some") {
+      expect(event.value.schema).toBe("openagents.pylon.assignment_run_lifecycle_event.v0.1")
+    }
+  })
+})

--- a/docs/fable/2026-07-01-khala-code-effect-integration-audit.md
+++ b/docs/fable/2026-07-01-khala-code-effect-integration-audit.md
@@ -309,6 +309,14 @@ migration they de-risk.
    subprocess service and the shared schema from phase 1, replacing
    argv+stdout string coupling. Stub layer for fixtures; this is also what
    the fleet-fan-out instructions' supervisor should consume.
+
+   **T7.3 update (2026-07-02):** the desktop now has
+   `clients/khala-code-desktop/src/bun/pylon-service.ts`, a `Context.Service`
+   that runs Pylon commands through the T7.1 process spine, publishes decoded
+   shared-schema assignment lifecycle events as isolated streams, maps
+   `khala request` assignment runs into supervisor dispatch results, and
+   exposes a fixture stub layer. The fleet-run supervisor and RPC adapter now
+   consume this service instead of calling the one-shot spawn helper directly.
 8. **khala-tools substrate fixes** (T7.4 landed 2026-07-01): dispatcher
    durations and event IDs now use injected runtime Clock/random; one-shot
    sandbox/exec process groups use `acquireRelease`; `exec-command.ts` keeps


### PR DESCRIPTION

## Summary

- Add a typed desktop `PylonService` Context service for Pylon command requests, assignment runs, decoded assignment lifecycle streams, and fixture stubs.
- Migrate the fleet-run supervisor manager and RPC adapter dispatch paths onto `PylonService.runAssignment` while keeping one-shot `codex_spawn` behavior intact.
- Tighten supervisor lifecycle events to the shared Pylon assignment lifecycle schema and update the T7.3 Fable audit note.

Closes #7862

## Verification

- `git diff --check`
- `bun test clients/khala-code-desktop/tests/pylon-service.test.ts clients/khala-code-desktop/tests/fleet-run-supervisor.test.ts clients/khala-code-desktop/tests/fleet-run-supervisor-rpc-adapter.test.ts clients/khala-code-desktop/tests/khala-fleet-tools.test.ts` (58 pass)
- `bun run --cwd clients/khala-code-desktop typecheck`
- `bun run --cwd clients/khala-code-desktop test` (472 pass)
- `bun run --cwd clients/khala-code-desktop verify` (typecheck, 472 tests, Vite build, Bun host bundle)
- `bun run --cwd apps/openagents.com check:deploy` (pass; includes expected negative contract-drift fixture messages inside the passing guard test)
