### PR TITLE
T9.3: auto v2 fleet routing

### DIFF
--- a/apps/openagents.com/workers/api/src/inference/coding-workflow-classifier.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/coding-workflow-classifier.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, test } from 'vitest'
 
-import { classifyCodingWorkflow } from './coding-workflow-classifier'
+import {
+  classifyCodingWorkflow,
+  fleetWorkerKindForCodingWorkflowClass,
+} from './coding-workflow-classifier'
 
 describe('coding workflow classifier', () => {
   test('classifies explicit structured workflow markers', () => {
@@ -47,5 +50,18 @@ describe('coding workflow classifier', () => {
       confidence: 0,
       workflowClass: 'none',
     })
+  })
+
+  test('projects workflow classes into fleet worker-kind hints without prose inference', () => {
+    expect(fleetWorkerKindForCodingWorkflowClass('claude_agent_task')).toBe(
+      'claude',
+    )
+    expect(fleetWorkerKindForCodingWorkflowClass('codex_agent_task')).toBe(
+      'codex',
+    )
+    expect(fleetWorkerKindForCodingWorkflowClass('cloud_coding_session')).toBe(
+      'codex',
+    )
+    expect(fleetWorkerKindForCodingWorkflowClass('none')).toBe('none')
   })
 })

--- a/apps/openagents.com/workers/api/src/inference/coding-workflow-classifier.ts
+++ b/apps/openagents.com/workers/api/src/inference/coding-workflow-classifier.ts
@@ -4,11 +4,28 @@ export type CodingWorkflowClass =
   | 'codex_agent_task'
   | 'none'
 
+export type CodingWorkflowFleetWorkerKind = 'claude' | 'codex' | 'none'
+
 export type CodingWorkflowClassification = Readonly<{
   confidence: number
   evidenceRefs: ReadonlyArray<string>
   workflowClass: CodingWorkflowClass
 }>
+
+export const fleetWorkerKindForCodingWorkflowClass = (
+  workflowClass: CodingWorkflowClass,
+): CodingWorkflowFleetWorkerKind => {
+  if (workflowClass === 'claude_agent_task') {
+    return 'claude'
+  }
+  if (
+    workflowClass === 'cloud_coding_session' ||
+    workflowClass === 'codex_agent_task'
+  ) {
+    return 'codex'
+  }
+  return 'none'
+}
 
 type ChatMessageLike = Readonly<{
   content?: unknown

--- a/clients/khala-code-desktop/src/bun/khala-fleet-tools.ts
+++ b/clients/khala-code-desktop/src/bun/khala-fleet-tools.ts
@@ -31,6 +31,7 @@ import {
   type KhalaFleetDelegateWorkerKind,
   type KhalaFleetDelegateWork,
   type KhalaFleetDelegationParameterSet,
+  type KhalaFleetDelegationWorkflowClassification,
   type KhalaToolDefinition,
   type KhalaToolResult,
   type RegisteredKhalaTool,
@@ -276,6 +277,7 @@ type SpawnCodexInstancesInput = {
   readonly timeoutMs?: number | undefined
   readonly verify?: string | undefined
   readonly workerKind?: FleetRunWorkerKind | undefined
+  readonly workflowClassification?: KhalaFleetDelegationWorkflowClassification | undefined
 }
 
 type NormalizedSpawnInput = {
@@ -294,6 +296,7 @@ type NormalizedSpawnInput = {
   readonly timeoutMs: number
   readonly verify?: string | undefined
   readonly workerKind: FleetRunWorkerKind
+  readonly workflowClassification?: KhalaFleetDelegationWorkflowClassification | undefined
 }
 
 type SpawnCodexInstancesResult = {
@@ -571,6 +574,23 @@ const codexSpawnToolDefinition: KhalaToolDefinition = {
         enum: ["codex", "claude", "auto"],
         type: "string",
       },
+      workflow_class: {
+        description:
+          "Optional structured server classifier result. Use only when an upstream typed marker already selected this exact workflow; never infer from prose.",
+        enum: ["claude_agent_task", "cloud_coding_session", "codex_agent_task", "none"],
+        type: "string",
+      },
+      workflow_confidence: {
+        description: "Classifier confidence paired with workflow_class.",
+        maximum: 1,
+        minimum: 0,
+        type: "number",
+      },
+      workflow_evidence_refs: {
+        description: "Public-safe evidence refs from the structured classifier.",
+        items: { type: "string" },
+        type: "array",
+      },
     },
     required: ["prompt"],
     type: "object",
@@ -601,6 +621,7 @@ const codexSpawnToolDefinition: KhalaToolDefinition = {
     "Require complete repo, branch, verify, and claim_ref pins only for real repository work; Desktop resolves or validates the live commit pin before dispatch.",
     "Do not run Codex or Claude login. If no ready Pylon account exists for the requested worker kind, tell the user to connect one first.",
     "Omit account_ref unless the user names a specific non-default account; Desktop prefers named ready accounts over the display-only default account.",
+    "For worker_kind=auto, pass workflow_class only from an exact structured classifier marker; never infer it from user prose or ordinary task wording.",
     "This MVP exposes only pylon_ensure, codex_fleet_status, and codex_spawn for fleet control. Do not invent codex_terminate or other fleet tools.",
     "After codex_spawn, summarize the returned assignment, auto-run, and closeout status; do not read guessed local output files.",
     "Keep count small; this MVP caps fan-out at five assignments.",
@@ -1065,6 +1086,7 @@ export async function spawnCodexInstances(
     objective: preparedInput.prompt,
     repo: preparedInput.repo,
     verify: preparedInput.verify,
+    workflowClassification: preparedInput.workflowClassification,
   }, {
     ensurePylon: () =>
       Effect.promise(async () => {
@@ -1270,6 +1292,7 @@ function executeCodexSpawnTool(
         timeoutMs: optionalInteger(input.timeout_ms),
         verify: optionalString(input.verify),
         workerKind: optionalWorkerKind(input.worker_kind),
+        workflowClassification: optionalWorkflowClassification(input),
       }, options)
       const tokensVerified = spawnVerifiedTokenTotal(result)
       const toolResult = khalaToolOk({
@@ -3843,6 +3866,45 @@ function optionalWorkSource(value: unknown): FleetRunWorkSource | undefined {
 
 function optionalWorkerKind(value: unknown): FleetRunWorkerKind | undefined {
   return value === "codex" || value === "claude" || value === "auto" ? value : undefined
+}
+
+function optionalWorkflowClassification(
+  input: Readonly<Record<string, unknown>>,
+): KhalaFleetDelegationWorkflowClassification | undefined {
+  const workflowClass = input.workflow_class
+  if (workflowClass === undefined || workflowClass === null || workflowClass === "") {
+    return undefined
+  }
+  if (
+    workflowClass !== "claude_agent_task" &&
+    workflowClass !== "cloud_coding_session" &&
+    workflowClass !== "codex_agent_task" &&
+    workflowClass !== "none"
+  ) {
+    throw new Error("workflow_class must be claude_agent_task, cloud_coding_session, codex_agent_task, or none")
+  }
+  const rawConfidence = input.workflow_confidence
+  const confidence = rawConfidence === undefined ? 1 : rawConfidence
+  if (typeof confidence !== "number" || !Number.isFinite(confidence) || confidence < 0 || confidence > 1) {
+    throw new Error("workflow_confidence must be a number between 0 and 1")
+  }
+  const rawRefs = input.workflow_evidence_refs
+  if (rawRefs !== undefined && !Array.isArray(rawRefs)) {
+    throw new Error("workflow_evidence_refs must be an array")
+  }
+  const evidenceRefs = rawRefs === undefined
+    ? [`evidence.coding_workflow.desktop_mcp.${workflowClass}`]
+    : rawRefs.map(ref => {
+        if (typeof ref !== "string" || !/^[A-Za-z0-9_.:-]+$/u.test(ref)) {
+          throw new Error("workflow_evidence_refs must contain public-safe refs only")
+        }
+        return ref
+      })
+  return {
+    confidence,
+    evidenceRefs,
+    workflowClass,
+  }
 }
 
 function requiredFleetRunControlVerb(value: unknown): FleetRunControlVerb {

--- a/clients/khala-code-desktop/tests/khala-fleet-tools.test.ts
+++ b/clients/khala-code-desktop/tests/khala-fleet-tools.test.ts
@@ -1048,6 +1048,130 @@ describe("Khala Code fleet tools", () => {
     expect(calls.every(call => pylonArgs(call).join(" ") !== "codex accounts list --json")).toBe(true)
   })
 
+  test("spawnCodexInstances auto v2 prefers structured classifier worker kind on tied capacity", async () => {
+    const fixture = await tempPylonFixture()
+    const calls: KhalaCodexFleetCommandInput[] = []
+    const codexAccountKey = "aaaaaaaaaaaaaaaa"
+    const claudeAccountKey = "bbbbbbbbbbbbbbbb"
+    const providerProjection = {
+      ok: true,
+      ownCapacityDispatch: {
+        claudeAccounts: [{ accountKey: claudeAccountKey, available: 1, busy: 0, queued: 0, ready: 1 }],
+        codexAccounts: [{ accountKey: codexAccountKey, available: 1, busy: 0, queued: 0, ready: 1 }],
+        totalAvailableClaudeAssignments: 1,
+        totalAvailableCodexAssignments: 1,
+      },
+      pylonRef: "pylon.local.test",
+    }
+    const runner = async (input: KhalaCodexFleetCommandInput): Promise<KhalaCodexFleetCommandResult> => {
+      calls.push(input)
+      const args = pylonArgs(input)
+      const joined = args.join(" ")
+      if (joined === "provider go-online --json") {
+        return ok(providerProjection)
+      }
+      if (joined === "accounts list --json") {
+        return ok({
+          accounts: [
+            {
+              accountRef: "codex",
+              accountRefHash: `account.pylon.codex.${codexAccountKey}`,
+              homeState: "present",
+              provider: "codex",
+            },
+            {
+              accountRef: "claude",
+              accountRefHash: `account.pylon.claude_agent.${claudeAccountKey}`,
+              homeState: "present",
+              provider: "claude_agent",
+            },
+          ],
+          schema: "openagents.pylon.accounts_list.v0.3",
+        })
+      }
+      if (joined === "accounts status --provider codex --json") {
+        return ok({
+          accounts: [
+            {
+              accountRef: "codex",
+              accountRefHash: `account.pylon.codex.${codexAccountKey}`,
+              provider: "codex",
+              quota: { state: "available" },
+              readiness: { state: "ready" },
+            },
+          ],
+          schema: "openagents.pylon.accounts_status.v0.1",
+        })
+      }
+      if (joined === "accounts status --provider claude_agent --json") {
+        return ok({
+          accounts: [
+            {
+              accountRef: "claude",
+              accountRefHash: `account.pylon.claude_agent.${claudeAccountKey}`,
+              provider: "claude_agent",
+              quota: { state: "available" },
+              readiness: { state: "ready" },
+            },
+          ],
+          schema: "openagents.pylon.accounts_status.v0.1",
+        })
+      }
+      if (joined === "khala apm --base-url https://openagents.com --json") {
+        return ok({ assignments: [] })
+      }
+      if (joined === "presence heartbeat --base-url https://openagents.com --json") {
+        return ok({
+          heartbeatRef: "heartbeat.pylon.local.test.1",
+          pylonRef: "pylon.local.test",
+        })
+      }
+      if (args[0] === "khala" && args[1] === "request") {
+        expect(args).toContain("--workflow")
+        expect(args).toContain("claude_agent_task")
+        expect(args).toContain("--account-ref")
+        expect(args).toContain("claude")
+        return ok({
+          assignmentRef: "assignment.public.claude_agent_task.auto_v2",
+          autoRun: {
+            attempted: false,
+            reason: "disabled_by_no_run",
+          },
+        })
+      }
+      return failed(`unexpected command: ${joined}`)
+    }
+
+    const result = await spawnCodexInstances({
+      count: 1,
+      noRun: true,
+      prompt: "Run the public fixture.",
+      workerKind: "auto",
+      workflowClassification: {
+        confidence: 1,
+        evidenceRefs: ["evidence.coding_workflow.structured_body"],
+        workflowClass: "claude_agent_task",
+      },
+    }, {
+      env: fixture.env,
+      runner,
+    })
+
+    expect(result).toMatchObject({
+      acceptedCount: 1,
+      pylonRef: "pylon.local.test",
+      requestedCount: 1,
+    })
+    expect(result.results[0]).toMatchObject({
+      accountRef: "claude",
+      assignmentRef: "assignment.public.claude_agent_task.auto_v2",
+      status: "accepted",
+    })
+    expect(result.delegateTrace?.some(step =>
+      step.refs.includes("workflow.public.khala_coding.claude_agent_task")
+    )).toBe(true)
+  })
+
   test("spawnCodexInstances resolves live commit pins and renders claim-aware real-work prompts", async () => {
     const fixture = await tempPylonFixture()
     const liveCommit = "abcdef0123456789abcdef0123456789abcdef01"

--- a/docs/fable/2026-07-01-claude-code-parity-and-codex-synergies.md
+++ b/docs/fable/2026-07-01-claude-code-parity-and-codex-synergies.md
@@ -283,6 +283,13 @@ accepts, requests changes (the annotate-diff loop from the Orca doc), or
 re-plans. The deterministic delegation program stays the control-flow authority;
 Claude supplies decomposition and review judgment, not per-call control.
 
+**T9.3 update (2026-07-02):** the `auto` target now has a classifier-aware
+parameter layer. A typed workflow-classification hint can bias `auto` toward
+Codex or Claude only when that lane has advertised free slots; admitted
+parameters tune confidence threshold, classifier bonus, and tie-breaker. This
+keeps Claude/Fable planning as advisory structure while `khala.fleet.delegate`
+continues to own deterministic control flow.
+
 ### 4.2 Claude as reviewer / verifier-adjacent
 
 Claude's review quality pairs with our verification gates. After a Codex worker's

--- a/docs/fable/2026-07-01-episode-245-completion-and-multi-harness-orchestration.md
+++ b/docs/fable/2026-07-01-episode-245-completion-and-multi-harness-orchestration.md
@@ -259,6 +259,15 @@ refs, and dispatch gate all exist:
   GEPA-optimizable *parameter* of the delegation program — never its
   control flow. That is the same DSPy split the episode teaches.
 
+  **T9.3 update (2026-07-02):** `auto` now consumes a structured
+  workflow-classification hint (`codex_agent_task`, `claude_agent_task`,
+  `cloud_coding_session`, or `none`) when one is already present from the
+  typed classifier seam. The deterministic delegation program scores only
+  available Codex/Claude slots, with Gym-admitted parameter knobs for the
+  classifier confidence threshold, classifier bonus slots, and tie-breaker.
+  No prose is parsed, and no optimizer candidate can change the control-flow
+  modules or self-promote at runtime.
+
 This gives the owner's dropdown its full meaning without inverting the
 pivot: **the chat harness stays a wrapper decision (Axis A); "or whomever
 else" is a delegation decision (Axis B).** A Codex-mode chat can spawn
@@ -284,12 +293,13 @@ the parity contract changes.
   bounded fixture/checkout work. This is the same work item as Lane B4 of
   `2026-07-01-fleet-fanout-coding-instructions.md` — implement it once,
   there, with the FleetRun `workerKind` enum.
-- **P3 (next): `auto` and Khala-as-router.** Local free-slot rule → server
-  classifier → GEPA-optimized routing parameters, admission-gated through
-  the same Gym path the episode demos. Separately, close the deferrable
-  Claude gaps (full-access posture decision, PR publisher, ATIF/per-turn
-  rows) only when Claude workers graduate from analysis/bounded work to PR
-  delivery.
+- **P3 (partly landed in T9.3): `auto` and Khala-as-router.** Local
+  free-slot rule → server classifier → GEPA-optimized routing parameters,
+  admission-gated through the same Gym path the episode demos. The
+  classifier-biased parameter layer is in; broader Khala-as-router and
+  deferrable Claude gaps (full-access posture decision, PR publisher,
+  ATIF/per-turn rows) remain for when Claude workers graduate from
+  analysis/bounded work to PR delivery.
 
 ### 3.4 Invariants to keep while doing this
 

--- a/packages/khala-tools/src/fleet-delegate-program.test.ts
+++ b/packages/khala-tools/src/fleet-delegate-program.test.ts
@@ -6,8 +6,11 @@ import {
   KhalaFleetDelegationParameterSet,
   KhalaFleetDelegationParameterSetSchemaVersion,
   KhalaFleetDelegateModuleError,
+  khalaFleetDelegationClassifierMinimumConfidence,
+  khalaFleetDelegationClassifierPreferenceBonusSlots,
   khalaFleetDelegationDispatchAttempts,
   khalaFleetDelegationParametersFromEnv,
+  khalaFleetDelegateWorkerKindForWorkflowClass,
   prepareKhalaFleetDelegateWork,
   renderKhalaFleetDelegationObjective,
   renderDefaultKhalaFleetDelegationObjective,
@@ -300,6 +303,177 @@ describe("khala.fleet.delegate deterministic program", () => {
       })
     })
 
+    test("auto v2 uses structured classifier output as a bounded routing preference", () => {
+      const parameters = admittedParameters({
+        delegationTarget: { workerKind: "auto" },
+      })
+      const accounts = [
+        readyAccount({ accountRef: "claude", availableSlots: 1, workerKind: "claude" }),
+        readyAccount({ accountRef: "codex", availableSlots: 1, workerKind: "codex" }),
+      ]
+
+      expect(resolveKhalaFleetDelegateWorkerKind(accounts, parameters, {
+        confidence: 1,
+        evidenceRefs: ["evidence.coding_workflow.structured_body"],
+        workflowClass: "claude_agent_task",
+      })).toBe("claude")
+      expect(selectKhalaFleetDelegateAccount({
+        workflowClassification: {
+          confidence: 1,
+          evidenceRefs: ["evidence.coding_workflow.structured_body"],
+          workflowClass: "claude_agent_task",
+        },
+      }, accounts, parameters)).toMatchObject({
+        account: { accountRef: "claude" },
+        status: "selected",
+        workerKind: "claude",
+      })
+    })
+
+    test("auto v2 ignores low-confidence classification and preserves free-slot selection", () => {
+      const parameters = admittedParameters({
+        delegationTarget: {
+          autoRouting: { classifierMinimumConfidence: 0.9 },
+          workerKind: "auto",
+        },
+      })
+      const accounts = [
+        readyAccount({ accountRef: "claude", availableSlots: 1, workerKind: "claude" }),
+        readyAccount({ accountRef: "codex", availableSlots: 2, workerKind: "codex" }),
+      ]
+
+      expect(resolveKhalaFleetDelegateWorkerKind(accounts, parameters, {
+        confidence: 0.5,
+        evidenceRefs: ["evidence.coding_workflow.structured_body"],
+        workflowClass: "claude_agent_task",
+      })).toBe("codex")
+    })
+
+    test("auto v2 cannot route to the classified worker kind without available slots", () => {
+      const parameters = admittedParameters({
+        delegationTarget: { workerKind: "auto" },
+      })
+      const accounts = [
+        readyAccount({ accountRef: "codex", availableSlots: 0, workerKind: "codex" }),
+        readyAccount({ accountRef: "claude", availableSlots: 1, workerKind: "claude" }),
+      ]
+
+      expect(resolveKhalaFleetDelegateWorkerKind(accounts, parameters, {
+        confidence: 1,
+        evidenceRefs: ["evidence.coding_workflow.structured_body"],
+        workflowClass: "codex_agent_task",
+      })).toBe("claude")
+    })
+
+    test("auto v2 tie-breaker is an admitted parameter and never invents capacity", () => {
+      const claudeTieBreak = admittedParameters({
+        delegationTarget: {
+          autoRouting: { tieBreakWorkerKind: "claude" },
+          workerKind: "auto",
+        },
+      })
+      const tiedAccounts = [
+        readyAccount({ accountRef: "claude", availableSlots: 1, workerKind: "claude" }),
+        readyAccount({ accountRef: "codex", availableSlots: 1, workerKind: "codex" }),
+      ]
+      const zeroClaudeAccounts = [
+        readyAccount({ accountRef: "claude", availableSlots: 0, workerKind: "claude" }),
+        readyAccount({ accountRef: "codex", availableSlots: 1, workerKind: "codex" }),
+      ]
+
+      expect(resolveKhalaFleetDelegateWorkerKind(tiedAccounts, claudeTieBreak)).toBe("claude")
+      expect(resolveKhalaFleetDelegateWorkerKind(zeroClaudeAccounts, claudeTieBreak)).toBe("codex")
+    })
+
+    test("auto v2 ignores malformed classifier hints before they reach trace refs", async () => {
+      const parameters = admittedParameters({
+        delegationTarget: { workerKind: "auto" },
+      })
+      const result = await Effect.runPromise(runKhalaFleetDelegateProgram({
+        objective: "Run the fixture",
+        workflowClassification: {
+          confidence: Number.NaN,
+          evidenceRefs: ["evidence.coding_workflow.structured_body", "unsafe/ref"],
+          workflowClass: "claude_agent_task",
+        },
+      }, {
+        ensurePylon: () => Effect.succeed({ pylonRef: "pylon.local.test" }),
+        advertiseCapacity: () =>
+          Effect.succeed({
+            capacity: {
+              accounts: [
+                readyAccount({ accountRef: "claude", availableSlots: 1, workerKind: "claude" }),
+                readyAccount({ accountRef: "codex", availableSlots: 1, workerKind: "codex" }),
+              ],
+              available: 2,
+              max: 2,
+            },
+          }),
+        dispatch: ({ account, workerKind }) =>
+          Effect.succeed({
+            assignmentRef: `assignment.public.khala_fleet_delegate.${workerKind}.${account.accountRef}`,
+            ok: true,
+          }),
+        verifyCloseout: () => Effect.succeed({ ok: true }),
+      }, {
+        parameters,
+      }))
+
+      expect(result.status).toBe("completed")
+      if (result.status !== "completed") return
+      expect(result.workerKind).toBe("codex")
+      expect(result.trace.flatMap(step => step.refs)).not.toContain("unsafe/ref")
+      expect(result.trace.flatMap(step => step.refs)).not.toContain("workflow.public.khala_coding.claude_agent_task")
+    })
+
+    test("explicit worker kind does not emit auto-routing classifier trace refs", async () => {
+      const parameters = admittedParameters({
+        delegationTarget: { workerKind: "codex" },
+      })
+      const result = await Effect.runPromise(runKhalaFleetDelegateProgram({
+        objective: "Run the fixture",
+        workflowClassification: {
+          confidence: 1,
+          evidenceRefs: ["evidence.coding_workflow.structured_body"],
+          workflowClass: "claude_agent_task",
+        },
+      }, {
+        ensurePylon: () => Effect.succeed({ pylonRef: "pylon.local.test" }),
+        advertiseCapacity: () =>
+          Effect.succeed({
+            capacity: {
+              accounts: [
+                readyAccount({ accountRef: "claude", availableSlots: 1, workerKind: "claude" }),
+                readyAccount({ accountRef: "codex", availableSlots: 1, workerKind: "codex" }),
+              ],
+              available: 2,
+              max: 2,
+            },
+          }),
+        dispatch: ({ account, workerKind }) =>
+          Effect.succeed({
+            assignmentRef: `assignment.public.khala_fleet_delegate.${workerKind}.${account.accountRef}`,
+            ok: true,
+          }),
+        verifyCloseout: () => Effect.succeed({ ok: true }),
+      }, {
+        parameters,
+      }))
+
+      expect(result.status).toBe("completed")
+      if (result.status !== "completed") return
+      expect(result.workerKind).toBe("codex")
+      expect(result.trace.flatMap(step => step.refs)).not.toContain("auto_route.worker_kind.claude")
+      expect(result.trace.flatMap(step => step.refs)).not.toContain("workflow.public.khala_coding.claude_agent_task")
+    })
+
+    test("workflow classes map to concrete worker kinds without prose parsing", () => {
+      expect(khalaFleetDelegateWorkerKindForWorkflowClass("claude_agent_task")).toBe("claude")
+      expect(khalaFleetDelegateWorkerKindForWorkflowClass("codex_agent_task")).toBe("codex")
+      expect(khalaFleetDelegateWorkerKindForWorkflowClass("cloud_coding_session")).toBe("codex")
+      expect(khalaFleetDelegateWorkerKindForWorkflowClass("none")).toBeUndefined()
+    })
+
     test("capacity blocker vocabulary is keyed by explicit worker kind", () => {
       const selected = selectKhalaFleetDelegateAccount({}, [
         readyAccount({ accountRef: "claude", availableSlots: 0, workerKind: "claude" }),
@@ -439,6 +613,13 @@ describe("khala.fleet.delegate deterministic program", () => {
     test("env admission decodes a bounded parameter set and rejects unsafe text", () => {
       const parameters = admittedParameters({
         advertiseCapacity: { perAccountConcurrency: 4 },
+        delegationTarget: {
+          autoRouting: {
+            classifierMinimumConfidence: 0.8,
+            classifierPreferenceBonusSlots: 3,
+          },
+          workerKind: "auto",
+        },
         objectiveTemplate: "Admitted: {objective}",
       })
       const decoded = khalaFleetDelegationParametersFromEnv({
@@ -447,6 +628,8 @@ describe("khala.fleet.delegate deterministic program", () => {
 
       expect(decoded.parameterSetRef).toBe(parameters.parameterSetRef)
       expect(decoded.advertiseCapacity?.perAccountConcurrency).toBe(4)
+      expect(khalaFleetDelegationClassifierMinimumConfidence(decoded)).toBe(0.8)
+      expect(khalaFleetDelegationClassifierPreferenceBonusSlots(decoded)).toBe(3)
       expect(() =>
         khalaFleetDelegationParametersFromEnv({
           [KhalaFleetDelegationAdmittedParametersEnv]: JSON.stringify(admittedParameters({
@@ -454,6 +637,16 @@ describe("khala.fleet.delegate deterministic program", () => {
           })),
         }),
       ).toThrow(/public-safe/)
+      expect(() =>
+        khalaFleetDelegationParametersFromEnv({
+          [KhalaFleetDelegationAdmittedParametersEnv]: JSON.stringify(admittedParameters({
+            delegationTarget: {
+              autoRouting: { classifierPreferenceBonusSlots: 65 },
+              workerKind: "auto",
+            },
+          })),
+        }),
+      ).toThrow(/classifierPreferenceBonusSlots/)
     })
   })
 

--- a/packages/khala-tools/src/fleet-delegate-program.ts
+++ b/packages/khala-tools/src/fleet-delegate-program.ts
@@ -64,12 +64,36 @@ export type KhalaFleetDelegateConcreteWorkerKind =
 export const KhalaFleetDelegateWorkerKind = S.Literals(["auto", "claude", "codex"])
 export type KhalaFleetDelegateWorkerKind = typeof KhalaFleetDelegateWorkerKind.Type
 
+export const KhalaFleetDelegationWorkflowClass = S.Literals([
+  "claude_agent_task",
+  "cloud_coding_session",
+  "codex_agent_task",
+  "none",
+])
+export type KhalaFleetDelegationWorkflowClass =
+  typeof KhalaFleetDelegationWorkflowClass.Type
+
+export const KhalaFleetDelegationWorkflowClassification = S.Struct({
+  confidence: S.Number,
+  evidenceRefs: S.Array(S.String),
+  workflowClass: KhalaFleetDelegationWorkflowClass,
+})
+export type KhalaFleetDelegationWorkflowClassification =
+  typeof KhalaFleetDelegationWorkflowClassification.Type
+
 const KhalaFleetDelegationAdvertiseCapacityPolicy = S.Struct({
   maxRequestedSlots: S.optionalKey(S.Number),
   perAccountConcurrency: S.optionalKey(S.Number),
 })
 
+const KhalaFleetDelegationAutoRoutingPolicy = S.Struct({
+  classifierMinimumConfidence: S.optionalKey(S.Number),
+  classifierPreferenceBonusSlots: S.optionalKey(S.Number),
+  tieBreakWorkerKind: S.optionalKey(KhalaFleetDelegateConcreteWorkerKind),
+})
+
 const KhalaFleetDelegationTargetPolicy = S.Struct({
+  autoRouting: S.optionalKey(KhalaFleetDelegationAutoRoutingPolicy),
   workerKind: S.optionalKey(KhalaFleetDelegateWorkerKind),
 })
 
@@ -154,6 +178,7 @@ export type KhalaFleetDelegateInput = Readonly<{
   objective: string
   repo?: string | undefined
   verify?: string | undefined
+  workflowClassification?: KhalaFleetDelegationWorkflowClassification | undefined
 }>
 
 export type KhalaFleetDelegateProgramOptions = Readonly<{
@@ -253,7 +278,10 @@ export type KhalaFleetDelegateAdvertiseReason =
 
 const DEFAULT_DISPATCH_ATTEMPTS = 4
 const DEFAULT_DUPLICATE_ACTIVE_ASSIGNMENT_BACKOFF_MS = 1_000
+const DEFAULT_CLASSIFIER_MINIMUM_CONFIDENCE = 0.75
+const DEFAULT_CLASSIFIER_PREFERENCE_BONUS_SLOTS = 2
 const DEFAULT_PARAMETER_SET_REF = "parameter_set.khala_fleet_delegation.default.v1"
+const publicSafeWorkflowEvidenceRefPattern = /^[A-Za-z0-9_.:-]+$/
 const unsafePolicyTextPattern =
   /(@|\/Users\/|\/home\/|access[_-]?token|auth\.json|bearer|cookie|credential|gho_[A-Za-z0-9_]+|ghp_[A-Za-z0-9_]+|lnbc|lntb|lnbcrt|lno1|mdk[_-]?(access[_-]?token|mnemonic|webhook[_-]?secret)|mnemonic|oauth|payment[_-]?(hash|id|preimage|proof)|preimage|private[_-]?(channel|key|repo)|provider[_-]?(grant|payload|secret|token)|raw[_-]?(auth|email|fixture|invoice|payment|payload|prompt|provider|runner|run[_-]?log|source[_-]?archive|trace|traces)|runner[_-]?log|secret|sk-[a-z0-9]|source[_-]?archive|token|wallet)/i
 
@@ -343,6 +371,38 @@ export function khalaFleetDelegationDuplicateBackoffMs(
     120_000,
     "retryBackoff.duplicateActiveAssignmentBackoffMs",
   )
+}
+
+export function khalaFleetDelegationClassifierMinimumConfidence(
+  parameters: KhalaFleetDelegationParameterSet,
+): number {
+  return boundedPolicyNumber(
+    parameters.delegationTarget?.autoRouting?.classifierMinimumConfidence,
+    DEFAULT_CLASSIFIER_MINIMUM_CONFIDENCE,
+    0,
+    1,
+    "delegationTarget.autoRouting.classifierMinimumConfidence",
+  )
+}
+
+export function khalaFleetDelegationClassifierPreferenceBonusSlots(
+  parameters: KhalaFleetDelegationParameterSet,
+): number {
+  return boundedPolicyInteger(
+    parameters.delegationTarget?.autoRouting?.classifierPreferenceBonusSlots,
+    DEFAULT_CLASSIFIER_PREFERENCE_BONUS_SLOTS,
+    0,
+    64,
+    "delegationTarget.autoRouting.classifierPreferenceBonusSlots",
+  )
+}
+
+export function khalaFleetDelegateWorkerKindForWorkflowClass(
+  workflowClass: KhalaFleetDelegationWorkflowClass,
+): KhalaFleetDelegateConcreteWorkerKind | undefined {
+  if (workflowClass === "claude_agent_task") return "claude"
+  if (workflowClass === "codex_agent_task" || workflowClass === "cloud_coding_session") return "codex"
+  return undefined
 }
 
 export function renderKhalaFleetDelegationObjective(
@@ -490,7 +550,9 @@ export const runKhalaFleetDelegateProgram = (
     const workerKind = resolveKhalaFleetDelegateWorkerKind(
       advertised instanceof KhalaFleetDelegateModuleError ? [] : advertised.capacity.accounts,
       parameters,
+      input.workflowClassification,
     )
+    const autoRoutingRefs = khalaFleetDelegateAutoRoutingRefs(input.workflowClassification, parameters)
     if (advertised instanceof KhalaFleetDelegateModuleError) {
       return block(
         ensure.pylonRef,
@@ -505,7 +567,10 @@ export const runKhalaFleetDelegateProgram = (
       message: `Advertised ${workerKind} capacity ${khalaFleetDelegateAvailableSlotsForKind(advertised.capacity.accounts, workerKind)}/${advertised.capacity.max}.`,
       module: "advertise_capacity",
       precondition: khalaFleetDelegateAdvertisedCapacityPrecondition(workerKind),
-      refs: advertised.heartbeatRef === undefined ? [] : [advertised.heartbeatRef],
+      refs: [
+        ...(advertised.heartbeatRef === undefined ? [] : [advertised.heartbeatRef]),
+        ...autoRoutingRefs,
+      ],
       status: khalaFleetDelegateAvailableSlotsForKind(advertised.capacity.accounts, workerKind) > 0 ? "satisfied" : "blocked",
     })
 
@@ -524,7 +589,7 @@ export const runKhalaFleetDelegateProgram = (
       message: `Selected ${selected.workerKind} account ${selected.account.accountRef}.`,
       module: "select_account",
       precondition: "ready_account_free_slot",
-      refs: [`worker_kind:${selected.workerKind}`, `account:${selected.account.accountRef}`],
+      refs: [`worker_kind:${selected.workerKind}`, `account:${selected.account.accountRef}`, ...autoRoutingRefs],
       status: "satisfied",
     })
 
@@ -635,7 +700,7 @@ export function prepareKhalaFleetDelegateWork(
 }
 
 export function selectKhalaFleetDelegateAccount(
-  input: Pick<KhalaFleetDelegateInput, "accountRef">,
+  input: Pick<KhalaFleetDelegateInput, "accountRef" | "workflowClassification">,
   accounts: ReadonlyArray<KhalaFleetDelegateAccount>,
   parameters: KhalaFleetDelegationParameterSet = DefaultKhalaFleetDelegationParameterSet,
 ):
@@ -650,7 +715,7 @@ export function selectKhalaFleetDelegateAccount(
     message: string
     status: "blocked"
   }> {
-  const workerKind = resolveKhalaFleetDelegateWorkerKind(accounts, parameters)
+  const workerKind = resolveKhalaFleetDelegateWorkerKind(accounts, parameters, input.workflowClassification)
   const requested = input.accountRef?.trim()
   const candidates = requested === undefined || requested.length === 0
     ? accounts.filter(account => khalaFleetDelegateAccountWorkerKind(account) === workerKind)
@@ -752,18 +817,20 @@ function normalizeKhalaFleetDelegationParameterSet(
   khalaFleetDelegationMaxRequestedSlots(parameters, 1)
   khalaFleetDelegationDispatchAttempts(parameters)
   khalaFleetDelegationDuplicateBackoffMs(parameters)
+  khalaFleetDelegationClassifierMinimumConfidence(parameters)
+  khalaFleetDelegationClassifierPreferenceBonusSlots(parameters)
   return parameters
 }
 
 export function resolveKhalaFleetDelegateWorkerKind(
   accounts: ReadonlyArray<KhalaFleetDelegateAccount>,
   parameters: KhalaFleetDelegationParameterSet = DefaultKhalaFleetDelegationParameterSet,
+  workflowClassification?: KhalaFleetDelegationWorkflowClassification | undefined,
 ): KhalaFleetDelegateConcreteWorkerKind {
-  const requested = resolveKhalaFleetDelegationParameters(parameters).delegationTarget?.workerKind ?? "codex"
+  const resolved = resolveKhalaFleetDelegationParameters(parameters)
+  const requested = resolved.delegationTarget?.workerKind ?? "codex"
   if (requested !== "auto") return requested
-  const codexSlots = khalaFleetDelegateAvailableSlotsForKind(accounts, "codex")
-  const claudeSlots = khalaFleetDelegateAvailableSlotsForKind(accounts, "claude")
-  return claudeSlots > codexSlots ? "claude" : "codex"
+  return scoreKhalaFleetDelegateAutoWorkerKind(accounts, resolved, workflowClassification)
 }
 
 function khalaFleetDelegateAccountWorkerKind(
@@ -782,6 +849,68 @@ function khalaFleetDelegateAvailableSlotsForKind(
       (account.readiness === "ready" || account.readiness === "available")
     )
     .reduce((total, account) => total + Math.max(0, account.availableSlots ?? 1), 0)
+}
+
+function scoreKhalaFleetDelegateAutoWorkerKind(
+  accounts: ReadonlyArray<KhalaFleetDelegateAccount>,
+  parameters: KhalaFleetDelegationParameterSet,
+  workflowClassification?: KhalaFleetDelegationWorkflowClassification | undefined,
+): KhalaFleetDelegateConcreteWorkerKind {
+  const codexSlots = khalaFleetDelegateAvailableSlotsForKind(accounts, "codex")
+  const claudeSlots = khalaFleetDelegateAvailableSlotsForKind(accounts, "claude")
+  const classifiedKind = khalaFleetDelegateClassifiedWorkerKind(parameters, workflowClassification)
+  const classifierBonus = khalaFleetDelegationClassifierPreferenceBonusSlots(parameters)
+  const codexScore = codexSlots + (classifiedKind === "codex" && codexSlots > 0 ? classifierBonus : 0)
+  const claudeScore = claudeSlots + (classifiedKind === "claude" && claudeSlots > 0 ? classifierBonus : 0)
+  if (claudeScore !== codexScore) return claudeScore > codexScore ? "claude" : "codex"
+
+  const tieBreak = parameters.delegationTarget?.autoRouting?.tieBreakWorkerKind ?? "codex"
+  const tieBreakSlots = tieBreak === "claude" ? claudeSlots : codexSlots
+  const other = tieBreak === "claude" ? "codex" : "claude"
+  const otherSlots = other === "claude" ? claudeSlots : codexSlots
+  if (tieBreakSlots > 0 || otherSlots === 0) return tieBreak
+  return other
+}
+
+function khalaFleetDelegateClassifiedWorkerKind(
+  parameters: KhalaFleetDelegationParameterSet,
+  workflowClassification?: KhalaFleetDelegationWorkflowClassification | undefined,
+): KhalaFleetDelegateConcreteWorkerKind | undefined {
+  if (workflowClassification === undefined) return undefined
+  if (!khalaFleetDelegationWorkflowClassificationIsPublicSafe(workflowClassification)) {
+    return undefined
+  }
+  if (workflowClassification.confidence < khalaFleetDelegationClassifierMinimumConfidence(parameters)) {
+    return undefined
+  }
+  return khalaFleetDelegateWorkerKindForWorkflowClass(workflowClassification.workflowClass)
+}
+
+function khalaFleetDelegateAutoRoutingRefs(
+  workflowClassification: KhalaFleetDelegationWorkflowClassification | undefined,
+  parameters: KhalaFleetDelegationParameterSet,
+): ReadonlyArray<string> {
+  if ((parameters.delegationTarget?.workerKind ?? "codex") !== "auto") {
+    return []
+  }
+  const workerKind = khalaFleetDelegateClassifiedWorkerKind(parameters, workflowClassification)
+  if (workerKind === undefined || workflowClassification === undefined) {
+    return []
+  }
+  return [
+    `auto_route.worker_kind.${workerKind}`,
+    `workflow.public.khala_coding.${workflowClassification.workflowClass}`,
+    ...workflowClassification.evidenceRefs,
+  ]
+}
+
+function khalaFleetDelegationWorkflowClassificationIsPublicSafe(
+  workflowClassification: KhalaFleetDelegationWorkflowClassification,
+): boolean {
+  return Number.isFinite(workflowClassification.confidence) &&
+    workflowClassification.confidence >= 0 &&
+    workflowClassification.confidence <= 1 &&
+    workflowClassification.evidenceRefs.every(ref => publicSafeWorkflowEvidenceRefPattern.test(ref))
 }
 
 function khalaFleetDelegateAdvertisedCapacityPrecondition(
@@ -813,6 +942,20 @@ function boundedPolicyInteger(
   if (value === undefined) return fallback
   if (!Number.isSafeInteger(value) || value < min || value > max) {
     throw new Error(`${label} must be an integer between ${min} and ${max}`)
+  }
+  return value
+}
+
+function boundedPolicyNumber(
+  value: number | undefined,
+  fallback: number,
+  min: number,
+  max: number,
+  label: string,
+): number {
+  if (value === undefined) return fallback
+  if (!Number.isFinite(value) || value < min || value > max) {
+    throw new Error(`${label} must be a number between ${min} and ${max}`)
   }
   return value
 }

--- a/packages/khala-tools/src/index.ts
+++ b/packages/khala-tools/src/index.ts
@@ -36,9 +36,13 @@ export {
   DefaultKhalaFleetDelegationParameterSet,
   KhalaFleetDelegationAccountRankingHeuristic,
   KhalaFleetDelegationAdmittedParametersEnv,
+  khalaFleetDelegationClassifierMinimumConfidence,
+  khalaFleetDelegationClassifierPreferenceBonusSlots,
   KhalaFleetDelegationParameterSet,
   KhalaFleetDelegationParameterSetSchemaVersion,
   KhalaFleetDelegationParameterSource,
+  KhalaFleetDelegationWorkflowClass,
+  KhalaFleetDelegationWorkflowClassification,
   KhalaFleetDelegateBlockerCode,
   KhalaFleetDelegateConcreteWorkerKind,
   KhalaFleetDelegateModuleError,
@@ -60,6 +64,7 @@ export {
   runKhalaFleetDelegateProgram,
   selectKhalaFleetDelegateAccount,
   type KhalaFleetDelegateAdvertiseReason,
+  khalaFleetDelegateWorkerKindForWorkflowClass,
   type KhalaFleetDelegateProgramOptions,
   type KhalaFleetDelegateAccount,
   type KhalaFleetDelegateAdvertiseResult,
@@ -74,6 +79,8 @@ export {
   type KhalaFleetDelegateStep,
   type KhalaFleetDelegateVerifyResult,
   type KhalaFleetDelegateWork,
+  type KhalaFleetDelegationWorkflowClass as KhalaFleetDelegationWorkflowClassType,
+  type KhalaFleetDelegationWorkflowClassification as KhalaFleetDelegationWorkflowClassificationType,
 } from "./fleet-delegate-program.js"
 
 export {


### PR DESCRIPTION
## Summary

- adds structured workflow-classification input to `khala.fleet.delegate` auto routing
- keeps auto routing deterministic by scoring advertised Codex/Claude free slots plus admitted confidence/bonus/tie-break parameters
- wires desktop `codex_spawn` to pass classifier hints only as structured public-safe fields, and documents the T9.3 Fable landing

Closes #7872

## Verification

- `bun test packages/khala-tools/src/fleet-delegate-program.test.ts`
- `bun test clients/khala-code-desktop/tests/khala-fleet-tools.test.ts`
- `bun run --cwd apps/openagents.com/workers/api test -- src/inference/coding-workflow-classifier.test.ts src/inference/coding-workflow-delegation.test.ts src/coding-capacity-validation.test.ts`
- `bun run --cwd packages/khala-tools typecheck`
- `bun run --cwd clients/khala-code-desktop typecheck`
- `bun run --cwd apps/openagents.com/workers/api typecheck`
- `git diff --check`
- `bun run --cwd packages/khala-tools test`
- `bun run --cwd clients/khala-code-desktop verify`
- `bun run --cwd apps/openagents.com check:deploy`