### PR TITLE
Implement plan DAG fleet fanout

### DIFF
--- a/apps/pylon/src/orchestration/store.ts
+++ b/apps/pylon/src/orchestration/store.ts
@@ -67,7 +67,7 @@ export const FLEET_RUN_SCHEMA = "openagents.khala_code.fleet_run.v1" as const
 export const FLEET_RUN_OWNER_LOCAL_STATE_SCHEMA = "openagents.khala_code.fleet_runs.owner_local.v1" as const
 export const WORK_CLAIM_SCHEMA = "openagents.khala_code.work_claim.v1" as const
 
-export const FleetRunWorkSourceSchema = S.Literals(["github_backlog", "issue_list", "fixture"])
+export const FleetRunWorkSourceSchema = S.Literals(["github_backlog", "issue_list", "fixture", "plan_dag"])
 export type FleetRunWorkSource = typeof FleetRunWorkSourceSchema.Type
 
 export const FleetRunWorkerKindSchema = S.Literals(["codex", "claude", "auto"])

--- a/apps/pylon/src/orchestration/work-planner.test.ts
+++ b/apps/pylon/src/orchestration/work-planner.test.ts
@@ -9,6 +9,7 @@ import {
 import {
   buildWorkPlannerRealWorkDispatch,
   githubBacklogCandidates,
+  planDagWork,
   planFixtureWork,
   planGithubBacklogWork,
   planIssueListWork,
@@ -220,6 +221,120 @@ describe("typed work planner", () => {
     await expect(
       githubBacklogCandidates({ kind: "github_backlog", repo }, async () => JSON.stringify({ items: [] })),
     ).rejects.toThrow(/non-array JSON/)
+  })
+
+  test("plan_dag emits only dependency-ready nodes as claimable", () => {
+    const source = {
+      kind: "plan_dag" as const,
+      planRef: "plan.t9_4",
+      repo,
+      baseCommit: "0123456789abcdef0123456789abcdef01234567",
+      verify: "bun test clients/khala-code-desktop/tests/claude-plan-fanout.test.ts",
+      nodes: [
+        {
+          ref: "root",
+          title: "Define typed contract",
+          objective: "Add the typed plan fan-out contract.",
+          issue: 7873,
+        },
+        {
+          ref: "adapter",
+          title: "Wire FleetRun source",
+          objective: "Convert the plan contract into FleetRun work units.",
+          dependsOn: ["root"],
+        },
+      ],
+    }
+
+    const first = planDagWork(source, { now })
+    expect(first.claimable.map(unit => unit.workUnitRef)).toEqual(["plan_dag:plan.t9_4:node:root"])
+    expect(first.claimable[0]).toMatchObject({
+      kind: "plan_task",
+      repo,
+      number: 7873,
+      body: "Add the typed plan fan-out contract.",
+      baseCommit: "0123456789abcdef0123456789abcdef01234567",
+    })
+    expect(skipReasonsByRef(first.skipped)).toEqual({
+      "plan_dag:plan.t9_4:node:adapter": "dependency_pending",
+    })
+
+    const store = createPylonOrchestrationStore(new Database(":memory:"))
+    const rootClaim = store.tryClaimWorkUnit({
+      claimRef: "claim.plan.root",
+      workUnitRef: "plan_dag:plan.t9_4:node:root",
+      runRef: "fleet_run.plan",
+      workerAccountRef: "codex",
+      ttl: 60_000,
+      now,
+    })
+    expect(rootClaim).not.toBeNull()
+    store.updateWorkClaimState("claim.plan.root", "closeout", now)
+
+    const second = planDagWork(source, {
+      claimRegistry: store,
+      completedWorkUnitRefs: ["plan_dag:plan.t9_4:node:root"],
+      now,
+    })
+    expect(second.claimable.map(unit => unit.workUnitRef)).toEqual([
+      "plan_dag:plan.t9_4:node:adapter",
+    ])
+  })
+
+  test("plan_dag marks dependents blocked when a prerequisite failed", () => {
+    const source = {
+      kind: "plan_dag" as const,
+      planRef: "plan.t9_4.failed",
+      nodes: [
+        { ref: "root", title: "Root", objective: "Root task." },
+        { ref: "dependent", title: "Dependent", objective: "Dependent task.", dependsOn: ["root"] },
+      ],
+    }
+
+    const result = planDagWork(source, {
+      failedWorkUnitRefs: ["plan_dag:plan.t9_4.failed:node:root"],
+      now,
+    })
+
+    expect(skipReasonsByRef(result.skipped)).toEqual({
+      "plan_dag:plan.t9_4.failed:node:dependent": "dependency_failed",
+    })
+  })
+
+  test("plan_dag rejects duplicate refs, unknown dependencies, and cycles", () => {
+    expect(() => planDagWork({
+      kind: "plan_dag",
+      planRef: "plan.t9_4.invalid",
+      nodes: [
+        { ref: "root", title: "Root", objective: "Root task." },
+        { ref: "root", title: "Duplicate", objective: "Duplicate task." },
+      ],
+    })).toThrow(/duplicate node ref/)
+
+    expect(() => planDagWork({
+      kind: "plan_dag",
+      planRef: "plan.t9_4.invalid",
+      nodes: [
+        { ref: "dependent", title: "Dependent", objective: "Dependent task.", dependsOn: ["missing"] },
+      ],
+    })).toThrow(/unknown node/)
+
+    expect(() => planDagWork({
+      kind: "plan_dag",
+      planRef: "plan.t9_4.invalid",
+      nodes: [
+        { ref: "a", title: "A", objective: "A task.", dependsOn: ["b"] },
+        { ref: "b", title: "B", objective: "B task.", dependsOn: ["a"] },
+      ],
+    })).toThrow(/cycle/)
+
+    expect(() => planDagWork({
+      kind: "plan_dag",
+      planRef: "plan t9_4 invalid",
+      nodes: [
+        { ref: "root", title: "Root", objective: "Root task." },
+      ],
+    })).toThrow(/public-safe ref/)
   })
 
   test("skip priority is deterministic and includes merged PR siblings", () => {

--- a/apps/pylon/src/orchestration/work-planner.ts
+++ b/apps/pylon/src/orchestration/work-planner.ts
@@ -4,14 +4,16 @@ import type { PylonOrchestrationStore } from "./store.js"
 
 export const WORK_PLANNER_SCHEMA = "openagents.khala_code.work_planner.v1" as const
 
-export const WorkPlannerSourceKindSchema = S.Literals(["github_backlog", "issue_list", "fixture"])
+export const WorkPlannerSourceKindSchema = S.Literals(["github_backlog", "issue_list", "fixture", "plan_dag"])
 export type WorkPlannerSourceKind = typeof WorkPlannerSourceKindSchema.Type
 
-export const WorkPlannerUnitKindSchema = S.Literals(["github_issue", "github_pr", "fixture"])
+export const WorkPlannerUnitKindSchema = S.Literals(["github_issue", "github_pr", "fixture", "plan_task"])
 export type WorkPlannerUnitKind = typeof WorkPlannerUnitKindSchema.Type
 
 export const WorkPlannerSkipReasonSchema = S.Literals([
   "already_claimed",
+  "dependency_failed",
+  "dependency_pending",
   "pr_exists",
   "merged",
   "closed",
@@ -27,12 +29,16 @@ export type WorkPlannerCandidate = {
   readonly kind: WorkPlannerUnitKind
   readonly title: string
   readonly source: WorkPlannerSourceKind
+  readonly branch?: string
+  readonly baseCommit?: string
+  readonly dependsOn?: readonly string[]
   readonly repo?: string
   readonly number?: number
   readonly url?: string
   readonly labels?: readonly string[]
   readonly state?: WorkPlannerCandidateState
   readonly body?: string
+  readonly verify?: string
 }
 
 export type WorkPlannerClaimableUnit = WorkPlannerCandidate & {
@@ -71,7 +77,9 @@ export type WorkPlannerClaimRegistry = Pick<PylonOrchestrationStore, "getLiveWor
 export type WorkPlannerOptions = {
   readonly now?: Date
   readonly claimRegistry?: WorkPlannerClaimRegistry
+  readonly completedWorkUnitRefs?: readonly string[]
   readonly excludedLabels?: readonly string[]
+  readonly failedWorkUnitRefs?: readonly string[]
   readonly needsOwnerLabels?: readonly string[]
   readonly pullRequests?: readonly WorkPlannerCandidate[]
 }
@@ -122,6 +130,81 @@ export type GithubBacklogWorkSource = {
   readonly limit?: number
 }
 
+export type PlanDagWorkSource = {
+  readonly kind: "plan_dag"
+  readonly planRef: string
+  readonly repo?: string
+  readonly branch?: string
+  readonly baseCommit?: string
+  readonly verify?: string
+  readonly nodes: readonly PlanDagWorkUnit[]
+}
+
+export type PlanDagWorkUnit = {
+  readonly ref: string
+  readonly title: string
+  readonly objective: string
+  readonly dependsOn?: readonly string[]
+  readonly repo?: string
+  readonly branch?: string
+  readonly baseCommit?: string
+  readonly verify?: string
+  readonly issue?: number
+  readonly labels?: readonly string[]
+  readonly url?: string
+}
+
+const PLAN_DAG_REF_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:/#-]{0,180}$/u
+
+const assertPlanDagRef = (field: string, ref: string): void => {
+  if (ref.trim().length === 0) throw new Error(`plan_dag ${field} is required`)
+  if (!PLAN_DAG_REF_PATTERN.test(ref)) {
+    throw new Error(`plan_dag ${field} must be a public-safe ref`)
+  }
+}
+
+export const validatePlanDagWorkSource = (source: PlanDagWorkSource): PlanDagWorkSource => {
+  assertPlanDagRef("planRef", source.planRef)
+  if (source.nodes.length === 0) throw new Error("plan_dag requires at least one node")
+
+  const nodesByRef = new Map<string, PlanDagWorkUnit>()
+  for (const node of source.nodes) {
+    assertPlanDagRef("node ref", node.ref)
+    if (node.title.trim().length === 0) throw new Error(`plan_dag node ${node.ref} requires title`)
+    if (node.objective.trim().length === 0) throw new Error(`plan_dag node ${node.ref} requires objective`)
+    if (nodesByRef.has(node.ref)) throw new Error(`plan_dag duplicate node ref: ${node.ref}`)
+    nodesByRef.set(node.ref, node)
+  }
+
+  for (const node of source.nodes) {
+    for (const depRef of node.dependsOn ?? []) {
+      assertPlanDagRef(`node ${node.ref} dependency ref`, depRef)
+      if (!nodesByRef.has(depRef)) {
+        throw new Error(`plan_dag node ${node.ref} depends on unknown node: ${depRef}`)
+      }
+    }
+  }
+
+  const visiting = new Set<string>()
+  const visited = new Set<string>()
+  const visit = (nodeRef: string, path: readonly string[]): void => {
+    if (visited.has(nodeRef)) return
+    if (visiting.has(nodeRef)) {
+      throw new Error(`plan_dag contains a cycle: ${[...path, nodeRef].join(" -> ")}`)
+    }
+    visiting.add(nodeRef)
+    const node = nodesByRef.get(nodeRef)
+    if (node !== undefined) {
+      for (const depRef of node.dependsOn ?? []) visit(depRef, [...path, nodeRef])
+    }
+    visiting.delete(nodeRef)
+    visited.add(nodeRef)
+  }
+  for (const node of source.nodes) visit(node.ref, [])
+
+  return source
+}
+
 export type GithubBacklogGhRunner = (args: readonly string[]) => Promise<string>
 
 type GithubLabel = { readonly name?: unknown }
@@ -164,6 +247,7 @@ const normalizeLabels = (labels: unknown): string[] => {
 
 const issueWorkUnitRef = (repo: string, issueNumber: number): string => `github:${repo}:issue:${issueNumber}`
 const prWorkUnitRef = (repo: string, prNumber: number): string => `github:${repo}:pr:${prNumber}`
+const planDagWorkUnitRef = (planRef: string, nodeRef: string): string => `plan_dag:${planRef}:node:${nodeRef}`
 
 const issueRefPatterns = (issueNumber: number): RegExp[] => [
   new RegExp(`(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\\s+#${issueNumber}(?!\\d)`, "i"),
@@ -238,6 +322,37 @@ export const issueListCandidates = (source: IssueListWorkSource): WorkPlannerCan
   ...source.issues.map((issue) => normalizeIssueListCandidate(source.repo, issue)),
   ...(source.pullRequests ?? []).map((pr) => normalizeIssueListCandidate(source.repo, { ...pr, kind: "pr" })),
 ]
+
+export const planDagCandidates = (source: PlanDagWorkSource): WorkPlannerCandidate[] => {
+  const validated = validatePlanDagWorkSource(source)
+  const workUnitRefsByNodeRef = new Map(
+    validated.nodes.map((node) => [node.ref, planDagWorkUnitRef(validated.planRef, node.ref)]),
+  )
+  return validated.nodes.map((node) => {
+    const repo = node.repo ?? validated.repo
+    const branch = node.branch ?? validated.branch
+    const baseCommit = node.baseCommit ?? validated.baseCommit
+    const verify = node.verify ?? validated.verify
+    return {
+      workUnitRef: workUnitRefsByNodeRef.get(node.ref) ?? planDagWorkUnitRef(validated.planRef, node.ref),
+      kind: "plan_task",
+      source: "plan_dag",
+      title: node.title,
+      body: node.objective,
+      state: "open",
+      dependsOn: [...(node.dependsOn ?? [])]
+        .map((depRef) => workUnitRefsByNodeRef.get(depRef))
+        .filter((depRef): depRef is string => depRef !== undefined),
+      ...(repo === undefined ? {} : { repo }),
+      ...(branch === undefined ? {} : { branch }),
+      ...(baseCommit === undefined ? {} : { baseCommit }),
+      ...(verify === undefined ? {} : { verify }),
+      ...(node.issue === undefined ? {} : { number: node.issue }),
+      ...(node.labels === undefined ? {} : { labels: [...node.labels] }),
+      ...(node.url === undefined ? {} : { url: node.url }),
+    }
+  })
+}
 
 const ghIssueRecordToCandidate = (repo: string, record: GhIssueRecord): WorkPlannerCandidate | null => {
   if (typeof record.number !== "number") return null
@@ -323,6 +438,8 @@ export const planWorkCandidates = (
   options: WorkPlannerOptions = {},
 ): WorkPlannerOutput => {
   const now = options.now ?? new Date()
+  const completedWorkUnitRefs = new Set(options.completedWorkUnitRefs ?? [])
+  const failedWorkUnitRefs = new Set(options.failedWorkUnitRefs ?? [])
   const excludedLabels = new Set((options.excludedLabels ?? []).map(normalizeLabel))
   const needsOwnerLabels = new Set((options.needsOwnerLabels ?? DEFAULT_NEEDS_OWNER_LABELS).map(normalizeLabel))
   const pullRequests = options.pullRequests ?? candidates.filter((candidate) => candidate.kind === "github_pr")
@@ -337,6 +454,10 @@ export const planWorkCandidates = (
     if (candidate.state === "closed") return skipped(candidate, "closed")
     const prSkip = skipForPrSibling(candidate, pullRequests)
     if (prSkip !== null) return prSkip
+    const missingDeps = (candidate.dependsOn ?? []).filter((depRef) => !completedWorkUnitRefs.has(depRef))
+    const failedDep = missingDeps.find((depRef) => failedWorkUnitRefs.has(depRef))
+    if (failedDep !== undefined) return skipped(candidate, "dependency_failed", failedDep)
+    if (missingDeps.length > 0) return skipped(candidate, "dependency_pending", missingDeps.join(","))
     const claim = options.claimRegistry?.getLiveWorkClaim(candidate.workUnitRef, now)
     if (claim !== undefined && claim !== null) return skipped(candidate, "already_claimed", claim.claimRef)
     return { ...candidate, status: "claimable" }
@@ -376,6 +497,14 @@ export const planGithubBacklogWork = async (
   options: WorkPlannerOptions = {},
 ): Promise<WorkPlannerOutput> => {
   const candidates = await githubBacklogCandidates(source, gh)
+  return planWorkCandidates(source.kind, candidates, options)
+}
+
+export const planDagWork = (
+  source: PlanDagWorkSource,
+  options: WorkPlannerOptions = {},
+): WorkPlannerOutput => {
+  const candidates = planDagCandidates(source)
   return planWorkCandidates(source.kind, candidates, options)
 }
 

--- a/clients/khala-code-desktop/src/bun/claude-plan-fanout.ts
+++ b/clients/khala-code-desktop/src/bun/claude-plan-fanout.ts
@@ -1,0 +1,273 @@
+import { Schema as S } from "effect"
+
+import type {
+  PlanDagWorkSource,
+  PlanDagWorkUnit,
+} from "../../../../apps/pylon/src/orchestration/work-planner.js"
+
+export const CLAUDE_PLAN_FANOUT_DAG_SCHEMA = "openagents.khala_code.claude_plan_fanout_dag.v1" as const
+export const CLAUDE_PLAN_FANOUT_REVIEW_SCHEMA = "openagents.khala_code.claude_plan_fanout_review.v1" as const
+
+export const ClaudePlanFanoutDagNodeSchema = S.Struct({
+  nodeRef: S.String,
+  title: S.String,
+  objective: S.String,
+  dependsOn: S.optional(S.Array(S.String)),
+  repo: S.optional(S.String),
+  branch: S.optional(S.String),
+  baseCommit: S.optional(S.String),
+  verify: S.optional(S.String),
+  issue: S.optional(S.Number),
+  labels: S.optional(S.Array(S.String)),
+  evidenceRefs: S.optional(S.Array(S.String)),
+})
+export type ClaudePlanFanoutDagNode = typeof ClaudePlanFanoutDagNodeSchema.Type
+
+export const ClaudePlanFanoutDagSchema = S.Struct({
+  schema: S.Literal(CLAUDE_PLAN_FANOUT_DAG_SCHEMA),
+  planRef: S.String,
+  source: S.Literal("claude_plan_mode"),
+  generatedAt: S.String,
+  objective: S.String,
+  repo: S.optional(S.String),
+  branch: S.optional(S.String),
+  baseCommit: S.optional(S.String),
+  verify: S.optional(S.String),
+  evidenceRefs: S.optional(S.Array(S.String)),
+  nodes: S.Array(ClaudePlanFanoutDagNodeSchema),
+})
+export type ClaudePlanFanoutDag = typeof ClaudePlanFanoutDagSchema.Type
+
+export const ClaudePlanFanoutReviewVerdictSchema = S.Literals(["accept", "request_changes", "replan"])
+export type ClaudePlanFanoutReviewVerdict = typeof ClaudePlanFanoutReviewVerdictSchema.Type
+
+export const ClaudePlanFanoutReviewSchema = S.Struct({
+  schema: S.Literal(CLAUDE_PLAN_FANOUT_REVIEW_SCHEMA),
+  reviewRef: S.String,
+  planRef: S.String,
+  generatedAt: S.String,
+  verdict: ClaudePlanFanoutReviewVerdictSchema,
+  summary: S.String,
+  targetNodeRefs: S.optional(S.Array(S.String)),
+  changeRequests: S.optional(S.Array(S.String)),
+  evidenceRefs: S.optional(S.Array(S.String)),
+})
+export type ClaudePlanFanoutReview = typeof ClaudePlanFanoutReviewSchema.Type
+
+export type ClaudePlanFanoutReviewAdvisorySignal = {
+  readonly advisory: true
+  readonly controlFlowAuthority: "khala.fleet.delegate"
+  readonly deterministicGateRequired: true
+  readonly planRef: string
+  readonly reviewRef: string
+  readonly targetNodeRefs: readonly string[]
+  readonly verdict: ClaudePlanFanoutReviewVerdict
+}
+
+export class ClaudePlanFanoutContractError extends Error {
+  readonly _tag = "ClaudePlanFanoutContractError"
+
+  constructor(message: string) {
+    super(message)
+    this.name = "ClaudePlanFanoutContractError"
+  }
+}
+
+const MAX_PLAN_NODES = 25
+const MAX_TEXT_LENGTH = 4_000
+const MAX_TITLE_LENGTH = 160
+const PUBLIC_REF_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:/#-]{0,180}$/u
+const UNSAFE_TEXT_PATTERNS: readonly RegExp[] = [
+  /(^|[\s"'`])\/Users\//iu,
+  /(^|[\s"'`])\/private\//iu,
+  /(^|[\s"'`])~\//iu,
+  /\.secrets\//iu,
+  /\b(?:OPENAI|ANTHROPIC|STRIPE|MDK|NEXUS|PROBE)_[A-Z0-9_]*(?:KEY|TOKEN|SECRET)\b/iu,
+  /\bBearer\s+[A-Za-z0-9._~+/=-]{12,}/u,
+  /[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/iu,
+]
+
+const nonEmpty = (field: string, value: string): string => {
+  const trimmed = value.trim()
+  if (trimmed.length === 0) throw new ClaudePlanFanoutContractError(`${field} is required`)
+  return trimmed
+}
+
+const assertText = (field: string, value: string, maxLength = MAX_TEXT_LENGTH): void => {
+  const trimmed = nonEmpty(field, value)
+  if (trimmed.length > maxLength) {
+    throw new ClaudePlanFanoutContractError(`${field} is too long`)
+  }
+  const unsafe = UNSAFE_TEXT_PATTERNS.find((pattern) => pattern.test(trimmed))
+  if (unsafe !== undefined) {
+    throw new ClaudePlanFanoutContractError(`${field} is not public-safe`)
+  }
+}
+
+const assertPublicRef = (field: string, value: string): void => {
+  const trimmed = nonEmpty(field, value)
+  if (!PUBLIC_REF_PATTERN.test(trimmed)) {
+    throw new ClaudePlanFanoutContractError(`${field} must be a public-safe ref`)
+  }
+  assertText(field, trimmed, 181)
+}
+
+const assertIsoDate = (field: string, value: string): void => {
+  assertText(field, value, 80)
+  if (Number.isNaN(Date.parse(value))) {
+    throw new ClaudePlanFanoutContractError(`${field} must be ISO-compatible`)
+  }
+}
+
+const assertOptionalText = (field: string, value: string | undefined, maxLength = MAX_TEXT_LENGTH): void => {
+  if (value !== undefined) assertText(field, value, maxLength)
+}
+
+const assertOptionalRefs = (field: string, refs: readonly string[] | undefined): void => {
+  for (const ref of refs ?? []) assertPublicRef(field, ref)
+}
+
+export function validateClaudePlanFanoutDag(dag: ClaudePlanFanoutDag): ClaudePlanFanoutDag {
+  assertPublicRef("planRef", dag.planRef)
+  assertIsoDate("generatedAt", dag.generatedAt)
+  assertText("objective", dag.objective)
+  assertOptionalText("repo", dag.repo, 120)
+  assertOptionalText("branch", dag.branch, 120)
+  assertOptionalText("baseCommit", dag.baseCommit, 80)
+  assertOptionalText("verify", dag.verify)
+  assertOptionalRefs("evidenceRefs", dag.evidenceRefs)
+  if (dag.nodes.length < 1) throw new ClaudePlanFanoutContractError("nodes must not be empty")
+  if (dag.nodes.length > MAX_PLAN_NODES) throw new ClaudePlanFanoutContractError("nodes exceeds bounded fan-out")
+
+  const nodesByRef = new Map<string, ClaudePlanFanoutDagNode>()
+  for (const node of dag.nodes) {
+    assertPublicRef("nodeRef", node.nodeRef)
+    if (nodesByRef.has(node.nodeRef)) {
+      throw new ClaudePlanFanoutContractError(`duplicate nodeRef: ${node.nodeRef}`)
+    }
+    nodesByRef.set(node.nodeRef, node)
+    assertText(`node ${node.nodeRef} title`, node.title, MAX_TITLE_LENGTH)
+    assertText(`node ${node.nodeRef} objective`, node.objective)
+    assertOptionalText(`node ${node.nodeRef} repo`, node.repo, 120)
+    assertOptionalText(`node ${node.nodeRef} branch`, node.branch, 120)
+    assertOptionalText(`node ${node.nodeRef} baseCommit`, node.baseCommit, 80)
+    assertOptionalText(`node ${node.nodeRef} verify`, node.verify)
+    assertOptionalRefs(`node ${node.nodeRef} labels`, node.labels)
+    assertOptionalRefs(`node ${node.nodeRef} evidenceRefs`, node.evidenceRefs)
+    if (node.issue !== undefined && (!Number.isInteger(node.issue) || node.issue < 1)) {
+      throw new ClaudePlanFanoutContractError(`node ${node.nodeRef} issue must be a positive integer`)
+    }
+  }
+
+  for (const node of dag.nodes) {
+    for (const depRef of node.dependsOn ?? []) {
+      assertPublicRef(`node ${node.nodeRef} dependsOn`, depRef)
+      if (!nodesByRef.has(depRef)) {
+        throw new ClaudePlanFanoutContractError(`node ${node.nodeRef} depends on unknown node ${depRef}`)
+      }
+    }
+  }
+
+  const visiting = new Set<string>()
+  const visited = new Set<string>()
+  const visit = (nodeRef: string, path: readonly string[]): void => {
+    if (visited.has(nodeRef)) return
+    if (visiting.has(nodeRef)) {
+      throw new ClaudePlanFanoutContractError(`plan DAG contains a cycle: ${[...path, nodeRef].join(" -> ")}`)
+    }
+    visiting.add(nodeRef)
+    const node = nodesByRef.get(nodeRef)
+    if (node !== undefined) {
+      for (const depRef of node.dependsOn ?? []) visit(depRef, [...path, nodeRef])
+    }
+    visiting.delete(nodeRef)
+    visited.add(nodeRef)
+  }
+  for (const node of dag.nodes) visit(node.nodeRef, [])
+
+  return dag
+}
+
+export function decodeClaudePlanFanoutDag(input: unknown): ClaudePlanFanoutDag {
+  return validateClaudePlanFanoutDag(S.decodeUnknownSync(ClaudePlanFanoutDagSchema)(input))
+}
+
+const nodeToWorkUnit = (node: ClaudePlanFanoutDagNode): PlanDagWorkUnit => ({
+  ref: node.nodeRef,
+  title: node.title,
+  objective: node.objective,
+  ...(node.dependsOn === undefined ? {} : { dependsOn: [...node.dependsOn] }),
+  ...(node.repo === undefined ? {} : { repo: node.repo }),
+  ...(node.branch === undefined ? {} : { branch: node.branch }),
+  ...(node.baseCommit === undefined ? {} : { baseCommit: node.baseCommit }),
+  ...(node.verify === undefined ? {} : { verify: node.verify }),
+  ...(node.issue === undefined ? {} : { issue: node.issue }),
+  ...(node.labels === undefined ? {} : { labels: [...node.labels] }),
+})
+
+export function claudePlanFanoutDagToWorkSource(dag: ClaudePlanFanoutDag): PlanDagWorkSource {
+  const validated = validateClaudePlanFanoutDag(dag)
+  return {
+    kind: "plan_dag",
+    planRef: validated.planRef,
+    nodes: validated.nodes.map(nodeToWorkUnit),
+    ...(validated.repo === undefined ? {} : { repo: validated.repo }),
+    ...(validated.branch === undefined ? {} : { branch: validated.branch }),
+    ...(validated.baseCommit === undefined ? {} : { baseCommit: validated.baseCommit }),
+    ...(validated.verify === undefined ? {} : { verify: validated.verify }),
+  }
+}
+
+export function validateClaudePlanFanoutReview(
+  review: ClaudePlanFanoutReview,
+  input: { readonly knownNodeRefs?: readonly string[] } = {},
+): ClaudePlanFanoutReview {
+  assertPublicRef("reviewRef", review.reviewRef)
+  assertPublicRef("planRef", review.planRef)
+  assertIsoDate("generatedAt", review.generatedAt)
+  assertText("summary", review.summary)
+  assertOptionalRefs("targetNodeRefs", review.targetNodeRefs)
+  assertOptionalRefs("evidenceRefs", review.evidenceRefs)
+  for (const request of review.changeRequests ?? []) assertText("changeRequests", request)
+  if (input.knownNodeRefs !== undefined) {
+    const known = new Set(input.knownNodeRefs)
+    const unknown = (review.targetNodeRefs ?? []).find(ref => !known.has(ref))
+    if (unknown !== undefined) {
+      throw new ClaudePlanFanoutContractError(`review targets unknown node ${unknown}`)
+    }
+  }
+  return review
+}
+
+export function decodeClaudePlanFanoutReview(
+  input: unknown,
+  options: { readonly knownNodeRefs?: readonly string[] } = {},
+): ClaudePlanFanoutReview {
+  return validateClaudePlanFanoutReview(S.decodeUnknownSync(ClaudePlanFanoutReviewSchema)(input), options)
+}
+
+export function claudePlanFanoutReviewAdvisorySignal(
+  review: ClaudePlanFanoutReview,
+): ClaudePlanFanoutReviewAdvisorySignal {
+  const validated = validateClaudePlanFanoutReview(review)
+  return {
+    advisory: true,
+    controlFlowAuthority: "khala.fleet.delegate",
+    deterministicGateRequired: true,
+    planRef: validated.planRef,
+    reviewRef: validated.reviewRef,
+    targetNodeRefs: [...(validated.targetNodeRefs ?? [])],
+    verdict: validated.verdict,
+  }
+}
+
+export function claudePlanFanoutPlanModeInstructions(): string {
+  return [
+    "You are in Claude plan mode for Khala Code plan-then-fan-out.",
+    "Do not edit files or dispatch workers directly.",
+    `Emit one JSON object matching ${CLAUDE_PLAN_FANOUT_DAG_SCHEMA}.`,
+    "Use source='claude_plan_mode'. Nodes must form an acyclic task DAG.",
+    "Each node objective must be public-safe and bounded for a Codex worker.",
+    "Use dependsOn nodeRef values only; deterministic FleetRun supervision owns control flow.",
+  ].join("\n")
+}

--- a/clients/khala-code-desktop/src/bun/fleet-run-supervisor-rpc-adapter.ts
+++ b/clients/khala-code-desktop/src/bun/fleet-run-supervisor-rpc-adapter.ts
@@ -13,16 +13,21 @@ import {
   type FleetRunState,
   type FleetRunStopCondition,
   type FleetRunWorkSource,
+  type WorkClaim,
   type PylonOrchestrationStore,
 } from "../../../../apps/pylon/src/orchestration/store.js"
 import {
+  planDagWork,
   planFixtureWork,
   planGithubBacklogWork,
   planIssueListWork,
+  validatePlanDagWorkSource,
   type FixtureWorkSource,
   type GithubBacklogWorkSource,
   type IssueListItem,
   type IssueListWorkSource,
+  type PlanDagWorkSource,
+  type PlanDagWorkUnit,
   type WorkPlannerOutput,
 } from "../../../../apps/pylon/src/orchestration/work-planner.js"
 import type { KhalaCodeDesktopFleetRunSupervisorRpc } from "./rpc-handlers.js"
@@ -58,13 +63,25 @@ type ActiveSupervisor = {
   readonly scope: Scope.Scope
 }
 
-type RpcIssueListItem = Exclude<
-  NonNullable<Extract<
-    KhalaCodeDesktopFleetRunStartRequest["workSource"],
-    { readonly kind: "issue_list" }
-  >["issues"]>[number],
-  number
->
+type RpcFleetRunWorkSource = KhalaCodeDesktopFleetRunStartRequest["workSource"]
+
+type RpcIssueListEntry = NonNullable<RpcFleetRunWorkSource["issues"]>[number]
+type RpcIssueListItem = Exclude<RpcIssueListEntry, number>
+
+type RpcPlanDagNode = NonNullable<RpcFleetRunWorkSource["nodes"]>[number]
+
+type SupervisorWorkSource = IssueListWorkSource | FixtureWorkSource | GithubBacklogWorkSource | PlanDagWorkSource
+
+const trimRequired = (field: string, value: string): string => {
+  const trimmed = value.trim()
+  if (trimmed.length === 0) throw new Error(`fleetRunStart plan_dag ${field} is required`)
+  return trimmed
+}
+
+const trimOptional = (value: string | undefined): string | undefined => {
+  const trimmed = value?.trim()
+  return trimmed === undefined || trimmed.length === 0 ? undefined : trimmed
+}
 
 export type KhalaCodeDesktopFleetRunSupervisorRpcAdapterOptions = {
   readonly capacity?: FleetRunSupervisorCapacity
@@ -108,15 +125,26 @@ const normalizeIssueItem = (item: number | RpcIssueListItem | IssueListItem): nu
 }
 
 const normalizeRpcIssueItem = (
-  item: NonNullable<Extract<
-    KhalaCodeDesktopFleetRunStartRequest["workSource"],
-    { readonly kind: "issue_list" }
-  >["issues"]>[number],
+  item: RpcIssueListEntry,
 ): number | IssueListItem => normalizeIssueItem(item as number | RpcIssueListItem)
+
+const normalizePlanDagNode = (node: RpcPlanDagNode): PlanDagWorkUnit => ({
+  ref: trimRequired("node ref", node.ref),
+  title: trimRequired("node title", node.title),
+  objective: trimRequired("node objective", node.objective),
+  ...(node.dependsOn === undefined ? {} : { dependsOn: node.dependsOn.map(ref => ref.trim()) }),
+  ...(trimOptional(node.repo) === undefined ? {} : { repo: trimOptional(node.repo)! }),
+  ...(trimOptional(node.branch) === undefined ? {} : { branch: trimOptional(node.branch)! }),
+  ...(trimOptional(node.baseCommit) === undefined ? {} : { baseCommit: trimOptional(node.baseCommit)! }),
+  ...(trimOptional(node.verify) === undefined ? {} : { verify: trimOptional(node.verify)! }),
+  ...(node.issue === undefined ? {} : { issue: node.issue }),
+  ...(node.labels === undefined ? {} : { labels: [...node.labels] }),
+  ...(trimOptional(node.url) === undefined ? {} : { url: trimOptional(node.url)! }),
+})
 
 const normalizeWorkSource = (
   source: KhalaCodeDesktopFleetRunStartRequest["workSource"],
-): IssueListWorkSource | FixtureWorkSource | GithubBacklogWorkSource => {
+): SupervisorWorkSource => {
   if (source.kind === "issue_list") {
     if (source.repo === undefined || source.repo.trim().length === 0) {
       throw new Error("fleetRunStart issue_list workSource requires repo")
@@ -137,6 +165,23 @@ const normalizeWorkSource = (
       ...(source.limit === undefined ? {} : { limit: Math.max(1, Math.trunc(source.limit)) }),
     }
   }
+  if (source.kind === "plan_dag") {
+    if (source.planRef === undefined || source.planRef.trim().length === 0) {
+      throw new Error("fleetRunStart plan_dag workSource requires planRef")
+    }
+    if (source.nodes === undefined || source.nodes.length === 0) {
+      throw new Error("fleetRunStart plan_dag workSource requires at least one node")
+    }
+    return validatePlanDagWorkSource({
+      kind: "plan_dag",
+      planRef: source.planRef.trim(),
+      nodes: source.nodes.map(normalizePlanDagNode),
+      ...(trimOptional(source.repo) === undefined ? {} : { repo: trimOptional(source.repo)! }),
+      ...(trimOptional(source.branch) === undefined ? {} : { branch: trimOptional(source.branch)! }),
+      ...(trimOptional(source.baseCommit) === undefined ? {} : { baseCommit: trimOptional(source.baseCommit)! }),
+      ...(trimOptional(source.verify) === undefined ? {} : { verify: trimOptional(source.verify)! }),
+    })
+  }
   return {
     kind: "fixture",
     ...(source.count === undefined ? {} : { count: Math.max(1, Math.trunc(source.count)) }),
@@ -144,13 +189,13 @@ const normalizeWorkSource = (
 }
 
 const workSourceKind = (
-  source: IssueListWorkSource | FixtureWorkSource | GithubBacklogWorkSource,
+  source: SupervisorWorkSource,
 ): FleetRunWorkSource => source.kind
 
 const runRefFor = (): string => `fleet_run.${randomUUID()}`
 
 const projectWorkSource = (
-  source: IssueListWorkSource | FixtureWorkSource | GithubBacklogWorkSource | undefined,
+  source: SupervisorWorkSource | undefined,
   fallback: FleetRunWorkSource,
 ): KhalaCodeDesktopFleetRunProjection["workSource"] => {
   if (source === undefined) return { kind: fallback }
@@ -158,7 +203,7 @@ const projectWorkSource = (
     return {
       kind: "issue_list",
       repo: source.repo,
-        issues: source.issues.map(issue => typeof issue === "number" ? issue : normalizeIssueItem(issue)),
+      issues: source.issues.map(issue => typeof issue === "number" ? issue : normalizeIssueItem(issue)),
     }
   }
   if (source.kind === "github_backlog") {
@@ -166,6 +211,29 @@ const projectWorkSource = (
       kind: "github_backlog",
       repo: source.repo,
       ...(source.limit === undefined ? {} : { limit: source.limit }),
+    }
+  }
+  if (source.kind === "plan_dag") {
+    return {
+      kind: "plan_dag",
+      planRef: source.planRef,
+      nodes: source.nodes.map(node => ({
+        ref: node.ref,
+        title: node.title,
+        objective: node.objective,
+        ...(node.dependsOn === undefined ? {} : { dependsOn: [...node.dependsOn] }),
+        ...(node.repo === undefined ? {} : { repo: node.repo }),
+        ...(node.branch === undefined ? {} : { branch: node.branch }),
+        ...(node.baseCommit === undefined ? {} : { baseCommit: node.baseCommit }),
+        ...(node.verify === undefined ? {} : { verify: node.verify }),
+        ...(node.issue === undefined ? {} : { issue: node.issue }),
+        ...(node.labels === undefined ? {} : { labels: [...node.labels] }),
+        ...(node.url === undefined ? {} : { url: node.url }),
+      })),
+      ...(source.repo === undefined ? {} : { repo: source.repo }),
+      ...(source.branch === undefined ? {} : { branch: source.branch }),
+      ...(source.baseCommit === undefined ? {} : { baseCommit: source.baseCommit }),
+      ...(source.verify === undefined ? {} : { verify: source.verify }),
     }
   }
   return {
@@ -178,7 +246,7 @@ const projectRun = (
   run: FleetRun,
   input: {
     readonly pylonRef: string | null
-    readonly workSource?: IssueListWorkSource | FixtureWorkSource | GithubBacklogWorkSource
+    readonly workSource?: SupervisorWorkSource
   },
 ): KhalaCodeDesktopFleetRunProjection => ({
   counters: run.counters,
@@ -204,15 +272,35 @@ const ghJson = async (args: readonly string[]): Promise<string> => {
   throw new Error(`gh ${args.join(" ")} failed: ${result.stderr.trim()}`)
 }
 
+const completedWorkUnitRefsForRun = (claims: readonly WorkClaim[]): readonly string[] =>
+  [...new Set(claims.filter(claim => claim.state === "closeout").map(claim => claim.workUnitRef))]
+
+const failedWorkUnitRefsForRun = (claims: readonly WorkClaim[]): readonly string[] => {
+  const completed = new Set(completedWorkUnitRefsForRun(claims))
+  return [...new Set(claims
+    .filter(claim => !completed.has(claim.workUnitRef))
+    .filter(claim => claim.state === "released" || claim.state === "expired")
+    .map(claim => claim.workUnitRef))]
+}
+
 const plannerFor = (
   store: PylonOrchestrationStore,
-  sources: ReadonlyMap<string, IssueListWorkSource | FixtureWorkSource | GithubBacklogWorkSource>,
+  sources: ReadonlyMap<string, SupervisorWorkSource>,
 ): FleetRunSupervisorPlanner => ({
   plan: async ({ run, now }): Promise<WorkPlannerOutput> => {
     const source = sources.get(run.runRef)
     if (source === undefined) return planFixtureWork({ kind: "fixture", count: 0 }, { now })
     if (source.kind === "fixture") return planFixtureWork(source, { now })
     if (source.kind === "issue_list") return planIssueListWork(source, { claimRegistry: store, now })
+    if (source.kind === "plan_dag") {
+      const claims = store.listWorkClaims({ runRef: run.runRef })
+      return planDagWork(source, {
+        claimRegistry: store,
+        completedWorkUnitRefs: completedWorkUnitRefsForRun(claims),
+        failedWorkUnitRefs: failedWorkUnitRefsForRun(claims),
+        now,
+      })
+    }
     return planGithubBacklogWork(source, ghJson, { claimRegistry: store, now })
   },
 })
@@ -255,11 +343,13 @@ const runnerFor = (input: {
     })
     return await Effect.runPromise(service.runAssignment({
       accountRef: dispatch.accountRef,
+      branch: dispatch.workUnit.branch,
+      commit: dispatch.workUnit.baseCommit,
       fixture,
-      objective: dispatch.run.objective,
+      objective: dispatch.workUnit.body ?? dispatch.run.objective,
       pylonRef: input.pylonRef ?? undefined,
       repo: dispatch.workUnit.repo,
-      verify: fixture ? undefined : DEFAULT_VERIFY,
+      verify: fixture ? undefined : dispatch.workUnit.verify ?? DEFAULT_VERIFY,
       workerKind: dispatch.run.workerKind,
     }))
   },
@@ -286,7 +376,7 @@ export function createKhalaCodeDesktopFleetRunSupervisorRpcAdapter(
   const env = options.env ?? {}
   const store = options.store ?? defaultStore(env)
   const pylonRef = options.pylonRef ?? null
-  const sources = new Map<string, IssueListWorkSource | FixtureWorkSource | GithubBacklogWorkSource>()
+  const sources = new Map<string, SupervisorWorkSource>()
   const active = new Map<string, ActiveSupervisor>()
   const paths = { home: resolvePylonHome(env) }
   const toolOptions = { ...options.toolOptions, env: { ...env, ...options.toolOptions?.env } }
@@ -302,7 +392,7 @@ export function createKhalaCodeDesktopFleetRunSupervisorRpcAdapter(
 
   const projectionInput = (
     runRef: string,
-  ): { readonly pylonRef: string | null; readonly workSource?: IssueListWorkSource | FixtureWorkSource | GithubBacklogWorkSource } => {
+  ): { readonly pylonRef: string | null; readonly workSource?: SupervisorWorkSource } => {
     const workSource = sources.get(runRef)
     return workSource === undefined ? { pylonRef } : { pylonRef, workSource }
   }

--- a/clients/khala-code-desktop/src/bun/fleet-run-supervisor.ts
+++ b/clients/khala-code-desktop/src/bun/fleet-run-supervisor.ts
@@ -244,6 +244,21 @@ const contextIdFor = (accountRef: string, taskId: string): string =>
 const claimRefFor = (runRef: string, workUnitRef: string, now: Date, ordinal: number): string =>
   `${runRef}.claim.${workUnitRef.replace(/[^a-zA-Z0-9_.-]/g, "_")}.${now.getTime()}.${ordinal}`
 
+const dependencyTaskIdsFor = (
+  store: PylonOrchestrationStore,
+  runRef: string,
+  workUnit: WorkPlannerClaimableUnit,
+): readonly string[] => {
+  if (workUnit.dependsOn === undefined || workUnit.dependsOn.length === 0) return []
+  const claimsByWorkUnit = new Map(
+    store.listWorkClaims({ runRef }).map(claim => [claim.workUnitRef, claim]),
+  )
+  return workUnit.dependsOn.flatMap((depRef) => {
+    const claim = claimsByWorkUnit.get(depRef)
+    return claim === undefined ? [] : [taskIdFor(runRef, claim.claimRef)]
+  })
+}
+
 const emit = async (
   sink: FleetRunSupervisorOptions["onLifecycle"],
   event: FleetRunSupervisorObservedEvent,
@@ -405,7 +420,8 @@ export async function tickFleetRunSupervisor(
   }
 
   const plan = await options.planner.plan({ run, now })
-  const plannedWorkUnitsTotal = Math.max(expectedWorkUnitsTotal, run.counters.workUnitsTotal)
+  const dependencyPending = plan.skipped.some(unit => unit.skipReason === "dependency_pending")
+  const plannedWorkUnitsTotal = Math.max(expectedWorkUnitsTotal, run.counters.workUnitsTotal, plan.units.length)
   let claimed = 0
   let dispatched = 0
   const claimOrdinalBase = store.listWorkClaims({ runRef: run.runRef }).length
@@ -440,11 +456,15 @@ export async function tickFleetRunSupervisor(
     }
     store.createTask({
       id: taskId,
+      deps: dependencyTaskIdsFor(store, run.runRef, workUnit),
       spec: {
         title: workUnit.title,
-        prompt: run.objective,
+        prompt: workUnit.body ?? run.objective,
         runnerKind: run.workerKind === "claude" ? "claude_agent" : "codex",
+        ...(workUnit.branch === undefined ? {} : { branch: workUnit.branch }),
+        ...(workUnit.baseCommit === undefined ? {} : { baseCommit: workUnit.baseCommit }),
         ...(workUnit.repo === undefined ? {} : { repo: workUnit.repo }),
+        ...(workUnit.verify === undefined ? {} : { verifyCommand: workUnit.verify }),
         issueRef: workUnit.number === undefined ? workUnit.workUnitRef : `#${workUnit.number}`,
         fleetRunRef: run.runRef,
       },
@@ -542,7 +562,7 @@ export async function tickFleetRunSupervisor(
   }
 
   let reconciled = store.reconcileFleetRun(run.runRef, clock.now())
-  const hasClaimableBacklog = plan.claimable.length > claimed
+  const hasClaimableBacklog = plan.claimable.length > claimed || dependencyPending
   const reviveForBacklog = hasClaimableBacklog &&
     (reconciled.state === "running" || isAutoRevivableFleetRun(reconciled))
   if (reconciled.counters.workUnitsTotal < plannedWorkUnitsTotal) {
@@ -564,6 +584,7 @@ export async function tickFleetRunSupervisor(
   if (
     reconciled.state === "running" &&
     plan.claimable.length === 0 &&
+    !dependencyPending &&
     activeAssignmentsForRun(store, run.runRef) === 0 &&
     reconciled.refillPolicy.stopCondition === "backlog_empty"
   ) {

--- a/clients/khala-code-desktop/src/bun/khala-fleet-tools.ts
+++ b/clients/khala-code-desktop/src/bun/khala-fleet-tools.ts
@@ -47,10 +47,14 @@ import {
 } from "../../../../apps/pylon/src/orchestration/store.js"
 import {
   fixtureCandidates,
+  planDagWork,
   planGithubBacklogWork,
   planIssueListWork,
   planWorkCandidates,
+  validatePlanDagWorkSource,
   type GithubBacklogGhRunner,
+  type PlanDagWorkSource,
+  type PlanDagWorkUnit,
 } from "../../../../apps/pylon/src/orchestration/work-planner.js"
 import {
   startFleetRunSupervisor,
@@ -122,6 +126,8 @@ export type KhalaFleetRunStartInput = {
   readonly fixtureCount?: number | undefined
   readonly issues?: readonly number[] | undefined
   readonly objective: string
+  readonly planRef?: string | undefined
+  readonly planNodes?: readonly PlanDagWorkUnit[] | undefined
   readonly pylonRef?: string | undefined
   readonly repo?: string | undefined
   readonly runRef?: string | undefined
@@ -653,6 +659,29 @@ const fleetRunStartToolDefinition: KhalaToolDefinition = {
         type: "array",
       },
       objective: { description: "Public-safe FleetRun objective.", type: "string" },
+      plan_nodes: {
+        description: "Typed Claude plan-mode DAG nodes when work_source is plan_dag.",
+        items: {
+          additionalProperties: false,
+          properties: {
+            baseCommit: { type: "string" },
+            branch: { type: "string" },
+            dependsOn: { items: { type: "string" }, type: "array" },
+            issue: { minimum: 1, type: "integer" },
+            labels: { items: { type: "string" }, type: "array" },
+            objective: { type: "string" },
+            ref: { type: "string" },
+            repo: { type: "string" },
+            title: { type: "string" },
+            url: { type: "string" },
+            verify: { type: "string" },
+          },
+          required: ["ref", "title", "objective"],
+          type: "object",
+        },
+        type: "array",
+      },
+      plan_ref: { description: "Claude plan-mode DAG ref when work_source is plan_dag.", type: "string" },
       pylon_ref: { description: "Optional target Pylon ref. Defaults to the local Pylon.", type: "string" },
       repo: { description: "Repository owner/name for issue_list or github_backlog work.", type: "string" },
       run_ref: { description: "Optional caller-provided run ref.", type: "string" },
@@ -673,7 +702,7 @@ const fleetRunStartToolDefinition: KhalaToolDefinition = {
       work_source: {
         default: "fixture",
         description: "Work source for the run.",
-        enum: ["github_backlog", "issue_list", "fixture"],
+        enum: ["github_backlog", "issue_list", "fixture", "plan_dag"],
         type: "string",
       },
     },
@@ -1326,6 +1355,8 @@ function executeFleetRunStartTool(
 ): Effect.Effect<KhalaToolResult, never> {
   return Effect.promise(async () => {
     try {
+      const planNodes = optionalPlanDagNodes(input.plan_nodes)
+      const planRef = optionalString(input.plan_ref)
       const result = await fleetRunSupervisorManager(options).start({
         baseUrl: optionalString(input.base_url),
         branch: optionalString(input.branch),
@@ -1333,6 +1364,8 @@ function executeFleetRunStartTool(
         fixtureCount: optionalInteger(input.fixture_count),
         issues: optionalIntegerArray(input.issues),
         objective: requiredString(input.objective, "fleet_run_start requires objective"),
+        ...(planNodes === undefined ? {} : { planNodes }),
+        ...(planRef === undefined ? {} : { planRef }),
         pylonRef: optionalString(input.pylon_ref),
         repo: optionalString(input.repo),
         runRef: optionalString(input.run_ref),
@@ -1419,6 +1452,7 @@ type FleetRunPlanConfig = {
   readonly commit?: string | undefined
   readonly fixtureCount: number
   readonly issues: readonly number[]
+  readonly planSource?: PlanDagWorkSource | undefined
   readonly repo?: string | undefined
   readonly timeoutMs?: number | undefined
   readonly verify?: string | undefined
@@ -1468,12 +1502,25 @@ export class DefaultKhalaFleetRunSupervisorManager implements KhalaFleetRunSuper
     if (workSource === "issue_list" && (input.issues ?? []).length === 0) {
       throw new Error("fleet_run_start issue_list requires at least one issue number")
     }
+    if (workSource === "plan_dag" && (input.planRef === undefined || input.planNodes === undefined || input.planNodes.length === 0)) {
+      throw new Error("fleet_run_start plan_dag requires plan_ref and plan_nodes")
+    }
     if (workSource !== "fixture" && (input.commit === undefined || input.verify === undefined)) {
       throw new Error(`fleet_run_start ${workSource} requires commit and verify pins`)
     }
+    const planSource: PlanDagWorkSource | undefined = workSource === "plan_dag" ? validatePlanDagWorkSource({
+      kind: "plan_dag",
+      planRef: input.planRef!,
+      nodes: input.planNodes!,
+      ...(input.repo === undefined ? {} : { repo: input.repo }),
+      ...(input.branch === undefined ? {} : { branch: input.branch }),
+      ...(input.commit === undefined ? {} : { baseCommit: input.commit }),
+      ...(input.verify === undefined ? {} : { verify: input.verify }),
+    }) : undefined
     const expectedWorkUnits =
       workSource === "fixture" ? fixtureCount :
       workSource === "issue_list" ? input.issues?.length ?? 0 :
+      workSource === "plan_dag" ? input.planNodes?.length ?? 0 :
       0
     this.store.createFleetRun({
       runRef,
@@ -1493,6 +1540,7 @@ export class DefaultKhalaFleetRunSupervisorManager implements KhalaFleetRunSuper
       commit: input.commit,
       fixtureCount,
       issues: [...(input.issues ?? [])],
+      planSource,
       repo: input.repo,
       timeoutMs: input.timeoutMs,
       verify: input.verify,
@@ -1603,6 +1651,15 @@ export class DefaultKhalaFleetRunSupervisorManager implements KhalaFleetRunSuper
             issues: config.issues,
           }, { now, claimRegistry: this.store })
         }
+        if (run.workSource === "plan_dag") {
+          if (config.planSource === undefined) throw new Error(`missing plan DAG for fleet run: ${runRef}`)
+          return planDagWork(config.planSource, {
+            now,
+            claimRegistry: this.store,
+            completedWorkUnitRefs: this.completedWorkUnitRefsFor(runRef),
+            failedWorkUnitRefs: this.failedWorkUnitRefsFor(runRef),
+          })
+        }
         if (config.repo === undefined) throw new Error(`missing repo for fleet run: ${runRef}`)
         return planGithubBacklogWork(
           { kind: "github_backlog", repo: config.repo },
@@ -1622,14 +1679,14 @@ export class DefaultKhalaFleetRunSupervisorManager implements KhalaFleetRunSuper
         return await Effect.runPromise(this.pylonService.runAssignment({
           accountRef,
           baseUrl: config.baseUrl,
-          branch: config.branch,
-          commit: fixture ? undefined : config.commit,
+          branch: workUnit.branch ?? config.branch,
+          commit: fixture ? undefined : workUnit.baseCommit ?? config.commit,
           fixture,
-          objective: renderFleetRunDispatchPrompt(run, workUnit),
+          objective: workUnit.body ?? renderFleetRunDispatchPrompt(run, workUnit),
           pylonRef,
-          repo: fixture ? undefined : config.repo,
+          repo: fixture ? undefined : workUnit.repo ?? config.repo,
           timeoutMs: config.timeoutMs,
-          verify: fixture ? undefined : config.verify,
+          verify: fixture ? undefined : workUnit.verify ?? config.verify,
           workerKind: run.workerKind,
         }))
       },
@@ -1672,6 +1729,24 @@ export class DefaultKhalaFleetRunSupervisorManager implements KhalaFleetRunSuper
       pylonRef: active?.pylonRef ?? this.retainedPylonRefs.get(runRef) ?? null,
       run,
     }
+  }
+
+  private completedWorkUnitRefsFor(runRef: string): readonly string[] {
+    return [...new Set(
+      this.store.listWorkClaims({ runRef })
+        .filter(claim => claim.state === "closeout")
+        .map(claim => claim.workUnitRef),
+    )]
+  }
+
+  private failedWorkUnitRefsFor(runRef: string): readonly string[] {
+    const completed = new Set(this.completedWorkUnitRefsFor(runRef))
+    return [...new Set(
+      this.store.listWorkClaims({ runRef })
+        .filter(claim => !completed.has(claim.workUnitRef))
+        .filter(claim => claim.state === "released" || claim.state === "expired")
+        .map(claim => claim.workUnitRef),
+    )]
   }
 }
 
@@ -3860,8 +3935,47 @@ function optionalIntegerArray(value: unknown): readonly number[] | undefined {
   return integers.length === value.length ? integers : undefined
 }
 
+function optionalStringArray(value: unknown): readonly string[] | undefined {
+  if (!Array.isArray(value)) return undefined
+  const strings = value.filter((item): item is string => typeof item === "string" && item.trim().length > 0)
+  return strings.length === value.length ? strings.map(item => item.trim()) : undefined
+}
+
+function optionalPlanDagNodes(value: unknown): readonly PlanDagWorkUnit[] | undefined {
+  if (!Array.isArray(value)) return undefined
+  return value.map((item, index): PlanDagWorkUnit => {
+    if (typeof item !== "object" || item === null || Array.isArray(item)) {
+      throw new Error(`plan_nodes[${index}] must be an object`)
+    }
+    const record = item as Readonly<Record<string, unknown>>
+    const baseCommit = optionalString(record.baseCommit)
+    const branch = optionalString(record.branch)
+    const dependsOn = optionalStringArray(record.dependsOn)
+    const issue = optionalInteger(record.issue)
+    const labels = optionalStringArray(record.labels)
+    const repo = optionalString(record.repo)
+    const url = optionalString(record.url)
+    const verify = optionalString(record.verify)
+    return {
+      ref: requiredString(record.ref, `plan_nodes[${index}] requires ref`),
+      title: requiredString(record.title, `plan_nodes[${index}] requires title`),
+      objective: requiredString(record.objective, `plan_nodes[${index}] requires objective`),
+      ...(dependsOn === undefined ? {} : { dependsOn }),
+      ...(repo === undefined ? {} : { repo }),
+      ...(branch === undefined ? {} : { branch }),
+      ...(baseCommit === undefined ? {} : { baseCommit }),
+      ...(verify === undefined ? {} : { verify }),
+      ...(issue === undefined ? {} : { issue }),
+      ...(labels === undefined ? {} : { labels }),
+      ...(url === undefined ? {} : { url }),
+    }
+  })
+}
+
 function optionalWorkSource(value: unknown): FleetRunWorkSource | undefined {
-  return value === "github_backlog" || value === "issue_list" || value === "fixture" ? value : undefined
+  return value === "github_backlog" || value === "issue_list" || value === "fixture" || value === "plan_dag"
+    ? value
+    : undefined
 }
 
 function optionalWorkerKind(value: unknown): FleetRunWorkerKind | undefined {

--- a/clients/khala-code-desktop/src/shared/rpc.ts
+++ b/clients/khala-code-desktop/src/shared/rpc.ts
@@ -1524,11 +1524,29 @@ const RpcFleetRunCounters = S.Struct({
   failedAssignments: S.Number,
   workUnitsTotal: S.Number,
 })
-const RpcFleetRunWorkSource = S.Struct({
-  kind: S.Literals(["github_backlog", "issue_list", "fixture"]),
+const RpcFleetRunPlanDagNode = S.Struct({
+  ref: S.String,
+  title: S.String,
+  objective: S.String,
+  dependsOn: S.optional(RpcStringArray),
   repo: S.optional(S.String),
+  branch: S.optional(S.String),
+  baseCommit: S.optional(S.String),
+  verify: S.optional(S.String),
+  issue: S.optional(S.Number),
+  labels: S.optional(RpcStringArray),
+  url: S.optional(S.String),
+})
+const RpcFleetRunWorkSource = S.Struct({
+  kind: S.Literals(["github_backlog", "issue_list", "fixture", "plan_dag"]),
+  repo: S.optional(S.String),
+  branch: S.optional(S.String),
+  baseCommit: S.optional(S.String),
+  verify: S.optional(S.String),
   limit: S.optional(S.Number),
   count: S.optional(S.Number),
+  planRef: S.optional(S.String),
+  nodes: S.optional(S.Array(RpcFleetRunPlanDagNode)),
   issues: S.optional(S.Array(S.Union([
     S.Number,
     S.Struct({

--- a/clients/khala-code-desktop/tests/claude-plan-fanout.test.ts
+++ b/clients/khala-code-desktop/tests/claude-plan-fanout.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, test } from "bun:test"
+
+import {
+  CLAUDE_PLAN_FANOUT_DAG_SCHEMA,
+  CLAUDE_PLAN_FANOUT_REVIEW_SCHEMA,
+  claudePlanFanoutDagToWorkSource,
+  claudePlanFanoutPlanModeInstructions,
+  claudePlanFanoutReviewAdvisorySignal,
+  decodeClaudePlanFanoutDag,
+  decodeClaudePlanFanoutReview,
+} from "../src/bun/claude-plan-fanout.js"
+
+const validDag = () => ({
+  schema: CLAUDE_PLAN_FANOUT_DAG_SCHEMA,
+  planRef: "plan.t9_4.fixture",
+  source: "claude_plan_mode",
+  generatedAt: "2026-07-02T10:00:00.000Z",
+  objective: "Plan a bounded implementation of public issue #7873.",
+  repo: "OpenAgentsInc/openagents",
+  branch: "main",
+  baseCommit: "0123456789abcdef0123456789abcdef01234567",
+  verify: "bun test clients/khala-code-desktop/tests/claude-plan-fanout.test.ts",
+  evidenceRefs: ["issue#7873", "docs/fable/ROADMAP.md"],
+  nodes: [
+    {
+      nodeRef: "contract",
+      title: "Define typed contract",
+      objective: "Add schema-backed Claude plan fan-out contracts.",
+      issue: 7873,
+      evidenceRefs: ["docs/fable/ROADMAP.md"],
+    },
+    {
+      nodeRef: "adapter",
+      title: "Wire FleetRun adapter",
+      objective: "Convert the typed plan DAG into FleetRun work units.",
+      dependsOn: ["contract"],
+    },
+  ],
+})
+
+describe("Claude plan-then-fan-out contract", () => {
+  test("decodes valid plan-mode JSON and maps it to a plan_dag work source", () => {
+    const dag = decodeClaudePlanFanoutDag(validDag())
+    const source = claudePlanFanoutDagToWorkSource(dag)
+
+    expect(source).toMatchObject({
+      kind: "plan_dag",
+      planRef: "plan.t9_4.fixture",
+      repo: "OpenAgentsInc/openagents",
+      baseCommit: "0123456789abcdef0123456789abcdef01234567",
+      verify: "bun test clients/khala-code-desktop/tests/claude-plan-fanout.test.ts",
+    })
+    expect(source.nodes.map(node => ({
+      ref: node.ref,
+      dependsOn: node.dependsOn,
+      objective: node.objective,
+    }))).toEqual([
+      {
+        ref: "contract",
+        dependsOn: undefined,
+        objective: "Add schema-backed Claude plan fan-out contracts.",
+      },
+      {
+        ref: "adapter",
+        dependsOn: ["contract"],
+        objective: "Convert the typed plan DAG into FleetRun work units.",
+      },
+    ])
+  })
+
+  test("rejects prose-only, cyclic, unknown-dependency, and unsafe plan output", () => {
+    expect(() => decodeClaudePlanFanoutDag("first do A, then B")).toThrow()
+
+    expect(() => decodeClaudePlanFanoutDag({
+      ...validDag(),
+      nodes: [
+        { nodeRef: "a", title: "A", objective: "A.", dependsOn: ["b"] },
+        { nodeRef: "b", title: "B", objective: "B.", dependsOn: ["a"] },
+      ],
+    })).toThrow(/cycle/)
+
+    expect(() => decodeClaudePlanFanoutDag({
+      ...validDag(),
+      nodes: [
+        { nodeRef: "a", title: "A", objective: "A.", dependsOn: ["missing"] },
+      ],
+    })).toThrow(/unknown node/)
+
+    expect(() => decodeClaudePlanFanoutDag({
+      ...validDag(),
+      nodes: [
+        { nodeRef: "secret", title: "Secret", objective: "Read /Users/operator/.secrets/token." },
+      ],
+    })).toThrow(/public-safe/)
+  })
+
+  test("decodes Claude review verdicts as advisory signals only", () => {
+    const review = decodeClaudePlanFanoutReview({
+      schema: CLAUDE_PLAN_FANOUT_REVIEW_SCHEMA,
+      reviewRef: "review.t9_4.1",
+      planRef: "plan.t9_4.fixture",
+      generatedAt: "2026-07-02T10:05:00.000Z",
+      verdict: "request_changes",
+      summary: "The adapter node needs a dependency-ordering regression.",
+      targetNodeRefs: ["adapter"],
+      changeRequests: ["Add a regression where the dependent node waits for root closeout."],
+      evidenceRefs: ["pr#7994"],
+    }, { knownNodeRefs: ["contract", "adapter"] })
+
+    expect(claudePlanFanoutReviewAdvisorySignal(review)).toEqual({
+      advisory: true,
+      controlFlowAuthority: "khala.fleet.delegate",
+      deterministicGateRequired: true,
+      planRef: "plan.t9_4.fixture",
+      reviewRef: "review.t9_4.1",
+      targetNodeRefs: ["adapter"],
+      verdict: "request_changes",
+    })
+    expect(() => decodeClaudePlanFanoutReview({
+      ...review,
+      targetNodeRefs: ["missing"],
+    }, { knownNodeRefs: ["contract", "adapter"] })).toThrow(/unknown node/)
+  })
+
+  test("plan-mode instructions name the schema and deterministic authority", () => {
+    const instructions = claudePlanFanoutPlanModeInstructions()
+    expect(instructions).toContain(CLAUDE_PLAN_FANOUT_DAG_SCHEMA)
+    expect(instructions).toContain("Do not edit files")
+    expect(instructions).toContain("deterministic FleetRun supervision owns control flow")
+  })
+})

--- a/clients/khala-code-desktop/tests/codex-fleet-mcp-bridge.test.ts
+++ b/clients/khala-code-desktop/tests/codex-fleet-mcp-bridge.test.ts
@@ -328,6 +328,54 @@ describe("Codex Fleet MCP bridge", () => {
     expect(mock.calls.controls).toEqual([{ runRef: "fleet_run.mock", verb: "pause" }])
   })
 
+  test("Fleet MCP run start accepts structured plan DAG inputs", async () => {
+    const mock = mockFleetRunSupervisor()
+    const registry = createKhalaCodeDesktopFleetMcpRegistry({
+      fleetRunSupervisor: mock.manager,
+    })
+
+    const start = await handleKhalaMcpRequest(
+      {
+        id: "start-plan",
+        jsonrpc: "2.0",
+        method: "tools/call",
+        params: {
+          arguments: {
+            commit: "0123456789abcdef0123456789abcdef01234567",
+            objective: "Execute Claude plan-mode DAG.",
+            plan_nodes: [
+              { ref: "root", title: "Root", objective: "Run root." },
+              { ref: "dependent", title: "Dependent", objective: "Run dependent.", dependsOn: ["root"] },
+            ],
+            plan_ref: "plan.t9_4.mcp",
+            repo: "OpenAgentsInc/openagents",
+            target_concurrency: 2,
+            verify: "bun test clients/khala-code-desktop/tests/codex-fleet-mcp-bridge.test.ts",
+            work_source: "plan_dag",
+          },
+          name: "fleet_run_start",
+        },
+      },
+      { policy: khalaCodeDesktopFleetMcpPolicy, registry },
+    )
+
+    expect(start.result?.content).toEqual([expect.objectContaining({
+      text: expect.stringContaining("FleetRun fleet_run.mock: running"),
+      type: "text",
+    })])
+    expect(mock.calls.starts).toEqual([expect.objectContaining({
+      objective: "Execute Claude plan-mode DAG.",
+      planRef: "plan.t9_4.mcp",
+      repo: "OpenAgentsInc/openagents",
+      verify: "bun test clients/khala-code-desktop/tests/codex-fleet-mcp-bridge.test.ts",
+      workSource: "plan_dag",
+    })])
+    expect(mock.calls.starts[0]?.planNodes?.map(node => ({ ref: node.ref, dependsOn: node.dependsOn }))).toEqual([
+      { ref: "root", dependsOn: undefined },
+      { ref: "dependent", dependsOn: ["root"] },
+    ])
+  })
+
   test("Fleet MCP run verbs round-trip through the scripted Codex app-server fixture", async () => {
     const root = await mkdtemp(join(tmpdir(), "khala-fleet-mcp-app-server-"))
     const host = createCodexAppServerHost({

--- a/clients/khala-code-desktop/tests/fleet-run-supervisor-rpc-adapter.test.ts
+++ b/clients/khala-code-desktop/tests/fleet-run-supervisor-rpc-adapter.test.ts
@@ -114,6 +114,103 @@ describe("Khala Code fleet run supervisor RPC adapter", () => {
     expect(dispatched).toEqual([{ accountRef: "claude-a", workerKind: "claude" }])
   })
 
+  test("starts plan_dag runs as Codex dispatches with node objectives", async () => {
+    const dispatched: Array<{ readonly objective: string; readonly workUnitRef: string; readonly verify: string | undefined }> = []
+    const { adapter, store } = adapterFixture({
+      advertisedCapacity: 2,
+      runner: {
+        dispatch: async input => {
+          dispatched.push({
+            objective: input.workUnit.body ?? input.run.objective,
+            workUnitRef: input.workUnit.workUnitRef,
+            verify: input.workUnit.verify,
+          })
+          return {
+            assignmentRef: "assignment.plan.root",
+            lifecycle: [],
+            status: "accepted",
+            summary: null,
+          }
+        },
+      },
+    })
+
+    const result = await adapter.start({
+      objective: "Execute a Claude plan-mode DAG.",
+      runRef: "fleet_run.adapter.plan_dag",
+      targetConcurrency: 2,
+      tickImmediately: true,
+      workSource: {
+        kind: "plan_dag",
+        planRef: "plan.t9_4.adapter",
+        repo: "OpenAgentsInc/openagents",
+        baseCommit: "0123456789abcdef0123456789abcdef01234567",
+        verify: "bun test clients/khala-code-desktop/tests/fleet-run-supervisor-rpc-adapter.test.ts",
+        nodes: [
+          {
+            ref: "root",
+            title: "Root node",
+            objective: "Run the root plan node.",
+            issue: 7873,
+          },
+          {
+            ref: "dependent",
+            title: "Dependent node",
+            objective: "Run the dependent plan node.",
+            dependsOn: ["root"],
+          },
+        ],
+      },
+    })
+
+    expect(result.run.workerKind).toBe("codex")
+    expect(result.run.workSource).toMatchObject({
+      kind: "plan_dag",
+      planRef: "plan.t9_4.adapter",
+      nodes: [
+        { ref: "root", objective: "Run the root plan node." },
+        { ref: "dependent", dependsOn: ["root"] },
+      ],
+    })
+    expect(dispatched).toEqual([{
+      objective: "Run the root plan node.",
+      workUnitRef: "plan_dag:plan.t9_4.adapter:node:root",
+      verify: "bun test clients/khala-code-desktop/tests/fleet-run-supervisor-rpc-adapter.test.ts",
+    }])
+    expect(store.listTasks("dispatched")[0]?.spec).toMatchObject({
+      fleetRunRef: "fleet_run.adapter.plan_dag",
+      issueRef: "#7873",
+      prompt: "Run the root plan node.",
+      runnerKind: "codex",
+    })
+  })
+
+  test("rejects invalid plan_dag work sources before creating a run", async () => {
+    const { adapter, store } = adapterFixture({ advertisedCapacity: 2 })
+
+    await expect(adapter.start({
+      objective: "Execute an invalid Claude plan-mode DAG.",
+      runRef: "fleet_run.adapter.invalid_plan_dag",
+      targetConcurrency: 2,
+      tickImmediately: true,
+      workSource: {
+        kind: "plan_dag",
+        planRef: "plan.t9_4.invalid",
+        repo: "OpenAgentsInc/openagents",
+        baseCommit: "0123456789abcdef0123456789abcdef01234567",
+        verify: "bun test clients/khala-code-desktop/tests/fleet-run-supervisor-rpc-adapter.test.ts",
+        nodes: [{
+          ref: "dependent",
+          title: "Dependent node",
+          objective: "Run the dependent plan node.",
+          dependsOn: ["missing"],
+        }],
+      },
+    })).rejects.toThrow(/unknown node/)
+
+    expect(store.getFleetRun("fleet_run.adapter.invalid_plan_dag")).toBeNull()
+  })
+
   test("accepts target_reached stop conditions in projections", async () => {
     const { adapter } = adapterFixture()
 

--- a/clients/khala-code-desktop/tests/fleet-run-supervisor.test.ts
+++ b/clients/khala-code-desktop/tests/fleet-run-supervisor.test.ts
@@ -10,7 +10,7 @@ import {
   createPylonOrchestrationStore,
   type FleetRun,
 } from "../../../apps/pylon/src/orchestration/store.js"
-import { fixtureCandidates, planFixtureWork, planWorkCandidates } from "../../../apps/pylon/src/orchestration/work-planner.js"
+import { fixtureCandidates, planDagWork, planFixtureWork, planWorkCandidates } from "../../../apps/pylon/src/orchestration/work-planner.js"
 import {
   FLEET_RUN_SUPERVISOR_MAX_SPAWN_COUNT,
   makeFleetRunSupervisor,
@@ -501,6 +501,85 @@ describe("FleetRunSupervisor", () => {
     expect(store.listTasks("completed")).toHaveLength(4)
     expect(store.getFleetRun(run.runRef)?.state).toBe("completed")
     expect(store.getFleetRun(run.runRef)?.counters.workUnitsTotal).toBe(4)
+  })
+
+  test("plan DAG dispatches dependent nodes only after prerequisite closeout", async () => {
+    const store = createPylonOrchestrationStore(new Database(":memory:"))
+    const run = store.createFleetRun({
+      runRef: "fleet_run.plan_dag",
+      objective: "Execute a Claude plan-mode DAG.",
+      workSource: "plan_dag",
+      targetConcurrency: 2,
+      workerKind: "codex",
+      state: "running",
+      startedAt: fixedNow,
+      now: fixedNow,
+      counters: { workUnitsTotal: 2 },
+    })
+    const source = {
+      kind: "plan_dag" as const,
+      planRef: "plan.t9_4.supervisor",
+      repo: "OpenAgentsInc/openagents",
+      nodes: [
+        { ref: "root", title: "Root node", objective: "Run root node." },
+        { ref: "adapter", title: "Wire adapter", objective: "Run adapter node.", dependsOn: ["root"] },
+      ],
+    }
+    const dispatched: string[] = []
+    const planner = {
+      plan: async ({ now }: { readonly now: Date }) => {
+        const claims = store.listWorkClaims({ runRef: run.runRef })
+        return planDagWork(source, {
+          now,
+          claimRegistry: store,
+          completedWorkUnitRefs: claims.filter(claim => claim.state === "closeout").map(claim => claim.workUnitRef),
+          failedWorkUnitRefs: claims
+            .filter(claim => claim.state === "released" || claim.state === "expired")
+            .map(claim => claim.workUnitRef),
+        })
+      },
+    }
+    const runner: FleetRunSupervisorRunner = {
+      dispatch: async (input) => {
+        dispatched.push(input.workUnit.workUnitRef)
+        return {
+          assignmentRef: `assignment.${input.claim.claimRef}`,
+          lifecycle: [lifecycleEvent("assignment_run.completed", { status: "closed" })],
+          status: "completed",
+        }
+      },
+    }
+
+    const first = await tickFleetRunSupervisor({
+      store,
+      pylonRef: "pylon.owner.plan",
+      runRef: run.runRef,
+      planner,
+      runner,
+      capacity: capacity([{ accountRef: "codex", advertisedCapacity: 2 }]),
+      clock: { now: () => fixedNow },
+    })
+    const second = await tickFleetRunSupervisor({
+      store,
+      pylonRef: "pylon.owner.plan",
+      runRef: run.runRef,
+      planner,
+      runner,
+      capacity: capacity([{ accountRef: "codex", advertisedCapacity: 2 }]),
+      clock: { now: () => new Date(fixedNow.getTime() + 1_000) },
+    })
+
+    expect(first.dispatched).toBe(1)
+    expect(first.run.state).toBe("running")
+    expect(second.dispatched).toBe(1)
+    expect(second.run.state).toBe("completed")
+    expect(dispatched).toEqual([
+      "plan_dag:plan.t9_4.supervisor:node:root",
+      "plan_dag:plan.t9_4.supervisor:node:adapter",
+    ])
+    const adapterTask = store.listTasks().find(task => task.spec.title === "Wire adapter")
+    expect(adapterTask?.deps).toHaveLength(1)
+    expect(adapterTask?.spec.prompt).toBe("Run adapter node.")
   })
 
   test("closeout claims do not consume account capacity on the next tick", async () => {

--- a/clients/khala-code-desktop/tests/khala-fleet-tools.test.ts
+++ b/clients/khala-code-desktop/tests/khala-fleet-tools.test.ts
@@ -465,6 +465,31 @@ describe("Khala Code fleet tools", () => {
     expect(second.active).toBe(false)
   })
 
+  test("DefaultKhalaFleetRunSupervisorManager rejects invalid plan DAGs before creating a run", async () => {
+    const manager = new DefaultKhalaFleetRunSupervisorManager({
+      runner: async () => failed("unexpected pylon command"),
+    })
+
+    await expect(manager.start({
+      commit: "0123456789abcdef0123456789abcdef01234567",
+      objective: "Execute an invalid Claude plan-mode DAG.",
+      planNodes: [{
+        ref: "dependent",
+        title: "Dependent node",
+        objective: "Run the dependent plan node.",
+        dependsOn: ["missing"],
+      }],
+      planRef: "plan.t9_4.invalid",
+      runRef: "fleet_run.test.invalid_plan_dag",
+      targetConcurrency: 1,
+      verify: "bun test clients/khala-code-desktop/tests/khala-fleet-tools.test.ts",
+      workSource: "plan_dag",
+    })).rejects.toThrow(/unknown node/)
+
+    await expect(manager.status({ runRef: "fleet_run.test.invalid_plan_dag" }))
+      .rejects.toThrow(/unknown fleet run/)
+  })
+
   test("DefaultKhalaFleetRunSupervisorManager stops a failed start record and closes the leaked scope", async () => {
     const fixture = await tempPylonFixture()
     const runner = async (input: KhalaCodexFleetCommandInput): Promise<KhalaCodexFleetCommandResult> => {

--- a/docs/fable/2026-07-01-claude-code-parity-and-codex-synergies.md
+++ b/docs/fable/2026-07-01-claude-code-parity-and-codex-synergies.md
@@ -290,6 +290,19 @@ parameters tune confidence threshold, classifier bonus, and tie-breaker. This
 keeps Claude/Fable planning as advisory structure while `khala.fleet.delegate`
 continues to own deterministic control flow.
 
+**T9.4 update (2026-07-02):** the plan-then-fan-out contract is now typed at
+the desktop/Pylon seam. Claude plan-mode output is decoded as
+`openagents.khala_code.claude_plan_fanout_dag.v1`, validated for public-safe
+refs, unknown deps, duplicate nodes, and cycles, then converted into a
+`plan_dag` FleetRun work source. The supervisor dispatches dependency-free
+nodes to Codex first, records task-DAG deps in the orchestration store, and
+releases dependent nodes only after predecessor closeout. Claude review output
+has a sibling typed verdict contract
+`openagents.khala_code.claude_plan_fanout_review.v1` with
+`accept | request_changes | replan`; it produces an advisory signal only, so
+verify commands and the deterministic FleetRun/delegation program remain the
+authority.
+
 ### 4.2 Claude as reviewer / verifier-adjacent
 
 Claude's review quality pairs with our verification gates. After a Codex worker's

--- a/docs/fable/2026-07-01-episode-245-completion-and-multi-harness-orchestration.md
+++ b/docs/fable/2026-07-01-episode-245-completion-and-multi-harness-orchestration.md
@@ -301,6 +301,16 @@ the parity contract changes.
   ATIF/per-turn rows) remain for when Claude workers graduate from
   analysis/bounded work to PR delivery.
 
+**T9.4 landing note (2026-07-02):** the first concrete Axis-A/Axis-B
+crossover now exists as a typed handoff rather than an implicit prompt
+pattern. A Claude plan-mode session can emit a bounded task DAG, Desktop
+validates it as public-safe structured data, and FleetRun accepts it as
+`work_source = plan_dag`. The supervisor keeps the deterministic control-flow
+role: it claims dependency-free nodes, dispatches them to Codex workers, and
+only unlocks dependent nodes after closeout. Claude's returned
+`accept | request_changes | replan` review verdict is represented as an
+advisory contract, not as merge or dispatch authority.
+
 ### 3.4 Invariants to keep while doing this
 
 - Isolated worker homes for every harness; never touch `~/.codex` or the

--- a/docs/fable/2026-07-01-fleet-fanout-coding-instructions.md
+++ b/docs/fable/2026-07-01-fleet-fanout-coding-instructions.md
@@ -169,6 +169,13 @@ Build:
 5. **RPC parity**: `fleetRunStart`, `fleetRunStatus`, `fleetRunControl`,
    `fleetRunList` methods; everything the UI can do, the bridge can do.
 
+T9.4 extends the same FleetRun entry point with a fourth work source,
+`plan_dag`, for Claude/Fable plan-mode decomposition. It is still supervised
+dispatch: Claude emits typed DAG data, the planner exposes dependency-ready
+nodes as work units, and the supervisor/claim registry decide what runs.
+Claude review verdicts stay advisory; verify and merge gates remain the
+authority.
+
 Acceptance:
 
 - Fixture tier: a fixture FleetRun with target 25 on a mocked Pylon runner


### PR DESCRIPTION
Closes #7873

## Summary
- add a typed Claude plan-mode fan-out DAG contract plus advisory Claude review verdict contract
- add `plan_dag` as a FleetRun/work-planner source with dependency-ready dispatch, failed-dependency skips, and task DAG deps
- thread plan DAG starts through desktop RPC/MCP supervisor paths and document the T9.4 landing notes

## Verification
- `git diff --check`
- `bun run --cwd apps/pylon typecheck`
- `bun run --cwd clients/khala-code-desktop typecheck`
- `bun test apps/pylon/src/orchestration/work-planner.test.ts`
- `bun test clients/khala-code-desktop/tests/claude-plan-fanout.test.ts clients/khala-code-desktop/tests/fleet-run-supervisor.test.ts clients/khala-code-desktop/tests/fleet-run-supervisor-rpc-adapter.test.ts clients/khala-code-desktop/tests/codex-fleet-mcp-bridge.test.ts clients/khala-code-desktop/tests/khala-fleet-tools.test.ts`
- `bun run --cwd clients/khala-code-desktop verify` (482 pass)
- `bun run --cwd apps/pylon test` (2049 pass, 3 skip)
- `bun run --cwd apps/openagents.com check:deploy` (green; expected negative drift-guard fixture output appears inside passing guard tests)