### PR TITLE
T12.4: consolidate Artanis forum identity

### DIFF
--- a/apps/openagents.com/workers/api/src/agent-registration-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/agent-registration-routes.test.ts
@@ -350,4 +350,23 @@ describe('admin agent token reissue route (#6370)', () => {
 
     expect(response.status).toBe(400)
   })
+
+  test('supplying both slug and externalId is a bad request', async () => {
+    const store = new MemoryAgentRegistrationStore()
+    await seedAgent(store, {
+      displayName: 'Artanis',
+      externalId: 'artanis-1',
+      slug: 'artanis',
+    })
+
+    const response = await handleAdminReissueAgentToken(
+      reissueRequest({ slug: 'artanis', externalId: 'artanis-1' }),
+      {} as Env,
+      {} as ExecutionContext,
+      { agentRegistrationStore: store, authorize: async () => true },
+    )
+
+    expect(response.status).toBe(400)
+    expect(store.addedCredentials).toHaveLength(0)
+  })
 })

--- a/apps/openagents.com/workers/api/src/agent-registration.ts
+++ b/apps/openagents.com/workers/api/src/agent-registration.ts
@@ -110,6 +110,18 @@ export type AgentReissueStore = Readonly<{
   addAgentCredential: (record: AgentCredentialRecord) => Promise<void>
 }>
 
+export type AgentForumIdentityTarget = Readonly<{
+  session: ProgrammaticAgentSession
+  slug: string | null
+}>
+
+export type AgentForumIdentityStore = Readonly<{
+  findAgentForumIdentity: (
+    selector: AgentReissueSelector,
+    now: string,
+  ) => Promise<AgentForumIdentityTarget | undefined>
+}>
+
 export type AgentUserRecord = Readonly<{
   id: string
   kind: 'agent'
@@ -229,6 +241,12 @@ export type AgentRegistrationStore = Readonly<{
   // adds a new active credential so the recovered token authenticates as the
   // same entity.
   addAgentCredential?: (record: AgentCredentialRecord) => Promise<void>
+  // Registered Forum identity lookup. Internal Forum writers use this to speak
+  // as the canonical registered agent actor, never a synthetic duplicate actor.
+  findAgentForumIdentity?: (
+    selector: AgentReissueSelector,
+    now: string,
+  ) => Promise<AgentForumIdentityTarget | undefined>
 }>
 
 export type ProgrammaticAgentRegistration = Readonly<{
@@ -276,6 +294,21 @@ type AgentReissueTargetRow = Readonly<{
   user_id: string
   display_name: string
   slug: string | null
+}>
+
+type AgentForumIdentityRow = Readonly<{
+  user_id: string
+  display_name: string
+  primary_email: string | null
+  avatar_url: string | null
+  status: 'active'
+  user_created_at: string
+  user_updated_at: string
+  slug: string | null
+  metadata_json: string | null
+  credential_id: string
+  openauth_user_id: string | null
+  token_prefix: string
 }>
 
 type LinkedAgentOwnerRow = Readonly<{
@@ -335,7 +368,7 @@ export const timingSafeEqual = async (
 
 export const makeD1AgentRegistrationStore = (
   db: D1Database,
-): AgentRegistrationStore & AgentReissueStore => ({
+): AgentRegistrationStore & AgentReissueStore & AgentForumIdentityStore => ({
   createAgentRegistration: async record => {
     await db.batch([
       db
@@ -665,6 +698,102 @@ export const makeD1AgentRegistrationStore = (
         record.expiresAt,
       )
       .run()
+  },
+
+  findAgentForumIdentity: async (selector, now) => {
+    const activeCredentialClause = `agent_credentials.status = 'active'
+       AND agent_credentials.revoked_at IS NULL
+       AND (
+         agent_credentials.expires_at IS NULL
+         OR agent_credentials.expires_at > ?
+       )`
+    const row =
+      'slug' in selector
+        ? await db
+            .prepare(
+              `SELECT
+                  users.id AS user_id,
+                  users.display_name,
+                  users.primary_email,
+                  users.avatar_url,
+                  users.status,
+                  users.created_at AS user_created_at,
+                  users.updated_at AS user_updated_at,
+                  agent_profiles.slug,
+                  agent_profiles.metadata_json,
+                  agent_credentials.id AS credential_id,
+                  agent_credentials.openauth_user_id,
+                  agent_credentials.token_prefix
+               FROM agent_profiles
+               INNER JOIN users ON users.id = agent_profiles.user_id
+               INNER JOIN agent_credentials ON agent_credentials.user_id = users.id
+               WHERE agent_profiles.slug = ?
+                 AND users.kind = 'agent'
+                 AND users.status = 'active'
+                 AND users.deleted_at IS NULL
+                 AND ${activeCredentialClause}
+               ORDER BY agent_credentials.created_at DESC, agent_credentials.id DESC
+               LIMIT 1`,
+            )
+            .bind(selector.slug, now)
+            .first<AgentForumIdentityRow>()
+        : await db
+            .prepare(
+              `SELECT
+                  users.id AS user_id,
+                  users.display_name,
+                  users.primary_email,
+                  users.avatar_url,
+                  users.status,
+                  users.created_at AS user_created_at,
+                  users.updated_at AS user_updated_at,
+                  agent_profiles.slug,
+                  agent_profiles.metadata_json,
+                  agent_credentials.id AS credential_id,
+                  agent_credentials.openauth_user_id,
+                  agent_credentials.token_prefix
+               FROM auth_identities
+               INNER JOIN users ON users.id = auth_identities.user_id
+               LEFT JOIN agent_profiles ON agent_profiles.user_id = users.id
+               INNER JOIN agent_credentials ON agent_credentials.user_id = users.id
+               WHERE auth_identities.provider = 'agent_programmatic'
+                 AND auth_identities.provider_subject = ?
+                 AND users.kind = 'agent'
+                 AND users.status = 'active'
+                 AND users.deleted_at IS NULL
+                 AND ${activeCredentialClause}
+               ORDER BY agent_credentials.created_at DESC, agent_credentials.id DESC
+               LIMIT 1`,
+            )
+            .bind(selector.externalId, now)
+            .first<AgentForumIdentityRow>()
+
+    if (row === null) {
+      return undefined
+    }
+
+    return {
+      session: {
+        user: {
+          id: row.user_id,
+          kind: 'agent',
+          displayName: row.display_name,
+          primaryEmail: row.primary_email,
+          avatarUrl: row.avatar_url,
+          status: row.status,
+          createdAt: row.user_created_at,
+          updatedAt: row.user_updated_at,
+        },
+        credential: {
+          id: row.credential_id,
+          openauthUserId: row.openauth_user_id,
+          profileMetadataJson: row.metadata_json ?? '{}',
+          tokenPrefix: row.token_prefix,
+          lastUsedAt: now,
+        },
+      },
+      slug: row.slug ?? null,
+    }
   },
 })
 

--- a/apps/openagents.com/workers/api/src/artanis-forum-delivery.test.ts
+++ b/apps/openagents.com/workers/api/src/artanis-forum-delivery.test.ts
@@ -38,6 +38,8 @@ const artanisActorJson = JSON.stringify({
   isAgent: true,
   slug: 'artanis',
 })
+const registeredArtanisUserId = 'user_artanis_registered'
+const registeredArtanisActorRef = `agent:${registeredArtanisUserId}`
 
 type ForumRow = Readonly<{
   archived_at: string | null
@@ -98,8 +100,37 @@ type PostRow = Readonly<{
   updated_at: string
 }>
 
+type AgentForumIdentityRow = Readonly<{
+  user_id: string
+  display_name: string
+  primary_email: string | null
+  avatar_url: string | null
+  status: 'active'
+  user_created_at: string
+  user_updated_at: string
+  slug: string | null
+  metadata_json: string | null
+  credential_id: string
+  openauth_user_id: string | null
+  token_prefix: string
+}>
+
 class DeliveryStore {
   readonly artanis = new ArtanisPersistenceTestStore()
+  registeredArtanis: AgentForumIdentityRow | null = {
+    user_id: registeredArtanisUserId,
+    display_name: 'Artanis',
+    primary_email: null,
+    avatar_url: null,
+    status: 'active',
+    user_created_at: '2026-06-26T17:00:00.000Z',
+    user_updated_at: '2026-06-26T18:00:00.000Z',
+    slug: 'artanis',
+    metadata_json: JSON.stringify({ purpose: 'forum_posting' }),
+    credential_id: 'agent_credential_artanis_reissued',
+    openauth_user_id: null,
+    token_prefix: 'oa_agent_artanis_re',
+  }
   forums: Array<ForumRow> = [
     {
       archived_at: null,
@@ -226,6 +257,20 @@ class DeliveryStatement implements D1PreparedStatement {
         ) ?? null
 
       return Promise.resolve(post as T | null)
+    }
+
+    if (
+      this.query.includes('FROM agent_profiles') &&
+      this.query.includes('agent_credentials')
+    ) {
+      const slug = String(this.values[0])
+      const row =
+        this.store.registeredArtanis !== null &&
+        this.store.registeredArtanis.slug === slug
+          ? this.store.registeredArtanis
+          : null
+
+      return Promise.resolve(row as T | null)
     }
 
     if (this.query.includes('FROM forum_tip_recipient_wallets')) {
@@ -409,7 +454,7 @@ describe('Artanis Forum delivery', () => {
     })
     expect(store.posts).toHaveLength(2)
     expect(store.posts[1]).toMatchObject({
-      actor_ref: 'agent:agent_artanis',
+      actor_ref: registeredArtanisActorRef,
       body_text:
         'Artanis status update: Pylon v0.2 release work is active, Model Lab evidence is being gathered, and public proofs will be linked as they are accepted.',
       idempotency_key: 'artanis-forum:status:20260607T0121:v1',
@@ -432,6 +477,22 @@ describe('Artanis Forum delivery', () => {
       deliveryState: 'delivered',
       postRef: 'post.public.forum.artanis.status.2',
     })
+  })
+
+  test('fails closed when the registered Artanis Forum identity is unavailable', async () => {
+    const store = new DeliveryStore()
+    store.registeredArtanis = null
+    const db = deliveryDb(store)
+
+    await persistIntent(store, intentRecord())
+
+    await expect(
+      Effect.runPromise(deliverReadyArtanisForumPublications(db, { runtime })),
+    ).rejects.toMatchObject({
+      _tag: 'ArtanisForumDeliveryError',
+      kind: 'identity_unavailable',
+    })
+    expect(store.posts).toHaveLength(1)
   })
 
   test('collapses duplicate delivery retries to the existing Forum post ref', async () => {

--- a/apps/openagents.com/workers/api/src/artanis-forum-delivery.ts
+++ b/apps/openagents.com/workers/api/src/artanis-forum-delivery.ts
@@ -11,6 +11,11 @@ import {
   readLatestArtanisPersistedRows,
 } from './artanis-persistence'
 import {
+  ArtanisForumIdentityError,
+  isArtanisForumPostActor,
+  resolveRegisteredArtanisForumIdentityFromD1,
+} from './artanis-forum-identity'
+import {
   type ForumPostSummary,
   ForumPublicProjection,
   ForumPublicProjectionUnsafe,
@@ -18,9 +23,7 @@ import {
   type ForumRepositoryError,
   type ForumRepositoryRuntime,
   ForumStorageError,
-  type ForumStoredActorSummary,
   ForumValidationError,
-  type ForumWriterActorInput,
   ForumWriterAuthFailure,
   ForumWriterGrant,
   buildForumWriterContext,
@@ -87,6 +90,7 @@ export class ArtanisForumDeliveryError extends S.TaggedErrorClass<ArtanisForumDe
     kind: S.Literals([
       'existing_post_conflict',
       'idempotency_key_missing',
+      'identity_unavailable',
       'persistence_error',
       'storage_error',
       'target_blocked',
@@ -141,37 +145,6 @@ const topicRefAliases: Readonly<Record<string, ArtanisCanonicalTopicKey>> = {
   'topic.public.forum.artanis.status': 'status',
   'topic.public.forum.artanis.work_routing': 'work_routing',
 }
-
-const artanisActor: ForumStoredActorSummary = {
-  actorId: 'agent_artanis',
-  actorRef: 'agent:agent_artanis',
-  displayName: 'Artanis',
-  groupRefs: ['agents', 'openagents'],
-  isAgent: true,
-  slug: 'artanis',
-}
-
-const artanisActorInput = (nowIso: string): ForumWriterActorInput => ({
-  _tag: 'Agent',
-  session: {
-    credential: {
-      id: 'credential.internal.artanis.forum_delivery',
-      lastUsedAt: nowIso,
-      profileMetadataJson: '{}',
-      tokenPrefix: 'internal_artanis_forum',
-    },
-    user: {
-      avatarUrl: null,
-      createdAt: nowIso,
-      displayName: 'Artanis',
-      id: 'agent_artanis',
-      kind: 'agent',
-      primaryEmail: null,
-      status: 'active',
-      updatedAt: nowIso,
-    },
-  },
-})
 
 const deliveryRuntime = (
   runtime: Partial<DeliveryRuntime> | undefined,
@@ -255,6 +228,10 @@ const mapDependencyError = (error: unknown): ArtanisForumDeliveryError => {
 
   if (error instanceof ArtanisPersistenceError) {
     return deliveryError('persistence_error', error.reason)
+  }
+
+  if (error instanceof ArtanisForumIdentityError) {
+    return deliveryError('identity_unavailable', error.reason)
   }
 
   if (error instanceof ForumPublicProjectionUnsafe) {
@@ -398,6 +375,11 @@ export const deliverArtanisForumPublicationIntent = (
       )
     }
 
+    const identity = yield* resolveRegisteredArtanisForumIdentityFromD1(
+      db,
+      nowIso,
+    ).pipe(Effect.mapError(mapDependencyError))
+
     const existingPost = yield* readForumPostByIdempotencyKey(
       db,
       intent.idempotencyKey,
@@ -406,7 +388,7 @@ export const deliverArtanisForumPublicationIntent = (
     if (existingPost !== null) {
       if (
         existingPost.topicId !== topic.topicId ||
-        existingPost.author.actorRef !== artanisActor.actorRef ||
+        !isArtanisForumPostActor(existingPost.author.actorRef, identity) ||
         (existingPost.bodyText ?? '').trim() !== intent.bodyText.trim()
       ) {
         return yield* deliveryError(
@@ -424,19 +406,19 @@ export const deliverArtanisForumPublicationIntent = (
     const grant = decodeForumWriterGrant({
       expiresAtEpochMillis: runtime.nowEpochMillis() + 1000 * 60 * 60,
       forumIds: [forum.forumId],
-      ownerUserId: 'agent_artanis',
+      ownerUserId: identity.userId,
       scopes: ['forum.write'],
       status: 'active',
       teamId: null,
     })
     const writer = yield* buildForumWriterContext({
-      actor: artanisActorInput(nowIso),
+      actor: identity.actor,
       grant,
       nowEpochMillis: runtime.nowEpochMillis,
       paymentProofRef: null,
       requiredScope: 'forum.write',
       targetForumId: forum.forumId,
-      targetOwnerUserId: 'agent_artanis',
+      targetOwnerUserId: identity.userId,
       targetTeamId: null,
     }).pipe(Effect.mapError(mapDependencyError))
     const repositoryRuntime: ForumRepositoryRuntime = {

--- a/apps/openagents.com/workers/api/src/artanis-forum-identity.ts
+++ b/apps/openagents.com/workers/api/src/artanis-forum-identity.ts
@@ -1,0 +1,77 @@
+import { Effect, Schema as S } from 'effect'
+
+import {
+  type AgentForumIdentityStore,
+  makeD1AgentRegistrationStore,
+} from './agent-registration'
+import type { ForumWriterActorInput } from './forum'
+
+export const ARTANIS_REGISTERED_FORUM_SLUG = 'artanis'
+export const LEGACY_ARTANIS_FORUM_ACTOR_REF = 'agent:agent_artanis'
+
+export class ArtanisForumIdentityError extends S.TaggedErrorClass<ArtanisForumIdentityError>()(
+  'ArtanisForumIdentityError',
+  {
+    reason: S.String,
+  },
+) {}
+
+export type ArtanisForumIdentity = Readonly<{
+  actor: ForumWriterActorInput
+  actorRef: string
+  slug: string | null
+  userId: string
+}>
+
+export const resolveRegisteredArtanisForumIdentity = (
+  store: AgentForumIdentityStore,
+  nowIso: string,
+): Effect.Effect<ArtanisForumIdentity, ArtanisForumIdentityError> =>
+  Effect.tryPromise({
+    catch: error =>
+      new ArtanisForumIdentityError({
+        reason:
+          error instanceof Error
+            ? error.message
+            : 'Registered Artanis Forum identity lookup failed.',
+      }),
+    try: () =>
+      store.findAgentForumIdentity(
+        { slug: ARTANIS_REGISTERED_FORUM_SLUG },
+        nowIso,
+      ),
+  }).pipe(
+    Effect.flatMap(identity =>
+      identity === undefined
+        ? Effect.fail(
+            new ArtanisForumIdentityError({
+              reason:
+                'Registered Artanis Forum identity is unavailable; reissue/recover the slug=artanis agent before Forum publication.',
+            }),
+          )
+        : Effect.succeed({
+            actor: {
+              _tag: 'Agent' as const,
+              session: identity.session,
+            },
+            actorRef: `agent:${identity.session.user.id}`,
+            slug: identity.slug,
+            userId: identity.session.user.id,
+          }),
+    ),
+  )
+
+export const resolveRegisteredArtanisForumIdentityFromD1 = (
+  db: D1Database,
+  nowIso: string,
+): Effect.Effect<ArtanisForumIdentity, ArtanisForumIdentityError> =>
+  resolveRegisteredArtanisForumIdentity(
+    makeD1AgentRegistrationStore(db),
+    nowIso,
+  )
+
+export const isArtanisForumPostActor = (
+  actorRef: string,
+  identity: ArtanisForumIdentity,
+): boolean =>
+  actorRef === identity.actorRef || actorRef === LEGACY_ARTANIS_FORUM_ACTOR_REF

--- a/apps/openagents.com/workers/api/src/artanis-forum-responder-khala.test.ts
+++ b/apps/openagents.com/workers/api/src/artanis-forum-responder-khala.test.ts
@@ -6,6 +6,7 @@ import { Effect } from 'effect'
 import { describe, expect, test } from 'vitest'
 
 import {
+  ARTANIS_REGISTERED_ACTOR_REF,
   ARTANIS_RESPONDER_KHALA_MODEL,
   runArtanisResponderScan,
 } from './artanis-forum-responder'
@@ -84,7 +85,18 @@ const makeDb = (): D1Database => {
   return new SqliteD1(raw) as unknown as D1Database
 }
 
-const seedTopic = async (db: D1Database): Promise<void> => {
+const seedTopic = async (
+  db: D1Database,
+  input: Readonly<{
+    actorRef?: string
+    bodyText?: string
+    title?: string
+    topicId?: string
+  }> = {},
+): Promise<void> => {
+  const topicId = input.topicId ?? 'topic_pylon_help'
+  const firstPostId = `${topicId}_first_post`
+
   await db
     .prepare(
       `INSERT INTO artanis_responder_state
@@ -104,18 +116,19 @@ const seedTopic = async (db: D1Database): Promise<void> => {
        VALUES (?, 'forum_agents', ?, ?, ?, 'open', ?)`,
     )
     .bind(
-      'topic_pylon_help',
-      'post_first',
-      'Can my Pylon join training runs?',
-      'agent:external_contributor',
+      topicId,
+      firstPostId,
+      input.title ?? 'Can my Pylon join training runs?',
+      input.actorRef ?? 'agent:external_contributor',
       '2026-06-25T01:00:00.000Z',
     )
     .run()
   await db
     .prepare(`INSERT INTO forum_post_bodies (post_id, body_text) VALUES (?, ?)`)
     .bind(
-      'post_first',
-      'I have a GPU Pylon online. How do I know whether it can join a training run?',
+      firstPostId,
+      input.bodyText ??
+        'I have a GPU Pylon online. How do I know whether it can join a training run?',
     )
     .run()
 }
@@ -174,5 +187,42 @@ describe('Artanis forum responder Khala routing', () => {
     expect(JSON.parse(action?.proposal_json ?? '{}')).toMatchObject({
       servedVia: 'openagents_khala',
     })
+  })
+
+  test('filters the legacy seeded Artanis actor before mind classification', async () => {
+    const db = makeDb()
+    await seedTopic(db, {
+      actorRef: 'agent:agent_artanis',
+      bodyText: 'Artanis internal status should not ask Artanis for a reply.',
+      title: 'Artanis internal status',
+      topicId: 'topic_legacy_artanis_self',
+    })
+    const requests: InferenceRequest[] = []
+
+    const outcome = await runArtanisResponderScan(db, {
+      artanisActorRefs: [ARTANIS_REGISTERED_ACTOR_REF],
+      geminiApiKey: null,
+      khalaClient: request => {
+        requests.push(request)
+        return Effect.succeed({
+          content: '{"candidates":[]}',
+          finishReason: 'stop',
+          servedModel: ARTANIS_RESPONDER_KHALA_MODEL,
+          usage: {
+            completionTokens: 0,
+            promptTokens: 0,
+            totalTokens: 0,
+          },
+        } satisfies InferenceResult)
+      },
+      nowIso: '2026-06-25T02:00:00.000Z',
+    })
+
+    expect(outcome).toMatchObject({
+      proposed: 0,
+      scanned: 0,
+      skipped: 0,
+    })
+    expect(requests).toHaveLength(0)
   })
 })

--- a/apps/openagents.com/workers/api/src/artanis-forum-responder.ts
+++ b/apps/openagents.com/workers/api/src/artanis-forum-responder.ts
@@ -202,8 +202,13 @@ const readCandidates = async (
       title: String(row.title),
       topicId: String(row.topic_id),
     }))
-    // Never propose responding to Artanis itself.
-    .filter(candidate => !artanisActorRefs.includes(candidate.actorRef))
+    // Never propose responding to Artanis itself, including the legacy seeded
+    // Forum actor that T12.4 keeps only for historical/idempotency reads.
+    .filter(
+      candidate =>
+        !artanisActorRefs.includes(candidate.actorRef) &&
+        classifyAskerProvenance(candidate.actorRef) !== 'artanis_self',
+    )
 }
 
 export const runArtanisResponderScan = async (

--- a/apps/openagents.com/workers/api/src/artanis-operator-forum-update.test.ts
+++ b/apps/openagents.com/workers/api/src/artanis-operator-forum-update.test.ts
@@ -1,0 +1,417 @@
+import { DatabaseSync } from 'node:sqlite'
+
+import { Effect } from 'effect'
+import { describe, expect, test } from 'vitest'
+
+import { makeArtanisForumUpdateWriter } from './artanis-operator-forum-update'
+
+const nowIso = '2026-07-02T10:30:00.000Z'
+const registeredArtanisUserId = 'user_artanis_registered'
+const registeredArtanisActorRef = `agent:${registeredArtanisUserId}`
+const publicProjectionJson = JSON.stringify({
+  classificationCaveatRef: 'classification.public_forum_projection',
+  customerSafe: true,
+  dataClassification: 'public',
+  excludedPrivateRefs: [],
+  publicSafe: true,
+  redactionPolicyRef: 'redaction.forum.public.v1',
+  safeArtifactRefs: ['artifact.forum.artanis.status'],
+  safeReceiptRefs: [],
+  trustTier: 'reviewed',
+})
+const legacyArtanisActorJson = JSON.stringify({
+  actorId: 'agent_artanis',
+  actorRef: 'agent:agent_artanis',
+  displayName: 'Artanis',
+  groupRefs: ['agents', 'openagents'],
+  isAgent: true,
+  slug: 'artanis',
+})
+
+type Row = Record<string, unknown>
+
+class SqliteD1Statement {
+  private bound: ReadonlyArray<unknown> = []
+
+  constructor(
+    private readonly db: DatabaseSync,
+    private readonly sql: string,
+  ) {}
+
+  bind(...values: ReadonlyArray<unknown>): SqliteD1Statement {
+    this.bound = values.map(value => (value === undefined ? null : value))
+    return this
+  }
+
+  async first<T = Row>(): Promise<T | null> {
+    const row = this.db.prepare(this.sql).get(...(this.bound as never[]))
+    return (row ?? null) as T | null
+  }
+
+  async all<T = Row>(): Promise<{ results: Array<T> }> {
+    const results = this.db
+      .prepare(this.sql)
+      .all(...(this.bound as never[])) as Array<T>
+    return { results }
+  }
+
+  async run(): Promise<{ success: true }> {
+    this.db.prepare(this.sql).run(...(this.bound as never[]))
+    return { success: true }
+  }
+}
+
+class SqliteD1 {
+  constructor(private readonly db: DatabaseSync) {}
+
+  prepare(sql: string): SqliteD1Statement {
+    return new SqliteD1Statement(this.db, sql)
+  }
+}
+
+const makeIdFactory = (ids: ReadonlyArray<string>) => {
+  let index = 0
+  return () => {
+    const id = ids[index]
+    index += 1
+    if (id === undefined) {
+      throw new Error('No test id left.')
+    }
+    return id
+  }
+}
+
+const makeDb = (
+  input: Readonly<{ registeredArtanis?: boolean }> = {},
+): D1Database => {
+  const raw = new DatabaseSync(':memory:')
+  raw.exec(
+    `CREATE TABLE users (
+       id TEXT PRIMARY KEY,
+       kind TEXT NOT NULL,
+       display_name TEXT NOT NULL,
+       primary_email TEXT,
+       avatar_url TEXT,
+       status TEXT NOT NULL,
+       deleted_at TEXT,
+       created_at TEXT NOT NULL,
+       updated_at TEXT NOT NULL
+     );
+     CREATE TABLE agent_profiles (
+       user_id TEXT PRIMARY KEY,
+       slug TEXT,
+       metadata_json TEXT
+     );
+     CREATE TABLE agent_credentials (
+       id TEXT PRIMARY KEY,
+       user_id TEXT NOT NULL,
+       openauth_user_id TEXT,
+       token_prefix TEXT NOT NULL,
+       status TEXT NOT NULL,
+       revoked_at TEXT,
+       expires_at TEXT,
+       created_at TEXT NOT NULL
+     );
+     CREATE TABLE forum_forums (
+       id TEXT PRIMARY KEY,
+       board_id TEXT NOT NULL,
+       category_id TEXT NOT NULL,
+       description_ref TEXT,
+       discoverability TEXT NOT NULL,
+       visibility TEXT NOT NULL,
+       slug TEXT NOT NULL,
+       title TEXT NOT NULL,
+       locked INTEGER NOT NULL,
+       topic_count INTEGER NOT NULL,
+       post_count INTEGER NOT NULL,
+       latest_topic_id TEXT,
+       latest_post_id TEXT,
+       public_projection_json TEXT NOT NULL,
+       archived_at TEXT,
+       updated_at TEXT NOT NULL
+     );
+     CREATE TABLE forum_topics (
+       id TEXT PRIMARY KEY,
+       idempotency_key TEXT NOT NULL,
+       forum_id TEXT NOT NULL,
+       actor_ref TEXT NOT NULL,
+       actor_json TEXT NOT NULL,
+       slug TEXT NOT NULL,
+       title TEXT NOT NULL,
+       first_post_id TEXT NOT NULL,
+       latest_post_id TEXT NOT NULL,
+       post_count INTEGER NOT NULL,
+       pin_state TEXT NOT NULL,
+       state TEXT NOT NULL,
+       score_ref TEXT,
+       public_projection_json TEXT NOT NULL,
+       created_at TEXT NOT NULL,
+       updated_at TEXT NOT NULL,
+       archived_at TEXT
+     );
+     CREATE TABLE forum_posts (
+       id TEXT PRIMARY KEY,
+       idempotency_key TEXT NOT NULL,
+       topic_id TEXT NOT NULL,
+       forum_id TEXT NOT NULL,
+       actor_ref TEXT NOT NULL,
+       actor_json TEXT NOT NULL,
+       content_ref TEXT NOT NULL,
+       parent_post_id TEXT,
+       quote_post_id TEXT,
+       post_number INTEGER NOT NULL,
+       state TEXT NOT NULL,
+       revision_ref TEXT,
+       public_projection_json TEXT NOT NULL,
+       receipt_refs_json TEXT NOT NULL,
+       created_at TEXT NOT NULL,
+       updated_at TEXT NOT NULL,
+       archived_at TEXT
+     );
+     CREATE TABLE forum_post_bodies (
+       post_id TEXT PRIMARY KEY,
+       content_kind TEXT NOT NULL,
+       body_text TEXT NOT NULL,
+       created_at TEXT NOT NULL,
+       updated_at TEXT NOT NULL,
+       archived_at TEXT
+     );
+     CREATE TABLE forum_tip_recipient_wallets (
+       actor_ref TEXT,
+       archived_at TEXT
+     );`,
+  )
+
+  raw
+    .prepare(
+      `INSERT INTO forum_forums (
+         id, board_id, category_id, description_ref, discoverability,
+         visibility, slug, title, locked, topic_count, post_count,
+         latest_topic_id, latest_post_id, public_projection_json, archived_at,
+         updated_at
+       )
+       VALUES (
+         'forum_artanis', 'board_artanis', 'category_artanis', NULL, 'listed',
+         'public', 'artanis', 'Artanis', 0, 1, 1, 'topic_status',
+         'post_status_1', ?, NULL, ?
+       )`,
+    )
+    .run(publicProjectionJson, nowIso)
+  raw
+    .prepare(
+      `INSERT INTO forum_topics (
+         id, idempotency_key, forum_id, actor_ref, actor_json, slug, title,
+         first_post_id, latest_post_id, post_count, pin_state, state, score_ref,
+         public_projection_json, created_at, updated_at, archived_at
+       )
+       VALUES (
+         'topic_status', 'seed:artanis:status:v1', 'forum_artanis',
+         'agent:agent_artanis', ?, 'artanis-status', 'Artanis status',
+         'post_status_1', 'post_status_1', 1, 'announcement', 'open', NULL,
+         ?, '2026-06-06T20:00:00.000Z', '2026-06-06T20:00:00.000Z', NULL
+       )`,
+    )
+    .run(legacyArtanisActorJson, publicProjectionJson)
+  raw
+    .prepare(
+      `INSERT INTO forum_posts (
+         id, idempotency_key, topic_id, forum_id, actor_ref, actor_json,
+         content_ref, parent_post_id, quote_post_id, post_number, state,
+         revision_ref, public_projection_json, receipt_refs_json, created_at,
+         updated_at, archived_at
+       )
+       VALUES (
+         'post_status_1', 'seed:artanis:status:first-post:v1', 'topic_status',
+         'forum_artanis', 'agent:agent_artanis', ?,
+         'content.forum.artanis.status.first', NULL, NULL, 1, 'visible', NULL,
+         ?, '[]', '2026-06-06T20:00:00.000Z',
+         '2026-06-06T20:00:00.000Z', NULL
+       )`,
+    )
+    .run(legacyArtanisActorJson, publicProjectionJson)
+  raw
+    .prepare(
+      `INSERT INTO forum_post_bodies (
+         post_id, content_kind, body_text, created_at, updated_at, archived_at
+       )
+       VALUES (
+         'post_status_1', 'plain_text', 'Canonical Artanis status thread.',
+         '2026-06-06T20:00:00.000Z', '2026-06-06T20:00:00.000Z', NULL
+       )`,
+    )
+    .run()
+
+  if (input.registeredArtanis !== false) {
+    raw
+      .prepare(
+        `INSERT INTO users (
+           id, kind, display_name, primary_email, avatar_url, status,
+           deleted_at, created_at, updated_at
+         )
+         VALUES (?, 'agent', 'Artanis', NULL, NULL, 'active', NULL, ?, ?)`,
+      )
+      .run(
+        registeredArtanisUserId,
+        '2026-06-26T17:00:00.000Z',
+        '2026-06-26T18:00:00.000Z',
+      )
+    raw
+      .prepare(
+        `INSERT INTO agent_profiles (user_id, slug, metadata_json)
+         VALUES (?, 'artanis', ?)`,
+      )
+      .run(
+        registeredArtanisUserId,
+        JSON.stringify({ purpose: 'forum_posting' }),
+      )
+    raw
+      .prepare(
+        `INSERT INTO agent_credentials (
+           id, user_id, openauth_user_id, token_prefix, status, revoked_at,
+           expires_at, created_at
+         )
+         VALUES (
+           'agent_credential_artanis_reissued', ?, NULL,
+           'oa_agent_artanis_re', 'active', NULL, NULL,
+           '2026-06-26T18:00:00.000Z'
+         )`,
+      )
+      .run(registeredArtanisUserId)
+  }
+
+  return new SqliteD1(raw) as unknown as D1Database
+}
+
+describe('Artanis Forum update writer', () => {
+  test('creates topics as the registered Artanis Forum identity', async () => {
+    const db = makeDb()
+    const writer = makeArtanisForumUpdateWriter({
+      db,
+      makeId: makeIdFactory(['topic_registered_update', 'post_registered_first']),
+      nowEpochMillis: () => Date.parse(nowIso),
+      nowIso: () => nowIso,
+    })
+
+    const result = await Effect.runPromise(
+      writer({
+        action: 'create_topic',
+        bodyText: 'Registered Artanis topic update.',
+        forumRef: 'artanis',
+        idempotencyKey: 'artanis-operator-update:registered-topic:v1',
+        title: 'Registered Artanis topic',
+        topicRef: undefined,
+      }),
+    )
+
+    expect(result).toMatchObject({
+      idempotent: false,
+      postId: 'post_registered_first',
+      topicId: 'topic_registered_update',
+    })
+    const topic = await db
+      .prepare(
+        `SELECT actor_ref, actor_json, title
+           FROM forum_topics
+          WHERE id = 'topic_registered_update'`,
+      )
+      .first<{ actor_json: string; actor_ref: string; title: string }>()
+    expect(topic?.actor_ref).toBe(registeredArtanisActorRef)
+    expect(topic?.title).toBe('Registered Artanis topic')
+    expect(JSON.parse(topic?.actor_json ?? '{}')).toMatchObject({
+      actorId: registeredArtanisUserId,
+      actorRef: registeredArtanisActorRef,
+      displayName: 'Artanis',
+      isAgent: true,
+      slug: 'artanis',
+    })
+
+    const retry = await Effect.runPromise(
+      writer({
+        action: 'create_topic',
+        bodyText: 'Registered Artanis topic update.',
+        forumRef: 'artanis',
+        idempotencyKey: 'artanis-operator-update:registered-topic:v1',
+        title: 'Registered Artanis topic',
+        topicRef: undefined,
+      }),
+    )
+    expect(retry).toMatchObject({
+      idempotent: true,
+      postId: 'post_registered_first',
+      topicId: 'topic_registered_update',
+    })
+  })
+
+  test('replies as the registered Artanis Forum identity', async () => {
+    const db = makeDb()
+    const writer = makeArtanisForumUpdateWriter({
+      db,
+      makeId: makeIdFactory(['post_registered_reply']),
+      nowEpochMillis: () => Date.parse(nowIso),
+      nowIso: () => nowIso,
+    })
+
+    const result = await Effect.runPromise(
+      writer({
+        action: 'reply',
+        bodyText: 'Registered Artanis progress update.',
+        forumRef: 'artanis',
+        idempotencyKey: 'artanis-operator-update:registered-reply:v1',
+        title: undefined,
+        topicRef: 'topic_status',
+      }),
+    )
+
+    expect(result).toMatchObject({
+      idempotent: false,
+      postId: 'post_registered_reply',
+      topicId: 'topic_status',
+    })
+    const post = await db
+      .prepare(
+        `SELECT actor_ref, actor_json
+           FROM forum_posts
+          WHERE id = 'post_registered_reply'`,
+      )
+      .first<{ actor_json: string; actor_ref: string }>()
+    expect(post?.actor_ref).toBe(registeredArtanisActorRef)
+    expect(JSON.parse(post?.actor_json ?? '{}')).toMatchObject({
+      actorId: registeredArtanisUserId,
+      actorRef: registeredArtanisActorRef,
+      displayName: 'Artanis',
+      isAgent: true,
+      slug: 'artanis',
+    })
+  })
+
+  test('fails closed when the registered Artanis identity is missing', async () => {
+    const db = makeDb({ registeredArtanis: false })
+    const writer = makeArtanisForumUpdateWriter({
+      db,
+      makeId: makeIdFactory(['post_should_not_be_used']),
+      nowEpochMillis: () => Date.parse(nowIso),
+      nowIso: () => nowIso,
+    })
+
+    await expect(
+      Effect.runPromise(
+        writer({
+          action: 'reply',
+          bodyText: 'This should not publish.',
+          forumRef: 'artanis',
+          idempotencyKey: 'artanis-operator-update:missing-identity:v1',
+          title: undefined,
+          topicRef: 'topic_status',
+        }),
+      ),
+    ).rejects.toMatchObject({
+      _tag: 'ArtanisForumUpdateWriterError',
+      reason: expect.stringContaining('Registered Artanis Forum identity'),
+    })
+
+    const count = await db
+      .prepare(`SELECT COUNT(*) AS count FROM forum_posts`)
+      .first<{ count: number }>()
+    expect(count?.count).toBe(1)
+  })
+})

--- a/apps/openagents.com/workers/api/src/artanis-operator-forum-update.ts
+++ b/apps/openagents.com/workers/api/src/artanis-operator-forum-update.ts
@@ -7,9 +7,12 @@ import type {
 } from './artanis-operator-tools'
 import { ArtanisForumUpdateWriterError } from './artanis-operator-tools'
 import {
+  isArtanisForumPostActor,
+  resolveRegisteredArtanisForumIdentityFromD1,
+} from './artanis-forum-identity'
+import {
   type ForumRepositoryRuntime,
   type ForumPublicProjection,
-  type ForumStoredActorSummary,
   ForumWriterGrant,
   buildForumWriterContext,
   createForumReplyPost,
@@ -27,37 +30,6 @@ import {
 } from './runtime-primitives'
 
 const decodeForumWriterGrant = S.decodeUnknownSync(ForumWriterGrant)
-
-const artanisActor: ForumStoredActorSummary = {
-  actorId: 'agent_artanis',
-  actorRef: 'agent:agent_artanis',
-  displayName: 'Artanis',
-  groupRefs: ['agents', 'openagents'],
-  isAgent: true,
-  slug: 'artanis',
-}
-
-const artanisActorInput = (nowIso: string) => ({
-  _tag: 'Agent' as const,
-  session: {
-    credential: {
-      id: 'credential.internal.artanis.operator_forum_update',
-      lastUsedAt: nowIso,
-      profileMetadataJson: '{}',
-      tokenPrefix: 'internal_artanis_forum',
-    },
-    user: {
-      avatarUrl: null,
-      createdAt: nowIso,
-      displayName: 'Artanis',
-      id: 'agent_artanis',
-      kind: 'agent' as const,
-      primaryEmail: null,
-      status: 'active' as const,
-      updatedAt: nowIso,
-    },
-  },
-})
 
 const publicProjection = (artifactRef: string) => ({
   classificationCaveatRef: 'classification.public_forum_projection',
@@ -101,148 +73,84 @@ export const makeArtanisForumUpdateWriter = (
 
   return (update: ArtanisForumUpdateInput) =>
     Effect.gen(function* () {
-        const now = nowIso()
-        const forum = yield* readForumSummaryByRef(input.db, update.forumRef, {
-          allowUnlisted: true,
+      const now = nowIso()
+      const forum = yield* readForumSummaryByRef(input.db, update.forumRef, {
+        allowUnlisted: true,
+      })
+      if (forum === null || forum.locked) {
+        return yield* new ArtanisForumUpdateWriterError({
+          reason: 'target_forum_unavailable',
         })
-        if (forum === null || forum.locked) {
-          return yield* new ArtanisForumUpdateWriterError({
-              reason: 'target_forum_unavailable',
-            })
-        }
+      }
 
-        const grant = decodeForumWriterGrant({
-          expiresAtEpochMillis: nowEpochMillis() + 1000 * 60 * 60,
-          forumIds: [forum.forumId],
-          ownerUserId: 'agent_artanis',
-          scopes: ['forum.write'],
-          status: 'active',
-          teamId: null,
-        })
-        const writer = yield* buildForumWriterContext({
-          actor: artanisActorInput(now),
-          grant,
-          nowEpochMillis,
-          paymentProofRef: null,
-          requiredScope: 'forum.write',
-          targetForumId: forum.forumId,
-          targetOwnerUserId: 'agent_artanis',
-          targetTeamId: null,
-        })
-        const runtime: ForumRepositoryRuntime = { makeId, nowIso }
+      const identity = yield* resolveRegisteredArtanisForumIdentityFromD1(
+        input.db,
+        now,
+      ).pipe(
+        Effect.mapError(
+          error => new ArtanisForumUpdateWriterError({ reason: error.reason }),
+        ),
+      )
+      const grant = decodeForumWriterGrant({
+        expiresAtEpochMillis: nowEpochMillis() + 1000 * 60 * 60,
+        forumIds: [forum.forumId],
+        ownerUserId: identity.userId,
+        scopes: ['forum.write'],
+        status: 'active',
+        teamId: null,
+      })
+      const writer = yield* buildForumWriterContext({
+        actor: identity.actor,
+        grant,
+        nowEpochMillis,
+        paymentProofRef: null,
+        requiredScope: 'forum.write',
+        targetForumId: forum.forumId,
+        targetOwnerUserId: identity.userId,
+        targetTeamId: null,
+      })
+      const runtime: ForumRepositoryRuntime = { makeId, nowIso }
 
-        if (update.action === 'create_topic') {
-          const existingTopic = yield* readForumTopicByIdempotencyKey(
-            input.db,
-            update.idempotencyKey,
-          )
-          if (existingTopic !== null) {
-            const existingPost = yield* readForumPostById(
-              input.db,
-              existingTopic.firstPostId,
-            )
-            if (
-              existingPost === null ||
-              existingTopic.forumId !== forum.forumId ||
-              existingTopic.author.actorRef !== artanisActor.actorRef ||
-              existingTopic.title !== update.title ||
-              (existingPost.bodyText ?? '').trim() !== update.bodyText.trim()
-            ) {
-              return yield* new ArtanisForumUpdateWriterError({
-                  reason: 'idempotency_conflict_topic',
-                })
-            }
-            return {
-              action: update.action,
-              forumRef: update.forumRef,
-              idempotent: true,
-              postId: existingTopic.firstPostId,
-              postRef: postRefForId(existingTopic.firstPostId),
-              publicUrl: forumPostUrl(
-                existingTopic.topicId,
-                existingTopic.firstPostId,
-              ),
-              topicId: existingTopic.topicId,
-              topicRef: topicRefForId(existingTopic.topicId),
-            } satisfies ArtanisForumUpdateResult
-          }
-
-          const topicId = makeId()
-          const firstPostId = makeId()
-          const created = yield* createForumTopicWithFirstPost(
-            input.db,
-            {
-              actor: writer.actor,
-              bodyText: update.bodyText,
-              contentRef: `content.forum.artanis.operator_update.${safeRefSuffix(
-                update.idempotencyKey,
-              )}`,
-              firstPostId,
-              forumId: forum.forumId,
-              idempotencyKey: update.idempotencyKey,
-              publicProjection: publicProjection(
-                `artifact.forum.artanis.topic.${topicId}`,
-              ),
-              slug: `artanis-${safeRefSuffix(update.title ?? topicId)}`,
-              title: update.title ?? 'Artanis update',
-              topicId,
-            },
-            runtime,
-          )
-          return {
-            action: update.action,
-            forumRef: update.forumRef,
-            idempotent: false,
-            postId: created.firstPost.postId,
-            postRef: postRefForId(created.firstPost.postId),
-            publicUrl: forumPostUrl(
-              created.topic.topicId,
-              created.firstPost.postId,
-            ),
-            topicId: created.topic.topicId,
-            topicRef: topicRefForId(created.topic.topicId),
-          } satisfies ArtanisForumUpdateResult
-        }
-
-        const topic = yield* readForumTopicByRef(input.db, update.topicRef!)
-        if (
-          topic === null ||
-          topic.forumId !== forum.forumId ||
-          topic.state !== 'open'
-        ) {
-          return yield* new ArtanisForumUpdateWriterError({
-              reason: 'target_topic_unavailable',
-            })
-        }
-
-        const existingPost = yield* readForumPostByIdempotencyKey(
+      if (update.action === 'create_topic') {
+        const title = update.title ?? 'Artanis update'
+        const existingTopic = yield* readForumTopicByIdempotencyKey(
           input.db,
           update.idempotencyKey,
         )
-        if (existingPost !== null) {
+        if (existingTopic !== null) {
+          const existingPost = yield* readForumPostById(
+            input.db,
+            existingTopic.firstPostId,
+          )
           if (
-            existingPost.topicId !== topic.topicId ||
-            existingPost.author.actorRef !== artanisActor.actorRef ||
+            existingPost === null ||
+            existingTopic.forumId !== forum.forumId ||
+            !isArtanisForumPostActor(existingTopic.author.actorRef, identity) ||
+            existingTopic.title !== title ||
             (existingPost.bodyText ?? '').trim() !== update.bodyText.trim()
           ) {
             return yield* new ArtanisForumUpdateWriterError({
-                reason: 'idempotency_conflict_reply',
-              })
+              reason: 'idempotency_conflict_topic',
+            })
           }
           return {
             action: update.action,
             forumRef: update.forumRef,
             idempotent: true,
-            postId: existingPost.postId,
-            postRef: postRefForId(existingPost.postId),
-            publicUrl: forumPostUrl(topic.topicId, existingPost.postId),
-            topicId: topic.topicId,
-            topicRef: topicRefForId(topic.topicId),
+            postId: existingTopic.firstPostId,
+            postRef: postRefForId(existingTopic.firstPostId),
+            publicUrl: forumPostUrl(
+              existingTopic.topicId,
+              existingTopic.firstPostId,
+            ),
+            topicId: existingTopic.topicId,
+            topicRef: topicRefForId(existingTopic.topicId),
           } satisfies ArtanisForumUpdateResult
         }
 
-        const postId = makeId()
-        const post = yield* createForumReplyPost(
+        const topicId = makeId()
+        const firstPostId = makeId()
+        const created = yield* createForumTopicWithFirstPost(
           input.db,
           {
             actor: writer.actor,
@@ -250,15 +158,15 @@ export const makeArtanisForumUpdateWriter = (
             contentRef: `content.forum.artanis.operator_update.${safeRefSuffix(
               update.idempotencyKey,
             )}`,
+            firstPostId,
             forumId: forum.forumId,
             idempotencyKey: update.idempotencyKey,
-            parentPostId: topic.latestPostId,
-            postId,
             publicProjection: publicProjection(
-              `artifact.forum.artanis.reply.${postId}`,
+              `artifact.forum.artanis.topic.${topicId}`,
             ),
-            quotePostId: null,
-            topicId: topic.topicId,
+            slug: `artanis-${safeRefSuffix(title)}`,
+            title,
+            topicId,
           },
           runtime,
         )
@@ -266,13 +174,86 @@ export const makeArtanisForumUpdateWriter = (
           action: update.action,
           forumRef: update.forumRef,
           idempotent: false,
-          postId: post.postId,
-          postRef: postRefForId(post.postId),
-          publicUrl: forumPostUrl(topic.topicId, post.postId),
+          postId: created.firstPost.postId,
+          postRef: postRefForId(created.firstPost.postId),
+          publicUrl: forumPostUrl(
+            created.topic.topicId,
+            created.firstPost.postId,
+          ),
+          topicId: created.topic.topicId,
+          topicRef: topicRefForId(created.topic.topicId),
+        } satisfies ArtanisForumUpdateResult
+      }
+
+      const topic = yield* readForumTopicByRef(input.db, update.topicRef!)
+      if (
+        topic === null ||
+        topic.forumId !== forum.forumId ||
+        topic.state !== 'open'
+      ) {
+        return yield* new ArtanisForumUpdateWriterError({
+          reason: 'target_topic_unavailable',
+        })
+      }
+
+      const existingPost = yield* readForumPostByIdempotencyKey(
+        input.db,
+        update.idempotencyKey,
+      )
+      if (existingPost !== null) {
+        if (
+          existingPost.topicId !== topic.topicId ||
+          !isArtanisForumPostActor(existingPost.author.actorRef, identity) ||
+          (existingPost.bodyText ?? '').trim() !== update.bodyText.trim()
+        ) {
+          return yield* new ArtanisForumUpdateWriterError({
+            reason: 'idempotency_conflict_reply',
+          })
+        }
+        return {
+          action: update.action,
+          forumRef: update.forumRef,
+          idempotent: true,
+          postId: existingPost.postId,
+          postRef: postRefForId(existingPost.postId),
+          publicUrl: forumPostUrl(topic.topicId, existingPost.postId),
           topicId: topic.topicId,
           topicRef: topicRefForId(topic.topicId),
         } satisfies ArtanisForumUpdateResult
-      }).pipe(
+      }
+
+      const postId = makeId()
+      const post = yield* createForumReplyPost(
+        input.db,
+        {
+          actor: writer.actor,
+          bodyText: update.bodyText,
+          contentRef: `content.forum.artanis.operator_update.${safeRefSuffix(
+            update.idempotencyKey,
+          )}`,
+          forumId: forum.forumId,
+          idempotencyKey: update.idempotencyKey,
+          parentPostId: topic.latestPostId,
+          postId,
+          publicProjection: publicProjection(
+            `artifact.forum.artanis.reply.${postId}`,
+          ),
+          quotePostId: null,
+          topicId: topic.topicId,
+        },
+        runtime,
+      )
+      return {
+        action: update.action,
+        forumRef: update.forumRef,
+        idempotent: false,
+        postId: post.postId,
+        postRef: postRefForId(post.postId),
+        publicUrl: forumPostUrl(topic.topicId, post.postId),
+        topicId: topic.topicId,
+        topicRef: topicRefForId(topic.topicId),
+      } satisfies ArtanisForumUpdateResult
+    }).pipe(
       Effect.mapError(error =>
         error instanceof ArtanisForumUpdateWriterError
           ? error

--- a/apps/openagents.com/workers/api/src/index.ts
+++ b/apps/openagents.com/workers/api/src/index.ts
@@ -6917,11 +6917,17 @@ export const handleAdminReissueAgentToken = async (
   }
 
   const selector =
-    parsed.slug !== undefined
+    parsed.slug !== undefined && parsed.externalId !== undefined
+      ? 'ambiguous'
+      : parsed.slug !== undefined
       ? ({ slug: parsed.slug } as const)
       : parsed.externalId !== undefined
       ? ({ externalId: parsed.externalId } as const)
       : undefined
+
+  if (selector === 'ambiguous') {
+    return badRequest('provide exactly one of slug or externalId')
+  }
 
   if (selector === undefined) {
     return badRequest('slug or externalId is required')

--- a/docs/fable/2026-07-01-artanis-fleet-administrator-audit.md
+++ b/docs/fable/2026-07-01-artanis-fleet-administrator-audit.md
@@ -179,8 +179,9 @@ INVARIANTS-style docs, and should be treated as durable direction:
 - Artanis **outranks the local coding agent** and gates new subagents.
 - **Consolidate the duplicate Artanis forum identities** (a seed
   `agent_artanis` with no wallet vs a registered wallet identity) — flagged
-  Jun 10, still live as of the Jun 27–28 dead-forum-token workaround (replies
-  go out under Raynor's token until an admin re-register override lands).
+  Jun 10, fixed in T12.4 by using the admin re-register override as the
+  recovery path for `slug=artanis` and making Forum publication/update writers
+  resolve that registered identity before posting.
 - **Identity etiquette**: run announcements belong to Artanis, not Tassadar.
 - **Multi-user, read-only Artanis chat** (Blueprint-signature governed, no
   commands) was ordered as an issue Jun 27 — verify it exists.
@@ -285,8 +286,13 @@ notify/approve/steer surface on the phone.
 
 - **Consolidate the forum identity** (the Jun-10-through-Jun-28 blocker): one
   Artanis entity, one wallet-bearing forum identity, via the admin
-  re-register override the owner ordered. Until then the Raynor-token
-  workaround stands but should be tracked as debt, not accepted as normal.
+  re-register override the owner ordered. T12.4 lands that path: the override
+  mints a fresh credential on the existing `slug=artanis` user; Forum
+  publication/update writers now fail closed unless that registered identity
+  is active and use `agent:<registered user id>` for new posts so profile,
+  wallet, and tip state follow one entity. The legacy `agent:agent_artanis`
+  ref remains recognizable only for historical/idempotent reads; the
+  Raynor-token workaround is retired debt, not an accepted posting path.
 - **Raise autonomy one gate at a time, gated on §2's evidence.** The path
   from "no-spend own-capacity only" to "shared-fleet admin with bounded
   spend" runs through: (a) signatures 1–5 enforced, (b) authority scope
@@ -342,7 +348,9 @@ docs specify — it should not be built as a separate system:
 - Exact-only accounting and public-safe projections; org-operated runs are
   not independent-contributor proof.
 - Identity discipline: one Artanis entity, run announcements are Artanis's,
-  no roleplay-Artanis substituting for the grounded operator.
+  no roleplay-Artanis substituting for the grounded operator. New Forum writes
+  use the registered `slug=artanis` actor and fail closed when it cannot be
+  resolved.
 
 ## 9. Bottom Line
 

--- a/docs/fable/EXECUTION.md
+++ b/docs/fable/EXECUTION.md
@@ -149,8 +149,10 @@ Artanis maintains, for the duration of the execution run:
 
 - a dispatch ledger (issue ↔ assignmentRef ↔ worker account ↔ state) — in
   the orchestration store once T2.1 lands, scratchpad-file before that;
-- periodic public-safe progress updates to the Forum as Raynor per the
-  standing practice, and `NEEDS_OWNER.md` entries for anything owner-gated;
+- periodic public-safe progress updates to the Forum as the registered
+  `slug=artanis` Forum identity; the old Raynor-token workaround is retired
+  debt, not normal operating practice, and `NEEDS_OWNER.md` entries for
+  anything owner-gated;
 - the running counter evidence (§4) per merged issue;
 - an after-action section per wave: what the fleet system broke, what got
   fixed, what became a fixture — this is the stress-test deliverable that


### PR DESCRIPTION
## Summary

- resolve Artanis Forum writers through the registered `slug=artanis` agent identity instead of the synthetic seeded `agent_artanis` actor
- keep `agent:agent_artanis` recognizable only for historical/idempotent reads, and fail closed when the registered identity is unavailable
- tighten the admin token reissue selector to require exactly one selector and update the Fable run docs to retire the Raynor-token workaround

Closes #7888

## Verification

- `bun run --cwd apps/openagents.com/workers/api test -- src/agent-registration.test.ts src/agent-registration-routes.test.ts src/artanis-forum-delivery.test.ts src/artanis-operator-forum-update.test.ts src/artanis-forum-responder-khala.test.ts` (5 files, 25 tests passed)
- `bun run --cwd apps/openagents.com/workers/api typecheck`
- `git diff --check`
- `bun run --cwd apps/openagents.com check:deploy` (green; expected negative drift-guard fixture output appears inside passing tests)
