### PR TITLE
[codex] Make Artanis authority scope first-class

### DIFF
--- a/apps/openagents.com/INVARIANTS.md
+++ b/apps/openagents.com/INVARIANTS.md
@@ -1819,19 +1819,27 @@ normalizedPatchDigest | behaviorReceiptDigest)`. Exactly one accepted
 - The Artanis operator agent may CREATE a Khala -> Pylon -> Codex
   `codex_agent_task` assignment through its gated `dispatch_codex_task` tool
   (#6366 follow-up), but only through this same own-capacity coding-delegation
-  seam and only behind an effective owner approval. The gated tool executes ONLY
-  when (a) the caller is the authenticated owner (the `/api/operator/artanis/chat`
-  route admits authenticated browser sessions, owner-linked agent bearers, or the
-  admin API token, always resolving to one owner scope), (b) a wired execution
-  seam is present, AND (c) a standing tenant approval for `pylon_job_dispatch`
-  exists. That standing approval is scoped to the tenant's own linked Pylons,
-  own-capacity, and no-spend dispatch only, and is resolved by
+  seam and only behind an effective owner approval. Every Artanis tool
+  invocation, pending approval gate, persisted approval gate, dispatch plan, and
+  assignment evidence carries a typed `authorityScope`:
+  `owner_self | shared_fleet | owner_operator`. `owner_self` means the caller's
+  own linked Pylons only; `shared_fleet` means org-operated pooled capacity and
+  is not wired to this own-capacity seam; `owner_operator` means human/operator
+  outward authority and does not imply coding capacity. The gated dispatch tool
+  executes ONLY when (a) the caller is the authenticated owner (the
+  `/api/operator/artanis/chat` route admits authenticated browser sessions,
+  owner-linked agent bearers, or the admin API token, always resolving to one
+  owner scope), (b) a wired execution seam is present, (c) the action is scoped
+  `owner_self`, and (d) a standing tenant approval for `pylon_job_dispatch`
+  exists in the same scope. That standing approval is scoped to the tenant's own
+  linked Pylons, own-capacity, and no-spend dispatch only, and is resolved by
   `readEffectiveArtanisPylonDispatchApprovalForOwner`. Every money-movement /
-  payout-bearing kind stays gated for everyone. If any precondition
-  is missing — no seam, no effective approval, no eligible linked Pylon — it
-  returns the public-safe plan and defers (`deferredToApprovalGate`); it never
-  fires and never fabricates an `assignmentRef`. The dispatch carries no spend
-  authority: it rides the `unpaid_smoke` coding-delegation path
+  payout-bearing kind stays gated for everyone. If any precondition is missing
+  — no seam, no effective same-scope approval, no eligible linked Pylon, or a
+  non-`owner_self` scope on the own-capacity path — it returns the public-safe
+  plan and defers (`deferredToApprovalGate`); it never fires and never
+  fabricates an `assignmentRef`. The dispatch carries no spend authority: it
+  rides the `unpaid_smoke` coding-delegation path
   (`paymentMode='unpaid_smoke'`, settlement `not_applicable`,
   `payoutClaimAllowed=false`), targets only the owner's own linked Pylons, and
   must never use pooled/third-party/marketplace capacity, move money, or grant
@@ -1858,26 +1866,32 @@ normalizedPatchDigest | behaviorReceiptDigest)`. Exactly one accepted
   `isOpenAgentsOwnerAgentOpenAuthUserId`, `isOpenAgentsOwnerAgentActorRef`,
   `ownerAgentHasStandingApprovalForRiskyAction`).
 - THE GRANT. (1) Owner-level access to the private Artanis operator chat channel
-  `/api/operator/artanis/chat` via Artanis's OWN agent bearer: `resolveOwnerAgentBearer`
-  admits the owner-promoted agent set alongside the human admin email set and the
-  admin API token, so Artanis no longer needs the human admin email to reach his
-  own operator surface. (2) A STANDING owner approval for Artanis's own
-  `pylon_job_dispatch` actions, so the gated `dispatch_codex_task` tool EXECUTES
+  `/api/operator/artanis/chat` via Artanis's OWN agent bearer:
+  `resolveOwnerAgentBearer` admits the owner-promoted agent set alongside the
+  human admin email set and the admin API token, so Artanis no longer needs the
+  human admin email to reach his own operator surface. (2) A STANDING owner
+  approval for Artanis's own `pylon_job_dispatch` actions in
+  `authorityScope=owner_self`, so the gated `dispatch_codex_task` tool EXECUTES
   for owner-Artanis (own-capacity, no-spend) WITHOUT a separately-armed
   `artanis_approval_gates` row — equivalent to a permanent owner approval for his
-  own Codex dispatch.
+  own linked-capacity Codex dispatch. (3) A standing `forum_post` approval is
+  `authorityScope=owner_operator`, because it is an outward owner/operator
+  publication action rather than a coding-capacity action. There is no standing
+  `shared_fleet` approval.
 - NEVER-WAIVABLE BOUNDS (hold even for owner-Artanis). The standing approval is
-  scoped to `pylon_job_dispatch` ONLY; `wallet_spend`, `settlement`,
-  `l402_redemption`, and every other money-movement / payout-bearing risky-action
-  kind remain gated and still require an explicit effective approval gate. The
-  self-approved dispatch still rides the existing own-capacity, no-spend
-  coding-delegation seam (`unpaid_smoke`, settlement `not_applicable`,
-  `payoutClaimAllowed=false`, owner's own linked Pylons only — never
-  pooled/third-party/marketplace capacity). The promotion grants NO new payout
-  authority and invents NO new custody path; real money movement still uses the
-  existing custody path. No-resale on SUBSCRIPTION accounts, no
-  secret/credential/wallet leakage, public-safe claims only, and no untraced
-  destructive actions are never-waivable regardless of owner promotion.
+  scoped by both risky-action kind and `authorityScope`: `pylon_job_dispatch`
+  only in `owner_self`, `forum_post` only in `owner_operator`; `shared_fleet`,
+  `wallet_spend`, `settlement`, `l402_redemption`, and every other
+  money-movement / payout-bearing risky-action kind remain gated and still
+  require an explicit effective approval gate. The self-approved dispatch still
+  rides the existing own-capacity, no-spend coding-delegation seam
+  (`unpaid_smoke`, settlement `not_applicable`, `payoutClaimAllowed=false`,
+  owner's own linked Pylons only — never pooled/third-party/marketplace
+  capacity). The promotion grants NO new payout authority and invents NO new
+  custody path; real money movement still uses the existing custody path.
+  No-resale on SUBSCRIPTION accounts, no secret/credential/wallet leakage,
+  public-safe claims only, and no untraced destructive actions are
+  never-waivable regardless of owner promotion.
 - Regression coverage lives in
   `workers/api/src/artanis-owner-authority.test.ts` and the owner-promotion
   cases in `workers/api/src/artanis-operator-dispatch-execution.test.ts`.

--- a/apps/openagents.com/workers/api/src/artanis-approval-gates.test.ts
+++ b/apps/openagents.com/workers/api/src/artanis-approval-gates.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, test } from 'vitest'
 
 import {
+  ARTANIS_OWNER_SELF_AUTHORITY_SCOPE,
+  ARTANIS_SHARED_FLEET_AUTHORITY_SCOPE,
+} from './artanis-authority-scope'
+import {
   ARTANIS_RISKY_ACTION_KINDS,
   ArtanisApprovalGateLedgerRecord,
   ArtanisApprovalGateRecord,
@@ -58,6 +62,7 @@ describe('Artanis approval gates', () => {
     expect(publicArtanis.effectiveGateRefs).toEqual([])
     expect(publicForum.effectiveGateRefs).toEqual([])
     expect(publicArtanis.gates[0]).toMatchObject({
+      authorityScope: ARTANIS_OWNER_SELF_AUTHORITY_SCOPE,
       authorityReceiptRefs: [],
       authoritySourceKinds: [],
       effective: false,
@@ -141,6 +146,23 @@ describe('Artanis approval gates', () => {
     ).toThrow(ArtanisApprovalGateUnsafe)
   })
 
+  test('requires pylon dispatch approval gates to stay owner_self scoped', () => {
+    const sharedFleetDispatch = new ArtanisApprovalGateRecord({
+      ...approvedGate,
+      authorityScope: ARTANIS_SHARED_FLEET_AUTHORITY_SCOPE,
+      gateRef: 'gate.public.artanis.shared_fleet_pylon_dispatch',
+      idempotencyKey: 'artanis-approval:shared-fleet-pylon-dispatch:v1',
+    })
+
+    expect(() =>
+      projectArtanisApprovalGateLedger(
+        ledgerWithGate(sharedFleetDispatch),
+        'operator',
+        nowIso,
+      ),
+    ).toThrow(ArtanisApprovalGateUnsafe)
+  })
+
   test('rejects Forum, Model Lab, retained-failure, and Pylon stats as authority sources by themselves', () => {
     const sourceKinds = [
       'forum_post',
@@ -192,6 +214,7 @@ describe('Artanis approval gates', () => {
     const pendingFleetMutation = new ArtanisApprovalGateRecord({
       ...approvedGate,
       actionRef: 'action.public.artanis.fleet_mutation.quarantine_replica',
+      authorityScope: ARTANIS_SHARED_FLEET_AUTHORITY_SCOPE,
       authorityReceiptRefs: [],
       authoritySourceKinds: ['operator_policy'],
       caveatRefs: [
@@ -254,6 +277,7 @@ describe('Artanis approval gates', () => {
       false,
     )
     expect(operator.gates[0]).toMatchObject({
+      authorityScope: ARTANIS_SHARED_FLEET_AUTHORITY_SCOPE,
       effective: false,
       kind: 'fleet_mutation',
       rollbackPosture: 'rollback_plan_recorded',
@@ -263,6 +287,7 @@ describe('Artanis approval gates', () => {
       state: 'pending',
     })
     expect(publicArtanis.gates[0]).toMatchObject({
+      authorityScope: ARTANIS_SHARED_FLEET_AUTHORITY_SCOPE,
       effective: false,
       kind: 'fleet_mutation',
       rollbackRefs: [],

--- a/apps/openagents.com/workers/api/src/artanis-approval-gates.ts
+++ b/apps/openagents.com/workers/api/src/artanis-approval-gates.ts
@@ -1,5 +1,10 @@
 import { Schema as S } from 'effect'
 
+import {
+  ARTANIS_OWNER_OPERATOR_AUTHORITY_SCOPE,
+  ARTANIS_OWNER_SELF_AUTHORITY_SCOPE,
+  ArtanisAuthorityScope,
+} from './artanis-authority-scope'
 import { friendlyBlueprintMissionBriefingTime } from './blueprint/services/continuation-mission-briefing'
 
 export const ArtanisApprovalGateAudience = S.Literals([
@@ -61,6 +66,7 @@ export class ArtanisApprovalGateRecord extends S.Class<ArtanisApprovalGateRecord
   'ArtanisApprovalGateRecord',
 )({
   actionRef: S.String,
+  authorityScope: ArtanisAuthorityScope,
   authorityReceiptRefs: S.Array(S.String),
   authoritySourceKinds: S.Array(ArtanisApprovalAuthoritySourceKind),
   caveatRefs: S.Array(S.String),
@@ -97,6 +103,7 @@ export class ArtanisApprovalGateProjection extends S.Class<ArtanisApprovalGatePr
   'ArtanisApprovalGateProjection',
 )({
   actionRef: S.String,
+  authorityScope: ArtanisAuthorityScope,
   authorityReceiptRefs: S.Array(S.String),
   authoritySourceKinds: S.Array(ArtanisApprovalAuthoritySourceKind),
   caveatRefs: S.Array(S.String),
@@ -319,6 +326,16 @@ const assertGate = (gate: ArtanisApprovalGateRecord): void => {
   }
 
   if (
+    gate.kind === 'pylon_job_dispatch' &&
+    gate.authorityScope !== ARTANIS_OWNER_SELF_AUTHORITY_SCOPE
+  ) {
+    throw new ArtanisApprovalGateUnsafe({
+      reason:
+        'Artanis pylon_job_dispatch gates must be scoped to owner_self until shared-fleet capacity is explicitly wired.',
+    })
+  }
+
+  if (
     !hasAny(gate.operatorReceiptRefs) ||
     !hasAny(gate.policyRefs) ||
     !hasAny(gate.caveatRefs) ||
@@ -413,6 +430,7 @@ const projectGate = (
           audience,
         )
       : [],
+    authorityScope: gate.authorityScope,
     authoritySourceKinds: audience === 'operator'
       ? [...gate.authoritySourceKinds].sort()
       : [],
@@ -592,6 +610,7 @@ export const exampleArtanisApprovalGateLedger =
     gates: [
       gate({
         actionRefSuffix: 'pylon_job_dispatch',
+        authorityScope: ARTANIS_OWNER_SELF_AUTHORITY_SCOPE,
         authorityReceiptRefs: ['authority.public.artanis.pylon_dispatch.approved'],
         authoritySourceKinds: ['operator_approval', 'operator_policy'],
         caveatRefs: ['caveat.public.dispatch_scope_limited'],
@@ -617,6 +636,7 @@ export const exampleArtanisApprovalGateLedger =
       }),
       gate({
         actionRefSuffix: 'bitcoin_spend_review',
+        authorityScope: ARTANIS_OWNER_OPERATOR_AUTHORITY_SCOPE,
         authorityReceiptRefs: [],
         authoritySourceKinds: ['operator_policy'],
         caveatRefs: ['caveat.public.no_live_bitcoin_spend'],
@@ -638,6 +658,7 @@ export const exampleArtanisApprovalGateLedger =
       }),
       gate({
         actionRefSuffix: 'training_launch',
+        authorityScope: ARTANIS_OWNER_OPERATOR_AUTHORITY_SCOPE,
         authorityReceiptRefs: [],
         authoritySourceKinds: ['operator_policy'],
         caveatRefs: ['caveat.public.training_launch_window_expired'],
@@ -659,6 +680,7 @@ export const exampleArtanisApprovalGateLedger =
       }),
       gate({
         actionRefSuffix: 'runtime_promotion',
+        authorityScope: ARTANIS_OWNER_OPERATOR_AUTHORITY_SCOPE,
         authorityReceiptRefs: [],
         authoritySourceKinds: ['operator_policy'],
         caveatRefs: ['caveat.public.runtime_promotion_superseded'],
@@ -680,6 +702,7 @@ export const exampleArtanisApprovalGateLedger =
       }),
       gate({
         actionRefSuffix: 'l402_redemption',
+        authorityScope: ARTANIS_OWNER_OPERATOR_AUTHORITY_SCOPE,
         authorityReceiptRefs: [],
         authoritySourceKinds: ['operator_policy'],
         caveatRefs: ['caveat.public.l402_redemption_pending'],

--- a/apps/openagents.com/workers/api/src/artanis-authority-scope.ts
+++ b/apps/openagents.com/workers/api/src/artanis-authority-scope.ts
@@ -1,0 +1,46 @@
+import { Schema as S } from 'effect'
+
+export const ArtanisAuthorityScope = S.Literals([
+  'owner_self',
+  'shared_fleet',
+  'owner_operator',
+])
+export type ArtanisAuthorityScope = typeof ArtanisAuthorityScope.Type
+
+export const ARTANIS_OWNER_SELF_AUTHORITY_SCOPE: ArtanisAuthorityScope =
+  'owner_self'
+export const ARTANIS_SHARED_FLEET_AUTHORITY_SCOPE: ArtanisAuthorityScope =
+  'shared_fleet'
+export const ARTANIS_OWNER_OPERATOR_AUTHORITY_SCOPE: ArtanisAuthorityScope =
+  'owner_operator'
+
+export const ARTANIS_AUTHORITY_SCOPES: ReadonlyArray<ArtanisAuthorityScope> = [
+  ARTANIS_OWNER_SELF_AUTHORITY_SCOPE,
+  ARTANIS_SHARED_FLEET_AUTHORITY_SCOPE,
+  ARTANIS_OWNER_OPERATOR_AUTHORITY_SCOPE,
+]
+
+export const isArtanisAuthorityScope = (
+  value: unknown,
+): value is ArtanisAuthorityScope =>
+  typeof value === 'string' &&
+  ARTANIS_AUTHORITY_SCOPES.includes(value as ArtanisAuthorityScope)
+
+export const artanisAuthorityScopeAllowsOwnerLinkedCapacity = (
+  authorityScope: ArtanisAuthorityScope,
+): boolean => authorityScope === ARTANIS_OWNER_SELF_AUTHORITY_SCOPE
+
+export const artanisAuthorityScopePublicRef = (
+  authorityScope: ArtanisAuthorityScope,
+): string => `authority.public.artanis.scope.${authorityScope}`
+
+export const artanisAuthorityScopeEvidenceRef = (
+  authorityScope: ArtanisAuthorityScope,
+): string => `evidence.khala_coding.authority_scope.${authorityScope}`
+
+export const artanisDefaultAuthorityScopeForRiskyAction = (
+  riskyActionKind: string,
+): ArtanisAuthorityScope =>
+  riskyActionKind === 'pylon_job_dispatch'
+    ? ARTANIS_OWNER_SELF_AUTHORITY_SCOPE
+    : ARTANIS_OWNER_OPERATOR_AUTHORITY_SCOPE

--- a/apps/openagents.com/workers/api/src/artanis-fleet-overseer-tick.ts
+++ b/apps/openagents.com/workers/api/src/artanis-fleet-overseer-tick.ts
@@ -7,6 +7,7 @@ import {
   artanisApprovalGateProjectionHasPrivateMaterial,
   projectArtanisApprovalGateLedger,
 } from './artanis-approval-gates'
+import { ARTANIS_SHARED_FLEET_AUTHORITY_SCOPE } from './artanis-authority-scope'
 import {
   artanisHealthProjectionHasPrivateMaterial,
   ArtanisHealthSignalRecord,
@@ -477,6 +478,7 @@ const approvalGateFor = (
 
   return new ArtanisApprovalGateRecord({
     actionRef: `action.public.artanis.fleet_overseer.${suffix}`,
+    authorityScope: ARTANIS_SHARED_FLEET_AUTHORITY_SCOPE,
     authorityReceiptRefs: [],
     authoritySourceKinds: ['operator_policy'],
     caveatRefs: [

--- a/apps/openagents.com/workers/api/src/artanis-operator-console-routes.ts
+++ b/apps/openagents.com/workers/api/src/artanis-operator-console-routes.ts
@@ -5,6 +5,7 @@ import {
   ArtanisApprovalGateRecord,
   projectArtanisApprovalGateLedger,
 } from './artanis-approval-gates'
+import { ARTANIS_OWNER_SELF_AUTHORITY_SCOPE } from './artanis-authority-scope'
 import {
   ArtanisForumPublicationIntentRecord,
   ArtanisForumPublicationQueueRecord,
@@ -492,6 +493,7 @@ const armedPylonDispatchGateRecord = (input: {
 
   return new ArtanisApprovalGateRecord({
     actionRef: 'action.public.artanis.arm_pylon_dispatch',
+    authorityScope: ARTANIS_OWNER_SELF_AUTHORITY_SCOPE,
     // Documents the owner directive ("arm it now", 2026-06-27). Operator-only;
     // excluded from the public projection.
     authorityReceiptRefs: [
@@ -571,6 +573,7 @@ const approvalActionRecord = (input: {
 
   return new ArtanisApprovalGateRecord({
     actionRef: input.source.actionRef,
+    authorityScope: input.source.authorityScope,
     authorityReceiptRefs: [
       `authority.public.artanis.operator_${input.action}.${suffix}`,
     ],

--- a/apps/openagents.com/workers/api/src/artanis-operator-dispatch-execution.test.ts
+++ b/apps/openagents.com/workers/api/src/artanis-operator-dispatch-execution.test.ts
@@ -102,6 +102,7 @@ const workspaceVerificationCommand = (
 }
 
 const plan: ArtanisDispatchPlanInput = {
+  authorityScope: 'owner_self',
   branch: 'main',
   filePaths: [],
   issue: 6320,
@@ -129,8 +130,7 @@ const makeDeps = (overrides: {
       nowIso: () => nowIso,
       ownerOpenAuthUserId: 'user_owner',
       pylonStore: store,
-      readEffectivePylonDispatchApproval: async () =>
-        overrides.approved ?? false,
+      readEffectivePylonDispatchApproval: async () => overrides.approved ?? false,
       resolveCommitSha: async () =>
         '0123456789abcdef0123456789abcdef01234567',
     },
@@ -145,8 +145,12 @@ describe('makeArtanisDispatchExecution (#6366 live seam)', () => {
     const denied = makeArtanisDispatchExecution(
       makeDeps({ approved: false }).deps,
     )
-    expect(await Effect.runPromise(approved.isOwnerApproved())).toBe(true)
-    expect(await Effect.runPromise(denied.isOwnerApproved())).toBe(false)
+    expect(await Effect.runPromise(approved.isOwnerApproved('owner_self'))).toBe(
+      true,
+    )
+    expect(await Effect.runPromise(denied.isOwnerApproved('owner_self'))).toBe(
+      false,
+    )
   })
 
   test('createCodexAssignment creates an own-capacity, no-spend assignment on the owner Pylon', async () => {
@@ -221,6 +225,30 @@ describe('makeArtanisDispatchExecution (#6366 live seam)', () => {
     const execution = makeArtanisDispatchExecution(deps)
     const result = await Effect.runPromise(execution.createCodexAssignment(plan))
     expect(result).toEqual({ kind: 'rejected', reason: 'no_linked_agents' })
+  })
+
+  test('rejects shared_fleet dispatch before owner-linked capacity lookup', async () => {
+    let listedLinkedAgents = false
+    const { created, deps } = makeDeps({ approved: true })
+    const execution = makeArtanisDispatchExecution({
+      ...deps,
+      listLinkedAgentUserIds: async () => {
+        listedLinkedAgents = true
+        return ['agent_owner']
+      },
+    })
+    const result = await Effect.runPromise(
+      execution.createCodexAssignment({
+        ...plan,
+        authorityScope: 'shared_fleet',
+      }),
+    )
+    expect(result).toEqual({
+      kind: 'rejected',
+      reason: 'authority_scope_capacity_unavailable',
+    })
+    expect(listedLinkedAgents).toBe(false)
+    expect(created).toHaveLength(0)
   })
 
   test('rejects with no_eligible_linked_pylon when no owner Pylon is eligible', async () => {
@@ -307,6 +335,7 @@ describe('readEffectiveArtanisPylonDispatchApprovalForOwner (owner promotion)', 
       }),
       nowIso,
       '   ',
+      'owner_self',
     )
     expect(approved).toBe(false)
     expect(queried).toBe(true)
@@ -333,7 +362,9 @@ describe('owner-promoted Artanis dispatch EXECUTES end-to-end (gated tool)', () 
         ),
     })
 
-    expect(await Effect.runPromise(execution.isOwnerApproved())).toBe(true)
+    expect(await Effect.runPromise(execution.isOwnerApproved('owner_self'))).toBe(
+      true,
+    )
 
     const result = await Effect.runPromise(execution.createCodexAssignment(plan))
     expect(result.kind).toBe('created')

--- a/apps/openagents.com/workers/api/src/artanis-operator-dispatch-execution.ts
+++ b/apps/openagents.com/workers/api/src/artanis-operator-dispatch-execution.ts
@@ -42,6 +42,12 @@ import {
   type ArtanisRiskyActionKind,
   artanisApprovalGateEffective,
 } from './artanis-approval-gates'
+import {
+  ARTANIS_OWNER_SELF_AUTHORITY_SCOPE,
+  artanisAuthorityScopeAllowsOwnerLinkedCapacity,
+  artanisAuthorityScopeEvidenceRef,
+  type ArtanisAuthorityScope,
+} from './artanis-authority-scope'
 import type {
   ArtanisDispatchCreateResult,
   ArtanisDispatchExecution,
@@ -94,6 +100,7 @@ const buildDelegationBody = (
   commitSha: string,
 ): Record<string, unknown> => {
   const coding: Record<string, unknown> = {
+    authorityScope: plan.authorityScope,
     objectiveSummary: plan.objective,
   }
   coding.workspace = {
@@ -114,6 +121,7 @@ const buildDelegationBody = (
     messages: [{ content: plan.prompt, role: 'user' }],
     model: 'openagents/khala',
     openagents: {
+      authorityScope: plan.authorityScope,
       coding,
       workflowClass: 'codex_agent_task',
     },
@@ -131,7 +139,9 @@ export type ArtanisDispatchExecutionDeps = Readonly<{
     ownerOpenAuthUserId: string,
   ) => Promise<ReadonlyArray<string>>
   // True iff an effective owner approval for `pylon_job_dispatch` exists now.
-  readEffectivePylonDispatchApproval: () => Promise<boolean>
+  readEffectivePylonDispatchApproval: (
+    authorityScope: ArtanisAuthorityScope,
+  ) => Promise<boolean>
   // Deterministic id + clock seams (testable).
   makeId: () => string
   nowIso: () => string
@@ -152,6 +162,9 @@ const createAssignmentPromise = async (
       return { kind: 'rejected', reason: 'command_source_not_verified' }
     }
     const verifiedPlan = { ...plan, verify: plan.verify }
+    if (!artanisAuthorityScopeAllowsOwnerLinkedCapacity(plan.authorityScope)) {
+      return { kind: 'rejected', reason: 'authority_scope_capacity_unavailable' }
+    }
     const ownerAgentUserIds = await deps.listLinkedAgentUserIds(
       deps.ownerOpenAuthUserId,
     )
@@ -173,9 +186,13 @@ const createAssignmentPromise = async (
     const result = await delegateCodingWorkflow({
       classification: {
         confidence: 1,
-        evidenceRefs: [ARTANIS_DISPATCH_EVIDENCE_REF],
+        evidenceRefs: [
+          ARTANIS_DISPATCH_EVIDENCE_REF,
+          artanisAuthorityScopeEvidenceRef(verifiedPlan.authorityScope),
+        ],
         workflowClass: 'codex_agent_task',
       },
+      authorityScope: verifiedPlan.authorityScope,
       linkedAgents,
       makeId: deps.makeId,
       nowIso,
@@ -217,10 +234,10 @@ export const makeArtanisDispatchExecution = (
         () => ({ kind: 'rejected', reason: 'dispatch_execution_error' }) as const,
       ),
     ),
-  isOwnerApproved: () =>
+  isOwnerApproved: (authorityScope: ArtanisAuthorityScope) =>
     Effect.tryPromise({
       catch: () => false,
-      try: () => deps.readEffectivePylonDispatchApproval(),
+      try: () => deps.readEffectivePylonDispatchApproval(authorityScope),
     }).pipe(Effect.orElseSucceed(() => false)),
 })
 
@@ -234,6 +251,7 @@ export const makeArtanisDispatchExecution = (
 export const readEffectiveArtanisPylonDispatchApproval = async (
   db: D1Database,
   nowIso: string,
+  authorityScope: ArtanisAuthorityScope = ARTANIS_OWNER_SELF_AUTHORITY_SCOPE,
 ): Promise<boolean> => {
   // `artanis_approval_gates` is the persisted Artanis approval-gate table
   // (`tableSpecs.approval_gate` in `artanis-persistence.ts`); `record_json`
@@ -254,6 +272,7 @@ export const readEffectiveArtanisPylonDispatchApproval = async (
       const record = S.decodeUnknownSync(ArtanisApprovalGateRecord)(parsed)
       if (
         record.kind === 'pylon_job_dispatch' &&
+        record.authorityScope === authorityScope &&
         artanisApprovalGateEffective(record, nowIso)
       ) {
         return true
@@ -269,6 +288,7 @@ export const readEffectiveArtanisApproval = async (
   db: D1Database,
   nowIso: string,
   kind: ArtanisRiskyActionKind,
+  authorityScope?: ArtanisAuthorityScope | undefined,
 ): Promise<boolean> => {
   const result = await db
     .prepare(
@@ -284,7 +304,11 @@ export const readEffectiveArtanisApproval = async (
     try {
       const parsed = parseJsonUnknown(row.record_json)
       const record = S.decodeUnknownSync(ArtanisApprovalGateRecord)(parsed)
-      if (record.kind === kind && artanisApprovalGateEffective(record, nowIso)) {
+      if (
+        record.kind === kind &&
+        (authorityScope === undefined || record.authorityScope === authorityScope) &&
+        artanisApprovalGateEffective(record, nowIso)
+      ) {
         return true
       }
     } catch {
@@ -317,12 +341,16 @@ export const readEffectiveArtanisPylonDispatchApprovalForOwner = async (
   db: D1Database,
   nowIso: string,
   ownerOpenAuthUserId: string,
+  authorityScope: ArtanisAuthorityScope = ARTANIS_OWNER_SELF_AUTHORITY_SCOPE,
 ): Promise<boolean> => {
+  if (!artanisAuthorityScopeAllowsOwnerLinkedCapacity(authorityScope)) {
+    return false
+  }
   // (a) Standing per-tenant approval — scoped to pylon_job_dispatch only. The
   // owner-promoted Artanis identity is included by this tenant-wide rule.
   if (ownerOpenAuthUserId.trim() !== '') {
     return true
   }
   // (b) Otherwise fall back to the armed D1 approval-gate path.
-  return readEffectiveArtanisPylonDispatchApproval(db, nowIso)
+  return readEffectiveArtanisPylonDispatchApproval(db, nowIso, authorityScope)
 }

--- a/apps/openagents.com/workers/api/src/artanis-operator-tools.test.ts
+++ b/apps/openagents.com/workers/api/src/artanis-operator-tools.test.ts
@@ -457,6 +457,7 @@ describe('#6366 dispatch_codex_task (gated; plan-only without a seam)', () => {
   const tool = makeArtanisDispatchCodexTaskTool()
 
   test('is a gated pylon_job_dispatch tool with a run() entry point', () => {
+    expect(tool.authorityScope).toBe('owner_self')
     expect(tool.kind).toBe('gated')
     expect(tool.riskyActionKind).toBe('pylon_job_dispatch')
     expect(typeof tool.run).toBe('function')
@@ -479,6 +480,7 @@ describe('#6366 dispatch_codex_task (gated; plan-only without a seam)', () => {
     if (result.outcome !== 'deferred') return
     expect(result.reason).toBe('execution_not_wired')
     expect(result.plan).toContain('pylon khala request')
+    expect(result.plan).toContain('authorityScope: owner_self')
     expect(result.plan).toContain('--workflow codex_agent_task')
     expect(result.plan).toContain('--repo OpenAgentsInc/openagents')
     expect(result.plan).toContain('run-no-spend')
@@ -534,7 +536,10 @@ describe('#6366 dispatch_codex_task (gated; LIVE execution behind the gate)', ()
             pylonRef: 'pylon.owner.alpha',
           } as const)
         },
-        isOwnerApproved: () => Effect.succeed(true),
+        isOwnerApproved: authorityScope => {
+          expect(authorityScope).toBe('owner_self')
+          return Effect.succeed(true)
+        },
       },
     })
 
@@ -550,6 +555,7 @@ describe('#6366 dispatch_codex_task (gated; LIVE execution behind the gate)', ()
     expect(result.assignmentRef).toBe('assignment.public.khala_coding.live123')
     expect(result.durableRequestId).toBe('req-live123')
     expect(createCalls).toHaveLength(1)
+    expect(createCalls[0]).toMatchObject({ authorityScope: 'owner_self' })
     // No-spend invariant is asserted in the public-safe summary.
     expect(result.summary).toContain('unpaid_smoke')
     expect(result.summary).toContain('settlement: not_applicable')
@@ -570,7 +576,10 @@ describe('#6366 dispatch_codex_task (gated; LIVE execution behind the gate)', ()
             pylonRef: 'pylon.owner.alpha',
           } as const)
         },
-        isOwnerApproved: () => Effect.succeed(false),
+        isOwnerApproved: authorityScope => {
+          expect(authorityScope).toBe('owner_self')
+          return Effect.succeed(false)
+        },
       },
     })
 
@@ -920,6 +929,7 @@ describe('#6435 post_forum_update (gated Artanis Forum writer)', () => {
       isOwnerApproved: () => Effect.succeed(false),
     })
 
+    expect(tool.authorityScope).toBe('owner_operator')
     expect(tool.kind).toBe('gated')
     expect(tool.riskyActionKind).toBe('forum_post')
 
@@ -1731,6 +1741,7 @@ describe('get_unsupported_requests (owner-scoped unsupported-request ledger read
     expect(askedStatus).toBe('needs_issue')
     expect(result.toolInvocations).toEqual([
       {
+        authorityScope: 'owner_operator',
         deferredToApprovalGate: false,
         executed: true,
         executedRef: null,
@@ -1956,6 +1967,7 @@ describe('open_unsupported_request_issue (owner-gated GitHub issue + ledger link
 
   test('is an owner-gated outward GitHub issue tool', () => {
     const tool = makeArtanisOpenUnsupportedRequestIssueTool()
+    expect(tool.authorityScope).toBe('owner_operator')
     expect(tool.kind).toBe('gated')
     expect(tool.definition.name).toBe('open_unsupported_request_issue')
     expect(tool.riskyActionKind).toBe(
@@ -2372,6 +2384,7 @@ describe('trigger_synthetic_load (RISKY plan-only) — iteration 4', () => {
 
   test('is a risky tool whose riskyActionKind is an enumerated kind', () => {
     expect(tool.kind).toBe('risky')
+    expect(tool.authorityScope).toBe('owner_operator')
     expect(tool.definition.name).toBe('trigger_synthetic_load')
     // It carries a riskyActionKind, and that kind is part of the approval-gate
     // vocabulary (synthetic load maps to eval_launch).
@@ -2997,6 +3010,7 @@ describe('makeArtanisOperatorTools default table', () => {
     )
     expect(tool).toBeDefined()
     expect(tool?.kind).toBe('write')
+    expect(tool?.authorityScope).toBe('owner_operator')
   })
 
   test('the default table includes a read-kind get_unsupported_requests tool', () => {
@@ -3006,6 +3020,7 @@ describe('makeArtanisOperatorTools default table', () => {
     )
     expect(tool).toBeDefined()
     expect(tool?.kind).toBe('read')
+    expect(tool?.authorityScope).toBe('owner_operator')
   })
 
   test('the default table includes a read-kind list_pylon_assignments tool', () => {
@@ -3015,6 +3030,7 @@ describe('makeArtanisOperatorTools default table', () => {
     )
     expect(tool).toBeDefined()
     expect(tool?.kind).toBe('read')
+    expect(tool?.authorityScope).toBe('owner_self')
   })
 
   test('the default table includes a read-kind get_glm_fleet_status tool', () => {
@@ -3022,6 +3038,7 @@ describe('makeArtanisOperatorTools default table', () => {
     const tool = tools.find(t => t.definition.name === 'get_glm_fleet_status')
     expect(tool).toBeDefined()
     expect(tool?.kind).toBe('read')
+    expect(tool?.authorityScope).toBe('owner_operator')
   })
 
   test('the default table includes a read-kind get_fleet_status tool', () => {
@@ -3029,6 +3046,7 @@ describe('makeArtanisOperatorTools default table', () => {
     const tool = tools.find(t => t.definition.name === 'get_fleet_status')
     expect(tool).toBeDefined()
     expect(tool?.kind).toBe('read')
+    expect(tool?.authorityScope).toBe('owner_operator')
   })
 
   test('the default table includes a read-kind get_synthetic_load_status tool', () => {
@@ -3038,6 +3056,7 @@ describe('makeArtanisOperatorTools default table', () => {
     )
     expect(tool).toBeDefined()
     expect(tool?.kind).toBe('read')
+    expect(tool?.authorityScope).toBe('owner_operator')
   })
 
   test('the default table includes a read-kind get_khala_feedback tool', () => {
@@ -3045,6 +3064,7 @@ describe('makeArtanisOperatorTools default table', () => {
     const tool = tools.find(t => t.definition.name === 'get_khala_feedback')
     expect(tool).toBeDefined()
     expect(tool?.kind).toBe('read')
+    expect(tool?.authorityScope).toBe('owner_operator')
   })
 
   test('the default table includes a read-kind get_trace_review tool', () => {
@@ -3052,6 +3072,7 @@ describe('makeArtanisOperatorTools default table', () => {
     const tool = tools.find(t => t.definition.name === 'get_trace_review')
     expect(tool).toBeDefined()
     expect(tool?.kind).toBe('read')
+    expect(tool?.authorityScope).toBe('owner_operator')
   })
 
   test('the default table includes a trigger_synthetic_load tool', () => {
@@ -3061,6 +3082,7 @@ describe('makeArtanisOperatorTools default table', () => {
     )
     expect(tool).toBeDefined()
     expect(tool?.kind).toBe('risky')
+    expect(tool?.authorityScope).toBe('owner_operator')
   })
 
   test('the default table includes a gated post_forum_update tool', () => {
@@ -3068,6 +3090,7 @@ describe('makeArtanisOperatorTools default table', () => {
     const tool = tools.find(t => t.definition.name === 'post_forum_update')
     expect(tool).toBeDefined()
     expect(tool?.kind).toBe('gated')
+    expect(tool?.authorityScope).toBe('owner_operator')
     if (tool?.kind !== 'gated') return
     expect(tool.riskyActionKind).toBe('forum_post')
   })

--- a/apps/openagents.com/workers/api/src/artanis-operator-tools.ts
+++ b/apps/openagents.com/workers/api/src/artanis-operator-tools.ts
@@ -45,6 +45,11 @@ import type {
   ArtanisRiskyActionKind,
 } from './artanis-operator'
 import {
+  ARTANIS_OWNER_OPERATOR_AUTHORITY_SCOPE,
+  ARTANIS_OWNER_SELF_AUTHORITY_SCOPE,
+  type ArtanisAuthorityScope,
+} from './artanis-authority-scope'
+import {
   type ArtanisGetNetworkStatsConfig,
   type ArtanisNetworkStats,
   fetchArtanisNetworkStats,
@@ -226,6 +231,7 @@ export const makeArtanisReadRepoFileTool = (
         }
         return text
       }),
+    authorityScope: ARTANIS_OWNER_SELF_AUTHORITY_SCOPE,
     kind: 'read',
   }
 }
@@ -312,6 +318,7 @@ export const makeArtanisListRepoDirTool = (
           ...entries.map(line => `- ${line}`),
         ].join('\n')
       }),
+    authorityScope: ARTANIS_OWNER_SELF_AUTHORITY_SCOPE,
     kind: 'read',
   }
 }
@@ -505,6 +512,7 @@ export const makeArtanisRepoPathExistsTool = (
         }
         return `(could not parse the existence check for "${path}"; existence UNGROUNDED)`
       }),
+    authorityScope: ARTANIS_OWNER_SELF_AUTHORITY_SCOPE,
     kind: 'read',
   }
 }
@@ -608,6 +616,7 @@ export const makeArtanisRepoGrepTool = (
           ...matches,
         ].join('\n')
       }),
+    authorityScope: ARTANIS_OWNER_SELF_AUTHORITY_SCOPE,
     kind: 'read',
   }
 }
@@ -797,6 +806,7 @@ export const makeArtanisRouteExistsTool = (
             : [...methodsForPath].sort().join(', ')
         return `GROUNDING: the path ${matchedLabel} exists in the OpenAPI registry, but ${method.toUpperCase()} is NOT registered on it (registered: ${methodList}). Treat ${method.toUpperCase()} ${path} as UNGROUNDED.`
       }),
+    authorityScope: ARTANIS_OWNER_SELF_AUTHORITY_SCOPE,
     kind: 'read',
   }
 }
@@ -1036,6 +1046,7 @@ export const makeArtanisReadGithubIssueTool = (
 
         return lines.join('\n')
       }),
+    authorityScope: ARTANIS_OWNER_SELF_AUTHORITY_SCOPE,
     kind: 'read',
   }
 }
@@ -1344,6 +1355,7 @@ export const makeArtanisListGithubIssuesTool = (
         const header = `${stateLabel} in ${owner}/${repo}${labelLabel} (${lines.length}):`
         return [header, ...lines].join('\n')
       }),
+    authorityScope: ARTANIS_OWNER_SELF_AUTHORITY_SCOPE,
     kind: 'read',
   }
 }
@@ -1583,6 +1595,7 @@ export const makeArtanisGetPylonJobStatusTool = (
         )
         return lines.join('\n')
       }),
+    authorityScope: ARTANIS_OWNER_SELF_AUTHORITY_SCOPE,
     kind: 'read',
   }
 }
@@ -1783,6 +1796,7 @@ export const makeArtanisListPylonAssignmentsTool = (
             : `Recent Pylon/Codex assignments with state "${stateFilter}" (${safe.length}):`
         return [header, ...safe.map(formatAssignmentSummaryLine)].join('\n')
       }),
+    authorityScope: ARTANIS_OWNER_SELF_AUTHORITY_SCOPE,
     kind: 'read',
   }
 }
@@ -2037,6 +2051,7 @@ export const makeArtanisPostForumUpdateTool = (
         type: 'object',
       },
     },
+    authorityScope: ARTANIS_OWNER_OPERATOR_AUTHORITY_SCOPE,
     kind: 'gated',
     riskyActionKind: ARTANIS_FORUM_POST_RISKY_ACTION_KIND,
     run: (args: unknown) =>
@@ -2292,6 +2307,7 @@ export const makeArtanisGetKhalaFeedbackTool = (
           ...safe.map(record => formatFeedbackRecordLine(record, maxTextChars)),
         ].join('\n')
       }),
+    authorityScope: ARTANIS_OWNER_OPERATOR_AUTHORITY_SCOPE,
     kind: 'read',
   }
 }
@@ -2567,6 +2583,7 @@ export const makeArtanisGetUnsupportedRequestsTool = (
           ),
         ].join('\n')
       }),
+    authorityScope: ARTANIS_OWNER_OPERATOR_AUTHORITY_SCOPE,
     kind: 'read',
   }
 }
@@ -2985,6 +3002,7 @@ export const makeArtanisUpdateUnsupportedRequestTool = (
         }
         return formatUpdatedUnsupportedRequest(updated)
       }),
+    authorityScope: ARTANIS_OWNER_OPERATOR_AUTHORITY_SCOPE,
     kind: 'write',
   }
 }
@@ -3062,6 +3080,7 @@ export const makeArtanisOpenUnsupportedRequestIssueTool = (
         type: 'object',
       },
     },
+    authorityScope: ARTANIS_OWNER_OPERATOR_AUTHORITY_SCOPE,
     kind: 'gated',
     riskyActionKind: ARTANIS_UNSUPPORTED_REQUEST_ISSUE_OPEN_RISKY_ACTION_KIND,
     run: (args: unknown): Effect.Effect<ArtanisOperatorGatedResult> =>
@@ -3254,6 +3273,7 @@ const commandProposalGateForVerify = (
 // The validated, public-safe plan input the gated tool hands to the execution
 // seam. Every field has already passed the public-safety gate.
 export type ArtanisDispatchPlanInput = Readonly<{
+  authorityScope: ArtanisAuthorityScope
   objective: string
   branch: string
   verify: string | undefined
@@ -3280,7 +3300,7 @@ export type ArtanisDispatchCreateResult =
 // no-spend assignment via the server coding-delegation route, targeting the
 // OWNER's linked Pylon. When absent, the tool stays plan-only (defers).
 export type ArtanisDispatchExecution = Readonly<{
-  isOwnerApproved: () => Effect.Effect<boolean>
+  isOwnerApproved: (authorityScope: ArtanisAuthorityScope) => Effect.Effect<boolean>
   createCodexAssignment: (
     plan: ArtanisDispatchPlanInput,
   ) => Effect.Effect<ArtanisDispatchCreateResult>
@@ -3292,6 +3312,7 @@ export type ArtanisDispatchExecution = Readonly<{
 const buildArtanisDispatchPlan = (
   args: unknown,
   defaultBranch: string,
+  authorityScope: ArtanisAuthorityScope,
 ):
   | Readonly<{ ok: true; input: ArtanisDispatchPlanInput; planText: string }>
   | Readonly<{ ok: false; message: string }> => {
@@ -3352,7 +3373,9 @@ const buildArtanisDispatchPlan = (
   const prompt = promptParts.join(' ')
 
   const lines: Array<string> = [
-    'Planned Khala -> Pylon -> Codex dispatch (own-capacity only, no spend):',
+    `Planned Khala -> Pylon -> Codex dispatch (${authorityScope}, own-capacity only, no spend):`,
+    '',
+    `  authorityScope: ${authorityScope}`,
     '',
     '  pylon khala request \\',
     `    --prompt "${prompt}" \\`,
@@ -3377,7 +3400,7 @@ const buildArtanisDispatchPlan = (
   }
 
   return {
-    input: { branch, filePaths, issue, objective, prompt, verify },
+    input: { authorityScope, branch, filePaths, issue, objective, prompt, verify },
     ok: true,
     planText: lines.join('\n'),
   }
@@ -3394,10 +3417,13 @@ const buildArtanisDispatchPlan = (
 // pooled/third-party capacity.
 export const makeArtanisDispatchCodexTaskTool = (
   config: Readonly<{
+    authorityScope?: ArtanisAuthorityScope | undefined
     defaultBranch?: string | undefined
     execution?: ArtanisDispatchExecution | undefined
   }> = {},
 ): ArtanisOperatorGatedTool => {
+  const authorityScope =
+    config.authorityScope ?? ARTANIS_OWNER_SELF_AUTHORITY_SCOPE
   const defaultBranch = config.defaultBranch ?? 'main'
   const execution = config.execution
 
@@ -3437,11 +3463,12 @@ export const makeArtanisDispatchCodexTaskTool = (
         type: 'object',
       },
     },
+    authorityScope,
     kind: 'gated',
     riskyActionKind: 'pylon_job_dispatch',
     run: (args: unknown): Effect.Effect<ArtanisOperatorGatedResult> =>
       Effect.gen(function* () {
-        const built = buildArtanisDispatchPlan(args, defaultBranch)
+        const built = buildArtanisDispatchPlan(args, defaultBranch, authorityScope)
         if (!built.ok) {
           // Invalid/blocked args never execute; defer with the honest message.
           return {
@@ -3463,7 +3490,7 @@ export const makeArtanisDispatchCodexTaskTool = (
         // Owner-approval gate. Default conservative: any failure reads as
         // "not approved" and defers — never an accidental execution.
         const approved = yield* execution
-          .isOwnerApproved()
+          .isOwnerApproved(built.input.authorityScope)
           .pipe(Effect.orElseSucceed(() => false))
         if (!approved) {
           return {
@@ -3507,6 +3534,7 @@ export const makeArtanisDispatchCodexTaskTool = (
 
         const summary = [
           `assignmentRef: ${created.assignmentRef}`,
+          `authorityScope: ${built.input.authorityScope}`,
           `pylonRef: ${created.pylonRef}`,
           `durableRequestId: ${created.durableRequestId ?? '(none)'}`,
           'paymentMode: unpaid_smoke (no spend, own_capacity)',
@@ -3576,6 +3604,7 @@ export const makeArtanisGetNetworkStatsTool = (
         ].join('\n')
       }),
     ),
+  authorityScope: ARTANIS_OWNER_OPERATOR_AUTHORITY_SCOPE,
   kind: 'read',
 })
 
@@ -3755,6 +3784,7 @@ export const makeArtanisGetFleetStatusTool = (
         formatFleetBrainLine(traceReview),
       ].join('\n')
     }),
+  authorityScope: ARTANIS_OWNER_OPERATOR_AUTHORITY_SCOPE,
   kind: 'read',
 })
 
@@ -3939,6 +3969,7 @@ export const makeArtanisGetGlmFleetStatusTool = (
         }
         return formatGlmFleetStatusLine(normalized)
       }),
+    authorityScope: ARTANIS_OWNER_OPERATOR_AUTHORITY_SCOPE,
     kind: 'read',
   }
 }
@@ -4295,6 +4326,7 @@ export const makeArtanisGetTraceReviewTool = (
         }
         return formatTraceReviewSummary(normalized)
       }),
+    authorityScope: ARTANIS_OWNER_OPERATOR_AUTHORITY_SCOPE,
     kind: 'read',
   }
 }
@@ -4494,6 +4526,7 @@ export const makeArtanisTriggerSyntheticLoadTool = (
         type: 'object',
       },
     },
+    authorityScope: ARTANIS_OWNER_OPERATOR_AUTHORITY_SCOPE,
     kind: 'risky',
     plan: (args: unknown) =>
       Effect.succeed(
@@ -4670,6 +4703,7 @@ export const makeArtanisGetSyntheticLoadStatusTool = (
           '\n',
         )
       }),
+    authorityScope: ARTANIS_OWNER_OPERATOR_AUTHORITY_SCOPE,
     kind: 'read',
   }
 }

--- a/apps/openagents.com/workers/api/src/artanis-operator.test.ts
+++ b/apps/openagents.com/workers/api/src/artanis-operator.test.ts
@@ -445,6 +445,7 @@ const makeFakeReadTool = (
         type: 'object',
       },
     },
+    authorityScope: 'owner_self',
     execute: (args: unknown) => {
       calls.push(args)
       return Effect.succeed(body)
@@ -470,6 +471,7 @@ const makeFakeRiskyTool = (): {
         type: 'object',
       },
     },
+    authorityScope: 'owner_self',
     kind: 'risky',
     plan: (args: unknown) => {
       planned.push(args)
@@ -499,6 +501,7 @@ const makeFakeGatedTool = (
         type: 'object',
       },
     },
+    authorityScope: 'owner_self',
     kind: 'gated',
     riskyActionKind: 'pylon_job_dispatch',
     run: (args: unknown) => {
@@ -723,6 +726,7 @@ describe('#6364 artanis operator bounded tool-calling loop', () => {
     expect(result.reply).toContain('#6316')
     expect(result.toolInvocations).toEqual([
       {
+        authorityScope: 'owner_self',
         deferredToApprovalGate: false,
         executed: true,
         executedRef: null,
@@ -802,6 +806,7 @@ describe('#6364 artanis operator bounded tool-calling loop', () => {
     expect(result.deferredToApprovalGate).toBe(false)
     expect(result.toolInvocations).toEqual([
       {
+        authorityScope: 'owner_operator',
         deferredToApprovalGate: false,
         executed: true,
         executedRef: null,
@@ -849,6 +854,7 @@ describe('#6364 artanis operator bounded tool-calling loop', () => {
     expect(result.deferredToApprovalGate).toBe(true)
     expect(result.pendingApprovalGates).toEqual([
       {
+        authorityScope: 'owner_self',
         gateRef: ARTANIS_OPERATOR_APPROVAL_GATE_REF,
         gateSystem: 'artanis-approval-gates',
         riskyActionKind: 'pylon_job_dispatch',
@@ -858,6 +864,7 @@ describe('#6364 artanis operator bounded tool-calling loop', () => {
     ])
     expect(result.toolInvocations).toEqual([
       {
+        authorityScope: 'owner_self',
         deferredToApprovalGate: true,
         executed: false,
         executedRef: null,
@@ -898,6 +905,7 @@ describe('#6364 artanis operator bounded tool-calling loop', () => {
     expect(result.deferredToApprovalGate).toBe(true)
     expect(result.toolInvocations).toEqual([
       {
+        authorityScope: 'owner_operator',
         deferredToApprovalGate: true,
         executed: false,
         executedRef: null,
@@ -949,6 +957,7 @@ describe('#6364 artanis operator bounded tool-calling loop', () => {
     expect(result.pendingApprovalGates).toEqual([])
     expect(result.toolInvocations).toEqual([
       {
+        authorityScope: 'owner_self',
         deferredToApprovalGate: false,
         executed: true,
         executedRef: 'assignment.public.khala_coding.abc123',
@@ -986,6 +995,7 @@ describe('#6364 artanis operator bounded tool-calling loop', () => {
     expect(result.deferredToApprovalGate).toBe(true)
     expect(result.pendingApprovalGates).toEqual([
       {
+        authorityScope: 'owner_self',
         gateRef: ARTANIS_OPERATOR_APPROVAL_GATE_REF,
         gateSystem: 'artanis-approval-gates',
         riskyActionKind: 'pylon_job_dispatch',
@@ -995,6 +1005,7 @@ describe('#6364 artanis operator bounded tool-calling loop', () => {
     ])
     expect(result.toolInvocations).toEqual([
       {
+        authorityScope: 'owner_self',
         deferredToApprovalGate: true,
         executed: false,
         executedRef: null,

--- a/apps/openagents.com/workers/api/src/artanis-operator.ts
+++ b/apps/openagents.com/workers/api/src/artanis-operator.ts
@@ -48,6 +48,7 @@ import { Effect, Schema as S } from 'effect'
 
 import { ARTANIS_RISKY_ACTION_KINDS } from './artanis-approval-gates'
 import type { ArtanisRiskyActionKind } from './artanis-approval-gates'
+import type { ArtanisAuthorityScope } from './artanis-authority-scope'
 import type { ArtanisMemoryEntry } from './artanis-owner-memory'
 import type { ArtanisSituationalAwareness } from './artanis-situational-awareness'
 import type {
@@ -498,6 +499,7 @@ export type ArtanisOperatorToolDefinition = Readonly<{
 // A read tool: executes freely, returns the text fed back as the `tool` message.
 export type ArtanisOperatorReadTool = Readonly<{
   kind: 'read'
+  authorityScope: ArtanisAuthorityScope
   definition: ArtanisOperatorToolDefinition
   // Execute with the parsed arguments and return the tool result text. Read
   // tools must be side-effect-free beyond reading public state; an empty/absent
@@ -516,6 +518,7 @@ export type ArtanisOperatorReadTool = Readonly<{
 // honest "(…)"-style string, never invention.
 export type ArtanisOperatorWriteTool = Readonly<{
   kind: 'write'
+  authorityScope: ArtanisAuthorityScope
   definition: ArtanisOperatorToolDefinition
   execute: (args: unknown) => Effect.Effect<string>
 }>
@@ -524,6 +527,7 @@ export type ArtanisOperatorWriteTool = Readonly<{
 // and returns a public-safe description of the exact action it WOULD take.
 export type ArtanisOperatorRiskyTool = Readonly<{
   kind: 'risky'
+  authorityScope: ArtanisAuthorityScope
   // The approval-gate risky-action kind this tool would require.
   riskyActionKind: ArtanisRiskyActionKind
   definition: ArtanisOperatorToolDefinition
@@ -567,6 +571,7 @@ export type ArtanisOperatorGatedResult =
 // target capacity is missing) and must never fake an execution or move money.
 export type ArtanisOperatorGatedTool = Readonly<{
   kind: 'gated'
+  authorityScope: ArtanisAuthorityScope
   // The approval-gate risky-action kind this tool's execution is gated behind.
   riskyActionKind: ArtanisRiskyActionKind
   definition: ArtanisOperatorToolDefinition
@@ -584,6 +589,8 @@ export type ArtanisOperatorTool =
 // result so the route/UI can show what Artanis did without re-deriving it.
 export type ArtanisOperatorToolInvocation = Readonly<{
   name: string
+  // The authority/capacity scope carried by this concrete tool call.
+  authorityScope: ArtanisAuthorityScope
   // True when the tool actually executed (a read tool that ran, OR a gated tool
   // that fired behind an effective owner approval).
   executed: boolean
@@ -607,6 +614,7 @@ export type ArtanisOperatorPendingApprovalGate = Readonly<{
   gateSystem: 'artanis-approval-gates'
   state: 'pending'
   toolName: string
+  authorityScope: ArtanisAuthorityScope
   riskyActionKind: ArtanisRiskyActionKind
 }>
 
@@ -1067,6 +1075,7 @@ const runToolCall = (
       return {
         content,
         invocation: {
+          authorityScope: tool.authorityScope,
           deferredToApprovalGate: false,
           executed: result._tag === 'Success',
           executedRef: null,
@@ -1090,6 +1099,7 @@ const runToolCall = (
             `This action (${tool.definition.name}) is a ${tool.riskyActionKind} action gated by ${ARTANIS_OPERATOR_APPROVAL_GATE_REF}. I could not build or run it just now, so I did not execute it.`,
           ].join('\n'),
           invocation: {
+            authorityScope: tool.authorityScope,
             deferredToApprovalGate: true,
             executed: false,
             executedRef: null,
@@ -1110,6 +1120,7 @@ const runToolCall = (
         return {
           content,
           invocation: {
+            authorityScope: tool.authorityScope,
             deferredToApprovalGate: false,
             executed: true,
             executedRef: outcome.assignmentRef,
@@ -1128,6 +1139,7 @@ const runToolCall = (
       return {
         content,
         invocation: {
+          authorityScope: tool.authorityScope,
           deferredToApprovalGate: true,
           executed: false,
           executedRef: null,
@@ -1153,6 +1165,7 @@ const runToolCall = (
     return {
       content,
       invocation: {
+        authorityScope: tool.authorityScope,
         deferredToApprovalGate: true,
         executed: false,
         executedRef: null,
@@ -1489,6 +1502,7 @@ export const artanisOperatorTurn = (input: {
           toolsDeferred = true
           if (invocation.riskyActionKind !== null) {
             pendingApprovalGates.push({
+              authorityScope: invocation.authorityScope,
               gateRef: ARTANIS_OPERATOR_APPROVAL_GATE_REF,
               gateSystem: 'artanis-approval-gates',
               riskyActionKind: invocation.riskyActionKind,

--- a/apps/openagents.com/workers/api/src/artanis-owner-authority.test.ts
+++ b/apps/openagents.com/workers/api/src/artanis-owner-authority.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, test } from 'vitest'
 
 import {
+  ARTANIS_OWNER_OPERATOR_AUTHORITY_SCOPE,
+  ARTANIS_OWNER_SELF_AUTHORITY_SCOPE,
+  ARTANIS_SHARED_FLEET_AUTHORITY_SCOPE,
+} from './artanis-authority-scope'
+import {
   ARTANIS_OWNER_AGENT_ACTOR_REF,
   ARTANIS_OWNER_AGENT_SLUG,
   ARTANIS_OWNER_OPENAUTH_USER_ID,
@@ -71,6 +76,30 @@ describe('owner promotion is bounded to pylon_job_dispatch and forum_post only',
     ).toBe(true)
   })
 
+  test('standing approval covers pylon_job_dispatch only in owner_self scope', () => {
+    expect(
+      ownerAgentHasStandingApprovalForRiskyAction(
+        ARTANIS_OWNER_OPENAUTH_USER_ID,
+        'pylon_job_dispatch',
+        ARTANIS_OWNER_SELF_AUTHORITY_SCOPE,
+      ),
+    ).toBe(true)
+    expect(
+      ownerAgentHasStandingApprovalForRiskyAction(
+        ARTANIS_OWNER_OPENAUTH_USER_ID,
+        'pylon_job_dispatch',
+        ARTANIS_SHARED_FLEET_AUTHORITY_SCOPE,
+      ),
+    ).toBe(false)
+    expect(
+      ownerAgentHasStandingApprovalForRiskyAction(
+        ARTANIS_OWNER_OPENAUTH_USER_ID,
+        'pylon_job_dispatch',
+        ARTANIS_OWNER_OPERATOR_AUTHORITY_SCOPE,
+      ),
+    ).toBe(false)
+  })
+
   test('standing approval covers forum_post for owner-Artanis', () => {
     expect(
       ownerAgentHasStandingApprovalForRiskyAction(
@@ -78,6 +107,30 @@ describe('owner promotion is bounded to pylon_job_dispatch and forum_post only',
         'forum_post',
       ),
     ).toBe(true)
+  })
+
+  test('standing approval covers forum_post only in owner_operator scope', () => {
+    expect(
+      ownerAgentHasStandingApprovalForRiskyAction(
+        ARTANIS_OWNER_OPENAUTH_USER_ID,
+        'forum_post',
+        ARTANIS_OWNER_OPERATOR_AUTHORITY_SCOPE,
+      ),
+    ).toBe(true)
+    expect(
+      ownerAgentHasStandingApprovalForRiskyAction(
+        ARTANIS_OWNER_OPENAUTH_USER_ID,
+        'forum_post',
+        ARTANIS_OWNER_SELF_AUTHORITY_SCOPE,
+      ),
+    ).toBe(false)
+    expect(
+      ownerAgentHasStandingApprovalForRiskyAction(
+        ARTANIS_OWNER_OPENAUTH_USER_ID,
+        'forum_post',
+        ARTANIS_SHARED_FLEET_AUTHORITY_SCOPE,
+      ),
+    ).toBe(false)
   })
 
   test('NEVER standing-approves money-movement / payout kinds (never-waivable)', () => {

--- a/apps/openagents.com/workers/api/src/artanis-owner-authority.ts
+++ b/apps/openagents.com/workers/api/src/artanis-owner-authority.ts
@@ -43,6 +43,13 @@
 // with the note `ARTANIS_OWNER_PROMOTION_NOTE`. It is documented in
 // `apps/openagents.com/INVARIANTS.md` ("Artanis Owner Promotion").
 
+import {
+  ARTANIS_OWNER_OPERATOR_AUTHORITY_SCOPE,
+  ARTANIS_OWNER_SELF_AUTHORITY_SCOPE,
+  artanisDefaultAuthorityScopeForRiskyAction,
+  type ArtanisAuthorityScope,
+} from './artanis-authority-scope'
+
 // The promoted operator agent's public identity.
 export const ARTANIS_OWNER_AGENT_SLUG = 'artanis'
 export const ARTANIS_OWNER_AGENT_ACTOR_REF =
@@ -96,6 +103,15 @@ const OWNER_AGENT_STANDING_APPROVAL_KINDS: ReadonlyArray<string> = [
   'pylon_job_dispatch',
 ]
 
+const ownerAgentStandingApprovalScopeForRiskyAction = (
+  riskyActionKind: string,
+): ArtanisAuthorityScope | null =>
+  riskyActionKind === 'pylon_job_dispatch'
+    ? ARTANIS_OWNER_SELF_AUTHORITY_SCOPE
+    : riskyActionKind === 'forum_post'
+      ? ARTANIS_OWNER_OPERATOR_AUTHORITY_SCOPE
+      : null
+
 // True when the owner-promoted operator agent holds a STANDING owner approval for
 // the given risky-action kind. The promotion standing-approves only bounded
 // no-spend dispatch and public Forum updates; every money-movement /
@@ -104,6 +120,15 @@ const OWNER_AGENT_STANDING_APPROVAL_KINDS: ReadonlyArray<string> = [
 export const ownerAgentHasStandingApprovalForRiskyAction = (
   openAuthUserId: string | null | undefined,
   riskyActionKind: string,
-): boolean =>
-  OWNER_AGENT_STANDING_APPROVAL_KINDS.includes(riskyActionKind) &&
-  isOpenAgentsOwnerAgentOpenAuthUserId(openAuthUserId)
+  authorityScope: ArtanisAuthorityScope =
+    artanisDefaultAuthorityScopeForRiskyAction(riskyActionKind),
+): boolean => {
+  const approvedScope =
+    ownerAgentStandingApprovalScopeForRiskyAction(riskyActionKind)
+  return (
+    approvedScope !== null &&
+    approvedScope === authorityScope &&
+    OWNER_AGENT_STANDING_APPROVAL_KINDS.includes(riskyActionKind) &&
+    isOpenAgentsOwnerAgentOpenAuthUserId(openAuthUserId)
+  )
+}

--- a/apps/openagents.com/workers/api/src/artanis-scheduled-runner.ts
+++ b/apps/openagents.com/workers/api/src/artanis-scheduled-runner.ts
@@ -28,6 +28,7 @@ import {
 import {
   ArtanisApprovalGateRecord,
 } from './artanis-approval-gates'
+import { ARTANIS_OWNER_OPERATOR_AUTHORITY_SCOPE } from './artanis-authority-scope'
 import {
   ArtanisForumPublicationIntentRecord,
   exampleArtanisForumPublicationQueue,
@@ -1195,6 +1196,7 @@ const scheduledSpendApprovalGate = (
 
   return new ArtanisApprovalGateRecord({
     actionRef: approval.actionRef,
+    authorityScope: ARTANIS_OWNER_OPERATOR_AUTHORITY_SCOPE,
     authorityReceiptRefs: [],
     authoritySourceKinds: ['operator_policy'],
     caveatRefs: approval.caveatRefs,

--- a/apps/openagents.com/workers/api/src/index.ts
+++ b/apps/openagents.com/workers/api/src/index.ts
@@ -102,6 +102,9 @@ import {
 } from './artanis-labor-receipt-routes'
 import { makeD1ArtanisLaborUnattendedReceiptStore } from './artanis-labor-receipt-store'
 import { ArtanisMindSmokeSystem, artanisMindComplete } from './artanis-mind'
+import {
+  ARTANIS_OWNER_OPERATOR_AUTHORITY_SCOPE,
+} from './artanis-authority-scope'
 import { makeOperatorArtanisChatRoutes } from './artanis-operator-chat-routes'
 import { loadArtanisNetworkStatsFromLedger } from './artanis-network-stats-d1'
 import { makeOperatorArtanisConsoleRoutes } from './artanis-operator-console-routes'
@@ -8880,6 +8883,7 @@ const operatorArtanisChatRoutes = makeOperatorArtanisChatRoutes({
               openAgentsDatabase(env),
               currentIsoTimestamp(),
               'github_issue_open',
+              ARTANIS_OWNER_OPERATOR_AUTHORITY_SCOPE,
             ),
           ),
         opener: makeArtanisGithubIssueOpener({
@@ -8897,6 +8901,7 @@ const operatorArtanisChatRoutes = makeOperatorArtanisChatRoutes({
             ownerAgentHasStandingApprovalForRiskyAction(
               session.user.userId,
               'forum_post',
+              ARTANIS_OWNER_OPERATOR_AUTHORITY_SCOPE,
             ),
           ),
         writer: makeArtanisForumUpdateWriter({
@@ -8909,7 +8914,7 @@ const operatorArtanisChatRoutes = makeOperatorArtanisChatRoutes({
         nowIso: currentIsoTimestamp,
         ownerOpenAuthUserId: session.user.userId,
         pylonStore: makeD1PylonApiStore(openAgentsDatabase(env)),
-        readEffectivePylonDispatchApproval: () =>
+        readEffectivePylonDispatchApproval: authorityScope =>
           // Owner-promotion-aware (owner-directed 2026-06-27): owner-Artanis
           // carries a STANDING owner approval for his own pylon_job_dispatch, so
           // his own-capacity no-spend Codex dispatch EXECUTES without a
@@ -8919,6 +8924,7 @@ const operatorArtanisChatRoutes = makeOperatorArtanisChatRoutes({
             openAgentsDatabase(env),
             currentIsoTimestamp(),
             session.user.userId,
+            authorityScope,
           ),
         // Resolve the current branch tip so a pinned-workspace dispatch uses a
         // real commit; on any failure the dispatch falls back to the bounded

--- a/apps/openagents.com/workers/api/src/inference/coding-workflow-delegation.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/coding-workflow-delegation.test.ts
@@ -218,6 +218,38 @@ describe('coding workflow delegation', () => {
       agentKind: 'codex_sdk',
       schema: 'openagents.pylon.codex_agent_task.v0.3',
     })
+    expect(assigned.evidenceRefs).toContain(
+      'evidence.khala_coding.authority_scope.owner_self',
+    )
+    expect(assigned.assignment.taskRefs).toContain(
+      'authority.public.artanis.scope.owner_self',
+    )
+  })
+
+  test('refuses shared_fleet scope on caller-owned linked capacity', async () => {
+    const result = await delegateCodingWorkflow({
+      authorityScope: 'shared_fleet',
+      classification,
+      linkedAgents: [linkedOwner],
+      makeId: () => 'id-shared',
+      nowIso,
+      pylonStore: makeStore({ registrations: [registration()] }),
+      rawBody: {},
+      requestId: 'chatcmpl_coding_shared_fleet_scope',
+    })
+
+    expect(result).toEqual({
+      error: 'authority_scope_capacity_unavailable',
+      evidenceRefs: [
+        'evidence.khala_coding.authority_scope.shared_fleet',
+        'evidence.khala_coding.authority_scope.owner_linked_capacity_not_allowed',
+      ],
+      kind: 'rejected',
+      reason:
+        'The shared_fleet Artanis authority scope is not wired to caller-owned linked Pylon capacity.',
+      requestedPylonRef: null,
+      statusCode: 403,
+    })
   })
 
   test('creates a controlled assignment on caller-owned Claude capacity (#6388)', async () => {

--- a/apps/openagents.com/workers/api/src/inference/coding-workflow-delegation.ts
+++ b/apps/openagents.com/workers/api/src/inference/coding-workflow-delegation.ts
@@ -1,5 +1,13 @@
 import type { LinkedAgentOwnerRecord } from '../agent-registration'
 import {
+  ARTANIS_OWNER_SELF_AUTHORITY_SCOPE,
+  artanisAuthorityScopeAllowsOwnerLinkedCapacity,
+  artanisAuthorityScopeEvidenceRef,
+  artanisAuthorityScopePublicRef,
+  isArtanisAuthorityScope,
+  type ArtanisAuthorityScope,
+} from '../artanis-authority-scope'
+import {
   type PylonApiAssignmentRecord,
   type PylonApiCreateAssignmentRequest,
   type PylonApiRegistrationRecord,
@@ -99,6 +107,7 @@ const codingAgentProfileFor = (
     : CODEX_AGENT_PROFILE
 
 export type CodingDelegationInput = Readonly<{
+  authorityScope?: ArtanisAuthorityScope | undefined
   classification: CodingWorkflowClassification
   linkedAgents: ReadonlyArray<
     LinkedAgentOwnerRecord | Readonly<{ agentUserId: string }>
@@ -121,6 +130,8 @@ export type CodingDelegationAssignmentResult = Readonly<{
 export type CodingDelegationRejection = Readonly<{
   error:
     | 'coding_delegation_store_unavailable'
+    | 'authority_scope_capacity_unavailable'
+    | 'invalid_authority_scope'
     | 'invalid_coding_objective_summary'
     | 'invalid_spawn_ref'
     | 'invalid_target_account_ref'
@@ -164,6 +175,53 @@ const rawCodingFromBody = (body: unknown): Record<string, unknown> | null => {
   return coding !== null && typeof coding === 'object'
     ? (coding as Record<string, unknown>)
     : null
+}
+
+const authorityScopeFromInput = (
+  input: CodingDelegationInput,
+  requestedPylonRef: string | null,
+):
+  | Readonly<{ kind: 'scope'; authorityScope: ArtanisAuthorityScope }>
+  | Readonly<{ kind: 'rejected'; rejection: CodingDelegationRejection }> => {
+  if (input.authorityScope !== undefined) {
+    return { authorityScope: input.authorityScope, kind: 'scope' }
+  }
+
+  const coding = rawCodingFromBody(input.rawBody)
+  const openagents =
+    input.rawBody !== null && typeof input.rawBody === 'object'
+      ? (input.rawBody as Record<string, unknown>).openagents
+      : undefined
+  const topLevelScope =
+    openagents !== null && typeof openagents === 'object'
+      ? (openagents as Record<string, unknown>).authorityScope
+      : undefined
+  const raw =
+    coding?.authorityScope ?? topLevelScope
+
+  if (raw === undefined || raw === null || raw === '') {
+    return {
+      authorityScope: ARTANIS_OWNER_SELF_AUTHORITY_SCOPE,
+      kind: 'scope',
+    }
+  }
+
+  if (!isArtanisAuthorityScope(raw)) {
+    return {
+      kind: 'rejected',
+      rejection: {
+        error: 'invalid_authority_scope',
+        evidenceRefs: ['evidence.khala_coding.authority_scope.invalid'],
+        kind: 'rejected',
+        reason:
+          'The coding delegation authorityScope must be owner_self, shared_fleet, or owner_operator.',
+        requestedPylonRef,
+        statusCode: 400,
+      },
+    }
+  }
+
+  return { authorityScope: raw, kind: 'scope' }
 }
 
 const rawWorkspaceFromBody = (
@@ -484,14 +542,19 @@ const assignmentRequestFromInput = (
   spawnRefs: ReadonlyArray<string>,
   profile: CodingAgentProfile,
   accountRefHash: string | null,
+  authorityScope: ArtanisAuthorityScope,
 ): PylonApiCreateAssignmentRequest => ({
   acceptanceCriteriaRefs: [
     'acceptance.public.khala_coding.owner_requested',
+    artanisAuthorityScopePublicRef(authorityScope),
     ...input.classification.evidenceRefs,
   ],
   assignmentRef: `assignment.public.khala_coding.${input.makeId()}`,
   campaignPaused: false,
-  campaignPolicyRefs: ['policy.public.khala_coding.own_capacity_only'],
+  campaignPolicyRefs: [
+    'policy.public.khala_coding.own_capacity_only',
+    artanisAuthorityScopePublicRef(authorityScope),
+  ],
   campaignRef: 'campaign.public.khala_coding.own_capacity',
   closeoutPathRefs: [
     'closeout.public.khala_coding.durable_stream',
@@ -520,6 +583,7 @@ const assignmentRequestFromInput = (
   taskRefs: [
     workflowRef(input.classification),
     khalaCodingRequestIdRef(input.requestId),
+    artanisAuthorityScopePublicRef(authorityScope),
     ...spawnRefs,
   ],
 })
@@ -924,6 +988,29 @@ const delegateCodingWorkflowUnsafe = async (
   }
   const targetAccountRefHash =
     targetAccount.kind === 'account' ? targetAccount.accountRefHash : null
+  const authorityScope = authorityScopeFromInput(
+    input,
+    target.kind === 'target' ? target.pylonRef : null,
+  )
+  if (authorityScope.kind === 'rejected') {
+    return authorityScope.rejection
+  }
+  if (
+    !artanisAuthorityScopeAllowsOwnerLinkedCapacity(authorityScope.authorityScope)
+  ) {
+    return {
+      error: 'authority_scope_capacity_unavailable',
+      evidenceRefs: [
+        artanisAuthorityScopeEvidenceRef(authorityScope.authorityScope),
+        'evidence.khala_coding.authority_scope.owner_linked_capacity_not_allowed',
+      ],
+      kind: 'rejected',
+      reason:
+        `The ${authorityScope.authorityScope} Artanis authority scope is not wired to caller-owned linked Pylon capacity.`,
+      requestedPylonRef: target.kind === 'target' ? target.pylonRef : null,
+      statusCode: 403,
+    }
+  }
   const targetAccountKey = codexAccountCapacityKeyFromAccountRefHash(
     targetAccountRefHash,
   )
@@ -1058,6 +1145,7 @@ const delegateCodingWorkflowUnsafe = async (
         spawnRefs.refs,
         profile,
         accountRefHash,
+        authorityScope.authorityScope,
       )
       const gate = controlledPylonAssignmentDispatchGate({
         activeAssignments,
@@ -1124,6 +1212,7 @@ const delegateCodingWorkflowUnsafe = async (
       evidenceRefs: [
         ...input.classification.evidenceRefs,
         'evidence.khala_coding.own_capacity_linked_pylon',
+        artanisAuthorityScopeEvidenceRef(authorityScope.authorityScope),
       ],
       kind: 'assigned',
       pylon: registration,


### PR DESCRIPTION
## Summary
- add a typed Artanis authorityScope model for owner_self, shared_fleet, and owner_operator
- thread authorityScope through Artanis tools, approval gates, dispatch plans, persisted projections, and Khala coding delegation evidence
- fail closed when non-owner_self scopes attempt owner-linked Pylon capacity, while preserving owner_operator forum authority as a separate standing scope
- update the openagents.com invariants and regression tests for same-scope approval behavior

Closes #7885

## Verification
- git diff --check
- bun run --cwd apps/openagents.com/workers/api test -- src/artanis-approval-gates.test.ts src/artanis-owner-authority.test.ts src/artanis-operator-dispatch-execution.test.ts src/inference/coding-workflow-delegation.test.ts src/artanis-operator.test.ts src/artanis-operator-tools.test.ts
- bun run --cwd apps/openagents.com/workers/api typecheck
- bun run --cwd apps/openagents.com check:deploy
- bun run --cwd apps/openagents.com/workers/api test -- src/artanis-operator-console-routes.test.ts src/artanis-scheduled-runner.test.ts src/artanis-loop.test.ts
- bun run --cwd apps/openagents.com/workers/api test -- src/artanis-persistence.test.ts src/artanis-fleet-overseer-tick.test.ts src/artanis-nexus-pylon-adapters.test.ts src/artanis-production-readiness-verifier.test.ts