### PR TITLE
T12.5: Add Artanis autonomy ladder

### DIFF
--- a/apps/openagents.com/INVARIANTS.md
+++ b/apps/openagents.com/INVARIANTS.md
@@ -1896,6 +1896,36 @@ normalizedPatchDigest | behaviorReceiptDigest)`. Exactly one accepted
   `workers/api/src/artanis-owner-authority.test.ts` and the owner-promotion
   cases in `workers/api/src/artanis-operator-dispatch-execution.test.ts`.
 
+## Artanis Autonomy Ladder
+
+- Artanis autonomy increases one gate at a time. The typed source of truth is
+  `workers/api/src/artanis-autonomy-ladder.ts`; owner standing approval must go
+  through that ladder before any risky-action kind is treated as standing
+  approved.
+- The only standing approvals today remain the current bounded rungs:
+  `pylon_job_dispatch` in `authorityScope=owner_self` for own-capacity,
+  no-spend Codex dispatch, and `forum_post` in
+  `authorityScope=owner_operator` for public-safe status updates. These rungs do
+  not depend on shared-fleet, wallet, settlement, provider mutation, deployment,
+  or release authority.
+- A `shared_fleet` standing gate is only a next-gate candidate after all five
+  Blueprint signature gates are terminal (`fleet-liveness=PROVEN_ALIVE`,
+  `diagnosis-grounding=GROUNDED`, `issue-close-safe=SAFE_TO_CLOSE`,
+  `command-source-verified=SAFE_TO_PROPOSE`, `merge-deploy=LIVE`) and the
+  clean unattended tick track record is retained. Even then it is only eligible
+  for an explicit owner promotion step; it is not implicitly standing-approved.
+- Treasury autonomy is always envelope-bounded. Wallet spend, settlement, and
+  L402 redemption cannot become standing-approved from the owner promotion
+  alone; they require the same signature and clean-tick evidence plus an active
+  owner cap envelope (`per_payout_cap_sat` and `per_day_cap_sat`) enforced by
+  `artanis_standing_spend_grants` / `runArtanisSpendDecision`. Over-cap or
+  unbounded spend must record/block (`blocked_over_cap` or the public ladder
+  blocker), never silently pay or widen authority.
+- Regression coverage lives in
+  `workers/api/src/artanis-autonomy-ladder.test.ts`,
+  `workers/api/src/artanis-owner-authority.test.ts`, and
+  `workers/api/src/artanis-public-report.test.ts`.
+
 ## Artanis Autonomous Khala Improvement Tick
 
 - The scheduled Artanis tick is the bounded owner loop for #6359. On every

--- a/apps/openagents.com/workers/api/src/artanis-autonomy-ladder.test.ts
+++ b/apps/openagents.com/workers/api/src/artanis-autonomy-ladder.test.ts
@@ -1,0 +1,241 @@
+import { describe, expect, test } from 'vitest'
+
+import {
+  ARTANIS_OWNER_OPERATOR_AUTHORITY_SCOPE,
+  ARTANIS_OWNER_SELF_AUTHORITY_SCOPE,
+  ARTANIS_SHARED_FLEET_AUTHORITY_SCOPE,
+} from './artanis-authority-scope'
+import {
+  ARTANIS_AUTONOMY_CLEAN_TICK_TRACK_RECORD_REF,
+  ARTANIS_AUTONOMY_TREASURY_ENVELOPE_REF,
+  ArtanisAutonomyLadderEvaluationInput,
+  ArtanisAutonomyTreasuryEnvelope,
+  defaultArtanisAutonomyCleanTickTrackRecord,
+  defaultArtanisAutonomyLadderInput,
+  defaultArtanisAutonomyTreasuryEnvelope,
+  evaluateArtanisAutonomyLadder,
+  notApplicableArtanisAutonomyTreasuryEnvelope,
+  ownerCapArtanisAutonomyTreasuryEnvelope,
+  retainedArtanisAutonomyCleanTickTrackRecord,
+  terminalArtanisAutonomySignatureGateEvidence,
+} from './artanis-autonomy-ladder'
+
+describe('Artanis autonomy ladder', () => {
+  test('keeps current pylon dispatch standing approval owner-self and no-spend', () => {
+    const projection = evaluateArtanisAutonomyLadder(
+      defaultArtanisAutonomyLadderInput({
+        authorityScope: ARTANIS_OWNER_SELF_AUTHORITY_SCOPE,
+        riskyActionKind: 'pylon_job_dispatch',
+      }),
+    )
+
+    expect(projection).toMatchObject({
+      authorityScope: 'owner_self',
+      nextGateEligible: false,
+      riskyActionKind: 'pylon_job_dispatch',
+      rung: 'owner_self_no_spend_dispatch',
+      standingApprovalAllowed: true,
+      treasuryEnvelopeBounded: false,
+    })
+    expect(projection.blockerRefs).toEqual([])
+    expect(projection.caveatRefs).toEqual(
+      expect.arrayContaining([
+        'authority.public.artanis.scope.owner_self',
+        'caveat.public.artanis.autonomy.current_standing_approval_only',
+        'caveat.public.artanis.autonomy.no_shared_fleet_or_money_movement',
+      ]),
+    )
+  })
+
+  test('keeps current forum post standing approval owner-operator only', () => {
+    const projection = evaluateArtanisAutonomyLadder(
+      defaultArtanisAutonomyLadderInput({
+        authorityScope: ARTANIS_OWNER_OPERATOR_AUTHORITY_SCOPE,
+        riskyActionKind: 'forum_post',
+      }),
+    )
+
+    expect(projection).toMatchObject({
+      authorityScope: 'owner_operator',
+      nextGateEligible: false,
+      riskyActionKind: 'forum_post',
+      rung: 'owner_operator_forum_post',
+      standingApprovalAllowed: true,
+    })
+    expect(projection.blockerRefs).toEqual([])
+  })
+
+  test('blocks shared-fleet standing approval until signatures and clean ticks exist', () => {
+    const projection = evaluateArtanisAutonomyLadder(
+      defaultArtanisAutonomyLadderInput({
+        authorityScope: ARTANIS_SHARED_FLEET_AUTHORITY_SCOPE,
+        riskyActionKind: 'pylon_job_dispatch',
+      }),
+    )
+
+    expect(projection).toMatchObject({
+      nextGateEligible: false,
+      rung: 'shared_fleet_admin_candidate',
+      signatureGatesTerminal: false,
+      standingApprovalAllowed: false,
+    })
+    expect(projection.blockerRefs).toEqual(
+      expect.arrayContaining([
+        'blocker.public.artanis.autonomy.standing_approval_not_granted',
+        'blocker.public.artanis.autonomy.signature.fleet-liveness.not_terminal',
+        'blocker.public.artanis.autonomy.signature.diagnosis-grounding.not_terminal',
+        'blocker.public.artanis.autonomy.signature.issue-close-safe.not_terminal',
+        'blocker.public.artanis.autonomy.signature.command-source-verified.not_terminal',
+        'blocker.public.artanis.autonomy.signature.merge-deploy.not_terminal',
+        'blocker.public.artanis.autonomy.clean_unattended_ticks_not_retained',
+      ]),
+    )
+    expect(projection.missingSignatureGateRefs).toEqual(
+      expect.arrayContaining([
+        'gate.public.artanis.autonomy.signature.fleet-liveness.PROVEN_ALIVE',
+        'gate.public.artanis.autonomy.signature.diagnosis-grounding.GROUNDED',
+        'gate.public.artanis.autonomy.signature.issue-close-safe.SAFE_TO_CLOSE',
+        'gate.public.artanis.autonomy.signature.command-source-verified.SAFE_TO_PROPOSE',
+        'gate.public.artanis.autonomy.signature.merge-deploy.LIVE',
+      ]),
+    )
+  })
+
+  test('makes shared-fleet the next eligible gate only after signatures and clean ticks', () => {
+    const projection = evaluateArtanisAutonomyLadder(
+      new ArtanisAutonomyLadderEvaluationInput({
+        actionRef: 'action.public.artanis.shared_fleet_dispatch',
+        authorityScope: ARTANIS_SHARED_FLEET_AUTHORITY_SCOPE,
+        cleanTickTrackRecord: retainedArtanisAutonomyCleanTickTrackRecord(),
+        riskyActionKind: 'pylon_job_dispatch',
+        signatureGates: terminalArtanisAutonomySignatureGateEvidence(),
+        treasuryEnvelope: notApplicableArtanisAutonomyTreasuryEnvelope(),
+      }),
+    )
+
+    expect(projection).toMatchObject({
+      cleanTickTrackRecordRetained: true,
+      nextGateEligible: true,
+      rung: 'shared_fleet_admin_candidate',
+      signatureGatesTerminal: true,
+      standingApprovalAllowed: false,
+    })
+    expect(projection.blockerRefs).toEqual([
+      'blocker.public.artanis.autonomy.standing_approval_not_granted',
+    ])
+    expect(projection.evidenceRefs).toEqual(
+      expect.arrayContaining([
+        'evidence.khala_coding.authority_scope.shared_fleet',
+        ARTANIS_AUTONOMY_CLEAN_TICK_TRACK_RECORD_REF,
+      ]),
+    )
+  })
+
+  test('keeps treasury spend blocked without an owner cap envelope', () => {
+    const projection = evaluateArtanisAutonomyLadder(
+      new ArtanisAutonomyLadderEvaluationInput({
+        actionRef: 'action.public.artanis.wallet_spend',
+        authorityScope: ARTANIS_OWNER_OPERATOR_AUTHORITY_SCOPE,
+        cleanTickTrackRecord: retainedArtanisAutonomyCleanTickTrackRecord(),
+        riskyActionKind: 'wallet_spend',
+        signatureGates: terminalArtanisAutonomySignatureGateEvidence(),
+        treasuryEnvelope: defaultArtanisAutonomyTreasuryEnvelope(),
+      }),
+    )
+
+    expect(projection).toMatchObject({
+      nextGateEligible: false,
+      rung: 'treasury_enveloped_spend_candidate',
+      standingApprovalAllowed: false,
+      treasuryEnvelopeBounded: false,
+    })
+    expect(projection.blockerRefs).toEqual(
+      expect.arrayContaining([
+        'blocker.public.artanis.autonomy.standing_approval_not_granted',
+        'blocker.public.artanis.autonomy.treasury_envelope_missing',
+      ]),
+    )
+  })
+
+  test('treats active owner caps as next-gate evidence without standing approving spend', () => {
+    const projection = evaluateArtanisAutonomyLadder(
+      new ArtanisAutonomyLadderEvaluationInput({
+        actionRef: 'action.public.artanis.wallet_spend',
+        authorityScope: ARTANIS_OWNER_OPERATOR_AUTHORITY_SCOPE,
+        cleanTickTrackRecord: retainedArtanisAutonomyCleanTickTrackRecord(),
+        riskyActionKind: 'wallet_spend',
+        signatureGates: terminalArtanisAutonomySignatureGateEvidence(),
+        treasuryEnvelope: ownerCapArtanisAutonomyTreasuryEnvelope({
+          perDayCapSat: 10_000,
+          perPayoutCapSat: 1_000,
+        }),
+      }),
+    )
+
+    expect(projection).toMatchObject({
+      nextGateEligible: true,
+      rung: 'treasury_enveloped_spend_candidate',
+      standingApprovalAllowed: false,
+      treasuryEnvelopeBounded: true,
+    })
+    expect(projection.blockerRefs).toEqual([
+      'blocker.public.artanis.autonomy.standing_approval_not_granted',
+    ])
+    expect(projection.evidenceRefs).toContain(
+      ARTANIS_AUTONOMY_TREASURY_ENVELOPE_REF,
+    )
+  })
+
+  test('forbids unbounded autonomy even if other evidence is clean', () => {
+    const projection = evaluateArtanisAutonomyLadder(
+      new ArtanisAutonomyLadderEvaluationInput({
+        actionRef: 'action.public.artanis.unbounded_autonomy',
+        authorityScope: ARTANIS_OWNER_OPERATOR_AUTHORITY_SCOPE,
+        cleanTickTrackRecord: retainedArtanisAutonomyCleanTickTrackRecord(),
+        riskyActionKind: 'unbounded_autonomy',
+        signatureGates: terminalArtanisAutonomySignatureGateEvidence(),
+        treasuryEnvelope: new ArtanisAutonomyTreasuryEnvelope({
+          blockerRefs: [],
+          evidenceRefs: [],
+          perDayCapSat: null,
+          perPayoutCapSat: null,
+          state: 'unbounded_requested',
+        }),
+      }),
+    )
+
+    expect(projection).toMatchObject({
+      nextGateEligible: false,
+      rung: 'unbounded_autonomy_forbidden',
+      standingApprovalAllowed: false,
+    })
+    expect(projection.blockerRefs).toEqual(
+      expect.arrayContaining([
+        'blocker.public.artanis.autonomy.standing_approval_not_granted',
+        'blocker.public.artanis.autonomy.unbounded_autonomy_forbidden',
+      ]),
+    )
+  })
+
+  test('requires retained clean ticks even when signatures are terminal', () => {
+    const projection = evaluateArtanisAutonomyLadder(
+      new ArtanisAutonomyLadderEvaluationInput({
+        actionRef: 'action.public.artanis.shared_fleet_dispatch',
+        authorityScope: ARTANIS_SHARED_FLEET_AUTHORITY_SCOPE,
+        cleanTickTrackRecord: defaultArtanisAutonomyCleanTickTrackRecord(),
+        riskyActionKind: 'pylon_job_dispatch',
+        signatureGates: terminalArtanisAutonomySignatureGateEvidence(),
+        treasuryEnvelope: notApplicableArtanisAutonomyTreasuryEnvelope(),
+      }),
+    )
+
+    expect(projection).toMatchObject({
+      cleanTickTrackRecordRetained: false,
+      nextGateEligible: false,
+      signatureGatesTerminal: true,
+    })
+    expect(projection.blockerRefs).toContain(
+      'blocker.public.artanis.autonomy.clean_unattended_ticks_not_retained',
+    )
+  })
+})

--- a/apps/openagents.com/workers/api/src/artanis-autonomy-ladder.ts
+++ b/apps/openagents.com/workers/api/src/artanis-autonomy-ladder.ts
@@ -1,0 +1,411 @@
+import type { BlueprintGateId } from '@openagentsinc/blueprint-contracts'
+import { Schema as S } from 'effect'
+
+import {
+  ARTANIS_OWNER_OPERATOR_AUTHORITY_SCOPE,
+  ARTANIS_OWNER_SELF_AUTHORITY_SCOPE,
+  ARTANIS_SHARED_FLEET_AUTHORITY_SCOPE,
+  ArtanisAuthorityScope,
+  artanisAuthorityScopeEvidenceRef,
+  artanisAuthorityScopePublicRef,
+} from './artanis-authority-scope'
+
+export const ArtanisAutonomyLadderRung = S.Literals([
+  'owner_self_no_spend_dispatch',
+  'owner_operator_forum_post',
+  'shared_fleet_admin_candidate',
+  'treasury_enveloped_spend_candidate',
+  'explicit_operator_gate_required',
+  'unbounded_autonomy_forbidden',
+])
+export type ArtanisAutonomyLadderRung = typeof ArtanisAutonomyLadderRung.Type
+
+export const ArtanisAutonomySignatureGateId = S.Literals([
+  'fleet-liveness',
+  'diagnosis-grounding',
+  'issue-close-safe',
+  'command-source-verified',
+  'merge-deploy',
+])
+export type ArtanisAutonomySignatureGateId =
+  typeof ArtanisAutonomySignatureGateId.Type
+
+export const ArtanisAutonomyCleanTickState = S.Literals([
+  'missing',
+  'regressed',
+  'retained',
+])
+export type ArtanisAutonomyCleanTickState =
+  typeof ArtanisAutonomyCleanTickState.Type
+
+export const ArtanisAutonomyTreasuryEnvelopeState = S.Literals([
+  'missing',
+  'not_applicable',
+  'owner_cap_active',
+  'unbounded_requested',
+])
+export type ArtanisAutonomyTreasuryEnvelopeState =
+  typeof ArtanisAutonomyTreasuryEnvelopeState.Type
+
+export class ArtanisAutonomySignatureGateEvidence extends S.Class<ArtanisAutonomySignatureGateEvidence>(
+  'ArtanisAutonomySignatureGateEvidence',
+)({
+  evidenceRefs: S.Array(S.String),
+  gateId: ArtanisAutonomySignatureGateId,
+  state: S.String,
+}) {}
+
+export class ArtanisAutonomyCleanTickTrackRecord extends S.Class<ArtanisAutonomyCleanTickTrackRecord>(
+  'ArtanisAutonomyCleanTickTrackRecord',
+)({
+  blockerRefs: S.Array(S.String),
+  evidenceRefs: S.Array(S.String),
+  state: ArtanisAutonomyCleanTickState,
+  tickCount: S.Number,
+}) {}
+
+export class ArtanisAutonomyTreasuryEnvelope extends S.Class<ArtanisAutonomyTreasuryEnvelope>(
+  'ArtanisAutonomyTreasuryEnvelope',
+)({
+  blockerRefs: S.Array(S.String),
+  evidenceRefs: S.Array(S.String),
+  perDayCapSat: S.NullOr(S.Number),
+  perPayoutCapSat: S.NullOr(S.Number),
+  state: ArtanisAutonomyTreasuryEnvelopeState,
+}) {}
+
+export class ArtanisAutonomyLadderEvaluationInput extends S.Class<ArtanisAutonomyLadderEvaluationInput>(
+  'ArtanisAutonomyLadderEvaluationInput',
+)({
+  actionRef: S.String,
+  authorityScope: ArtanisAuthorityScope,
+  cleanTickTrackRecord: ArtanisAutonomyCleanTickTrackRecord,
+  riskyActionKind: S.String,
+  signatureGates: S.Array(ArtanisAutonomySignatureGateEvidence),
+  treasuryEnvelope: ArtanisAutonomyTreasuryEnvelope,
+}) {}
+
+export class ArtanisAutonomyLadderProjection extends S.Class<ArtanisAutonomyLadderProjection>(
+  'ArtanisAutonomyLadderProjection',
+)({
+  actionRef: S.String,
+  authorityScope: ArtanisAuthorityScope,
+  blockerRefs: S.Array(S.String),
+  caveatRefs: S.Array(S.String),
+  cleanTickTrackRecordRetained: S.Boolean,
+  evidenceRefs: S.Array(S.String),
+  missingSignatureGateRefs: S.Array(S.String),
+  nextGateEligible: S.Boolean,
+  requiredSignatureGateRefs: S.Array(S.String),
+  riskyActionKind: S.String,
+  rung: ArtanisAutonomyLadderRung,
+  signatureGatesTerminal: S.Boolean,
+  standingApprovalAllowed: S.Boolean,
+  treasuryEnvelopeBounded: S.Boolean,
+}) {}
+
+type SignatureTerminal = Readonly<{
+  gateId: BlueprintGateId
+  publicRef: string
+  terminalState: string
+}>
+
+export const ARTANIS_AUTONOMY_SIGNATURE_TERMINALS: ReadonlyArray<SignatureTerminal> =
+  [
+    {
+      gateId: 'fleet-liveness',
+      publicRef: 'gate.public.artanis.autonomy.signature.fleet-liveness.PROVEN_ALIVE',
+      terminalState: 'PROVEN_ALIVE',
+    },
+    {
+      gateId: 'diagnosis-grounding',
+      publicRef: 'gate.public.artanis.autonomy.signature.diagnosis-grounding.GROUNDED',
+      terminalState: 'GROUNDED',
+    },
+    {
+      gateId: 'issue-close-safe',
+      publicRef: 'gate.public.artanis.autonomy.signature.issue-close-safe.SAFE_TO_CLOSE',
+      terminalState: 'SAFE_TO_CLOSE',
+    },
+    {
+      gateId: 'command-source-verified',
+      publicRef:
+        'gate.public.artanis.autonomy.signature.command-source-verified.SAFE_TO_PROPOSE',
+      terminalState: 'SAFE_TO_PROPOSE',
+    },
+    {
+      gateId: 'merge-deploy',
+      publicRef: 'gate.public.artanis.autonomy.signature.merge-deploy.LIVE',
+      terminalState: 'LIVE',
+    },
+  ]
+
+export const ARTANIS_AUTONOMY_CLEAN_TICK_TRACK_RECORD_REF =
+  'evidence.public.artanis.autonomy.clean_unattended_ticks.retained'
+export const ARTANIS_AUTONOMY_TREASURY_ENVELOPE_REF =
+  'policy.public.artanis.autonomy.treasury_owner_cap_envelope'
+export const ARTANIS_AUTONOMY_OWNER_PROMOTION_STEP_REF =
+  'policy.public.artanis.autonomy.owner_promotes_one_gate_at_a_time'
+
+const treasurySpendKinds = new Set([
+  'wallet_spend',
+  'settlement',
+  'l402_redemption',
+])
+
+const uniqueRefs = (refs: ReadonlyArray<string>): ReadonlyArray<string> => [
+  ...new Set(refs.filter(ref => ref.trim().length > 0)),
+]
+
+const signatureBlockerRef = (gateId: string): string =>
+  `blocker.public.artanis.autonomy.signature.${gateId}.not_terminal`
+
+const currentStandingRung = (
+  riskyActionKind: string,
+  authorityScope: ArtanisAuthorityScope,
+): ArtanisAutonomyLadderRung | null =>
+  riskyActionKind === 'pylon_job_dispatch' &&
+  authorityScope === ARTANIS_OWNER_SELF_AUTHORITY_SCOPE
+    ? 'owner_self_no_spend_dispatch'
+    : riskyActionKind === 'forum_post' &&
+        authorityScope === ARTANIS_OWNER_OPERATOR_AUTHORITY_SCOPE
+      ? 'owner_operator_forum_post'
+      : null
+
+export const artanisAutonomyLadderRungForRiskyAction = (
+  riskyActionKind: string,
+  authorityScope: ArtanisAuthorityScope,
+): ArtanisAutonomyLadderRung => {
+  const current = currentStandingRung(riskyActionKind, authorityScope)
+  if (current !== null) {
+    return current
+  }
+
+  if (
+    riskyActionKind === 'unbounded_autonomy' ||
+    riskyActionKind === 'ungated_production_admin'
+  ) {
+    return 'unbounded_autonomy_forbidden'
+  }
+
+  if (
+    authorityScope === ARTANIS_SHARED_FLEET_AUTHORITY_SCOPE ||
+    riskyActionKind === 'fleet_mutation'
+  ) {
+    return 'shared_fleet_admin_candidate'
+  }
+
+  if (treasurySpendKinds.has(riskyActionKind)) {
+    return 'treasury_enveloped_spend_candidate'
+  }
+
+  return 'explicit_operator_gate_required'
+}
+
+export const defaultArtanisAutonomyCleanTickTrackRecord =
+  (): ArtanisAutonomyCleanTickTrackRecord =>
+    new ArtanisAutonomyCleanTickTrackRecord({
+      blockerRefs: ['blocker.public.artanis.autonomy.clean_unattended_ticks_missing'],
+      evidenceRefs: [],
+      state: 'missing',
+      tickCount: 0,
+    })
+
+export const retainedArtanisAutonomyCleanTickTrackRecord = (input?: {
+  evidenceRefs?: ReadonlyArray<string> | undefined
+  tickCount?: number | undefined
+}): ArtanisAutonomyCleanTickTrackRecord =>
+  new ArtanisAutonomyCleanTickTrackRecord({
+    blockerRefs: [],
+    evidenceRefs: uniqueRefs([
+      ARTANIS_AUTONOMY_CLEAN_TICK_TRACK_RECORD_REF,
+      ...(input?.evidenceRefs ?? []),
+    ]),
+    state: 'retained',
+    tickCount: input?.tickCount ?? 3,
+  })
+
+export const defaultArtanisAutonomyTreasuryEnvelope =
+  (): ArtanisAutonomyTreasuryEnvelope =>
+    new ArtanisAutonomyTreasuryEnvelope({
+      blockerRefs: ['blocker.public.artanis.autonomy.treasury_envelope_missing'],
+      evidenceRefs: [],
+      perDayCapSat: null,
+      perPayoutCapSat: null,
+      state: 'missing',
+    })
+
+export const ownerCapArtanisAutonomyTreasuryEnvelope = (input: {
+  evidenceRefs?: ReadonlyArray<string> | undefined
+  perDayCapSat: number
+  perPayoutCapSat: number
+}): ArtanisAutonomyTreasuryEnvelope =>
+  new ArtanisAutonomyTreasuryEnvelope({
+    blockerRefs: [],
+    evidenceRefs: uniqueRefs([
+      ARTANIS_AUTONOMY_TREASURY_ENVELOPE_REF,
+      ...(input.evidenceRefs ?? []),
+    ]),
+    perDayCapSat: input.perDayCapSat,
+    perPayoutCapSat: input.perPayoutCapSat,
+    state: 'owner_cap_active',
+  })
+
+export const notApplicableArtanisAutonomyTreasuryEnvelope =
+  (): ArtanisAutonomyTreasuryEnvelope =>
+    new ArtanisAutonomyTreasuryEnvelope({
+      blockerRefs: [],
+      evidenceRefs: [],
+      perDayCapSat: null,
+      perPayoutCapSat: null,
+      state: 'not_applicable',
+    })
+
+export const terminalArtanisAutonomySignatureGateEvidence =
+  (): ReadonlyArray<ArtanisAutonomySignatureGateEvidence> =>
+    ARTANIS_AUTONOMY_SIGNATURE_TERMINALS.map(
+      terminal =>
+        new ArtanisAutonomySignatureGateEvidence({
+          evidenceRefs: [terminal.publicRef],
+          gateId: terminal.gateId,
+          state: terminal.terminalState,
+        }),
+    )
+
+export const defaultArtanisAutonomyLadderInput = (input: {
+  actionRef?: string | undefined
+  authorityScope: ArtanisAuthorityScope
+  riskyActionKind: string
+}): ArtanisAutonomyLadderEvaluationInput =>
+  new ArtanisAutonomyLadderEvaluationInput({
+    actionRef: input.actionRef ?? `action.public.artanis.${input.riskyActionKind}`,
+    authorityScope: input.authorityScope,
+    cleanTickTrackRecord: defaultArtanisAutonomyCleanTickTrackRecord(),
+    riskyActionKind: input.riskyActionKind,
+    signatureGates: [],
+    treasuryEnvelope: notApplicableArtanisAutonomyTreasuryEnvelope(),
+  })
+
+export const evaluateArtanisAutonomyLadder = (
+  input: ArtanisAutonomyLadderEvaluationInput,
+): ArtanisAutonomyLadderProjection => {
+  const rung = artanisAutonomyLadderRungForRiskyAction(
+    input.riskyActionKind,
+    input.authorityScope,
+  )
+  const signatureEvidenceByGate = new Map(
+    input.signatureGates.map(gate => [gate.gateId, gate]),
+  )
+  const missingSignatureTerminals = ARTANIS_AUTONOMY_SIGNATURE_TERMINALS.filter(
+    terminal =>
+      signatureEvidenceByGate.get(terminal.gateId)?.state !==
+      terminal.terminalState,
+  )
+  const cleanTickTrackRecordRetained =
+    input.cleanTickTrackRecord.state === 'retained' &&
+    input.cleanTickTrackRecord.tickCount > 0 &&
+    input.cleanTickTrackRecord.blockerRefs.length === 0
+  const treasuryEnvelopeBounded =
+    input.treasuryEnvelope.state === 'owner_cap_active' &&
+    (input.treasuryEnvelope.perDayCapSat ?? 0) > 0 &&
+    (input.treasuryEnvelope.perPayoutCapSat ?? 0) > 0 &&
+    input.treasuryEnvelope.blockerRefs.length === 0
+  const signaturesAndCleanTicksSatisfied =
+    missingSignatureTerminals.length === 0 && cleanTickTrackRecordRetained
+
+  const currentStandingAllowed =
+    rung === 'owner_self_no_spend_dispatch' ||
+    rung === 'owner_operator_forum_post'
+  const sharedFleetCandidate = rung === 'shared_fleet_admin_candidate'
+  const treasuryCandidate = rung === 'treasury_enveloped_spend_candidate'
+  const nextGateEligible =
+    (sharedFleetCandidate && signaturesAndCleanTicksSatisfied) ||
+    (treasuryCandidate &&
+      signaturesAndCleanTicksSatisfied &&
+      treasuryEnvelopeBounded)
+
+  const blockerRefs = [
+    ...(currentStandingAllowed
+      ? []
+      : ['blocker.public.artanis.autonomy.standing_approval_not_granted']),
+    ...(rung === 'unbounded_autonomy_forbidden'
+      ? ['blocker.public.artanis.autonomy.unbounded_autonomy_forbidden']
+      : []),
+    ...(sharedFleetCandidate || treasuryCandidate
+      ? missingSignatureTerminals.map(terminal =>
+          signatureBlockerRef(terminal.gateId),
+        )
+      : []),
+    ...(sharedFleetCandidate || treasuryCandidate
+      ? cleanTickTrackRecordRetained
+        ? []
+        : [
+            'blocker.public.artanis.autonomy.clean_unattended_ticks_not_retained',
+            ...input.cleanTickTrackRecord.blockerRefs,
+          ]
+      : []),
+    ...(treasuryCandidate
+      ? treasuryEnvelopeBounded
+        ? []
+        : [
+            ...(input.treasuryEnvelope.state === 'unbounded_requested'
+              ? [
+                  'blocker.public.artanis.autonomy.unbounded_treasury_forbidden',
+                ]
+              : ['blocker.public.artanis.autonomy.treasury_envelope_missing']),
+            ...input.treasuryEnvelope.blockerRefs,
+          ]
+      : []),
+  ]
+
+  return new ArtanisAutonomyLadderProjection({
+    actionRef: input.actionRef,
+    authorityScope: input.authorityScope,
+    blockerRefs: uniqueRefs(blockerRefs),
+    caveatRefs: uniqueRefs([
+      artanisAuthorityScopePublicRef(input.authorityScope),
+      ...(currentStandingAllowed
+        ? [
+            'caveat.public.artanis.autonomy.current_standing_approval_only',
+            'caveat.public.artanis.autonomy.no_shared_fleet_or_money_movement',
+          ]
+        : []),
+      ...(nextGateEligible
+        ? [ARTANIS_AUTONOMY_OWNER_PROMOTION_STEP_REF]
+        : []),
+      ...(treasuryCandidate
+        ? ['caveat.public.artanis.autonomy.treasury_owner_cap_required']
+        : []),
+    ]),
+    cleanTickTrackRecordRetained,
+    evidenceRefs: uniqueRefs([
+      artanisAuthorityScopeEvidenceRef(input.authorityScope),
+      ...input.signatureGates.flatMap(gate => gate.evidenceRefs),
+      ...input.cleanTickTrackRecord.evidenceRefs,
+      ...input.treasuryEnvelope.evidenceRefs,
+    ]),
+    missingSignatureGateRefs: uniqueRefs(
+      missingSignatureTerminals.map(terminal => terminal.publicRef),
+    ),
+    nextGateEligible,
+    requiredSignatureGateRefs: uniqueRefs(
+      ARTANIS_AUTONOMY_SIGNATURE_TERMINALS.map(terminal => terminal.publicRef),
+    ),
+    riskyActionKind: input.riskyActionKind,
+    rung,
+    signatureGatesTerminal: missingSignatureTerminals.length === 0,
+    standingApprovalAllowed: currentStandingAllowed,
+    treasuryEnvelopeBounded,
+  })
+}
+
+export const artanisAutonomyLadderAllowsStandingApproval = (input: {
+  authorityScope: ArtanisAuthorityScope
+  riskyActionKind: string
+}): boolean =>
+  evaluateArtanisAutonomyLadder(
+    defaultArtanisAutonomyLadderInput({
+      authorityScope: input.authorityScope,
+      riskyActionKind: input.riskyActionKind,
+    }),
+  ).standingApprovalAllowed

--- a/apps/openagents.com/workers/api/src/artanis-owner-authority.ts
+++ b/apps/openagents.com/workers/api/src/artanis-owner-authority.ts
@@ -43,6 +43,7 @@
 // with the note `ARTANIS_OWNER_PROMOTION_NOTE`. It is documented in
 // `apps/openagents.com/INVARIANTS.md` ("Artanis Owner Promotion").
 
+import { artanisAutonomyLadderAllowsStandingApproval } from './artanis-autonomy-ladder'
 import {
   ARTANIS_OWNER_OPERATOR_AUTHORITY_SCOPE,
   ARTANIS_OWNER_SELF_AUTHORITY_SCOPE,
@@ -128,6 +129,10 @@ export const ownerAgentHasStandingApprovalForRiskyAction = (
   return (
     approvedScope !== null &&
     approvedScope === authorityScope &&
+    artanisAutonomyLadderAllowsStandingApproval({
+      authorityScope,
+      riskyActionKind,
+    }) &&
     OWNER_AGENT_STANDING_APPROVAL_KINDS.includes(riskyActionKind) &&
     isOpenAgentsOwnerAgentOpenAuthUserId(openAuthUserId)
   )

--- a/apps/openagents.com/workers/api/src/artanis-public-report.test.ts
+++ b/apps/openagents.com/workers/api/src/artanis-public-report.test.ts
@@ -97,6 +97,8 @@ describe('Artanis public report', () => {
       reportRef: 'report.public.artanis.status_aggregator',
       runtimeState: 'running',
       authoritySummary: {
+        autonomyLadderCandidateStandingApprovalAllowed: false,
+        autonomyLadderNextGateEligible: false,
         dispatchAuthorityAllowed: false,
         dispatcherGateGreen: false,
         forumAutoPublishAllowed: false,
@@ -327,6 +329,13 @@ describe('Artanis public report', () => {
         'blocker.public.artanis.provider_mutation_not_granted',
         'blocker.public.artanis.settlement_authority_not_granted',
         'blocker.public.artanis.spend_authority_not_granted',
+        'blocker.public.artanis.autonomy.clean_unattended_ticks_not_retained',
+        'blocker.public.artanis.autonomy.signature.command-source-verified.not_terminal',
+        'blocker.public.artanis.autonomy.signature.diagnosis-grounding.not_terminal',
+        'blocker.public.artanis.autonomy.signature.fleet-liveness.not_terminal',
+        'blocker.public.artanis.autonomy.signature.issue-close-safe.not_terminal',
+        'blocker.public.artanis.autonomy.signature.merge-deploy.not_terminal',
+        'blocker.public.artanis.autonomy.treasury_envelope_missing',
       ]),
     )
     expect(report.publicBlockerRefs).not.toContain(
@@ -361,6 +370,21 @@ describe('Artanis public report', () => {
         'blocker.public.artanis.provider_mutation_not_granted',
         'blocker.public.artanis.settlement_authority_not_granted',
         'blocker.public.artanis.spend_authority_not_granted',
+        'blocker.public.artanis.autonomy.standing_approval_not_granted',
+        'blocker.public.artanis.autonomy.treasury_envelope_missing',
+      ]),
+    )
+    expect(report.authoritySummary.autonomyLadderBlockerRefs).toEqual(
+      expect.arrayContaining([
+        'blocker.public.artanis.autonomy.clean_unattended_ticks_not_retained',
+        'blocker.public.artanis.autonomy.standing_approval_not_granted',
+        'blocker.public.artanis.autonomy.treasury_envelope_missing',
+      ]),
+    )
+    expect(report.authoritySummary.autonomyLadderEvidenceRefs).toEqual(
+      expect.arrayContaining([
+        'evidence.khala_coding.authority_scope.owner_operator',
+        'evidence.khala_coding.authority_scope.shared_fleet',
       ]),
     )
     expect(report.authoritySummary.authorityBlockerRefs).not.toContain(

--- a/apps/openagents.com/workers/api/src/artanis-public-report.ts
+++ b/apps/openagents.com/workers/api/src/artanis-public-report.ts
@@ -18,6 +18,14 @@ import {
   projectArtanisForumRewardVisibility,
 } from './artanis-forum-reward-visibility'
 import {
+  defaultArtanisAutonomyLadderInput,
+  evaluateArtanisAutonomyLadder,
+} from './artanis-autonomy-ladder'
+import {
+  ARTANIS_OWNER_OPERATOR_AUTHORITY_SCOPE,
+  ARTANIS_SHARED_FLEET_AUTHORITY_SCOPE,
+} from './artanis-authority-scope'
+import {
   ArtanisGepaProductionSmokeProjection,
   exampleArtanisGepaProductionSmokeRecord,
   projectArtanisGepaProductionSmoke,
@@ -245,6 +253,10 @@ export class ArtanisPublicReportHealthSummary extends S.Class<ArtanisPublicRepor
 export class ArtanisPublicReportAuthoritySummary extends S.Class<ArtanisPublicReportAuthoritySummary>(
   'ArtanisPublicReportAuthoritySummary',
 )({
+  autonomyLadderBlockerRefs: S.Array(S.String),
+  autonomyLadderCandidateStandingApprovalAllowed: S.Boolean,
+  autonomyLadderEvidenceRefs: S.Array(S.String),
+  autonomyLadderNextGateEligible: S.Boolean,
   authorityBlockerRefs: S.Array(S.String),
   dispatchAuthorityAllowed: S.Boolean,
   dispatcherGateGreen: S.Boolean,
@@ -1242,6 +1254,28 @@ export const artanisPublicReportSnapshot = (input: {
   const decisionLog = decisionLogFromTickMonitor(input.tickMonitor, nowIso)
   const productionLaunchGate =
     exampleArtanisProductionLaunchGateProjection(nowIso)
+  const autonomyLadderProjections = [
+    evaluateArtanisAutonomyLadder(
+      defaultArtanisAutonomyLadderInput({
+        actionRef: 'action.public.artanis.shared_fleet_dispatch',
+        authorityScope: ARTANIS_SHARED_FLEET_AUTHORITY_SCOPE,
+        riskyActionKind: 'pylon_job_dispatch',
+      }),
+    ),
+    evaluateArtanisAutonomyLadder(
+      defaultArtanisAutonomyLadderInput({
+        actionRef: 'action.public.artanis.wallet_spend',
+        authorityScope: ARTANIS_OWNER_OPERATOR_AUTHORITY_SCOPE,
+        riskyActionKind: 'wallet_spend',
+      }),
+    ),
+  ]
+  const autonomyLadderBlockerRefs = uniqueRefs(
+    autonomyLadderProjections.flatMap(projection => projection.blockerRefs),
+  )
+  const autonomyLadderEvidenceRefs = uniqueRefs(
+    autonomyLadderProjections.flatMap(projection => projection.evidenceRefs),
+  )
   const health = projectArtanisHealthSnapshot(
     currentArtanisHealthSnapshot({
       modelLab: {
@@ -1370,6 +1404,14 @@ export const artanisPublicReportSnapshot = (input: {
   const greenLaunchCopyAllowed =
     statusProjectionAllowed && healthAllowsGreenLaunchCopy
   const authoritySummary = new ArtanisPublicReportAuthoritySummary({
+    autonomyLadderBlockerRefs,
+    autonomyLadderCandidateStandingApprovalAllowed: autonomyLadderProjections.some(
+      projection => projection.standingApprovalAllowed,
+    ),
+    autonomyLadderEvidenceRefs,
+    autonomyLadderNextGateEligible: autonomyLadderProjections.some(
+      projection => projection.nextGateEligible,
+    ),
     authorityBlockerRefs: uniqueRefs([
       ...(greenLaunchCopyAllowed
         ? []
@@ -1398,6 +1440,7 @@ export const artanisPublicReportSnapshot = (input: {
       ...(productionLaunchGate.forumAutoPublishAllowed
         ? []
         : ['blocker.public.artanis.forum_auto_publish_not_granted']),
+      ...autonomyLadderBlockerRefs,
     ]),
     dispatchAuthorityAllowed: productionLaunchGate.dispatchAuthorityAllowed,
     dispatcherGateGreen: productionLaunchGate.dispatchAuthorityAllowed,


### PR DESCRIPTION
## Summary
- add a typed Artanis autonomy ladder projection for current standing rungs, shared-fleet next-gate eligibility, and treasury envelope requirements
- guard owner-agent standing approvals through the ladder so future broadening goes through one policy surface
- expose autonomy-ladder blocker/evidence refs in the Artanis public authority summary and document the invariant

## Verification
- git diff --check
- bun run --cwd apps/openagents.com/workers/api test -- src/artanis-autonomy-ladder.test.ts src/artanis-owner-authority.test.ts src/artanis-approval-gates.test.ts src/artanis-operator-dispatch-execution.test.ts src/inference/coding-workflow-delegation.test.ts src/artanis-public-report.test.ts src/artanis-production-launch-gate.test.ts
- bun run --cwd apps/openagents.com/workers/api typecheck
- bun run --cwd apps/openagents.com check:deploy

Closes #7889