### PR TITLE
T12.3 wire Artanis onto status spine

### DIFF
--- a/apps/openagents.com/INVARIANTS.md
+++ b/apps/openagents.com/INVARIANTS.md
@@ -1953,10 +1953,21 @@ normalizedPatchDigest | behaviorReceiptDigest)`. Exactly one accepted
   path before any executor treats them as authorized. Owner-Artanis's standing
   approval remains scoped only to `pylon_job_dispatch` over the owner's own
   linked capacity and no-spend coding delegation.
+- Artanis fleet administration reads and writes through the shared runner-status
+  spine, not a private status fork. `get_fleet_status` may read the public-safe
+  operator fleet snapshot backed by `pylon_agent_runner_status_events`; the
+  fleet-overseer tick may append a neutral Artanis runner-status event with
+  public refs/counts only. `dispatch_codex_task` may carry FleetRun start,
+  status, and control intent refs through the existing coding-delegation
+  assignment metadata, but that is orchestration intent only until a separately
+  approved FleetRun executor exists. The live dispatch boundary remains
+  `owner_self`, own-capacity, `unpaid_smoke`, and no payout.
 - Regression coverage lives in
   `workers/api/src/artanis-scheduled-runner.test.ts` for persisted tick source
   refs, Khala burndown work-routing proposal refs, and owner-promotion dispatch
-  caveats, plus the dispatch execution tests named above.
+  caveats, `workers/api/src/artanis-fleet-overseer-tick.test.ts` for the
+  Artanis runner-status spine event, and the dispatch execution tests named
+  above.
 
 ## Spark Address Payout Target Registration
 

--- a/apps/openagents.com/workers/api/src/artanis-fleet-overseer-tick.test.ts
+++ b/apps/openagents.com/workers/api/src/artanis-fleet-overseer-tick.test.ts
@@ -18,6 +18,13 @@ const context: ArtanisFleetOverseerContext = {
   heartbeatRunRefs: ['heartbeat.hydralisk.glm_52_reap_504b.20260627t1159'],
   readyReplicaCount: 2,
   reclaimedReplicaRefs: ['replica.hydralisk.glm_52_reap_504b.replica-b'],
+  statusSpineActiveAssignmentCount: 1,
+  statusSpineLiveRunnerCount: 2,
+  statusSpineRetainedRunnerCount: 1,
+  statusSpineSourceRefs: [
+    'status.public.operator_fleet_status.spine',
+    'event.public.operator.runner_status.codex_1',
+  ],
   totalReplicaCount: 3,
   warmOrReadyMaxInflight: 2,
 }
@@ -75,6 +82,22 @@ describe('Artanis fleet overseer tick', () => {
       reason: 'schema_invalid_mind_output',
     })
     expect(store.rows('artanis_health_snapshots')).toHaveLength(1)
+    expect(store.rows('pylon_agent_runner_status_events')).toHaveLength(1)
+    const statusEvent = JSON.parse(
+      store.rows('pylon_agent_runner_status_events')[0]!.event_json!,
+    )
+    expect(statusEvent).toMatchObject({
+      runnerRef: 'runner.public.artanis.fleet_overseer',
+      schemaVersion: 'openagents.pylon.agent_runner_status_event.v1',
+      state: 'blocked',
+    })
+    expect(statusEvent.refs).toEqual(
+      expect.arrayContaining([
+        'status.public.artanis.fleet_overseer.on_status_spine',
+        'status.public.operator_fleet_status.spine',
+        'load.coding.codex.busy=1',
+      ]),
+    )
   })
 
   test('risky replica quarantine proposal creates pending approval only', async () => {
@@ -117,5 +140,19 @@ describe('Artanis fleet overseer tick', () => {
       executionAllowed: false,
       kind: 'request_replica_quarantine',
     })
+    expect(store.rows('pylon_agent_runner_status_events')).toHaveLength(1)
+    const statusEvent = JSON.parse(
+      store.rows('pylon_agent_runner_status_events')[0]!.event_json!,
+    )
+    expect(statusEvent).toMatchObject({
+      runnerRef: 'runner.public.artanis.fleet_overseer',
+      state: 'waiting',
+    })
+    expect(statusEvent.refs).toEqual(
+      expect.arrayContaining([
+        'status.public.artanis.fleet_overseer.decision_state.approval_requested',
+        'capacity.coding.codex.ready=2',
+      ]),
+    )
   })
 })

--- a/apps/openagents.com/workers/api/src/artanis-fleet-overseer-tick.ts
+++ b/apps/openagents.com/workers/api/src/artanis-fleet-overseer-tick.ts
@@ -17,6 +17,7 @@ import {
 } from './artanis-health'
 import { artanisMindComplete } from './artanis-mind'
 import { parseJsonWithSchema } from './json-boundary'
+import { PYLON_AGENT_RUNNER_STATUS_EVENT_SCHEMA_VERSION } from './operator-pro-status-routes'
 import { epochMillisToIsoTimestamp, randomUuid } from './runtime-primitives'
 
 type FleetHeartbeatRow = Readonly<{
@@ -26,6 +27,16 @@ type FleetHeartbeatRow = Readonly<{
   warm_state: string | null
   watchdog_status: string | null
 }>
+
+type FleetStatusSpineRow = Readonly<{
+  assignment_ref: string | null
+  event_ref: string
+  retention_state: 'live' | 'retained'
+  runner_ref: string
+  state: string
+}>
+
+type FleetOverseerRunnerStatusState = 'waiting' | 'blocked'
 
 const FleetOverseerAction = S.Union([
   S.Struct({
@@ -72,6 +83,10 @@ export type ArtanisFleetOverseerContext = Readonly<{
   heartbeatRunRefs: ReadonlyArray<string>
   readyReplicaCount: number
   reclaimedReplicaRefs: ReadonlyArray<string>
+  statusSpineActiveAssignmentCount: number
+  statusSpineLiveRunnerCount: number
+  statusSpineRetainedRunnerCount: number
+  statusSpineSourceRefs: ReadonlyArray<string>
   totalReplicaCount: number
   warmOrReadyMaxInflight: number
 }>
@@ -277,6 +292,207 @@ const actionSummary = (
   ],
 })
 
+const statusSpineActiveRunnerState = (state: string): boolean =>
+  state === 'queued' ||
+  state === 'working' ||
+  state === 'waiting' ||
+  state === 'blocked'
+
+const publicStatusSpineRefPattern =
+  /^(agent|assignment|assignment-event|assignment-status|blocker|capability|capacity|command|dispatch|dispatch-context|dispatch-context-status|event|issue|load|merge-action|merge-wave|pylon|runner|runner-kind|task|task-status|worktree|ref|status)\.[A-Za-z0-9_.:=\-]+$/
+
+const safePublicStatusSpineRefs = (
+  refs: ReadonlyArray<string>,
+): ReadonlyArray<string> =>
+  refs
+    .filter(ref => publicStatusSpineRefPattern.test(ref))
+    .slice(0, 32)
+
+const runnerStatusStateForDecision = (
+  state: ArtanisFleetOverseerDecisionState,
+): FleetOverseerRunnerStatusState =>
+  state === 'blocked' || state === 'skipped' ? 'blocked' : 'waiting'
+
+const readFleetOverseerStatusSpineContext = async (
+  db: D1Database,
+): Promise<
+  Pick<
+    ArtanisFleetOverseerContext,
+    | 'statusSpineActiveAssignmentCount'
+    | 'statusSpineLiveRunnerCount'
+    | 'statusSpineRetainedRunnerCount'
+    | 'statusSpineSourceRefs'
+  >
+> => {
+  try {
+    const response = await db
+      .prepare(
+        `SELECT event_ref, runner_ref, assignment_ref, state, retention_state
+           FROM pylon_agent_runner_status_events
+          WHERE archived_at IS NULL
+          ORDER BY updated_at DESC
+          LIMIT 200`,
+      )
+      .all<FleetStatusSpineRow>()
+    const rows = response.results ?? []
+    const liveRows = rows.filter(row => row.retention_state === 'live')
+    const activeAssignmentRefs = new Set(
+      liveRows
+        .filter(row => statusSpineActiveRunnerState(row.state))
+        .map(row => row.assignment_ref ?? row.runner_ref),
+    )
+    return {
+      statusSpineActiveAssignmentCount: activeAssignmentRefs.size,
+      statusSpineLiveRunnerCount: liveRows.length,
+      statusSpineRetainedRunnerCount: rows.filter(
+        row => row.retention_state === 'retained',
+      ).length,
+      statusSpineSourceRefs: safePublicStatusSpineRefs([
+        'status.public.operator_fleet_status.spine',
+        `status.public.operator_fleet_status.live_runners=${liveRows.length}`,
+        `status.public.operator_fleet_status.retained_runners=${
+          rows.filter(row => row.retention_state === 'retained').length
+        }`,
+        `status.public.operator_fleet_status.active_assignments=${
+          activeAssignmentRefs.size
+        }`,
+        ...rows.map(row => row.event_ref),
+      ]),
+    }
+  } catch {
+    return {
+      statusSpineActiveAssignmentCount: 0,
+      statusSpineLiveRunnerCount: 0,
+      statusSpineRetainedRunnerCount: 0,
+      statusSpineSourceRefs: [
+        'status.public.operator_fleet_status.spine_unavailable',
+      ],
+    }
+  }
+}
+
+const recordFleetOverseerRunnerStatus = async (
+  db: D1Database,
+  input: Readonly<{
+    context: ArtanisFleetOverseerContext
+    decisionId: string
+    healthSnapshotRef: string | null
+    nowIso: string
+    reason: string | null
+    state: ArtanisFleetOverseerDecisionState
+  }>,
+): Promise<void> => {
+  const runnerState = runnerStatusStateForDecision(input.state)
+  const eventRef = `event.public.artanis.fleet_overseer.${isoSlug(input.nowIso)}`
+  const runnerRef = 'runner.public.artanis.fleet_overseer'
+  const refs = safePublicStatusSpineRefs([
+    'status.public.artanis.fleet_overseer.on_status_spine',
+    `status.public.artanis.fleet_overseer.decision_state.${input.state}`,
+    `capacity.coding.codex.ready=${input.context.readyReplicaCount}`,
+    `capacity.coding.codex.available=${input.context.warmOrReadyMaxInflight}`,
+    `load.coding.codex.busy=${input.context.statusSpineActiveAssignmentCount}`,
+    'load.coding.codex.queued=0',
+    `task.public.artanis.fleet_overseer.${input.decisionId}`,
+    ...(input.healthSnapshotRef === null ? [] : [input.healthSnapshotRef]),
+    ...input.context.statusSpineSourceRefs,
+  ])
+  const blockerRefs =
+    runnerState === 'blocked'
+      ? safePublicStatusSpineRefs([
+          input.state === 'skipped'
+            ? 'blocker.public.artanis.fleet_overseer.skipped'
+            : 'blocker.public.artanis.fleet_overseer.blocked',
+        ])
+      : []
+  const event = {
+    schemaVersion: PYLON_AGENT_RUNNER_STATUS_EVENT_SCHEMA_VERSION,
+    eventRef,
+    runnerRef,
+    runnerKind: 'artanis_fleet_overseer',
+    state: runnerState,
+    stateStartedAt: input.nowIso,
+    updatedAt: input.nowIso,
+    capabilityRefs: [
+      'capability.public.artanis.fleet_status_spine',
+      'capability.public.artanis.fleet_overseer.read_only',
+    ],
+    refs,
+    blockerRefs,
+    supportedControlVerbs: ['status.list', 'task.list'],
+    stateHistory: [
+      {
+        state: runnerState,
+        stateStartedAt: input.nowIso,
+      },
+    ],
+    taskId: `task.public.artanis.fleet_overseer.${input.decisionId}`,
+    worktreeRef: 'worktree.public.artanis.none',
+    ...(input.reason === null
+      ? {}
+      : {
+          assigneeHandle: `artanis_fleet_overseer:${publicDispatchReason(input.reason)}`,
+        }),
+  }
+
+  await db
+    .prepare(
+      `UPDATE pylon_agent_runner_status_events
+          SET retention_state = 'retained',
+              retained_at = COALESCE(retained_at, ?)
+        WHERE owner_agent_user_id = ?
+          AND runner_ref = ?
+          AND event_ref <> ?
+          AND retention_state = 'live'
+          AND archived_at IS NULL`,
+    )
+    .bind(input.nowIso, 'agent_artanis', runnerRef, eventRef)
+    .run()
+
+  await db
+    .prepare(
+      `INSERT INTO pylon_agent_runner_status_events (
+         event_ref, owner_agent_user_id, runner_ref, runner_kind, pylon_ref,
+         assignment_ref, state, state_started_at, updated_at, retention_state,
+         event_json, created_at, retained_at, archived_at
+       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL)
+       ON CONFLICT(event_ref) DO UPDATE SET
+         runner_kind = excluded.runner_kind,
+         pylon_ref = excluded.pylon_ref,
+         assignment_ref = excluded.assignment_ref,
+         state = excluded.state,
+         state_started_at = excluded.state_started_at,
+         updated_at = excluded.updated_at,
+         retention_state = excluded.retention_state,
+         event_json = excluded.event_json,
+         retained_at = excluded.retained_at
+       WHERE owner_agent_user_id = ?`,
+    )
+    .bind(
+      eventRef,
+      'agent_artanis',
+      runnerRef,
+      event.runnerKind,
+      null,
+      null,
+      runnerState,
+      input.nowIso,
+      input.nowIso,
+      'live',
+      JSON.stringify(event),
+      input.nowIso,
+      null,
+      'agent_artanis',
+    )
+    .run()
+}
+
+const publicDispatchReason = (reason: string): string =>
+  reason
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '_')
+    .replace(/^_+|_+$/g, '')
+    .slice(0, 48) || 'reason'
+
 const insertDecision = async (
   db: D1Database,
   input: Readonly<{
@@ -367,7 +583,10 @@ const assembleContext = async (
   db: D1Database,
   nowIso: string,
 ): Promise<ArtanisFleetOverseerContext> => {
-  const records = await readLatestFleetHeartbeatRows(db)
+  const [records, statusSpine] = await Promise.all([
+    readLatestFleetHeartbeatRows(db),
+    readFleetOverseerStatusSpineContext(db),
+  ])
   const ready = records.filter(
     record =>
       record.watchdog_status === 'healthy' &&
@@ -388,6 +607,7 @@ const assembleContext = async (
     reclaimedReplicaRefs: reclaimed.map(
       record => `replica.hydralisk.glm_52_reap_504b.${record.replica_id}`,
     ),
+    ...statusSpine,
     totalReplicaCount: records.length,
     warmOrReadyMaxInflight: ready.length,
   }
@@ -425,6 +645,7 @@ const fleetSignal = (
     sourceRefs: [
       'tick.public.artanis.fleet_overseer',
       ...input.context.heartbeatRunRefs,
+      ...input.context.statusSpineSourceRefs,
     ],
     state: 'blocked',
     subjectUpdatedAtIso: input.nowIso,
@@ -459,6 +680,7 @@ const healthSnapshot = (
     sourceRefs: [
       'tick.public.artanis.fleet_overseer',
       ...context.heartbeatRunRefs,
+      ...context.statusSpineSourceRefs,
     ],
     updatedAtIso: nowIso,
   })
@@ -554,6 +776,14 @@ export const runArtanisFleetOverseerTick = async (
       nowIso: deps.nowIso,
       state: 'skipped',
     })
+    await recordFleetOverseerRunnerStatus(db, {
+      context,
+      decisionId,
+      healthSnapshotRef: null,
+      nowIso: deps.nowIso,
+      reason,
+      state: 'skipped',
+    }).catch(() => undefined)
     return {
       approvalGateRef: null,
       decisionId,
@@ -618,6 +848,14 @@ export const runArtanisFleetOverseerTick = async (
       nowIso: deps.nowIso,
       state: 'blocked',
     })
+    await recordFleetOverseerRunnerStatus(db, {
+      context,
+      decisionId,
+      healthSnapshotRef: snapshot.snapshotRef,
+      nowIso: deps.nowIso,
+      reason: 'schema_invalid_mind_output',
+      state: 'blocked',
+    }).catch(() => undefined)
     return {
       approvalGateRef: null,
       decisionId,
@@ -649,6 +887,14 @@ export const runArtanisFleetOverseerTick = async (
     nowIso: deps.nowIso,
     state,
   })
+  await recordFleetOverseerRunnerStatus(db, {
+    context,
+    decisionId,
+    healthSnapshotRef: snapshot.snapshotRef,
+    nowIso: deps.nowIso,
+    reason: action.rationale.slice(0, 200),
+    state,
+  }).catch(() => undefined)
 
   return {
     approvalGateRef: gate?.gateRef ?? null,

--- a/apps/openagents.com/workers/api/src/artanis-operator-dispatch-execution.test.ts
+++ b/apps/openagents.com/workers/api/src/artanis-operator-dispatch-execution.test.ts
@@ -105,6 +105,23 @@ const plan: ArtanisDispatchPlanInput = {
   authorityScope: 'owner_self',
   branch: 'main',
   filePaths: [],
+  fleetRunPlan: {
+    controlRefs: [
+      'command.public.khala_fleet.fleet_run_start',
+      'command.public.khala_fleet.fleet_run_status',
+      'command.public.khala_fleet.fleet_run_control',
+    ],
+    evidenceRefs: [
+      'dispatch-context.public.artanis.fleet_run.issue_6320',
+      'capacity.public.artanis.own_capacity_only',
+      'status.public.artanis.fleet_run.pending_executor',
+    ],
+    runRef: 'spawn.public.khala_coding.artanis_fleet_run.issue_6320',
+    targetConcurrency: 1,
+    workerKind: 'codex',
+    workerRef: 'worker.public.khala_coding.codex',
+    workSourceRef: 'issue.public.github.openagents.6320',
+  },
   issue: 6320,
   objective: 'Burn down public issue work per the roadmap.',
   prompt: 'Implement public issue #6320. Burn down public issue work.',
@@ -172,6 +189,18 @@ describe('makeArtanisDispatchExecution (#6366 live seam)', () => {
     expect(created[0]?.jobKind).toBe('codex_agent_task')
     expect(created[0]?.ownerAgentUserId).toBe('agent_owner')
     expect(created[0]?.pylonRef).toBe('pylon.owner.codex')
+    expect(created[0]?.taskRefs).toEqual(
+      expect.arrayContaining([
+        'spawn.public.khala_coding.artanis_fleet_run.issue_6320',
+        'worker.public.khala_coding.codex',
+      ]),
+    )
+    expect(created[0]?.acceptanceCriteriaRefs).toEqual(
+      expect.arrayContaining([
+        'dispatch-context.public.artanis.fleet_run.issue_6320',
+        'status.public.artanis.fleet_run.pending_executor',
+      ]),
+    )
     expect(workspaceVerificationCommand(created[0])).toMatchObject({
       commandRef: 'command.public.artanis_dispatch.verify',
     })

--- a/apps/openagents.com/workers/api/src/artanis-operator-dispatch-execution.ts
+++ b/apps/openagents.com/workers/api/src/artanis-operator-dispatch-execution.ts
@@ -101,7 +101,17 @@ const buildDelegationBody = (
 ): Record<string, unknown> => {
   const coding: Record<string, unknown> = {
     authorityScope: plan.authorityScope,
+    fleetRunIntent: {
+      controlRefs: plan.fleetRunPlan.controlRefs,
+      evidenceRefs: plan.fleetRunPlan.evidenceRefs,
+      runRef: plan.fleetRunPlan.runRef,
+      targetConcurrency: plan.fleetRunPlan.targetConcurrency,
+      workerKind: plan.fleetRunPlan.workerKind,
+      workSourceRef: plan.fleetRunPlan.workSourceRef,
+    },
     objectiveSummary: plan.objective,
+    spawnRunRef: plan.fleetRunPlan.runRef,
+    spawnWorkerRef: plan.fleetRunPlan.workerRef,
   }
   coding.workspace = {
     kind: 'git_checkout',
@@ -189,6 +199,7 @@ const createAssignmentPromise = async (
         evidenceRefs: [
           ARTANIS_DISPATCH_EVIDENCE_REF,
           artanisAuthorityScopeEvidenceRef(verifiedPlan.authorityScope),
+          ...verifiedPlan.fleetRunPlan.evidenceRefs,
         ],
         workflowClass: 'codex_agent_task',
       },

--- a/apps/openagents.com/workers/api/src/artanis-operator-tools.test.ts
+++ b/apps/openagents.com/workers/api/src/artanis-operator-tools.test.ts
@@ -484,6 +484,9 @@ describe('#6366 dispatch_codex_task (gated; plan-only without a seam)', () => {
     expect(result.plan).toContain('--workflow codex_agent_task')
     expect(result.plan).toContain('--repo OpenAgentsInc/openagents')
     expect(result.plan).toContain('run-no-spend')
+    expect(result.plan).toContain('FleetRun spine intent')
+    expect(result.plan).toContain('fleet_run_start --run-ref')
+    expect(result.plan).toContain('spawn.public.khala_coding.artanis_fleet_run.issue_6320')
     expect(result.plan).toContain('#6320')
     expect(result.plan).toContain('src/foo.test.ts')
   })
@@ -555,8 +558,18 @@ describe('#6366 dispatch_codex_task (gated; LIVE execution behind the gate)', ()
     expect(result.assignmentRef).toBe('assignment.public.khala_coding.live123')
     expect(result.durableRequestId).toBe('req-live123')
     expect(createCalls).toHaveLength(1)
-    expect(createCalls[0]).toMatchObject({ authorityScope: 'owner_self' })
+    expect(createCalls[0]).toMatchObject({
+      authorityScope: 'owner_self',
+      fleetRunPlan: {
+        runRef:
+          'spawn.public.khala_coding.artanis_fleet_run.objective_burn_down_public_issue_work_per_the_roadmap',
+        targetConcurrency: 1,
+        workerKind: 'codex',
+      },
+    })
     // No-spend invariant is asserted in the public-safe summary.
+    expect(result.summary).toContain('fleetRunRef: spawn.public.khala_coding')
+    expect(result.summary).toContain('fleetRunControls:')
     expect(result.summary).toContain('unpaid_smoke')
     expect(result.summary).toContain('settlement: not_applicable')
     expect(result.summary).toContain('payoutClaimAllowed: false')
@@ -2319,6 +2332,24 @@ describe('get_fleet_status (unified operator fleet read)', () => {
           },
         ],
       },
+      statusSpine: {
+        loadSnapshot: async () => ({
+          fleet: {
+            activeAssignmentCount: 2,
+            activeSlots: 3,
+            busySlots: 1,
+            queuedSlots: 2,
+            readySlots: 4,
+            sourceRefs: ['d1:pylon_agent_runner_status_events'],
+          },
+          spine: {
+            liveRunnerCount: 5,
+            retainedRunnerCount: 7,
+            schemaVersion: 'openagents.pylon.agent_runner_status_event.v1',
+            sourceRefs: ['d1:pylon_agent_runner_status_events'],
+          },
+        }),
+      },
       traceReview: {
         loadReport: async () => ({
           aggregates: {
@@ -2347,6 +2378,10 @@ describe('get_fleet_status (unified operator fleet read)', () => {
       'Fleet: 2 recent Pylon/Codex assignments; active=1, pass=1, fail=0, in-progress=1.',
     )
     expect(result).toContain('assignment.public.pylon_api.running')
+    expect(result).toContain(
+      'Status spine: schema=openagents.pylon.agent_runner_status_event.v1; live=5; retained=7; activeAssignments=2; slots ready=4 active=3 busy=1 queued=2.',
+    )
+    expect(result).toContain('Status spine refs: d1:pylon_agent_runner_status_events.')
     expect(result).toContain('Watchdog: 1 active synthetic-load run')
     expect(result).toContain('2500/10000 tokens')
     expect(result).toContain('GLM: status=ready, ready=4/5, warm=1.')
@@ -2371,6 +2406,7 @@ describe('get_fleet_status (unified operator fleet read)', () => {
 
     const result = await Effect.runPromise(tool.execute({}))
     expect(result).toContain('Pace: unavailable')
+    expect(result).toContain('Status spine: unavailable')
     expect(result).toContain('Fleet: unavailable')
     expect(result).toContain('Watchdog: unavailable')
     expect(result).toContain('GLM: unavailable')

--- a/apps/openagents.com/workers/api/src/artanis-operator-tools.ts
+++ b/apps/openagents.com/workers/api/src/artanis-operator-tools.ts
@@ -3279,9 +3279,58 @@ export type ArtanisDispatchPlanInput = Readonly<{
   verify: string | undefined
   issue: number | undefined
   filePaths: ReadonlyArray<string>
+  fleetRunPlan: ArtanisDispatchFleetRunPlan
   // The composed public-safe prompt the Pylon/Codex runner receives.
   prompt: string
 }>
+
+export type ArtanisDispatchFleetRunPlan = Readonly<{
+  controlRefs: ReadonlyArray<string>
+  evidenceRefs: ReadonlyArray<string>
+  runRef: string
+  targetConcurrency: number
+  workerKind: 'codex'
+  workerRef: string
+  workSourceRef: string
+}>
+
+const publicDispatchRefSegment = (value: string): string => {
+  const segment = value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '_')
+    .replace(/^_+|_+$/g, '')
+    .slice(0, 60)
+  return segment === '' ? 'task' : segment
+}
+
+const buildArtanisDispatchFleetRunPlan = (
+  input: Readonly<{ issue: number | undefined; objective: string }>,
+): ArtanisDispatchFleetRunPlan => {
+  const target =
+    input.issue === undefined
+      ? `objective_${publicDispatchRefSegment(input.objective)}`
+      : `issue_${input.issue}`
+  return {
+    controlRefs: [
+      'command.public.khala_fleet.fleet_run_start',
+      'command.public.khala_fleet.fleet_run_status',
+      'command.public.khala_fleet.fleet_run_control',
+    ],
+    evidenceRefs: [
+      `dispatch-context.public.artanis.fleet_run.${target}`,
+      'capacity.public.artanis.own_capacity_only',
+      'status.public.artanis.fleet_run.pending_executor',
+    ],
+    runRef: `spawn.public.khala_coding.artanis_fleet_run.${target}`,
+    targetConcurrency: 1,
+    workerKind: 'codex',
+    workerRef: 'worker.public.khala_coding.codex',
+    workSourceRef:
+      input.issue === undefined
+        ? `task.public.artanis.${target}`
+        : `issue.public.github.openagents.${input.issue}`,
+  }
+}
 
 // What the execution seam returns: a real created assignment, or a typed
 // rejection (mapped to a deferral so Artanis never fakes an execution).
@@ -3371,6 +3420,7 @@ const buildArtanisDispatchPlan = (
   }
   promptParts.push(`Run the named verification.`)
   const prompt = promptParts.join(' ')
+  const fleetRunPlan = buildArtanisDispatchFleetRunPlan({ issue, objective })
 
   const lines: Array<string> = [
     `Planned Khala -> Pylon -> Codex dispatch (${authorityScope}, own-capacity only, no spend):`,
@@ -3392,6 +3442,13 @@ const buildArtanisDispatchPlan = (
     '  Then execute locally with no spend: pylon assignment run-no-spend --json',
   )
   lines.push('')
+  lines.push('  FleetRun spine intent:')
+  lines.push(
+    `    fleet_run_start --run-ref ${fleetRunPlan.runRef} --worker-kind ${fleetRunPlan.workerKind} --target-concurrency ${fleetRunPlan.targetConcurrency} --work-source-ref ${fleetRunPlan.workSourceRef}`,
+  )
+  lines.push(`    fleet_run_status --run-ref ${fleetRunPlan.runRef}`)
+  lines.push(`    fleet_run_control --run-ref ${fleetRunPlan.runRef} --verb drain`)
+  lines.push('')
   lines.push(
     'For parallel burndown, set OPENAGENTS_PYLON_CODEX_CONCURRENCY=N and publish capacity (pylon presence heartbeat), then run-no-spend per assignment ref. Verify each closeout against the exact token_usage_events + agent_traces rows before merging non-spend code.',
   )
@@ -3400,7 +3457,16 @@ const buildArtanisDispatchPlan = (
   }
 
   return {
-    input: { authorityScope, branch, filePaths, issue, objective, prompt, verify },
+    input: {
+      authorityScope,
+      branch,
+      filePaths,
+      fleetRunPlan,
+      issue,
+      objective,
+      prompt,
+      verify,
+    },
     ok: true,
     planText: lines.join('\n'),
   }
@@ -3535,6 +3601,8 @@ export const makeArtanisDispatchCodexTaskTool = (
         const summary = [
           `assignmentRef: ${created.assignmentRef}`,
           `authorityScope: ${built.input.authorityScope}`,
+          `fleetRunRef: ${built.input.fleetRunPlan.runRef}`,
+          `fleetRunControls: ${built.input.fleetRunPlan.controlRefs.join(', ')}`,
           `pylonRef: ${created.pylonRef}`,
           `durableRequestId: ${created.durableRequestId ?? '(none)'}`,
           'paymentMode: unpaid_smoke (no spend, own_capacity)',
@@ -3626,6 +3694,23 @@ export type ArtanisFleetStatusConfig = Readonly<{
   glmFleetStatus?: ArtanisGlmFleetStatusConfig | undefined
   syntheticLoadStatus?: ArtanisSyntheticLoadStatusConfig | undefined
   traceReview?: ArtanisTraceReviewConfig | undefined
+  statusSpine?: ArtanisFleetStatusSpineConfig | undefined
+}>
+
+export type ArtanisFleetStatusSpineConfig = Readonly<{
+  loadSnapshot?: (() => Promise<unknown>) | undefined
+}>
+
+type ArtanisFleetStatusSpineSummary = Readonly<{
+  activeAssignmentCount: number
+  activeSlots: number
+  busySlots: number
+  liveRunnerCount: number
+  queuedSlots: number
+  readySlots: number
+  retainedRunnerCount: number
+  schemaVersion: string
+  sourceRefs: ReadonlyArray<string>
 }>
 
 const fleetStatusUnavailableLine = (label: string): string =>
@@ -3685,6 +3770,61 @@ const loadFleetStatusTraceReview = (
   )
 }
 
+const fleetStatusRecord = (value: unknown): Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {}
+
+const fleetStatusCount = (value: unknown): number =>
+  typeof value === 'number' && Number.isFinite(value) && value >= 0
+    ? Math.trunc(value)
+    : 0
+
+const fleetStatusString = (
+  value: unknown,
+  fallback: string,
+): string => (typeof value === 'string' && value !== '' ? value : fallback)
+
+const fleetStatusSourceRefs = (value: unknown): ReadonlyArray<string> =>
+  Array.isArray(value)
+    ? value
+        .filter((item): item is string => typeof item === 'string')
+        .slice(0, 12)
+    : []
+
+const normalizeFleetStatusSpineSummary = (
+  snapshot: unknown,
+): ArtanisFleetStatusSpineSummary => {
+  const record = fleetStatusRecord(snapshot)
+  const fleet = fleetStatusRecord(record.fleet)
+  const spine = fleetStatusRecord(record.spine)
+  return {
+    activeAssignmentCount: fleetStatusCount(fleet.activeAssignmentCount),
+    activeSlots: fleetStatusCount(fleet.activeSlots),
+    busySlots: fleetStatusCount(fleet.busySlots),
+    liveRunnerCount: fleetStatusCount(spine.liveRunnerCount),
+    queuedSlots: fleetStatusCount(fleet.queuedSlots),
+    readySlots: fleetStatusCount(fleet.readySlots),
+    retainedRunnerCount: fleetStatusCount(spine.retainedRunnerCount),
+    schemaVersion: fleetStatusString(spine.schemaVersion, 'unknown'),
+    sourceRefs: fleetStatusSourceRefs(
+      Array.isArray(spine.sourceRefs) ? spine.sourceRefs : fleet.sourceRefs,
+    ),
+  }
+}
+
+const loadFleetStatusSpine = (
+  config: ArtanisFleetStatusSpineConfig | undefined,
+): Effect.Effect<ArtanisFleetStatusSpineSummary | null> => {
+  if (config?.loadSnapshot === undefined) {
+    return Effect.succeed(null)
+  }
+  return Effect.tryPromise(() => config.loadSnapshot!()).pipe(
+    Effect.map(normalizeFleetStatusSpineSummary),
+    Effect.orElseSucceed(() => null),
+  )
+}
+
 const formatFleetAssignmentSpread = (
   assignments: ReadonlyArray<ArtanisPylonAssignmentSummary> | null,
 ): string => {
@@ -3709,6 +3849,18 @@ const formatFleetAssignmentSpread = (
     ...assignments.slice(0, 8).map(formatAssignmentSummaryLine),
   ].join('\n')
 }
+
+const formatFleetStatusSpineLine = (
+  spine: ArtanisFleetStatusSpineSummary | null,
+): string =>
+  spine === null
+    ? fleetStatusUnavailableLine('Status spine')
+    : [
+        `Status spine: schema=${spine.schemaVersion}; live=${spine.liveRunnerCount}; retained=${spine.retainedRunnerCount}; activeAssignments=${spine.activeAssignmentCount}; slots ready=${spine.readySlots} active=${spine.activeSlots} busy=${spine.busySlots} queued=${spine.queuedSlots}.`,
+        spine.sourceRefs.length === 0
+          ? 'Status spine refs: (none reported).'
+          : `Status spine refs: ${spine.sourceRefs.join(', ')}.`,
+      ].join('\n')
 
 const formatFleetGlmLine = (status: ArtanisGlmFleetStatus | null): string =>
   status === null
@@ -3756,13 +3908,21 @@ export const makeArtanisGetFleetStatusTool = (
   },
   execute: (_args: unknown) =>
     Effect.gen(function* () {
-      const [networkStats, assignments, glm, syntheticRuns, traceReview] =
+      const [
+        networkStats,
+        assignments,
+        glm,
+        syntheticRuns,
+        traceReview,
+        statusSpine,
+      ] =
         yield* Effect.all([
           loadFleetStatusNetworkStats(config.networkStats),
           loadFleetStatusAssignments(config.pylonAssignments),
           loadFleetStatusGlm(config.glmFleetStatus),
           loadFleetStatusSyntheticRuns(config.syntheticLoadStatus),
           loadFleetStatusTraceReview(config.traceReview),
+          loadFleetStatusSpine(config.statusSpine),
         ])
 
       const pace =
@@ -3774,6 +3934,8 @@ export const makeArtanisGetFleetStatusTool = (
         'Unified fleet status:',
         '',
         `Pace: ${pace}`,
+        '',
+        formatFleetStatusSpineLine(statusSpine),
         '',
         formatFleetAssignmentSpread(assignments),
         '',
@@ -4824,6 +4986,7 @@ export const makeArtanisOperatorTools = (
       networkStats: config.fleetStatus?.networkStats ?? config.networkStats,
       pylonAssignments:
         config.fleetStatus?.pylonAssignments ?? config.pylonAssignments,
+      statusSpine: config.fleetStatus?.statusSpine,
       syntheticLoadStatus:
         config.fleetStatus?.syntheticLoadStatus ??
         config.syntheticLoadStatus,

--- a/apps/openagents.com/workers/api/src/index.ts
+++ b/apps/openagents.com/workers/api/src/index.ts
@@ -786,7 +786,10 @@ import {
 import { makeOperatorBillingHandlers } from './operator-billing-routes'
 import { makeOperatorBuyModeRoutes } from './operator-buy-mode-routes'
 import { makeOperatorEmailInspectionRoutes } from './operator-email-inspection-routes'
-import { makeOperatorFleetStatusRoutes } from './operator-fleet-status-routes'
+import {
+  makeOperatorFleetStatusRoutes,
+  readOperatorFleetStatusSnapshotFromSpine,
+} from './operator-fleet-status-routes'
 import { makeOperatorProStatusRoutes } from './operator-pro-status-routes'
 import { makeOperatorOrderTriageRoutes } from './operator-order-triage-routes'
 import { makeOperatorProviderAccountRoutes } from './operator-provider-account-routes'
@@ -8853,6 +8856,17 @@ const operatorArtanisChatRoutes = makeOperatorArtanisChatRoutes({
           nowIso: currentIsoTimestamp,
           store: makeD1KhalaTraceReviewStore(openAgentsDatabase(env)),
         }),
+      },
+      fleetStatus: {
+        statusSpine: {
+          loadSnapshot: () =>
+            readOperatorFleetStatusSnapshotFromSpine(
+              openAgentsDatabase(env),
+              currentIsoTimestamp(),
+              { kind: 'admin' },
+              false,
+            ),
+        },
       },
       // iteration-8: the owner-scoped unsupported-request ledger READ tool. Reads
       // the live `khala_unsupported_requests` ledger of user-facing capability

--- a/apps/openagents.com/workers/api/src/operator-fleet-status-routes.ts
+++ b/apps/openagents.com/workers/api/src/operator-fleet-status-routes.ts
@@ -47,7 +47,7 @@ type CacheEntry = Readonly<{
   response: unknown
 }>
 
-type OperatorFleetReadScope =
+export type OperatorFleetReadScope =
   | Readonly<{ kind: 'admin' }>
   | Readonly<{ kind: 'agent'; userId: string }>
 
@@ -119,7 +119,7 @@ const eventRefs = (event: Record<string, unknown>): ReadonlyArray<string> => [
   ...parseJsonStringArray(JSON.stringify(event.capabilityRefs ?? [])),
 ]
 
-const buildFleetStatusSnapshotFromSpine = async (
+export const readOperatorFleetStatusSnapshotFromSpine = async (
   db: D1Database,
   nowIso: string,
   scope: OperatorFleetReadScope,
@@ -443,7 +443,7 @@ export const makeOperatorFleetStatusRoutes = <
       })
     }
 
-    const response = await buildFleetStatusSnapshotFromSpine(
+    const response = await readOperatorFleetStatusSnapshotFromSpine(
       openAgentsDatabase(env),
       nowIso,
       scope,

--- a/apps/openagents.com/workers/api/src/test/artanis-persistence-fixture.ts
+++ b/apps/openagents.com/workers/api/src/test/artanis-persistence-fixture.ts
@@ -3,21 +3,32 @@ type PersistenceRow = Readonly<{
   action_json?: string | undefined
   agent_id: string
   approval_gate_ref?: string | null | undefined
+  archived_at?: string | null | undefined
+  assignment_ref?: string | null | undefined
   closed_at: string | null
   closeout_json: string | null
   context_json?: string | undefined
   content_hash: string
   created_at: string
+  event_json?: string | undefined
+  event_ref?: string | undefined
   health_snapshot_ref?: string | null | undefined
   id: string
   idempotency_key: string
+  owner_agent_user_id?: string | undefined
   parent_ref: string | null
+  pylon_ref?: string | null | undefined
   public_projection_json: string
   record_json: string
   record_ref: string
+  retained_at?: string | null | undefined
+  retention_state?: string | undefined
+  runner_kind?: string | undefined
+  runner_ref?: string | undefined
   scope_ref: string | null
   source_kind: string
   state: string
+  state_started_at?: string | undefined
   updated_at: string
 }>
 
@@ -122,6 +133,42 @@ class ArtanisPersistenceTestStatement implements D1PreparedStatement {
         return Promise.resolve({ success: true } as D1Result<T>)
       }
 
+      if (table === 'pylon_agent_runner_status_events') {
+        rows.push({
+          active: this.values[9] === 'live' ? 1 : 0,
+          agent_id: String(this.values[1]),
+          archived_at: null,
+          assignment_ref:
+            this.values[5] === null ? null : String(this.values[5]),
+          closed_at: null,
+          closeout_json: null,
+          content_hash: String(this.values[10]),
+          created_at: String(this.values[11]),
+          event_json: String(this.values[10]),
+          event_ref: String(this.values[0]),
+          id: String(this.values[0]),
+          idempotency_key: String(this.values[0]),
+          owner_agent_user_id: String(this.values[1]),
+          parent_ref: null,
+          public_projection_json: String(this.values[10]),
+          pylon_ref: this.values[4] === null ? null : String(this.values[4]),
+          record_json: String(this.values[10]),
+          record_ref: String(this.values[0]),
+          retained_at:
+            this.values[12] === null ? null : String(this.values[12]),
+          retention_state: String(this.values[9]),
+          runner_kind: String(this.values[3]),
+          runner_ref: String(this.values[2]),
+          scope_ref: null,
+          source_kind: 'pylon_agent_runner_status_event',
+          state: String(this.values[6]),
+          state_started_at: String(this.values[7]),
+          updated_at: String(this.values[8]),
+        })
+
+        return Promise.resolve({ success: true } as D1Result<T>)
+      }
+
       if (
         rows.every(
           row =>
@@ -148,6 +195,29 @@ class ArtanisPersistenceTestStatement implements D1PreparedStatement {
           state: String(this.values[4]),
           updated_at: String(this.values[14]),
         })
+      }
+
+      return Promise.resolve({ success: true } as D1Result<T>)
+    }
+
+    if (this.query.includes('UPDATE pylon_agent_runner_status_events')) {
+      const ownerAgentUserId = String(this.values[1])
+      const runnerRef = String(this.values[2])
+      const eventRef = String(this.values[3])
+      for (const [index, row] of rows.entries()) {
+        if (
+          row.owner_agent_user_id === ownerAgentUserId &&
+          row.runner_ref === runnerRef &&
+          row.event_ref !== eventRef &&
+          row.retention_state === 'live' &&
+          row.archived_at === null
+        ) {
+          rows[index] = {
+            ...row,
+            retained_at: row.retained_at ?? String(this.values[0]),
+            retention_state: 'retained',
+          }
+        }
       }
 
       return Promise.resolve({ success: true } as D1Result<T>)


### PR DESCRIPTION
Closes #7887.

## Summary
- Reuses the operator fleet runner-status snapshot in Artanis get_fleet_status.
- Adds public FleetRun start/status/control intent refs to dispatch_codex_task and carries them through the own-capacity coding delegation assignment metadata.
- Lets the Artanis fleet-overseer tick read pylon_agent_runner_status_events and publish a public-safe neutral runner-status event while preserving the existing no-spend/no-mutation authority boundary.
- Updates the Artanis invariants and focused fixtures/tests.

## Verification
- git diff --check
- bun run --cwd apps/openagents.com/workers/api test -- src/artanis-operator-tools.test.ts src/artanis-operator-dispatch-execution.test.ts src/artanis-fleet-overseer-tick.test.ts src/operator-fleet-status-routes.test.ts src/operator-pro-status-routes.test.ts
- bun run --cwd apps/openagents.com/workers/api typecheck
- bun run --cwd apps/openagents.com check:deploy