### PR TITLE
T13.2: embed fleet cockpit as Foldkit program

### DIFF
--- a/clients/khala-code-desktop/src/ui/fleet-status.ts
+++ b/clients/khala-code-desktop/src/ui/fleet-status.ts
@@ -29,6 +29,9 @@ import {
   defaultKhalaFleetDelegationActiveParameters,
   type KhalaGymDelegationOptimizationRun,
 } from "./gym-proof-loader"
+import { mountKhalaCodeFleetCockpit } from "./foldkit/runtime"
+import type { KhalaCodeFleetCockpitEmbedHandle } from "./foldkit/runtime"
+import type { KhalaCodeFleetCockpitSnapshot } from "./foldkit/model"
 
 // Fleet status panel for Khala Code Desktop: current Codex fleet state — all
 // linked accounts (with signed-in email + readiness), local Pylon health +
@@ -94,7 +97,6 @@ type Handlers = Readonly<{
   onFleetRunStart: () => void
   onLoadGymDemoProof: () => void
   onOptimizationStart: () => void
-  onRefresh: () => void
   onRemove: (accountRef: string) => void
   onConnect: (accountRef: string) => void
   onPauseAccount: (accountRef: string, paused: boolean) => void
@@ -201,6 +203,9 @@ const accountReadinessState = (
 const titleize = (value: string): string =>
   value.replace(/[_-]+/g, " ").replace(/\b\w/g, char => char.toUpperCase())
 
+const nextFleetAccountRef = (): string =>
+  `codex-${crypto.randomUUID().slice(0, 8)}`
+
 const summaryLine = (parts: ReadonlyArray<string | null>): string =>
   parts.filter((part): part is string => Boolean(part)).join("  ·  ")
 
@@ -238,18 +243,6 @@ const iconButton = (
     el("span", "khala-fleet-button-label", label),
   )
   return button
-}
-
-const setIconButtonLabel = (
-  button: HTMLButtonElement,
-  label: string,
-): void => {
-  const labelNode = button.querySelector<HTMLElement>(".khala-fleet-button-label")
-  if (labelNode === null) {
-    button.append(el("span", "khala-fleet-button-label", label))
-    return
-  }
-  labelNode.textContent = label
 }
 
 const unknownNumber = (value: number | null): string =>
@@ -404,6 +397,33 @@ const fleetInFlightLabel = (
     ? ""
     : `, ${tokenRate.inFlightTokensPerMinute}/min`
   return `${tokenRate.inFlightTokens} token(s)${rate}`
+}
+
+const fleetCockpitSnapshot = (
+  data: KhalaCodeDesktopFleetStatus,
+  activeRun: ActiveFleetRunView,
+): KhalaCodeFleetCockpitSnapshot => {
+  const readyAccounts = data.accounts.filter(
+    account => accountReadinessState(account.readiness) === "ready",
+  ).length
+  const run = activeRun.run
+  return {
+    activeAssignments: data.activeAssignments.length,
+    activeRunActual: run?.counters.activeAssignments ?? null,
+    activeRunRef: run?.runRef ?? null,
+    activeRunRemaining: run === null ? null : runBacklogRemaining(run),
+    activeRunState: run?.state ?? null,
+    activeRunTarget: run?.targetConcurrency ?? null,
+    freeSlots: data.availableCodexAssignments,
+    inFlightLabel: fleetInFlightLabel(data.tokenRate),
+    maxSlots: data.maxCodexAssignments,
+    observedAt: data.observedAt,
+    pylonLabel: data.pylon.pylonRef ?? "local Pylon",
+    pylonStatus: data.pylon.status,
+    readyAccounts,
+    tokenRateLabel: fleetTokenRateLabel(data.tokenRate),
+    totalAccounts: data.accounts.length,
+  }
 }
 
 type ThroughputGaugeState = "exact" | "not_measured" | "pending"
@@ -1454,24 +1474,6 @@ const render = (
 ): void => {
   container.replaceChildren()
 
-  const header = el("header", "khala-fleet-header")
-  header.append(el("h2", "khala-fleet-title", "Fleet status"))
-  const actions = el("div", "khala-fleet-actions")
-  const connectBtn = iconButton("Connect account", "Plus")
-  connectBtn.disabled = activeConnect !== null
-  connectBtn.addEventListener("click", () => {
-    // Auto-assign a short, unique ref — no name prompt.
-    handlers.onConnect(`codex-${crypto.randomUUID().slice(0, 8)}`)
-  })
-  actions.append(connectBtn)
-  const refresh = iconButton("Refresh", "Reload")
-  refresh.dataset.fleetAction = "refresh"
-  refresh.disabled = view.phase === "loading"
-  refresh.addEventListener("click", handlers.onRefresh)
-  actions.append(refresh)
-  header.append(actions)
-  container.append(header)
-
   const body = el("div", "khala-fleet-body")
   // The connect device-auth card renders inline at the top; the fleet list stays
   // visible and live below it.
@@ -1496,6 +1498,12 @@ export const mountFleetPanel = (
   container: HTMLElement,
   options: FleetPanelOptions,
 ): FleetPanelHandle => {
+  container.replaceChildren()
+  const cockpitHost = el("div", "khala-fleet-cockpit-host")
+  const detailHost = el("div", "khala-fleet-detail-host")
+  container.append(cockpitHost, detailHost)
+
+  let cockpit: KhalaCodeFleetCockpitEmbedHandle | null = null
   let inFlight = false
   let delegateInFlight = false
   let delegateForm: FleetDelegateFormState = {
@@ -1528,6 +1536,7 @@ export const mountFleetPanel = (
   let optimizationInFlight = false
   let optimizationRun: OptimizationRunView = { phase: "idle" }
   let lastData: KhalaCodeDesktopFleetStatus | null = null
+  let fleetLoadError: string | null = null
   let lifecycleFrames: readonly KhalaFleetWorkerLifecycleFrame[] = []
   let lifecycleStarted = false
   let connectPoll = 0
@@ -1536,23 +1545,40 @@ export const mountFleetPanel = (
   let pollTimer = 0
   const now = options.now ?? (() => new Date())
 
-  const setRefreshBusy = (busy: boolean): void => {
-    const buttons = container.querySelectorAll<HTMLButtonElement>('[data-fleet-action="refresh"]')
-    for (const button of buttons) {
-      button.disabled = busy
-      setIconButtonLabel(button, busy ? "Refreshing" : "Refresh")
-    }
-  }
-
   const currentView = (): FleetView =>
     lastData !== null
       ? { phase: "ready", data: lastData }
+      : fleetLoadError !== null
+        ? { phase: "error", message: fleetLoadError }
       : { phase: "loading" }
 
-  const paint = (): void =>
+  const syncCockpit = (view: FleetView = currentView()): void => {
+    cockpit?.send({
+      _tag: "HostFleetCockpitBusy",
+      connectBusy: activeConnect !== null,
+      controlInFlight: activeRun.controlInFlight,
+      refreshBusy: inFlight,
+    })
+    if (view.phase === "loading") {
+      cockpit?.send({ _tag: "HostFleetCockpitLoading" })
+      return
+    }
+    if (view.phase === "error") {
+      cockpit?.send({ _tag: "HostFleetCockpitError", message: view.message })
+      return
+    }
+    cockpit?.send({
+      _tag: "HostFleetCockpitStatus",
+      snapshot: fleetCockpitSnapshot(view.data, activeRun),
+    })
+  }
+
+  const paint = (): void => {
+    const view = currentView()
+    syncCockpit(view)
     render(
-      container,
-      currentView(),
+      detailHost,
+      view,
       handlers,
       activeConnect,
       delegateForm,
@@ -1564,6 +1590,7 @@ export const mountFleetPanel = (
       optimizationRun,
       now(),
     )
+  }
 
   const fleetRunPreview = (): readonly FleetRunPreviewSlot[] | string => {
     const targetConcurrency = Number.parseInt(fleetRunForm.targetConcurrency, 10)
@@ -1710,7 +1737,6 @@ export const mountFleetPanel = (
     onFleetRunStart: () => onFleetRunStart(),
     onLoadGymDemoProof: () => onLoadGymDemoProof(),
     onOptimizationStart: () => onOptimizationStart(),
-    onRefresh: () => void refresh(),
     onRemove: (accountRef: string) => onRemove(accountRef),
     onConnect: (accountRef: string) => onConnect(accountRef),
     onPauseAccount: (accountRef: string, paused: boolean) => onPauseAccount(accountRef, paused),
@@ -1888,7 +1914,7 @@ export const mountFleetPanel = (
       const result = await options.removeAccount(accountRef)
       if (!result.ok) {
         render(
-          container,
+          detailHost,
           { phase: "error", message: result.error ?? "remove failed" },
           handlers,
           activeConnect,
@@ -1921,7 +1947,7 @@ export const mountFleetPanel = (
       const result = await options.setAccountPaused({ accountRef, paused })
       if (!result.ok) {
         render(
-          container,
+          detailHost,
           { phase: "error", message: result.error ?? "pause failed" },
           handlers,
           activeConnect,
@@ -1945,7 +1971,7 @@ export const mountFleetPanel = (
       const result = await options.consumeResetCredit({ accountRef })
       if (!result.ok) {
         render(
-          container,
+          detailHost,
           { phase: "error", message: result.error ?? "reset credit failed" },
           handlers,
           activeConnect,
@@ -1999,10 +2025,11 @@ export const mountFleetPanel = (
   const refresh = async (): Promise<void> => {
     if (inFlight) return
     inFlight = true
+    if (lastData === null) fleetLoadError = null
     if (lastData === null && activeConnect === null) {
       paint()
     } else {
-      setRefreshBusy(true)
+      syncCockpit()
     }
     try {
       const [data, list] = await Promise.all([
@@ -2010,6 +2037,7 @@ export const mountFleetPanel = (
         options.fleetRunList(),
       ])
       lastData = data
+      fleetLoadError = null
       const selected = selectActiveFleetRun(list.runs)
       activeRun = {
         controlInFlight: activeRun.controlInFlight,
@@ -2025,9 +2053,12 @@ export const mountFleetPanel = (
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error)
       if (lastData === null) {
+        fleetLoadError = message
+        const errorView: FleetView = { phase: "error", message }
+        syncCockpit(errorView)
         render(
-          container,
-          { phase: "error", message },
+          detailHost,
+          errorView,
           handlers,
           activeConnect,
           delegateForm,
@@ -2045,10 +2076,11 @@ export const mountFleetPanel = (
           controlInFlight: null,
           error: message,
         }
-        setRefreshBusy(false)
+        paint()
       }
     } finally {
       inFlight = false
+      syncCockpit()
     }
   }
 
@@ -2064,6 +2096,26 @@ export const mountFleetPanel = (
       if (visible && !inFlight) void refresh()
     }, 5000)
   }
+
+  cockpit = mountKhalaCodeFleetCockpit(cockpitHost)
+  cockpit?.ports.program.subscribe(message => {
+    switch (message._tag) {
+      case "ProgramMounted":
+        syncCockpit()
+        break
+      case "ProgramRequestedRefresh":
+        void refresh()
+        break
+      case "ProgramRequestedConnectAccount":
+        onConnect(nextFleetAccountRef())
+        break
+      case "ProgramRequestedFleetRunControl":
+        onFleetRunControl(message.verb)
+        break
+      case "ProgramUnmounted":
+        break
+    }
+  })
 
   paint()
   return { refresh, setVisible }

--- a/clients/khala-code-desktop/src/ui/foldkit/message.ts
+++ b/clients/khala-code-desktop/src/ui/foldkit/message.ts
@@ -1,21 +1,29 @@
 import { Schema as S } from "effect"
 import { m } from "foldkit/message"
 
-import { KhalaCodeFoldkitHostPortMessage } from "./ports.js"
+import { FleetCockpitControlVerb } from "./model.js"
+import { KhalaCodeFleetCockpitHostPortMessage } from "./ports.js"
 
-export const FoldkitDemoClickedPing = m("FoldkitDemoClickedPing")
-export const FoldkitDemoReceivedHostPort = m("FoldkitDemoReceivedHostPort", {
-  message: KhalaCodeFoldkitHostPortMessage,
+export const FleetCockpitClickedRefresh = m("FleetCockpitClickedRefresh")
+export const FleetCockpitClickedConnectAccount = m("FleetCockpitClickedConnectAccount")
+export const FleetCockpitClickedRunControl = m("FleetCockpitClickedRunControl", {
+  verb: FleetCockpitControlVerb,
 })
-export const FoldkitDemoMounted = m("FoldkitDemoMounted")
-export const FoldkitDemoUnmounted = m("FoldkitDemoUnmounted")
-export const FoldkitDemoCompletedPortEmit = m("FoldkitDemoCompletedPortEmit")
+export const FleetCockpitReceivedHostPort = m("FleetCockpitReceivedHostPort", {
+  message: KhalaCodeFleetCockpitHostPortMessage,
+})
+export const FleetCockpitMounted = m("FleetCockpitMounted")
+export const FleetCockpitUnmounted = m("FleetCockpitUnmounted")
+export const FleetCockpitCompletedPortEmit = m("FleetCockpitCompletedPortEmit")
 
-export const KhalaCodeFoldkitMessage = S.Union([
-  FoldkitDemoClickedPing,
-  FoldkitDemoReceivedHostPort,
-  FoldkitDemoMounted,
-  FoldkitDemoUnmounted,
-  FoldkitDemoCompletedPortEmit,
+export const KhalaCodeFleetCockpitMessage = S.Union([
+  FleetCockpitClickedRefresh,
+  FleetCockpitClickedConnectAccount,
+  FleetCockpitClickedRunControl,
+  FleetCockpitReceivedHostPort,
+  FleetCockpitMounted,
+  FleetCockpitUnmounted,
+  FleetCockpitCompletedPortEmit,
 ])
-export type KhalaCodeFoldkitMessage = typeof KhalaCodeFoldkitMessage.Type
+export type KhalaCodeFleetCockpitMessage =
+  typeof KhalaCodeFleetCockpitMessage.Type

--- a/clients/khala-code-desktop/src/ui/foldkit/model.ts
+++ b/clients/khala-code-desktop/src/ui/foldkit/model.ts
@@ -1,17 +1,81 @@
 import { Schema as S } from "effect"
 
-export const KhalaCodeFoldkitModel = S.Struct({
-  label: S.String,
+export const FleetCockpitControlVerb = S.Literals([
+  "pause",
+  "resume",
+  "drain",
+  "stop",
+])
+export type FleetCockpitControlVerb = typeof FleetCockpitControlVerb.Type
+
+export const KhalaCodeFleetCockpitSnapshot = S.Struct({
+  activeAssignments: S.Number,
+  activeRunActual: S.NullOr(S.Number),
+  activeRunRef: S.NullOr(S.String),
+  activeRunRemaining: S.NullOr(S.Number),
+  activeRunState: S.NullOr(S.String),
+  activeRunTarget: S.NullOr(S.Number),
+  freeSlots: S.NullOr(S.Number),
+  inFlightLabel: S.NullOr(S.String),
+  maxSlots: S.NullOr(S.Number),
+  observedAt: S.String,
+  pylonLabel: S.String,
+  pylonStatus: S.String,
+  readyAccounts: S.Number,
+  tokenRateLabel: S.String,
+  totalAccounts: S.Number,
+})
+export type KhalaCodeFleetCockpitSnapshot =
+  typeof KhalaCodeFleetCockpitSnapshot.Type
+
+export const KhalaCodeFleetCockpitModel = S.Struct({
+  activeAssignments: S.Number,
+  activeRunActual: S.NullOr(S.Number),
+  activeRunRef: S.NullOr(S.String),
+  activeRunRemaining: S.NullOr(S.Number),
+  activeRunState: S.NullOr(S.String),
+  activeRunTarget: S.NullOr(S.Number),
+  connectBusy: S.Boolean,
+  controlInFlight: S.NullOr(FleetCockpitControlVerb),
+  error: S.NullOr(S.String),
+  freeSlots: S.NullOr(S.Number),
+  inFlightLabel: S.NullOr(S.String),
+  maxSlots: S.NullOr(S.Number),
   mountId: S.String,
-  pingCount: S.Number,
+  observedAt: S.NullOr(S.String),
+  phase: S.Literals(["loading", "ready", "error"]),
+  pylonLabel: S.String,
+  pylonStatus: S.String,
+  readyAccounts: S.Number,
+  refreshBusy: S.Boolean,
+  tokenRateLabel: S.String,
+  totalAccounts: S.Number,
 })
-export type KhalaCodeFoldkitModel = typeof KhalaCodeFoldkitModel.Type
+export type KhalaCodeFleetCockpitModel =
+  typeof KhalaCodeFleetCockpitModel.Type
 
-export const initialKhalaCodeFoldkitModel = (
+export const initialKhalaCodeFleetCockpitModel = (
   mountId: string,
-): KhalaCodeFoldkitModel => ({
-  label: "Foldkit skeleton",
+): KhalaCodeFleetCockpitModel => ({
+  activeAssignments: 0,
+  activeRunActual: null,
+  activeRunRef: null,
+  activeRunRemaining: null,
+  activeRunState: null,
+  activeRunTarget: null,
+  connectBusy: false,
+  controlInFlight: null,
+  error: null,
+  freeSlots: null,
+  inFlightLabel: null,
+  maxSlots: null,
   mountId,
-  pingCount: 0,
+  observedAt: null,
+  phase: "loading",
+  pylonLabel: "local Pylon",
+  pylonStatus: "loading",
+  readyAccounts: 0,
+  refreshBusy: false,
+  tokenRateLabel: "pending",
+  totalAccounts: 0,
 })
-

--- a/clients/khala-code-desktop/src/ui/foldkit/ports.ts
+++ b/clients/khala-code-desktop/src/ui/foldkit/ports.ts
@@ -1,48 +1,60 @@
 import { Schema as S } from "effect"
 import { ts } from "foldkit/schema"
 
-export const KhalaCodeFoldkitHostPortMessage = S.Union([
-  ts("HostPing", {
-    nonce: S.String,
+import {
+  FleetCockpitControlVerb,
+  KhalaCodeFleetCockpitSnapshot,
+} from "./model.js"
+
+export const KhalaCodeFleetCockpitHostPortMessage = S.Union([
+  ts("HostFleetCockpitLoading", {}),
+  ts("HostFleetCockpitStatus", {
+    snapshot: KhalaCodeFleetCockpitSnapshot,
   }),
-  ts("HostSetLabel", {
-    label: S.String,
+  ts("HostFleetCockpitError", {
+    message: S.String,
+  }),
+  ts("HostFleetCockpitBusy", {
+    connectBusy: S.Boolean,
+    controlInFlight: S.NullOr(FleetCockpitControlVerb),
+    refreshBusy: S.Boolean,
   }),
 ])
-export type KhalaCodeFoldkitHostPortMessage =
-  typeof KhalaCodeFoldkitHostPortMessage.Type
+export type KhalaCodeFleetCockpitHostPortMessage =
+  typeof KhalaCodeFleetCockpitHostPortMessage.Type
 
-export const KhalaCodeFoldkitProgramPortMessage = S.Union([
+export const KhalaCodeFleetCockpitProgramPortMessage = S.Union([
   ts("ProgramMounted", {
     mountId: S.String,
   }),
-  ts("ProgramPong", {
-    nonce: S.String,
-    count: S.Number,
+  ts("ProgramRequestedRefresh", {}),
+  ts("ProgramRequestedConnectAccount", {}),
+  ts("ProgramRequestedFleetRunControl", {
+    verb: FleetCockpitControlVerb,
   }),
   ts("ProgramUnmounted", {
     mountId: S.String,
   }),
 ])
-export type KhalaCodeFoldkitProgramPortMessage =
-  typeof KhalaCodeFoldkitProgramPortMessage.Type
+export type KhalaCodeFleetCockpitProgramPortMessage =
+  typeof KhalaCodeFleetCockpitProgramPortMessage.Type
 
-const decodeHostPortMessage = S.decodeUnknownSync(KhalaCodeFoldkitHostPortMessage)
-const decodeProgramPortMessage = S.decodeUnknownSync(KhalaCodeFoldkitProgramPortMessage)
+const decodeHostPortMessage = S.decodeUnknownSync(KhalaCodeFleetCockpitHostPortMessage)
+const decodeProgramPortMessage = S.decodeUnknownSync(KhalaCodeFleetCockpitProgramPortMessage)
 
-export type KhalaCodeFoldkitPortListener<Message> = (message: Message) => void
+export type KhalaCodeFleetCockpitPortListener<Message> = (message: Message) => void
 
-export type KhalaCodeFoldkitHostPort = Readonly<{
-  send: (message: unknown) => KhalaCodeFoldkitHostPortMessage
+export type KhalaCodeFleetCockpitHostPort = Readonly<{
+  send: (message: unknown) => KhalaCodeFleetCockpitHostPortMessage
   subscribe: (
-    listener: KhalaCodeFoldkitPortListener<KhalaCodeFoldkitHostPortMessage>,
+    listener: KhalaCodeFleetCockpitPortListener<KhalaCodeFleetCockpitHostPortMessage>,
   ) => () => void
 }>
 
-export type KhalaCodeFoldkitProgramPort = Readonly<{
-  emit: (message: unknown) => KhalaCodeFoldkitProgramPortMessage
+export type KhalaCodeFleetCockpitProgramPort = Readonly<{
+  emit: (message: unknown) => KhalaCodeFleetCockpitProgramPortMessage
   subscribe: (
-    listener: KhalaCodeFoldkitPortListener<KhalaCodeFoldkitProgramPortMessage>,
+    listener: KhalaCodeFleetCockpitPortListener<KhalaCodeFleetCockpitProgramPortMessage>,
   ) => () => void
 }>
 
@@ -50,9 +62,9 @@ const makePort = <Message>(
   decode: (message: unknown) => Message,
 ): Readonly<{
   publish: (message: unknown) => Message
-  subscribe: (listener: KhalaCodeFoldkitPortListener<Message>) => () => void
+  subscribe: (listener: KhalaCodeFleetCockpitPortListener<Message>) => () => void
 }> => {
-  const listeners = new Set<KhalaCodeFoldkitPortListener<Message>>()
+  const listeners = new Set<KhalaCodeFleetCockpitPortListener<Message>>()
   return {
     publish: (message) => {
       const decoded = decode(message)
@@ -66,12 +78,12 @@ const makePort = <Message>(
   }
 }
 
-export type KhalaCodeFoldkitPorts = Readonly<{
-  host: KhalaCodeFoldkitHostPort
-  program: KhalaCodeFoldkitProgramPort
+export type KhalaCodeFleetCockpitPorts = Readonly<{
+  host: KhalaCodeFleetCockpitHostPort
+  program: KhalaCodeFleetCockpitProgramPort
 }>
 
-export const makeKhalaCodeFoldkitPorts = (): KhalaCodeFoldkitPorts => {
+export const makeKhalaCodeFleetCockpitPorts = (): KhalaCodeFleetCockpitPorts => {
   const host = makePort(decodeHostPortMessage)
   const program = makePort(decodeProgramPortMessage)
   return {

--- a/clients/khala-code-desktop/src/ui/foldkit/runtime.ts
+++ b/clients/khala-code-desktop/src/ui/foldkit/runtime.ts
@@ -2,64 +2,67 @@ import { Effect, Fiber } from "effect"
 import { Runtime } from "foldkit"
 import type { MakeRuntimeReturn } from "foldkit/runtime"
 
-import { KhalaCodeFoldkitMessage } from "./message.js"
-import { initialKhalaCodeFoldkitModel, KhalaCodeFoldkitModel } from "./model.js"
+import { KhalaCodeFleetCockpitMessage } from "./message.js"
 import {
-  makeKhalaCodeFoldkitPorts,
-  type KhalaCodeFoldkitPorts,
+  initialKhalaCodeFleetCockpitModel,
+  KhalaCodeFleetCockpitModel,
+} from "./model.js"
+import {
+  makeKhalaCodeFleetCockpitPorts,
+  type KhalaCodeFleetCockpitPorts,
 } from "./ports.js"
-import { makeKhalaCodeFoldkitSubscriptions } from "./subscriptions.js"
-import { makeKhalaCodeFoldkitUpdate } from "./update.js"
+import { makeKhalaCodeFleetCockpitSubscriptions } from "./subscriptions.js"
+import { makeKhalaCodeFleetCockpitUpdate } from "./update.js"
 import { view } from "./view.js"
 
-export type KhalaCodeFoldkitEmbedHandle = Readonly<{
+export type KhalaCodeFleetCockpitEmbedHandle = Readonly<{
   mountId: string
-  ports: KhalaCodeFoldkitPorts
-  send: KhalaCodeFoldkitPorts["host"]["send"]
+  ports: KhalaCodeFleetCockpitPorts
+  send: KhalaCodeFleetCockpitPorts["host"]["send"]
   unmount: () => void
 }>
 
-export type KhalaCodeFoldkitEmbedOptions = Readonly<{
+export type KhalaCodeFleetCockpitEmbedOptions = Readonly<{
   mountId?: string
-  ports?: KhalaCodeFoldkitPorts
+  ports?: KhalaCodeFleetCockpitPorts
 }>
 
 const nextMountId = (() => {
   let seq = 0
   return () => {
     seq += 1
-    return `khala-code-foldkit-${seq}`
+    return `khala-code-fleet-cockpit-${seq}`
   }
 })()
 
 const startRuntimeFiber = (program: MakeRuntimeReturn): Fiber.Fiber<void> =>
   Effect.runFork(program.start())
 
-export const embedKhalaCodeFoldkitProgram = (
+export const embedKhalaCodeFleetCockpitProgram = (
   container: HTMLElement,
-  options: KhalaCodeFoldkitEmbedOptions = {},
-): KhalaCodeFoldkitEmbedHandle => {
+  options: KhalaCodeFleetCockpitEmbedOptions = {},
+): KhalaCodeFleetCockpitEmbedHandle => {
   const mountId = options.mountId ?? nextMountId()
-  const ports = options.ports ?? makeKhalaCodeFoldkitPorts()
+  const ports = options.ports ?? makeKhalaCodeFleetCockpitPorts()
   const runtimeContainer = document.createElement("div")
   runtimeContainer.id = mountId
-  runtimeContainer.dataset.khalaCodeFoldkitRuntime = "true"
+  runtimeContainer.dataset.khalaCodeFleetCockpitRuntime = "true"
   container.replaceChildren(runtimeContainer)
 
   const program = Runtime.makeProgram({
-    Model: KhalaCodeFoldkitModel,
-    init: () => [initialKhalaCodeFoldkitModel(mountId), []],
-    update: makeKhalaCodeFoldkitUpdate(ports.program),
+    Model: KhalaCodeFleetCockpitModel,
+    init: () => [initialKhalaCodeFleetCockpitModel(mountId), []],
+    update: makeKhalaCodeFleetCockpitUpdate(ports.program),
     view,
-    subscriptions: makeKhalaCodeFoldkitSubscriptions(ports.host),
+    subscriptions: makeKhalaCodeFleetCockpitSubscriptions(ports.host),
     container: runtimeContainer,
     devTools: {
       show: "Development",
-      Message: KhalaCodeFoldkitMessage,
+      Message: KhalaCodeFleetCockpitMessage,
     },
     crash: {
       report: ({ error }) => {
-        console.error("[khala-code-desktop/foldkit] crash:", error)
+        console.error("[khala-code-desktop/fleet-cockpit] crash:", error)
       },
     },
   })
@@ -81,8 +84,7 @@ export const embedKhalaCodeFoldkitProgram = (
   }
 }
 
-export const mountKhalaCodeFoldkitDemo = (
+export const mountKhalaCodeFleetCockpit = (
   container: HTMLElement | null,
-): KhalaCodeFoldkitEmbedHandle | null =>
-  container === null ? null : embedKhalaCodeFoldkitProgram(container)
-
+): KhalaCodeFleetCockpitEmbedHandle | null =>
+  container === null ? null : embedKhalaCodeFleetCockpitProgram(container)

--- a/clients/khala-code-desktop/src/ui/foldkit/subscriptions.ts
+++ b/clients/khala-code-desktop/src/ui/foldkit/subscriptions.ts
@@ -1,31 +1,31 @@
 import { Effect, Queue, Stream } from "effect"
 import { Subscription } from "foldkit"
 
-import { FoldkitDemoMounted, FoldkitDemoReceivedHostPort } from "./message.js"
-import type { KhalaCodeFoldkitMessage } from "./message.js"
-import type { KhalaCodeFoldkitModel } from "./model.js"
-import type { KhalaCodeFoldkitHostPort } from "./ports.js"
+import { FleetCockpitMounted, FleetCockpitReceivedHostPort } from "./message.js"
+import type { KhalaCodeFleetCockpitMessage } from "./message.js"
+import type { KhalaCodeFleetCockpitModel } from "./model.js"
+import type { KhalaCodeFleetCockpitHostPort } from "./ports.js"
 
-const mountedStream = Stream.make(FoldkitDemoMounted())
+const mountedStream = Stream.make(FleetCockpitMounted())
 
 const hostPortStream = (
-  port: KhalaCodeFoldkitHostPort,
-): Stream.Stream<KhalaCodeFoldkitMessage> =>
-  Stream.callback<KhalaCodeFoldkitMessage>((queue) =>
+  port: KhalaCodeFleetCockpitHostPort,
+): Stream.Stream<KhalaCodeFleetCockpitMessage> =>
+  Stream.callback<KhalaCodeFleetCockpitMessage>((queue) =>
     Effect.acquireRelease(
       Effect.sync(() =>
         port.subscribe((message) => {
-          Queue.offerUnsafe(queue, FoldkitDemoReceivedHostPort({ message }))
+          Queue.offerUnsafe(queue, FleetCockpitReceivedHostPort({ message }))
         }),
       ),
       (unsubscribe) => Effect.sync(unsubscribe),
     ),
   )
 
-export const makeKhalaCodeFoldkitSubscriptions = (
-  port: KhalaCodeFoldkitHostPort,
+export const makeKhalaCodeFleetCockpitSubscriptions = (
+  port: KhalaCodeFleetCockpitHostPort,
 ) =>
-  Subscription.make<KhalaCodeFoldkitModel, KhalaCodeFoldkitMessage>()(() => ({
+  Subscription.make<KhalaCodeFleetCockpitModel, KhalaCodeFleetCockpitMessage>()(() => ({
     mounted: Subscription.persistent(mountedStream),
     hostPort: Subscription.persistent(hostPortStream(port)),
   }))

--- a/clients/khala-code-desktop/src/ui/foldkit/update.ts
+++ b/clients/khala-code-desktop/src/ui/foldkit/update.ts
@@ -1,72 +1,111 @@
 import { Effect } from "effect"
 import type { Command } from "foldkit"
 
-import type { KhalaCodeFoldkitMessage } from "./message.js"
-import { FoldkitDemoCompletedPortEmit } from "./message.js"
-import type { KhalaCodeFoldkitModel } from "./model.js"
+import {
+  FleetCockpitCompletedPortEmit,
+  type KhalaCodeFleetCockpitMessage,
+} from "./message.js"
+import type { KhalaCodeFleetCockpitModel } from "./model.js"
 import type {
-  KhalaCodeFoldkitProgramPort,
-  KhalaCodeFoldkitProgramPortMessage,
+  KhalaCodeFleetCockpitProgramPort,
+  KhalaCodeFleetCockpitProgramPortMessage,
 } from "./ports.js"
 
 type UpdateResult = readonly [
-  KhalaCodeFoldkitModel,
-  ReadonlyArray<Command.Command<KhalaCodeFoldkitMessage>>,
+  KhalaCodeFleetCockpitModel,
+  ReadonlyArray<Command.Command<KhalaCodeFleetCockpitMessage>>,
 ]
 
-const noCommands: ReadonlyArray<Command.Command<KhalaCodeFoldkitMessage>> = []
+const noCommands: ReadonlyArray<Command.Command<KhalaCodeFleetCockpitMessage>> = []
 
 const emitProgramPort = (
-  port: KhalaCodeFoldkitProgramPort,
-  message: KhalaCodeFoldkitProgramPortMessage,
-): Command.Command<KhalaCodeFoldkitMessage> => ({
-  name: "KhalaCodeFoldkitEmitProgramPort",
+  port: KhalaCodeFleetCockpitProgramPort,
+  message: KhalaCodeFleetCockpitProgramPortMessage,
+): Command.Command<KhalaCodeFleetCockpitMessage> => ({
+  name: "KhalaCodeFleetCockpitEmitProgramPort",
   args: { tag: message._tag },
   effect: Effect.sync(() => {
     port.emit(message)
-    return FoldkitDemoCompletedPortEmit()
+    return FleetCockpitCompletedPortEmit()
   }),
 })
 
-export const makeKhalaCodeFoldkitUpdate =
-  (port: KhalaCodeFoldkitProgramPort) =>
+export const makeKhalaCodeFleetCockpitUpdate =
+  (port: KhalaCodeFleetCockpitProgramPort) =>
   (
-    model: KhalaCodeFoldkitModel,
-    message: KhalaCodeFoldkitMessage,
+    model: KhalaCodeFleetCockpitModel,
+    message: KhalaCodeFleetCockpitMessage,
   ): UpdateResult => {
     switch (message._tag) {
-      case "FoldkitDemoClickedPing": {
-        const next = { ...model, pingCount: model.pingCount + 1 }
+      case "FleetCockpitClickedRefresh":
         return [
-          next,
+          { ...model, refreshBusy: true },
           [
             emitProgramPort(port, {
-              _tag: "ProgramPong",
-              count: next.pingCount,
-              nonce: `ui:${next.pingCount}`,
+              _tag: "ProgramRequestedRefresh",
             }),
           ],
         ]
-      }
-      case "FoldkitDemoReceivedHostPort":
-        switch (message.message._tag) {
-          case "HostPing": {
-            const next = { ...model, pingCount: model.pingCount + 1 }
-            return [
-              next,
-              [
-                emitProgramPort(port, {
-                  _tag: "ProgramPong",
-                  count: next.pingCount,
-                  nonce: message.message.nonce,
-                }),
-              ],
-            ]
-          }
-          case "HostSetLabel":
-            return [{ ...model, label: message.message.label }, noCommands]
+      case "FleetCockpitClickedConnectAccount":
+        if (model.connectBusy) return [model, noCommands]
+        return [
+          { ...model, connectBusy: true },
+          [
+            emitProgramPort(port, {
+              _tag: "ProgramRequestedConnectAccount",
+            }),
+          ],
+        ]
+      case "FleetCockpitClickedRunControl":
+        if (model.activeRunRef === null || model.controlInFlight !== null) {
+          return [model, noCommands]
         }
-      case "FoldkitDemoMounted":
+        return [
+          { ...model, controlInFlight: message.verb },
+          [
+            emitProgramPort(port, {
+              _tag: "ProgramRequestedFleetRunControl",
+              verb: message.verb,
+            }),
+          ],
+        ]
+      case "FleetCockpitReceivedHostPort":
+        switch (message.message._tag) {
+          case "HostFleetCockpitLoading":
+            return [{ ...model, error: null, phase: "loading" }, noCommands]
+          case "HostFleetCockpitStatus":
+            return [
+              {
+                ...model,
+                ...message.message.snapshot,
+                error: null,
+                phase: "ready",
+                refreshBusy: false,
+              },
+              noCommands,
+            ]
+          case "HostFleetCockpitError":
+            return [
+              {
+                ...model,
+                error: message.message.message,
+                phase: "error",
+                refreshBusy: false,
+              },
+              noCommands,
+            ]
+          case "HostFleetCockpitBusy":
+            return [
+              {
+                ...model,
+                connectBusy: message.message.connectBusy,
+                controlInFlight: message.message.controlInFlight,
+                refreshBusy: message.message.refreshBusy,
+              },
+              noCommands,
+            ]
+        }
+      case "FleetCockpitMounted":
         return [
           model,
           [
@@ -76,7 +115,7 @@ export const makeKhalaCodeFoldkitUpdate =
             }),
           ],
         ]
-      case "FoldkitDemoUnmounted":
+      case "FleetCockpitUnmounted":
         return [
           model,
           [
@@ -86,7 +125,7 @@ export const makeKhalaCodeFoldkitUpdate =
             }),
           ],
         ]
-      case "FoldkitDemoCompletedPortEmit":
+      case "FleetCockpitCompletedPortEmit":
         return [model, noCommands]
     }
   }

--- a/clients/khala-code-desktop/src/ui/foldkit/view.ts
+++ b/clients/khala-code-desktop/src/ui/foldkit/view.ts
@@ -1,29 +1,138 @@
+import { iconView, type IconName } from "@openagentsinc/ui/icon"
 import type { Document } from "foldkit/html"
 import { html } from "foldkit/html"
 
-import { FoldkitDemoClickedPing } from "./message.js"
-import type { KhalaCodeFoldkitMessage } from "./message.js"
-import type { KhalaCodeFoldkitModel } from "./model.js"
+import {
+  FleetCockpitClickedConnectAccount,
+  FleetCockpitClickedRefresh,
+  FleetCockpitClickedRunControl,
+} from "./message.js"
+import type { KhalaCodeFleetCockpitMessage } from "./message.js"
+import type {
+  FleetCockpitControlVerb,
+  KhalaCodeFleetCockpitModel,
+} from "./model.js"
 
-const h = html<KhalaCodeFoldkitMessage>()
+const titleize = (value: string): string =>
+  value.replace(/[_-]+/g, " ").replace(/\b\w/g, char => char.toUpperCase())
 
-export const view = (model: KhalaCodeFoldkitModel): Document => ({
-  title: "Khala Code",
-  body: h.section(
-    [
-      h.Class("khala-code-foldkit-demo"),
-      h.DataAttribute("foldkit-mount-id", model.mountId),
-    ],
-    [
-      h.p([h.Class("khala-code-foldkit-demo-label")], [model.label]),
-      h.button(
-        [
-          h.Type("button"),
-          h.Class("khala-code-foldkit-demo-ping"),
-          h.OnClick(FoldkitDemoClickedPing()),
-        ],
-        [`Ping ${model.pingCount}`],
-      ),
-    ],
-  ),
-})
+const valueLabel = (value: number | string | null): string =>
+  value === null ? "pending" : String(value)
+
+const slotsLabel = (model: KhalaCodeFleetCockpitModel): string => {
+  if (model.freeSlots === null || model.maxSlots === null) return "pending"
+  return `${model.freeSlots}/${model.maxSlots}`
+}
+
+const activeRunLabel = (model: KhalaCodeFleetCockpitModel): string =>
+  model.activeRunRef === null
+    ? "none"
+    : `${model.activeRunRef} · ${titleize(model.activeRunState ?? "unknown")}`
+
+const buttonLabel = (
+  label: string,
+  busyLabel: string,
+  busy: boolean,
+): string => busy ? busyLabel : label
+
+const controlIcon: Record<FleetCockpitControlVerb, IconName> = {
+  drain: "Circle",
+  pause: "Pause",
+  resume: "Play",
+  stop: "Stop",
+}
+
+export const view = (model: KhalaCodeFleetCockpitModel): Document => {
+  const h = html<KhalaCodeFleetCockpitMessage>()
+  const chip = (label: string, value: string) =>
+    h.span([h.Class("khala-fleet-chip")], [
+      h.span([h.Class("khala-fleet-chip-label")], [label]),
+      h.span([h.Class("khala-fleet-chip-value")], [value]),
+    ])
+  const control = (verb: FleetCockpitControlVerb) =>
+    h.button(
+      [
+        h.Type("button"),
+        h.Class(verb === "stop" ? "khala-fleet-run khala-fleet-run-danger" : "khala-fleet-run"),
+        h.Disabled(model.activeRunRef === null || model.controlInFlight !== null),
+        h.OnClick(FleetCockpitClickedRunControl({ verb })),
+      ],
+      [
+        iconView<KhalaCodeFleetCockpitMessage>(controlIcon[verb], "khala-fleet-button-icon"),
+        h.span([h.Class("khala-fleet-button-label")], [
+          model.controlInFlight === verb ? `${titleize(verb)}...` : titleize(verb),
+        ]),
+      ],
+    )
+
+  return {
+    title: "Khala Code",
+    body: h.section(
+      [
+        h.Class("khala-fleet-cockpit"),
+        h.DataAttribute("foldkit-mount-id", model.mountId),
+        h.DataAttribute("state", model.phase),
+      ],
+      [
+        h.header([h.Class("khala-fleet-header")], [
+          h.div([h.Class("khala-fleet-cockpit-heading")], [
+            h.h2([h.Class("khala-fleet-title")], ["Fleet cockpit"]),
+            h.p([h.Class("khala-fleet-cockpit-subtitle")], [
+              model.phase === "error"
+                ? model.error ?? "Fleet status unavailable."
+                : `${model.readyAccounts}/${model.totalAccounts} accounts ready · ${model.activeAssignments} active`,
+            ]),
+          ]),
+          h.div([h.Class("khala-fleet-actions")], [
+            h.button(
+              [
+                h.Type("button"),
+                h.Class("khala-fleet-refresh"),
+                h.Disabled(model.connectBusy),
+                h.OnClick(FleetCockpitClickedConnectAccount()),
+              ],
+              [
+                iconView<KhalaCodeFleetCockpitMessage>("Plus", "khala-fleet-button-icon"),
+                h.span([h.Class("khala-fleet-button-label")], [
+                  buttonLabel("Connect account", "Connecting", model.connectBusy),
+                ]),
+              ],
+            ),
+            h.button(
+              [
+                h.Type("button"),
+                h.Class("khala-fleet-refresh"),
+                h.Disabled(model.refreshBusy),
+                h.OnClick(FleetCockpitClickedRefresh()),
+              ],
+              [
+                iconView<KhalaCodeFleetCockpitMessage>("Reload", "khala-fleet-button-icon"),
+                h.span([h.Class("khala-fleet-button-label")], [
+                  buttonLabel("Refresh", "Refreshing", model.refreshBusy),
+                ]),
+              ],
+            ),
+          ]),
+        ]),
+        h.section([h.Class("khala-fleet-cockpit-strip")], [
+          chip("pylon", `${model.pylonLabel} · ${titleize(model.pylonStatus)}`),
+          chip("slots", slotsLabel(model)),
+          chip("tokens", model.tokenRateLabel),
+          chip("in flight", model.inFlightLabel ?? "none"),
+          chip("run", activeRunLabel(model)),
+          chip("target", valueLabel(model.activeRunTarget)),
+          chip("actual", valueLabel(model.activeRunActual)),
+          chip("remaining", valueLabel(model.activeRunRemaining)),
+        ]),
+        model.activeRunRef === null
+          ? h.p([h.Class("khala-fleet-empty")], ["No active FleetRun."])
+          : h.div(
+              [
+                h.Class("khala-fleet-run-controls khala-fleet-cockpit-controls"),
+              ],
+              [control("pause"), control("resume"), control("drain"), control("stop")],
+            ),
+      ],
+    ),
+  }
+}

--- a/clients/khala-code-desktop/src/ui/index.html
+++ b/clients/khala-code-desktop/src/ui/index.html
@@ -188,12 +188,6 @@
         aria-label="Codex settings"
         hidden
       ></section>
-      <section
-        id="foldkit-demo-panel"
-        class="khala-code-foldkit-host"
-        aria-label="Foldkit embedding skeleton"
-        hidden
-      ></section>
     </main>
     <script type="module" src="./main.ts"></script>
   </body>

--- a/clients/khala-code-desktop/src/ui/main.ts
+++ b/clients/khala-code-desktop/src/ui/main.ts
@@ -89,7 +89,6 @@ import {
   mountKhalaCodeSidebar,
   projectKhalaCodeSidebarFleetCounts,
 } from "./sidebar"
-import { mountKhalaCodeFoldkitDemo } from "./foldkit/runtime"
 import { mountUnifiedInboxPanel } from "./inbox"
 import type { KhalaCodeDesktopCodexThreadSummary } from "../shared/codex-threads"
 import { sessionCatalogEntryToThreadSummary } from "../shared/session-catalog"
@@ -2787,7 +2786,6 @@ const forumPanelEl = document.getElementById("forum-panel")
 const inboxPanelEl = document.getElementById("inbox-panel")
 const gymPanelEl = document.getElementById("gym-panel")
 const settingsPanelEl = document.getElementById("settings-panel")
-const foldkitDemoPanelEl = document.getElementById("foldkit-demo-panel")
 const threadShell = document.querySelector<HTMLElement>(".khala-code-thread-shell")
 const composerDock = document.querySelector<HTMLElement>(".composer-dock")
 const initialGymState = gymPaneStateFromLocation(globalThis.location)
@@ -2969,8 +2967,6 @@ const forumPanel =
 
 const gymPanel =
   gymPanelEl === null ? null : mountGymPane(gymPanelEl, initialGymState)
-const foldkitDemo =
-  foldkitDemoPanelEl === null ? null : mountKhalaCodeFoldkitDemo(foldkitDemoPanelEl)
 
 let claudeSettingsSection: ReturnType<typeof mountClaudeSettingsSection> | null = null
 let plansSection: ReturnType<typeof mountKhalaCodePlansPanel> | null = null
@@ -3161,7 +3157,6 @@ const setActiveView = (value: string): void => {
   if (forumPanelEl !== null) forumPanelEl.hidden = !showForum
   if (inboxPanelEl !== null) inboxPanelEl.hidden = !showInbox
   if (settingsPanelEl !== null) settingsPanelEl.hidden = !showSettings
-  if (foldkitDemoPanelEl !== null) foldkitDemoPanelEl.hidden = true
   gymPanel?.setVisible(false)
   if (threadShell !== null) threadShell.hidden = showFleet || showForum || showInbox || showSettings
   if (composerDock !== null) composerDock.hidden = showFleet || showForum || showInbox || showSettings
@@ -3186,7 +3181,6 @@ function showGymProofPane(): void {
   if (forumPanelEl !== null) forumPanelEl.hidden = true
   if (inboxPanelEl !== null) inboxPanelEl.hidden = true
   if (settingsPanelEl !== null) settingsPanelEl.hidden = true
-  if (foldkitDemoPanelEl !== null) foldkitDemoPanelEl.hidden = true
   if (threadShell !== null) threadShell.hidden = true
   if (composerDock !== null) composerDock.hidden = true
   gymPanel?.setVisible(true)
@@ -3217,7 +3211,6 @@ const refreshFleetSidebarCounts = async (): Promise<void> => {
 if (sidebarNavRoot !== null) {
   void refreshFleetSidebarCounts()
 }
-void foldkitDemo?.send({ _tag: "HostSetLabel", label: "Foldkit skeleton mounted" })
 setActiveView(initialView)
 renderThreadTokenCounter()
 void refreshThreadTokenSummary()

--- a/clients/khala-code-desktop/src/ui/styles.css
+++ b/clients/khala-code-desktop/src/ui/styles.css
@@ -3497,36 +3497,45 @@ button {
   color: var(--oa-color-component-text);
 }
 
-.khala-code-foldkit-host {
-  position: fixed;
-  inset: auto 1rem 1rem auto;
-  z-index: 8;
-  max-width: 18rem;
+.khala-fleet-cockpit-host,
+.khala-fleet-detail-host {
+  min-width: 0;
 }
 
-.khala-code-foldkit-demo {
+.khala-fleet-cockpit {
   display: grid;
-  gap: 0.55rem;
-  padding: 0.75rem;
-  color: var(--oa-color-component-text);
-  background: var(--oa-color-component-surface);
-  border: 1px solid var(--oa-color-component-border);
-  border-radius: 0.5rem;
+  gap: 0.7rem;
+  min-width: 0;
 }
 
-.khala-code-foldkit-demo-label {
+.khala-fleet-cockpit-heading {
+  display: grid;
+  gap: 0.18rem;
+  min-width: 0;
+}
+
+.khala-fleet-cockpit-subtitle {
   margin: 0;
+  color: color-mix(in srgb, var(--oa-color-component-text) 56%, transparent);
   font-size: 0.78rem;
+  line-height: 1.35;
 }
 
-.khala-code-foldkit-demo-ping {
-  justify-self: start;
-  font: inherit;
-  font-size: 0.78rem;
-  color: var(--oa-color-component-text);
-  background: var(--oa-color-component-surface-active);
-  border: 1px solid var(--oa-color-component-border);
-  border-radius: 0.4rem;
-  padding: 0.3rem 0.65rem;
-  cursor: pointer;
+.khala-fleet-cockpit-strip {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  min-width: 0;
+}
+
+.khala-fleet-cockpit-controls {
+  padding-top: 0.1rem;
+}
+
+@media (max-width: 720px) {
+  .khala-fleet-cockpit .khala-fleet-header {
+    align-items: stretch;
+    flex-direction: column;
+    gap: 0.65rem;
+  }
 }

--- a/clients/khala-code-desktop/tests/app-shell.test.ts
+++ b/clients/khala-code-desktop/tests/app-shell.test.ts
@@ -118,8 +118,8 @@ describe("khala code desktop app shell", () => {
     expect(html).toContain('id="inbox-panel"')
     expect(html).toContain('id="gym-panel"')
     expect(html).toContain('id="settings-panel"')
-    expect(html).toContain('id="foldkit-demo-panel"')
-    expect(html).toContain("Foldkit embedding skeleton")
+    expect(html).not.toContain('id="foldkit-demo-panel"')
+    expect(html).not.toContain("Foldkit embedding skeleton")
     expect(html).not.toContain("Pylons")
   })
 
@@ -828,11 +828,16 @@ describe("khala code desktop app shell", () => {
   test("renders Fleet status with a board graph and run timeline mount", async () => {
     const main = await Bun.file(new URL("../src/ui/main.ts", import.meta.url)).text()
     const panel = await Bun.file(new URL("../src/ui/fleet-status.ts", import.meta.url)).text()
+    const foldkitRuntime = await Bun.file(new URL("../src/ui/foldkit/runtime.ts", import.meta.url)).text()
     const projection = await Bun.file(new URL("../src/ui/fleet-board-projection.ts", import.meta.url)).text()
     const renderer = await Bun.file(new URL("../src/ui/fleet-board-renderer.ts", import.meta.url)).text()
     const css = await Bun.file(new URL("../src/ui/styles.css", import.meta.url)).text()
 
     expect(main).toContain("mountFleetPanel")
+    expect(main).not.toContain("foldkitDemoPanelEl")
+    expect(panel).toContain("mountKhalaCodeFleetCockpit")
+    expect(panel).toContain("HostFleetCockpitStatus")
+    expect(foldkitRuntime).toContain("embedKhalaCodeFleetCockpitProgram")
     expect(panel).toContain("appendFleetBoard(container, data)")
     expect(panel).toContain("buildKhalaFleetBoardProjection")
     expect(panel).toContain("renderKhalaFleetBoardHtml")

--- a/clients/khala-code-desktop/tests/foldkit-embedding.test.ts
+++ b/clients/khala-code-desktop/tests/foldkit-embedding.test.ts
@@ -3,13 +3,13 @@ import { Effect, Schema as S } from "effect"
 import { Window } from "happy-dom"
 
 import {
-  KhalaCodeFoldkitHostPortMessage,
-  KhalaCodeFoldkitProgramPortMessage,
-  makeKhalaCodeFoldkitPorts,
+  KhalaCodeFleetCockpitHostPortMessage,
+  KhalaCodeFleetCockpitProgramPortMessage,
+  makeKhalaCodeFleetCockpitPorts,
 } from "../src/ui/foldkit/ports"
-import { FoldkitDemoReceivedHostPort } from "../src/ui/foldkit/message"
-import { initialKhalaCodeFoldkitModel } from "../src/ui/foldkit/model"
-import { makeKhalaCodeFoldkitUpdate } from "../src/ui/foldkit/update"
+import { FleetCockpitClickedRunControl } from "../src/ui/foldkit/message"
+import { initialKhalaCodeFleetCockpitModel } from "../src/ui/foldkit/model"
+import { makeKhalaCodeFleetCockpitUpdate } from "../src/ui/foldkit/update"
 
 const installDom = (): {
   readonly flushAnimationFrame: () => void
@@ -68,94 +68,113 @@ const flushDomWork = async (
 const yieldTask = (): Promise<void> =>
   new Promise(resolve => setTimeout(resolve, 0))
 
-describe("khala code Foldkit embedding skeleton", () => {
+const fixtureSnapshot = {
+  activeAssignments: 3,
+  activeRunActual: 3,
+  activeRunRef: "fleet.run.fixture",
+  activeRunRemaining: 4,
+  activeRunState: "running",
+  activeRunTarget: 5,
+  freeSlots: 7,
+  inFlightLabel: "120 token(s), 30/min",
+  maxSlots: 10,
+  observedAt: "2026-07-02T00:00:00.000Z",
+  pylonLabel: "pylon.fixture",
+  pylonStatus: "online",
+  readyAccounts: 2,
+  tokenRateLabel: "42/min exact",
+  totalAccounts: 3,
+} as const
+
+describe("khala code Foldkit fleet cockpit", () => {
   test("keeps program update pure until returned commands run", async () => {
-    const ports = makeKhalaCodeFoldkitPorts()
+    const ports = makeKhalaCodeFleetCockpitPorts()
     const emitted: unknown[] = []
     ports.program.subscribe(message => emitted.push(message))
-    const update = makeKhalaCodeFoldkitUpdate(ports.program)
-    const model = initialKhalaCodeFoldkitModel("fixture-foldkit")
+    const update = makeKhalaCodeFleetCockpitUpdate(ports.program)
+    const model = {
+      ...initialKhalaCodeFleetCockpitModel("fixture-cockpit"),
+      activeRunRef: "fleet.run.fixture",
+    }
 
     const [next, commands] = update(
       model,
-      FoldkitDemoReceivedHostPort({
-        message: { _tag: "HostPing", nonce: "fixture-nonce" },
-      }),
+      FleetCockpitClickedRunControl({ verb: "pause" }),
     )
 
-    expect(next).toEqual({
-      label: "Foldkit skeleton",
-      mountId: "fixture-foldkit",
-      pingCount: 1,
-    })
+    expect(next.controlInFlight).toBe("pause")
     expect(emitted).toEqual([])
     expect(commands).toHaveLength(1)
 
     await Effect.runPromise(commands[0]!.effect)
 
     expect(emitted).toEqual([
-      { _tag: "ProgramPong", count: 1, nonce: "fixture-nonce" },
+      { _tag: "ProgramRequestedFleetRunControl", verb: "pause" },
     ])
   })
 
   test("decodes both host and program port schemas", () => {
-    expect(S.decodeUnknownSync(KhalaCodeFoldkitHostPortMessage)({
-      _tag: "HostSetLabel",
-      label: "Mounted",
-    })).toEqual({ _tag: "HostSetLabel", label: "Mounted" })
-    expect(S.decodeUnknownSync(KhalaCodeFoldkitProgramPortMessage)({
-      _tag: "ProgramPong",
-      count: 2,
-      nonce: "round-trip",
-    })).toEqual({ _tag: "ProgramPong", count: 2, nonce: "round-trip" })
+    expect(S.decodeUnknownSync(KhalaCodeFleetCockpitHostPortMessage)({
+      _tag: "HostFleetCockpitStatus",
+      snapshot: fixtureSnapshot,
+    })).toEqual({ _tag: "HostFleetCockpitStatus", snapshot: fixtureSnapshot })
+    expect(S.decodeUnknownSync(KhalaCodeFleetCockpitProgramPortMessage)({
+      _tag: "ProgramRequestedFleetRunControl",
+      verb: "drain",
+    })).toEqual({ _tag: "ProgramRequestedFleetRunControl", verb: "drain" })
 
     expect(() =>
-      S.decodeUnknownSync(KhalaCodeFoldkitHostPortMessage)({
-        _tag: "HostPing",
-        nonce: 42,
+      S.decodeUnknownSync(KhalaCodeFleetCockpitProgramPortMessage)({
+        _tag: "ProgramRequestedFleetRunControl",
+        verb: "restart",
       }),
     ).toThrow()
   })
 
-  test("mounts, round-trips ports, and unmounts from a designated container", async () => {
+  test("mounts, receives status, emits refresh, and unmounts", async () => {
     const dom = installDom()
-    const { embedKhalaCodeFoldkitProgram } = await import("../src/ui/foldkit/runtime")
+    const { embedKhalaCodeFleetCockpitProgram } = await import("../src/ui/foldkit/runtime")
     const container = document.createElement("section")
-    container.id = "foldkit-demo-fixture"
+    container.id = "fleet-cockpit-fixture"
     document.body.append(container)
-    const ports = makeKhalaCodeFoldkitPorts()
+    const ports = makeKhalaCodeFleetCockpitPorts()
     const emitted: unknown[] = []
     ports.program.subscribe(message => emitted.push(message))
 
-    const handle = embedKhalaCodeFoldkitProgram(container, {
-      mountId: "foldkit-demo-fixture-runtime",
+    const handle = embedKhalaCodeFleetCockpitProgram(container, {
+      mountId: "fleet-cockpit-fixture-runtime",
       ports,
     })
     await flushDomWork(dom)
 
-    expect(container.querySelector("[data-foldkit-mount-id='foldkit-demo-fixture-runtime']")).not.toBeNull()
-    expect(container.textContent ?? "").toContain("Foldkit skeleton")
+    expect(container.querySelector("[data-foldkit-mount-id='fleet-cockpit-fixture-runtime']")).not.toBeNull()
+    expect(container.textContent ?? "").toContain("Fleet cockpit")
     expect(emitted).toContainEqual({
       _tag: "ProgramMounted",
-      mountId: "foldkit-demo-fixture-runtime",
+      mountId: "fleet-cockpit-fixture-runtime",
     })
 
-    handle.send({ _tag: "HostPing", nonce: "host-fixture" })
+    handle.send({ _tag: "HostFleetCockpitStatus", snapshot: fixtureSnapshot })
     await flushDomWork(dom)
 
-    expect(container.textContent ?? "").toContain("Ping 1")
-    expect(emitted).toContainEqual({
-      _tag: "ProgramPong",
-      count: 1,
-      nonce: "host-fixture",
-    })
+    expect(container.textContent ?? "").toContain("2/3 accounts ready")
+    expect(container.textContent ?? "").toContain("42/min exact")
+    expect(container.textContent ?? "").toContain("fleet.run.fixture")
+
+    const refresh = [...container.querySelectorAll("button")]
+      .find(button => button.textContent === "Refresh")
+    expect(refresh).not.toBeUndefined()
+    refresh?.click()
+    await flushDomWork(dom)
+
+    expect(emitted).toContainEqual({ _tag: "ProgramRequestedRefresh" })
 
     handle.unmount()
 
     expect(container.childElementCount).toBe(0)
     expect(emitted).toContainEqual({
       _tag: "ProgramUnmounted",
-      mountId: "foldkit-demo-fixture-runtime",
+      mountId: "fleet-cockpit-fixture-runtime",
     })
   })
 })


### PR DESCRIPTION
## Summary
- replace the dormant Foldkit skeleton with a Schema-typed Fleet Cockpit program
- embed the cockpit inside the visible Fleet panel and bridge status/control through ports
- remove the hidden demo host and update cockpit/Foldkit tests

## Verification
- bun test clients/khala-code-desktop/tests/foldkit-embedding.test.ts clients/khala-code-desktop/tests/fleet-status.test.ts clients/khala-code-desktop/tests/app-shell.test.ts
- bun run --cwd clients/khala-code-desktop typecheck
- bun run --cwd clients/khala-code-desktop verify
- bun run --cwd apps/openagents.com check:deploy

Closes #7893