### PR TITLE
[codex] Add desktop diff review annotations

### DIFF
--- a/clients/khala-code-desktop/src/shared/diff-review.ts
+++ b/clients/khala-code-desktop/src/shared/diff-review.ts
@@ -1,0 +1,70 @@
+import { Schema as S } from "effect"
+
+export const KHALA_CODE_DIFF_REVIEW_COMMENT_SCHEMA =
+  "openagents.khala_code.diff_review_comment.v1" as const
+export const KHALA_CODE_DIFF_REVIEW_SUBMIT_EVENT =
+  "khala-code-diff-review-submit" as const
+
+export const KhalaCodeDiffReviewLineKindSchema = S.Literals([
+  "add",
+  "context",
+  "remove",
+])
+export type KhalaCodeDiffReviewLineKind =
+  typeof KhalaCodeDiffReviewLineKindSchema.Type
+
+export const KhalaCodeDiffReviewLineSideSchema = S.Literals(["new", "old"])
+export type KhalaCodeDiffReviewLineSide =
+  typeof KhalaCodeDiffReviewLineSideSchema.Type
+
+export const KhalaCodeDiffReviewCommentSchema = S.Struct({
+  body: S.String,
+  commentRef: S.String,
+  filePath: S.String,
+  lineKind: KhalaCodeDiffReviewLineKindSchema,
+  lineNo: S.Number,
+  lineSide: KhalaCodeDiffReviewLineSideSchema,
+  patchRef: S.String,
+  schema: S.Literal(KHALA_CODE_DIFF_REVIEW_COMMENT_SCHEMA),
+})
+export type KhalaCodeDiffReviewComment =
+  typeof KhalaCodeDiffReviewCommentSchema.Type
+
+export const KhalaCodeDiffReviewSubmitDetailSchema = S.Struct({
+  body: S.String,
+  filePath: S.String,
+  lineKind: KhalaCodeDiffReviewLineKindSchema,
+  lineNo: S.Number,
+  lineSide: KhalaCodeDiffReviewLineSideSchema,
+  patchRef: S.String,
+})
+export type KhalaCodeDiffReviewSubmitDetail =
+  typeof KhalaCodeDiffReviewSubmitDetailSchema.Type
+
+export const khalaCodeDiffReviewLineLabel = (
+  input: Pick<KhalaCodeDiffReviewComment, "filePath" | "lineNo" | "lineSide">,
+): string => `${input.filePath}:${input.lineSide === "new" ? "+" : "-"}${input.lineNo}`
+
+export const khalaCodeDiffReviewComment = (
+  input: KhalaCodeDiffReviewSubmitDetail & { readonly commentRef: string },
+): KhalaCodeDiffReviewComment => ({
+  body: input.body.trim(),
+  commentRef: input.commentRef,
+  filePath: input.filePath,
+  lineKind: input.lineKind,
+  lineNo: input.lineNo,
+  lineSide: input.lineSide,
+  patchRef: input.patchRef,
+  schema: KHALA_CODE_DIFF_REVIEW_COMMENT_SCHEMA,
+})
+
+export const khalaCodeDiffReviewSteeringNote = (
+  comment: KhalaCodeDiffReviewComment,
+): string => [
+  `Diff review comment (${comment.schema})`,
+  `Ref: ${comment.commentRef}`,
+  `Line: ${khalaCodeDiffReviewLineLabel(comment)}`,
+  `Kind: ${comment.lineKind}`,
+  "",
+  comment.body,
+].join("\n")

--- a/clients/khala-code-desktop/src/ui/main.ts
+++ b/clients/khala-code-desktop/src/ui/main.ts
@@ -97,6 +97,13 @@ import {
   recentThreadsForHotkeys,
 } from "./thread-hotkeys"
 import {
+  KHALA_CODE_DIFF_REVIEW_SUBMIT_EVENT,
+  KhalaCodeDiffReviewSubmitDetailSchema,
+  khalaCodeDiffReviewComment,
+  khalaCodeDiffReviewLineLabel,
+  khalaCodeDiffReviewSteeringNote,
+} from "../shared/diff-review"
+import {
   initialKhalaCodeMainShellModel,
   updateKhalaCodeMainShellModel,
   type KhalaCodeMainShellMessage,
@@ -2012,6 +2019,76 @@ const respondToCodexApproval = async (button: HTMLButtonElement): Promise<void> 
   }])
 }
 
+const nextDiffReviewCommentRef = (): string =>
+  `diff_review.${Date.now().toString(36)}.${Math.random().toString(36).slice(2, 8)}`
+
+const stageDiffReviewNoteInComposer = (note: string): void => {
+  const existing = composerInput.value.trimEnd()
+  composerInput.value = existing.length === 0 ? note : `${existing}\n\n${note}`
+  shellModel().lastTurnFailed = false
+  renderComposer()
+  requestAnimationFrame(focusComposerInput)
+}
+
+const handleDiffReviewSubmit = async (event: Event): Promise<void> => {
+  const rawDetail = "detail" in event
+    ? (event as CustomEvent<unknown>).detail
+    : undefined
+  let detail: typeof KhalaCodeDiffReviewSubmitDetailSchema.Type
+  try {
+    detail = S.decodeUnknownSync(KhalaCodeDiffReviewSubmitDetailSchema)(rawDetail)
+  } catch (error) {
+    appendMessages([{
+      body: `Diff review comment failed schema validation: ${error instanceof Error ? error.message : String(error)}`,
+      id: nextMessageId("system"),
+      role: "system",
+    }])
+    return
+  }
+
+  const comment = khalaCodeDiffReviewComment({
+    ...detail,
+    commentRef: nextDiffReviewCommentRef(),
+  })
+  const note = khalaCodeDiffReviewSteeringNote(comment)
+
+  if (!shellModel().pendingTurn) {
+    stageDiffReviewNoteInComposer(note)
+    appendMessages([{
+      body: `Staged diff review comment for ${khalaCodeDiffReviewLineLabel(comment)} in the composer.`,
+      id: nextMessageId("system"),
+      role: "system",
+    }])
+    return
+  }
+
+  const turnIds = [...activeTurnIds]
+  const targets = turnIds.length === 0 ? [undefined] : turnIds
+  try {
+    const results = await Promise.all(targets.map(turnId =>
+      rpc.request.codexTurnSteer({
+        clientUserMessageId: comment.commentRef,
+        sessionId,
+        text: note,
+        ...(turnId === undefined ? {} : { turnId }),
+      })))
+    const failed = results.find(result => !result.ok)
+    appendMessages([{
+      body: failed === undefined
+        ? `Sent diff review comment to the active Codex turn: ${khalaCodeDiffReviewLineLabel(comment)}.`
+        : `Diff review steering failed: ${failed.error ?? "unknown error"}`,
+      id: nextMessageId("system"),
+      role: "system",
+    }])
+  } catch (error) {
+    appendMessages([{
+      body: `Diff review steering failed: ${error instanceof Error ? error.message : String(error)}`,
+      id: nextMessageId("system"),
+      role: "system",
+    }])
+  }
+}
+
 const handledClaudeApprovals = new Set<string>()
 const respondToClaudeApprovalRequest = async (
   request: Awaited<ReturnType<DesktopRpcRequests["claudeApprovalPending"]>>["requests"][number],
@@ -2533,6 +2610,11 @@ messageList.addEventListener("click", event => {
   event.preventDefault()
   event.stopPropagation()
   void respondToCodexApproval(button)
+})
+messageList.addEventListener(KHALA_CODE_DIFF_REVIEW_SUBMIT_EVENT, event => {
+  event.preventDefault()
+  event.stopPropagation()
+  void handleDiffReviewSubmit(event)
 })
 messageList.addEventListener("scroll", () => {
   shellModel().transcriptPinnedToEnd = isNearTranscriptEnd()

--- a/clients/khala-code-desktop/src/ui/styles.css
+++ b/clients/khala-code-desktop/src/ui/styles.css
@@ -1182,6 +1182,98 @@ button {
   white-space: pre;
 }
 
+.cb-diff-comment-button {
+  flex: none;
+  align-self: center;
+  min-height: 24px;
+  margin: 1px 6px 1px 0;
+  border: 1px solid color-mix(in srgb, var(--oa-color-khala-energy-cyan) 32%, transparent);
+  border-radius: 3px;
+  background: color-mix(in srgb, var(--oa-color-khala-surface-raised) 72%, transparent);
+  color: var(--oa-color-khala-energy-text);
+  cursor: pointer;
+  font: inherit;
+  font-size: 0.68rem;
+  line-height: 1;
+  opacity: 0.72;
+  padding: 3px 6px;
+}
+
+.cb-diff-comment-button:hover,
+.cb-diff-comment-button:focus-visible {
+  border-color: color-mix(in srgb, var(--oa-color-khala-energy-cyan) 76%, transparent);
+  background: color-mix(in srgb, var(--oa-color-khala-energy-blue) 18%, var(--oa-color-khala-surface-raised));
+  outline: 1px solid color-mix(in srgb, var(--oa-color-khala-energy-cyan) 34%, transparent);
+}
+
+.cb-diff-review-editor {
+  display: grid;
+  gap: 7px;
+  padding: 8px 10px 9px 84px;
+  border-left: 2px solid color-mix(in srgb, var(--oa-color-khala-energy-cyan) 58%, transparent);
+  background:
+    linear-gradient(90deg, color-mix(in srgb, var(--oa-color-khala-energy-cyan) 7%, transparent), transparent 42%),
+    color-mix(in srgb, var(--oa-color-khala-surface-raised) 70%, transparent);
+  white-space: normal;
+}
+
+.cb-diff-review-textarea {
+  width: min(100%, 44rem);
+  min-height: 4.75rem;
+  border: 1px solid color-mix(in srgb, var(--oa-color-khala-energy-cyan) 32%, transparent);
+  border-radius: 4px;
+  background: color-mix(in srgb, var(--oa-color-khala-void) 78%, transparent);
+  color: var(--oa-color-khala-text-primary);
+  font: inherit;
+  font-size: 0.75rem;
+  line-height: 1.45;
+  padding: 7px 8px;
+  resize: vertical;
+}
+
+.cb-diff-review-textarea:focus-visible {
+  border-color: color-mix(in srgb, var(--oa-color-khala-energy-cyan) 86%, transparent);
+  outline: 1px solid color-mix(in srgb, var(--oa-color-khala-energy-cyan) 58%, transparent);
+}
+
+.cb-diff-review-actions {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.cb-diff-review-submit,
+.cb-diff-review-cancel {
+  min-height: 28px;
+  border: 1px solid color-mix(in srgb, var(--oa-color-khala-energy-blue) 42%, transparent);
+  border-radius: 3px;
+  background: color-mix(in srgb, var(--oa-color-khala-surface-raised) 82%, transparent);
+  color: var(--oa-color-khala-text-primary);
+  cursor: pointer;
+  font: inherit;
+  font-size: 0.72rem;
+  line-height: 1;
+  padding: 5px 9px;
+}
+
+.cb-diff-review-submit {
+  border-color: color-mix(in srgb, var(--oa-color-khala-success-border) 78%, transparent);
+  background: color-mix(in srgb, var(--oa-color-khala-surface-success) 86%, transparent);
+  color: var(--oa-color-khala-success-strong);
+}
+
+.cb-diff-review-submit:hover,
+.cb-diff-review-submit:focus-visible,
+.cb-diff-review-cancel:hover,
+.cb-diff-review-cancel:focus-visible {
+  outline: 1px solid color-mix(in srgb, var(--oa-color-khala-energy-cyan) 38%, transparent);
+}
+
+.cb-diff-review-submit:disabled {
+  cursor: not-allowed;
+  opacity: 0.54;
+}
+
 @media (max-width: 640px) {
   .message-bubble--user {
     max-width: 92%;

--- a/clients/khala-code-desktop/src/ui/transcript-render.ts
+++ b/clients/khala-code-desktop/src/ui/transcript-render.ts
@@ -17,6 +17,13 @@ import type {
   KhalaCodeDesktopMessageRole,
 } from "../shared/rpc"
 import type { KhalaCodeDesktopCodexApprovalAction } from "../shared/codex-approval-decisions"
+import {
+  KHALA_CODE_DIFF_REVIEW_SUBMIT_EVENT,
+  khalaCodeDiffReviewLineLabel,
+  type KhalaCodeDiffReviewLineKind,
+  type KhalaCodeDiffReviewLineSide,
+  type KhalaCodeDiffReviewSubmitDetail,
+} from "../shared/diff-review"
 import { displayLocalPathsForKhalaCode } from "../shared/display-paths"
 
 const EXT_LANGUAGE: Readonly<Record<string, string>> = {
@@ -267,6 +274,124 @@ const diffGutter = (
   return span
 }
 
+const diffReviewSide = (row: DiffRow): KhalaCodeDiffReviewLineSide =>
+  row.kind === "remove" ? "old" : "new"
+
+const diffReviewLineNo = (row: DiffRow): number | null => {
+  if (row.kind === "remove") return row.oldNo ?? null
+  return row.newNo ?? row.oldNo ?? null
+}
+
+const diffReviewKind = (row: DiffRow): KhalaCodeDiffReviewLineKind | null => {
+  if (row.kind === "add" || row.kind === "context" || row.kind === "remove") {
+    return row.kind
+  }
+  return null
+}
+
+const removeOpenDiffReviewEditors = (root: HTMLElement): void => {
+  for (const editor of root.querySelectorAll(".cb-diff-review-editor")) {
+    editor.remove()
+  }
+}
+
+const openDiffReviewEditor = (
+  root: HTMLElement,
+  line: HTMLElement,
+  detail: Omit<KhalaCodeDiffReviewSubmitDetail, "body">,
+): void => {
+  removeOpenDiffReviewEditors(root)
+
+  const editor = document.createElement("span")
+  editor.className = "cb-diff-review-editor"
+  editor.dataset.patchRef = detail.patchRef
+
+  const textarea = document.createElement("textarea")
+  textarea.className = "cb-diff-review-textarea"
+  textarea.name = "khala-diff-review-comment"
+  textarea.rows = 3
+  textarea.placeholder = "Comment for this line"
+  textarea.setAttribute("aria-label", `Comment for ${khalaCodeDiffReviewLineLabel(detail)}`)
+
+  const actions = document.createElement("span")
+  actions.className = "cb-diff-review-actions"
+
+  const submit = document.createElement("button")
+  submit.type = "button"
+  submit.className = "cb-diff-review-submit"
+  submit.textContent = "Send"
+
+  const cancel = document.createElement("button")
+  cancel.type = "button"
+  cancel.className = "cb-diff-review-cancel"
+  cancel.textContent = "Cancel"
+
+  submit.addEventListener("click", event => {
+    event.preventDefault()
+    event.stopPropagation()
+    const body = textarea.value.trim()
+    if (body.length === 0) {
+      textarea.focus({ preventScroll: true })
+      return
+    }
+    root.dispatchEvent(new CustomEvent<KhalaCodeDiffReviewSubmitDetail>(
+      KHALA_CODE_DIFF_REVIEW_SUBMIT_EVENT,
+      {
+        bubbles: true,
+        detail: {
+          ...detail,
+          body,
+        },
+      },
+    ))
+    editor.dataset.sent = "true"
+    textarea.disabled = true
+    submit.disabled = true
+  })
+
+  cancel.addEventListener("click", event => {
+    event.preventDefault()
+    event.stopPropagation()
+    editor.remove()
+  })
+
+  textarea.addEventListener("keydown", event => {
+    if (event.key === "Escape") {
+      event.preventDefault()
+      editor.remove()
+    }
+  })
+
+  actions.append(submit, cancel)
+  editor.append(textarea, actions)
+  line.after(editor)
+  textarea.focus({ preventScroll: true })
+}
+
+const diffReviewButton = (
+  root: HTMLElement,
+  line: HTMLElement,
+  detail: Omit<KhalaCodeDiffReviewSubmitDetail, "body">,
+): HTMLButtonElement => {
+  const button = document.createElement("button")
+  button.type = "button"
+  button.className = "cb-diff-comment-button"
+  button.title = "Annotate diff line"
+  button.setAttribute("aria-label", `Annotate ${khalaCodeDiffReviewLineLabel(detail)}`)
+  button.dataset.patchRef = detail.patchRef
+  button.dataset.filePath = detail.filePath
+  button.dataset.lineKind = detail.lineKind
+  button.dataset.lineNo = String(detail.lineNo)
+  button.dataset.lineSide = detail.lineSide
+  button.textContent = "Comment"
+  button.addEventListener("click", event => {
+    event.preventDefault()
+    event.stopPropagation()
+    openDiffReviewEditor(root, line, detail)
+  })
+  return button
+}
+
 export const diffElement = (input: {
   readonly patch: string
   readonly language?: string
@@ -325,6 +450,18 @@ export const diffElement = (input: {
     content.className = "cb-diff-code"
     tokenizeInto(content, row.text, language)
     line.append(content)
+    const lineNo = diffReviewLineNo(row)
+    const lineKind = diffReviewKind(row)
+    if (lineNo !== null && lineKind !== null) {
+      const filePath = parsed.filename ?? "diff"
+      line.append(diffReviewButton(root, line, {
+        filePath,
+        lineKind,
+        lineNo,
+        lineSide: diffReviewSide(row),
+        patchRef: `diff.${filePath}.${lineKind}.${lineNo}`,
+      }))
+    }
     code.append(line)
   }
 

--- a/clients/khala-code-desktop/tests/app-shell.test.ts
+++ b/clients/khala-code-desktop/tests/app-shell.test.ts
@@ -1671,6 +1671,23 @@ describe("khala code desktop app shell", () => {
     ])
   })
 
+  test("wires desktop diff line comments back as review steering input", async () => {
+    const main = await Bun.file(new URL("../src/ui/main.ts", import.meta.url)).text()
+    const renderer = await Bun.file(new URL("../src/ui/transcript-render.ts", import.meta.url)).text()
+    const shared = await Bun.file(new URL("../src/shared/diff-review.ts", import.meta.url)).text()
+    const css = await Bun.file(new URL("../src/ui/styles.css", import.meta.url)).text()
+
+    expect(shared).toContain("openagents.khala_code.diff_review_comment.v1")
+    expect(renderer).toContain("cb-diff-comment-button")
+    expect(renderer).toContain("KHALA_CODE_DIFF_REVIEW_SUBMIT_EVENT")
+    expect(main).toContain("KhalaCodeDiffReviewSubmitDetailSchema")
+    expect(main).toContain("khalaCodeDiffReviewSteeringNote")
+    expect(main).toContain("rpc.request.codexTurnSteer")
+    expect(main).toContain("stageDiffReviewNoteInComposer")
+    expect(css).toContain(".cb-diff-review-editor")
+    expect(css).toContain(".cb-diff-review-textarea")
+  })
+
   test("parses assistant prose as markdown instead of literal asterisks", () => {
     const blocks = parseMarkdownBlocks(
       "We can:\n\n- **Explore** files\n- Run `tests`\n\n[Docs](/docs) [bad](javascript:alert(1))",

--- a/clients/khala-code-desktop/tests/diff-review.test.ts
+++ b/clients/khala-code-desktop/tests/diff-review.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test"
+import { Window } from "happy-dom"
+import { Schema as S } from "effect"
+
+import {
+  KHALA_CODE_DIFF_REVIEW_COMMENT_SCHEMA,
+  KHALA_CODE_DIFF_REVIEW_SUBMIT_EVENT,
+  KhalaCodeDiffReviewCommentSchema,
+  khalaCodeDiffReviewComment,
+  khalaCodeDiffReviewSteeringNote,
+} from "../src/shared/diff-review"
+import { diffElement } from "../src/ui/transcript-render"
+
+let previousDocument: typeof globalThis.document | undefined
+let previousWindow: typeof globalThis.window | undefined
+let previousCustomEvent: typeof globalThis.CustomEvent | undefined
+
+const installDom = (): void => {
+  const window = new Window()
+  previousDocument = globalThis.document
+  previousWindow = globalThis.window
+  previousCustomEvent = globalThis.CustomEvent
+  Object.defineProperty(globalThis, "window", { configurable: true, value: window })
+  Object.defineProperty(globalThis, "document", { configurable: true, value: window.document })
+  Object.defineProperty(globalThis, "CustomEvent", { configurable: true, value: window.CustomEvent })
+}
+
+const restoreDom = (): void => {
+  Object.defineProperty(globalThis, "window", { configurable: true, value: previousWindow })
+  Object.defineProperty(globalThis, "document", { configurable: true, value: previousDocument })
+  Object.defineProperty(globalThis, "CustomEvent", { configurable: true, value: previousCustomEvent })
+}
+
+describe("Khala Code diff review annotations", () => {
+  beforeEach(installDom)
+  afterEach(restoreDom)
+
+  test("formats line comments as structured steering notes", () => {
+    const comment = khalaCodeDiffReviewComment({
+      body: "Please keep this export named; downstream imports rely on it.",
+      commentRef: "diff_review.test.1",
+      filePath: "src/example.ts",
+      lineKind: "add",
+      lineNo: 12,
+      lineSide: "new",
+      patchRef: "diff.src/example.ts.add.12",
+    })
+
+    expect(S.decodeUnknownSync(KhalaCodeDiffReviewCommentSchema)(comment)).toEqual(comment)
+    expect(khalaCodeDiffReviewSteeringNote(comment)).toContain(
+      `Diff review comment (${KHALA_CODE_DIFF_REVIEW_COMMENT_SCHEMA})`,
+    )
+    expect(khalaCodeDiffReviewSteeringNote(comment)).toContain("Line: src/example.ts:+12")
+    expect(khalaCodeDiffReviewSteeringNote(comment)).toContain(comment.body)
+  })
+
+  test("diff rows emit typed review comment submit details", () => {
+    const root = diffElement({
+      patch: [
+        "--- a/src/example.ts",
+        "+++ b/src/example.ts",
+        "@@ -1 +1 @@",
+        "-export const oldName = true",
+        "+export const newName = true",
+        "",
+      ].join("\n"),
+    })
+    document.body.append(root)
+
+    let submitted: unknown
+    root.addEventListener(KHALA_CODE_DIFF_REVIEW_SUBMIT_EVENT, event => {
+      submitted = (event as CustomEvent<unknown>).detail
+    })
+
+    const buttons = root.querySelectorAll<HTMLButtonElement>(".cb-diff-comment-button")
+    expect(buttons).toHaveLength(2)
+    buttons[1]?.click()
+
+    const textarea = root.querySelector<HTMLTextAreaElement>(".cb-diff-review-textarea")
+    expect(textarea).not.toBeNull()
+    textarea!.value = "The rename needs a migration note."
+
+    root.querySelector<HTMLButtonElement>(".cb-diff-review-submit")?.click()
+
+    expect(submitted).toMatchObject({
+      body: "The rename needs a migration note.",
+      filePath: "src/example.ts",
+      lineKind: "add",
+      lineNo: 1,
+      lineSide: "new",
+      patchRef: "diff.src/example.ts.add.1",
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- add a typed Khala Code diff-review comment schema and steering-note formatter
- render inline Comment controls for unified diff rows in transcript output
- submit review comments into active turn steering, or stage them in the composer when no turn is pending

Fixes #7900

## Validation
- bun test clients/khala-code-desktop/tests/diff-review.test.ts clients/khala-code-desktop/tests/transcript-render.property.test.ts clients/khala-code-desktop/tests/app-shell.test.ts
- bun run --cwd clients/khala-code-desktop typecheck
- bun run --cwd clients/khala-code-desktop verify
- git diff --check
- bun run --cwd apps/openagents.com check:deploy