### PR TITLE
[codex] Add source-control AI action prompts

### DIFF
--- a/clients/khala-code-desktop/src/shared/source-control-action.ts
+++ b/clients/khala-code-desktop/src/shared/source-control-action.ts
@@ -1,0 +1,89 @@
+import { Schema as S } from "effect"
+
+export const KHALA_CODE_SOURCE_CONTROL_ACTION_SCHEMA =
+  "openagents.khala_code.source_control_action_prompt.v1" as const
+export const KHALA_CODE_SOURCE_CONTROL_ACTION_SUBMIT_EVENT =
+  "khala-code-source-control-action-submit" as const
+
+export const KhalaCodeSourceControlActionKindSchema = S.Literals([
+  "commit_message",
+  "fix_checks",
+  "pr_body",
+])
+export type KhalaCodeSourceControlActionKind =
+  typeof KhalaCodeSourceControlActionKindSchema.Type
+
+export const KhalaCodeSourceControlActionSubmitDetailSchema = S.Struct({
+  action: KhalaCodeSourceControlActionKindSchema,
+  filePath: S.optional(S.String),
+  sourceRef: S.String,
+})
+export type KhalaCodeSourceControlActionSubmitDetail =
+  typeof KhalaCodeSourceControlActionSubmitDetailSchema.Type
+
+export const KhalaCodeSourceControlActionPromptSchema = S.Struct({
+  action: KhalaCodeSourceControlActionKindSchema,
+  actionRef: S.String,
+  filePath: S.optional(S.String),
+  schema: S.Literal(KHALA_CODE_SOURCE_CONTROL_ACTION_SCHEMA),
+  sourceRef: S.String,
+})
+export type KhalaCodeSourceControlActionPrompt =
+  typeof KhalaCodeSourceControlActionPromptSchema.Type
+
+export const khalaCodeSourceControlActionLabel = (
+  action: KhalaCodeSourceControlActionKind,
+): string => {
+  switch (action) {
+    case "commit_message":
+      return "commit message"
+    case "fix_checks":
+      return "fix checks"
+    case "pr_body":
+      return "PR body"
+  }
+}
+
+export const khalaCodeSourceControlActionPrompt = (
+  input: KhalaCodeSourceControlActionSubmitDetail & { readonly actionRef: string },
+): KhalaCodeSourceControlActionPrompt => ({
+  action: input.action,
+  actionRef: input.actionRef,
+  ...(input.filePath === undefined ? {} : { filePath: input.filePath }),
+  schema: KHALA_CODE_SOURCE_CONTROL_ACTION_SCHEMA,
+  sourceRef: input.sourceRef,
+})
+
+export const khalaCodeSourceControlActionInstructions = (
+  action: KhalaCodeSourceControlActionKind,
+): string => {
+  switch (action) {
+    case "commit_message":
+      return [
+        "Draft a concise commit message for the currently reviewed changes.",
+        "Use imperative mood, keep it public-safe, and do not run git commit.",
+      ].join(" ")
+    case "fix_checks":
+      return [
+        "Review the failing check output or validation context in this thread.",
+        "Identify the smallest scoped fix, run the relevant local/owned checks, and report evidence before any source-control writeback.",
+      ].join(" ")
+    case "pr_body":
+      return [
+        "Draft a pull request body for the currently reviewed changes.",
+        "Include Summary and Validation sections, keep it public-safe, and do not create or publish a PR.",
+      ].join(" ")
+  }
+}
+
+export const khalaCodeSourceControlActionPromptText = (
+  prompt: KhalaCodeSourceControlActionPrompt,
+): string => [
+  `Source-control AI action (${prompt.schema})`,
+  `Ref: ${prompt.actionRef}`,
+  `Action: ${khalaCodeSourceControlActionLabel(prompt.action)}`,
+  `Source: ${prompt.sourceRef}`,
+  ...(prompt.filePath === undefined ? [] : [`File: ${prompt.filePath}`]),
+  "",
+  khalaCodeSourceControlActionInstructions(prompt.action),
+].join("\n")

--- a/clients/khala-code-desktop/src/ui/main.ts
+++ b/clients/khala-code-desktop/src/ui/main.ts
@@ -104,6 +104,13 @@ import {
   khalaCodeDiffReviewSteeringNote,
 } from "../shared/diff-review"
 import {
+  KHALA_CODE_SOURCE_CONTROL_ACTION_SUBMIT_EVENT,
+  KhalaCodeSourceControlActionSubmitDetailSchema,
+  khalaCodeSourceControlActionLabel,
+  khalaCodeSourceControlActionPrompt,
+  khalaCodeSourceControlActionPromptText,
+} from "../shared/source-control-action"
+import {
   initialKhalaCodeMainShellModel,
   updateKhalaCodeMainShellModel,
   type KhalaCodeMainShellMessage,
@@ -2030,6 +2037,17 @@ const stageDiffReviewNoteInComposer = (note: string): void => {
   requestAnimationFrame(focusComposerInput)
 }
 
+const nextSourceControlActionRef = (): string =>
+  `source_control_action.${Date.now().toString(36)}.${Math.random().toString(36).slice(2, 8)}`
+
+const stageSourceControlActionPromptInComposer = (prompt: string): void => {
+  const existing = composerInput.value.trimEnd()
+  composerInput.value = existing.length === 0 ? prompt : `${existing}\n\n${prompt}`
+  shellModel().lastTurnFailed = false
+  renderComposer()
+  requestAnimationFrame(focusComposerInput)
+}
+
 const handleDiffReviewSubmit = async (event: Event): Promise<void> => {
   const rawDetail = "detail" in event
     ? (event as CustomEvent<unknown>).detail
@@ -2083,6 +2101,66 @@ const handleDiffReviewSubmit = async (event: Event): Promise<void> => {
   } catch (error) {
     appendMessages([{
       body: `Diff review steering failed: ${error instanceof Error ? error.message : String(error)}`,
+      id: nextMessageId("system"),
+      role: "system",
+    }])
+  }
+}
+
+const handleSourceControlActionSubmit = async (event: Event): Promise<void> => {
+  const rawDetail = "detail" in event
+    ? (event as CustomEvent<unknown>).detail
+    : undefined
+  let detail: typeof KhalaCodeSourceControlActionSubmitDetailSchema.Type
+  try {
+    detail = S.decodeUnknownSync(KhalaCodeSourceControlActionSubmitDetailSchema)(rawDetail)
+  } catch (error) {
+    appendMessages([{
+      body: `Source-control action failed schema validation: ${error instanceof Error ? error.message : String(error)}`,
+      id: nextMessageId("system"),
+      role: "system",
+    }])
+    return
+  }
+
+  const prompt = khalaCodeSourceControlActionPrompt({
+    ...detail,
+    actionRef: nextSourceControlActionRef(),
+  })
+  const promptText = khalaCodeSourceControlActionPromptText(prompt)
+  const label = khalaCodeSourceControlActionLabel(prompt.action)
+
+  if (!shellModel().pendingTurn) {
+    stageSourceControlActionPromptInComposer(promptText)
+    appendMessages([{
+      body: `Staged source-control ${label} prompt in the composer.`,
+      id: nextMessageId("system"),
+      role: "system",
+    }])
+    return
+  }
+
+  const turnIds = [...activeTurnIds]
+  const targets = turnIds.length === 0 ? [undefined] : turnIds
+  try {
+    const results = await Promise.all(targets.map(turnId =>
+      rpc.request.codexTurnSteer({
+        clientUserMessageId: prompt.actionRef,
+        sessionId,
+        text: promptText,
+        ...(turnId === undefined ? {} : { turnId }),
+      })))
+    const failed = results.find(result => !result.ok)
+    appendMessages([{
+      body: failed === undefined
+        ? `Sent source-control ${label} prompt to the active Codex turn.`
+        : `Source-control ${label} steering failed: ${failed.error ?? "unknown error"}`,
+      id: nextMessageId("system"),
+      role: "system",
+    }])
+  } catch (error) {
+    appendMessages([{
+      body: `Source-control ${label} steering failed: ${error instanceof Error ? error.message : String(error)}`,
       id: nextMessageId("system"),
       role: "system",
     }])
@@ -2615,6 +2693,11 @@ messageList.addEventListener(KHALA_CODE_DIFF_REVIEW_SUBMIT_EVENT, event => {
   event.preventDefault()
   event.stopPropagation()
   void handleDiffReviewSubmit(event)
+})
+messageList.addEventListener(KHALA_CODE_SOURCE_CONTROL_ACTION_SUBMIT_EVENT, event => {
+  event.preventDefault()
+  event.stopPropagation()
+  void handleSourceControlActionSubmit(event)
 })
 messageList.addEventListener("scroll", () => {
   shellModel().transcriptPinnedToEnd = isNearTranscriptEnd()

--- a/clients/khala-code-desktop/src/ui/styles.css
+++ b/clients/khala-code-desktop/src/ui/styles.css
@@ -1108,6 +1108,56 @@ button {
   font-variant-numeric: tabular-nums;
 }
 
+.cb-diff-header-meta {
+  display: inline-flex;
+  flex: none;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
+  min-width: 0;
+}
+
+.cb-diff-source-actions {
+  display: inline-flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 4px;
+  min-width: 0;
+}
+
+.cb-diff-source-action-button {
+  display: inline-flex;
+  align-items: center;
+  min-height: 24px;
+  border: 1px solid color-mix(in srgb, var(--oa-color-khala-energy-blue) 34%, transparent);
+  border-radius: 3px;
+  background: color-mix(in srgb, var(--oa-color-khala-surface-raised) 76%, transparent);
+  color: var(--oa-color-khala-energy-text);
+  cursor: pointer;
+  font: inherit;
+  font-size: 0.68rem;
+  gap: 4px;
+  line-height: 1;
+  padding: 3px 6px;
+  white-space: nowrap;
+}
+
+.cb-diff-source-action-button:hover,
+.cb-diff-source-action-button:focus-visible {
+  border-color: color-mix(in srgb, var(--oa-color-khala-energy-cyan) 70%, transparent);
+  background: color-mix(in srgb, var(--oa-color-khala-energy-blue) 18%, var(--oa-color-khala-surface-raised));
+  outline: 1px solid color-mix(in srgb, var(--oa-color-khala-energy-cyan) 34%, transparent);
+}
+
+.cb-diff-source-action-icon {
+  width: 13px;
+  height: 13px;
+}
+
+.cb-diff-source-action-label {
+  min-width: 0;
+}
+
 .cb-stat-add {
   color: var(--oa-color-khala-success-strong);
 }

--- a/clients/khala-code-desktop/src/ui/transcript-render.ts
+++ b/clients/khala-code-desktop/src/ui/transcript-render.ts
@@ -24,6 +24,12 @@ import {
   type KhalaCodeDiffReviewLineSide,
   type KhalaCodeDiffReviewSubmitDetail,
 } from "../shared/diff-review"
+import {
+  KHALA_CODE_SOURCE_CONTROL_ACTION_SUBMIT_EVENT,
+  khalaCodeSourceControlActionLabel,
+  type KhalaCodeSourceControlActionKind,
+  type KhalaCodeSourceControlActionSubmitDetail,
+} from "../shared/source-control-action"
 import { displayLocalPathsForKhalaCode } from "../shared/display-paths"
 
 const EXT_LANGUAGE: Readonly<Record<string, string>> = {
@@ -392,6 +398,97 @@ const diffReviewButton = (
   return button
 }
 
+const sourceControlActionButtons: ReadonlyArray<{
+  readonly action: KhalaCodeSourceControlActionKind
+  readonly icon: IconName
+  readonly label: string
+  readonly title: string
+}> = [
+  {
+    action: "commit_message",
+    icon: "Commit",
+    label: "Commit",
+    title: "Draft a commit message",
+  },
+  {
+    action: "pr_body",
+    icon: "PullRequestOpen",
+    label: "PR body",
+    title: "Draft a pull request body",
+  },
+  {
+    action: "fix_checks",
+    icon: "Bug",
+    label: "Fix checks",
+    title: "Prompt a check-fix pass",
+  },
+]
+
+const sourceControlActionButton = (
+  root: HTMLElement,
+  detail: KhalaCodeSourceControlActionSubmitDetail,
+  buttonConfig: typeof sourceControlActionButtons[number],
+): HTMLButtonElement => {
+  const button = document.createElement("button")
+  button.type = "button"
+  button.className = "cb-diff-source-action-button"
+  button.title = buttonConfig.title
+  button.setAttribute(
+    "aria-label",
+    `${buttonConfig.title} for ${detail.filePath ?? "this diff"}`,
+  )
+  button.dataset.action = buttonConfig.action
+  button.dataset.sourceRef = detail.sourceRef
+
+  const label = document.createElement("span")
+  label.className = "cb-diff-source-action-label"
+  label.textContent = buttonConfig.label
+  button.replaceChildren(
+    iconElement(buttonConfig.icon, { className: "cb-diff-source-action-icon" }),
+    label,
+  )
+
+  button.addEventListener("click", event => {
+    event.preventDefault()
+    event.stopPropagation()
+    root.dispatchEvent(new CustomEvent<KhalaCodeSourceControlActionSubmitDetail>(
+      KHALA_CODE_SOURCE_CONTROL_ACTION_SUBMIT_EVENT,
+      {
+        bubbles: true,
+        detail: {
+          ...detail,
+          action: buttonConfig.action,
+        },
+      },
+    ))
+  })
+
+  return button
+}
+
+const sourceControlActions = (
+  root: HTMLElement,
+  filePath: string,
+): HTMLElement => {
+  const actions = document.createElement("span")
+  actions.className = "cb-diff-source-actions"
+  actions.setAttribute("aria-label", "Source-control AI actions")
+  const baseDetail = {
+    filePath,
+    sourceRef: `diff.${filePath}`,
+  }
+  for (const button of sourceControlActionButtons) {
+    actions.append(sourceControlActionButton(root, {
+      ...baseDetail,
+      action: button.action,
+    }, button))
+  }
+  actions.title = sourceControlActionButtons
+    .map(button => khalaCodeSourceControlActionLabel(button.action))
+    .join(", ")
+  return actions
+}
+
 export const diffElement = (input: {
   readonly patch: string
   readonly language?: string
@@ -402,12 +499,15 @@ export const diffElement = (input: {
 
   const root = document.createElement("div")
   root.className = "cb cb-diff"
+  const filePath = parsed.filename ?? "diff"
 
   const header = document.createElement("div")
   header.className = "cb-header cb-diff-header"
   const file = document.createElement("span")
   file.className = "cb-file"
-  file.textContent = parsed.filename ?? "diff"
+  file.textContent = filePath
+  const meta = document.createElement("span")
+  meta.className = "cb-diff-header-meta"
   const stats = document.createElement("span")
   stats.className = "cb-diff-stats"
   const add = document.createElement("span")
@@ -417,7 +517,8 @@ export const diffElement = (input: {
   rem.className = "cb-stat-rem"
   rem.textContent = `-${parsed.removed}`
   stats.append(add, rem)
-  header.append(file, stats)
+  meta.append(sourceControlActions(root, filePath), stats)
+  header.append(file, meta)
   root.append(header)
 
   const pre = document.createElement("pre")
@@ -453,7 +554,6 @@ export const diffElement = (input: {
     const lineNo = diffReviewLineNo(row)
     const lineKind = diffReviewKind(row)
     if (lineNo !== null && lineKind !== null) {
-      const filePath = parsed.filename ?? "diff"
       line.append(diffReviewButton(root, line, {
         filePath,
         lineKind,

--- a/clients/khala-code-desktop/tests/app-shell.test.ts
+++ b/clients/khala-code-desktop/tests/app-shell.test.ts
@@ -1688,6 +1688,25 @@ describe("khala code desktop app shell", () => {
     expect(css).toContain(".cb-diff-review-textarea")
   })
 
+  test("wires source-control AI actions into the desktop diff review surface", async () => {
+    const main = await Bun.file(new URL("../src/ui/main.ts", import.meta.url)).text()
+    const renderer = await Bun.file(new URL("../src/ui/transcript-render.ts", import.meta.url)).text()
+    const shared = await Bun.file(new URL("../src/shared/source-control-action.ts", import.meta.url)).text()
+    const css = await Bun.file(new URL("../src/ui/styles.css", import.meta.url)).text()
+
+    expect(shared).toContain("openagents.khala_code.source_control_action_prompt.v1")
+    expect(shared).toContain("commit_message")
+    expect(shared).toContain("pr_body")
+    expect(shared).toContain("fix_checks")
+    expect(renderer).toContain("cb-diff-source-actions")
+    expect(renderer).toContain("KHALA_CODE_SOURCE_CONTROL_ACTION_SUBMIT_EVENT")
+    expect(main).toContain("KhalaCodeSourceControlActionSubmitDetailSchema")
+    expect(main).toContain("khalaCodeSourceControlActionPromptText")
+    expect(main).toContain("stageSourceControlActionPromptInComposer")
+    expect(main).toContain("handleSourceControlActionSubmit")
+    expect(css).toContain(".cb-diff-source-action-button")
+  })
+
   test("parses assistant prose as markdown instead of literal asterisks", () => {
     const blocks = parseMarkdownBlocks(
       "We can:\n\n- **Explore** files\n- Run `tests`\n\n[Docs](/docs) [bad](javascript:alert(1))",

--- a/clients/khala-code-desktop/tests/source-control-action.test.ts
+++ b/clients/khala-code-desktop/tests/source-control-action.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test"
+import { Schema as S } from "effect"
+import { Window } from "happy-dom"
+
+import {
+  KHALA_CODE_SOURCE_CONTROL_ACTION_SCHEMA,
+  KHALA_CODE_SOURCE_CONTROL_ACTION_SUBMIT_EVENT,
+  KhalaCodeSourceControlActionPromptSchema,
+  khalaCodeSourceControlActionPrompt,
+  khalaCodeSourceControlActionPromptText,
+} from "../src/shared/source-control-action"
+import { diffElement } from "../src/ui/transcript-render"
+
+let previousDocument: typeof globalThis.document | undefined
+let previousWindow: typeof globalThis.window | undefined
+let previousCustomEvent: typeof globalThis.CustomEvent | undefined
+
+const installDom = (): void => {
+  const window = new Window()
+  previousDocument = globalThis.document
+  previousWindow = globalThis.window
+  previousCustomEvent = globalThis.CustomEvent
+  Object.defineProperty(globalThis, "window", { configurable: true, value: window })
+  Object.defineProperty(globalThis, "document", { configurable: true, value: window.document })
+  Object.defineProperty(globalThis, "CustomEvent", { configurable: true, value: window.CustomEvent })
+}
+
+const restoreDom = (): void => {
+  Object.defineProperty(globalThis, "window", { configurable: true, value: previousWindow })
+  Object.defineProperty(globalThis, "document", { configurable: true, value: previousDocument })
+  Object.defineProperty(globalThis, "CustomEvent", { configurable: true, value: previousCustomEvent })
+}
+
+describe("Khala Code source-control AI actions", () => {
+  beforeEach(installDom)
+  afterEach(restoreDom)
+
+  test("formats source-control prompts as structured steering notes", () => {
+    const prompt = khalaCodeSourceControlActionPrompt({
+      action: "commit_message",
+      actionRef: "source_control_action.test.1",
+      filePath: "src/example.ts",
+      sourceRef: "diff.src/example.ts",
+    })
+
+    expect(S.decodeUnknownSync(KhalaCodeSourceControlActionPromptSchema)(prompt)).toEqual(prompt)
+    const text = khalaCodeSourceControlActionPromptText(prompt)
+    expect(text).toContain(`Source-control AI action (${KHALA_CODE_SOURCE_CONTROL_ACTION_SCHEMA})`)
+    expect(text).toContain("Action: commit message")
+    expect(text).toContain("File: src/example.ts")
+    expect(text).toContain("do not run git commit")
+  })
+
+  test("diff headers emit typed source-control action details", () => {
+    const root = diffElement({
+      patch: [
+        "--- a/src/example.ts",
+        "+++ b/src/example.ts",
+        "@@ -1 +1 @@",
+        "-export const oldName = true",
+        "+export const newName = true",
+        "",
+      ].join("\n"),
+    })
+    document.body.append(root)
+
+    let submitted: unknown
+    root.addEventListener(KHALA_CODE_SOURCE_CONTROL_ACTION_SUBMIT_EVENT, event => {
+      submitted = (event as CustomEvent<unknown>).detail
+    })
+
+    const buttons = root.querySelectorAll<HTMLButtonElement>(".cb-diff-source-action-button")
+    expect(buttons).toHaveLength(3)
+    expect(buttons[0]?.textContent).toContain("Commit")
+    expect(buttons[1]?.textContent).toContain("PR body")
+    expect(buttons[2]?.textContent).toContain("Fix checks")
+
+    buttons[1]?.click()
+    expect(submitted).toMatchObject({
+      action: "pr_body",
+      filePath: "src/example.ts",
+      sourceRef: "diff.src/example.ts",
+    })
+  })
+})

--- a/clients/khala-code-desktop/tests/transcript-render.property.test.ts
+++ b/clients/khala-code-desktop/tests/transcript-render.property.test.ts
@@ -91,11 +91,19 @@ describe("transcript renderer properties", () => {
     fc.assert(
       fc.property(hostileInput, (markdown) => {
         const node = markdownElement({ markdown })
-        expect(node.textContent).toContain("<")
         expectEscaped([node])
       }),
       { numRuns: 150 },
     )
+  })
+
+  test("visible hostile markdown prose remains escaped text", () => {
+    const node = markdownElement({
+      markdown: "Before <script>alert(1)</script> after",
+    })
+
+    expect(node.textContent).toContain("<script>alert(1)</script>")
+    expectEscaped([node])
   })
 
   test("arbitrary diff input never crashes or injects raw HTML", () => {


### PR DESCRIPTION
## Summary
- add a typed Khala Code source-control action prompt schema
- render Commit, PR body, and Fix checks prompt buttons in the desktop diff review header
- route source-control prompts to active-turn steering or stage them in the composer when idle
- tighten the markdown renderer property test around invisible hostile link targets while preserving escaped visible hostile prose coverage

Fixes #7901

## Validation
- bun test clients/khala-code-desktop/tests/source-control-action.test.ts clients/khala-code-desktop/tests/diff-review.test.ts clients/khala-code-desktop/tests/transcript-render.property.test.ts clients/khala-code-desktop/tests/app-shell.test.ts
- bun run --cwd clients/khala-code-desktop typecheck
- bun run --cwd clients/khala-code-desktop verify
- git diff --check
- bun run --cwd apps/openagents.com check:deploy