### PR TITLE
[codex] Ship Claude closeout token diagnostics

### DIFF
--- a/apps/pylon/docs/claude-agent-task-smoke.md
+++ b/apps/pylon/docs/claude-agent-task-smoke.md
@@ -40,8 +40,9 @@ verification runs in the workspace) → progress → artifacts → closeout —
 then scans every retained request and the closeout for redaction
 violations. Exit 0 requires: closeout `accepted`,
 `fixture_repair_passed` result ref, `payoutClaimAllowed: false`,
-`settlementState: not_applicable`, `redacted: true`, zero scan
-violations.
+`settlementState: not_applicable`, `redacted: true`,
+`result.public.pylon.claude_agent_task.token_usage_reported`, no
+token-accounting blocker refs, and zero scan violations.
 
 The same leg runs inside `bun test` (`tests/claude-agent-task-smoke.test.ts`),
 so the release gate covers it on every run.
@@ -104,3 +105,10 @@ promise; nobody flips their own.
 - `blocker.assignment.claude_agent_workspace_escape_blocked` or
   `…budget_exceeded`: the sandbox or budget stopped the session; both
   are typed, terminal, and reportable as-is.
+- `blocker.assignment.claude_agent_token_usage_missing`: the SDK result did
+  not surface positive exact usage, so no fabricated row was posted.
+- `blocker.assignment.claude_agent_token_usage_reporter_unconfigured` or
+  `…report_failed`: the local code may have passed, but the exact
+  `/api/pylon/claude/turns` row is not proven. Treat this as an accounting
+  closeout blocker and rerun after fixing the agent token/base URL or ingest
+  route.

--- a/apps/pylon/src/claude-agent-executor.ts
+++ b/apps/pylon/src/claude-agent-executor.ts
@@ -395,26 +395,45 @@ const finiteToken = (value: unknown): number =>
     ? Math.trunc(value)
     : 0
 
+const firstFiniteToken = (...values: unknown[]): number => {
+  for (const value of values) {
+    const token = finiteToken(value)
+    if (token > 0) return token
+  }
+  return 0
+}
+
 /**
  * Reads cumulative exact token usage from the Claude Agent SDK `result`
- * message. The SDK reports usage with Anthropic-native field names
- * (`input_tokens`, `output_tokens`, `cache_read_input_tokens`). Returns null
- * when no positive usage is present so a missing/zero usage does not post a
- * fabricated token row.
+ * message. SDK builds have surfaced both Anthropic-native snake_case fields and
+ * JS-friendly camelCase fields; accept both but still return null when no
+ * positive usage is present so a missing/zero usage does not post a fabricated
+ * token row.
  */
 export function claudeUsageFrom(value: unknown): ClaudeAgentTurnUsage | null {
   if (value === null || typeof value !== "object") return null
   const usage = value as {
+    cachedInputTokens?: unknown
+    cacheCreationInputTokens?: unknown
+    cacheReadInputTokens?: unknown
     input_tokens?: unknown
+    inputTokens?: unknown
     output_tokens?: unknown
+    outputTokens?: unknown
     cache_read_input_tokens?: unknown
     cache_creation_input_tokens?: unknown
   }
-  const inputTokens = finiteToken(usage.input_tokens)
-  const outputTokens = finiteToken(usage.output_tokens)
+  const inputTokens = firstFiniteToken(usage.input_tokens, usage.inputTokens)
+  const outputTokens = firstFiniteToken(usage.output_tokens, usage.outputTokens)
+  const cacheReadTokens = firstFiniteToken(usage.cache_read_input_tokens, usage.cacheReadInputTokens)
+  const cacheCreationTokens = firstFiniteToken(
+    usage.cache_creation_input_tokens,
+    usage.cacheCreationInputTokens,
+  )
   const cachedInputTokens =
-    finiteToken(usage.cache_read_input_tokens) +
-    finiteToken(usage.cache_creation_input_tokens)
+    cacheReadTokens + cacheCreationTokens > 0
+      ? cacheReadTokens + cacheCreationTokens
+      : firstFiniteToken(usage.cachedInputTokens)
   if (inputTokens === 0 && outputTokens === 0 && cachedInputTokens === 0) {
     return null
   }
@@ -557,12 +576,98 @@ type ClaudeAgentLease = {
   codingAssignment?: unknown
 }
 
+type ClaudeTokenUsageReportDiagnostic = {
+  blockerRefs: string[]
+  proofRefs: string[]
+  resultRefs: string[]
+  summaryRefs: string[]
+}
+
+type ClaudeTokenUsageReportState =
+  | "reported"
+  | "missing"
+  | "report_failed"
+  | "reporter_unconfigured"
+
+function claudeTokenUsageReportDiagnostic(
+  state: ClaudeTokenUsageReportState,
+  seed: string,
+): ClaudeTokenUsageReportDiagnostic {
+  const resultRef = `result.public.pylon.claude_agent_task.token_usage_${state}`
+  const summaryRef = `summary.public.pylon.claude_agent_task.token_usage_${state}`
+  return {
+    blockerRefs:
+      state === "reported"
+        ? []
+        : [`blocker.assignment.claude_agent_token_usage_${state}`],
+    proofRefs: [stableRef(`proof.pylon.claude_agent_task.token_usage_${state}`, seed)],
+    resultRefs: [resultRef],
+    summaryRefs: [summaryRef],
+  }
+}
+
+async function reportClaudeAgentTurnUsage(input: {
+  lease: ClaudeAgentLease
+  materialized: Awaited<ReturnType<typeof materializeClaudeAgentWorkspace>>
+  now: Date
+  options: ClaudeAgentExecutionOptions
+  run: ClaudeAgentRunResult
+  runRef: string
+  state: PylonLocalState
+}): Promise<ClaudeTokenUsageReportDiagnostic> {
+  const seed = [
+    input.lease.assignmentRef,
+    input.lease.leaseRef,
+    input.runRef,
+    input.run.sessionRef ?? "session.pending",
+    input.materialized.workspaceRef,
+  ].join(":")
+  if (input.run.usage === null) {
+    return claudeTokenUsageReportDiagnostic("missing", seed)
+  }
+
+  const reporter =
+    input.options.claudeTurnReporter ??
+    createPylonClaudeTurnReporter({
+      ...(input.options.agentToken === undefined ? {} : { agentToken: input.options.agentToken }),
+      ...(input.options.baseUrl === undefined ? {} : { baseUrl: input.options.baseUrl }),
+      ...(input.options.fetch === undefined ? {} : { fetch: input.options.fetch }),
+    })
+  if (reporter === undefined) {
+    return claudeTokenUsageReportDiagnostic("reporter_unconfigured", seed)
+  }
+
+  try {
+    await reporter({
+      assignmentRef: input.lease.assignmentRef,
+      leaseRef: input.lease.leaseRef,
+      pylonRef: input.state.identity.pylonRef,
+      runRef: input.runRef,
+      ...(input.run.sessionRef === null ? {} : { sessionRef: input.run.sessionRef }),
+      workspaceRef: input.materialized.workspaceRef,
+      turnIndex: 1,
+      observedAt: input.now.toISOString(),
+      usage: {
+        inputTokens: input.run.usage.inputTokens,
+        cachedInputTokens: input.run.usage.cachedInputTokens,
+        outputTokens: input.run.usage.outputTokens,
+      },
+    })
+    return claudeTokenUsageReportDiagnostic("reported", seed)
+  } catch {
+    return claudeTokenUsageReportDiagnostic("report_failed", seed)
+  }
+}
+
 function refusalRecord(input: {
   lease: ClaudeAgentLease
   runRef: string
   blockerRefs: string[]
+  proofRefs?: string[]
   resultRef: string
+  resultRefs?: string[]
   summaryRef: string
+  summaryRefs?: string[]
   message: string
 }) {
   const failureRef = stableRef(
@@ -579,11 +684,11 @@ function refusalRecord(input: {
     buildRefs: [input.runRef],
     message: input.message,
     previewRefs: [],
-    proofRefs: [failureRef],
-    resultRefs: [input.resultRef],
+    proofRefs: [failureRef, ...(input.proofRefs ?? [])],
+    resultRefs: [input.resultRef, ...(input.resultRefs ?? [])],
     runRefs: [input.runRef],
     status: "rejected" as const,
-    summaryRefs: [input.summaryRef],
+    summaryRefs: [input.summaryRef, ...(input.summaryRefs ?? [])],
     testRefs: [failureRef],
   }
 }
@@ -675,13 +780,29 @@ export async function executeClaudeAgentAssignment(
     })
   }
 
+  const tokenUsageReport = await reportClaudeAgentTurnUsage({
+    lease,
+    materialized,
+    now,
+    options,
+    run,
+    runRef,
+    state,
+  })
+
   if (run.outcome === "workspace_escape_blocked") {
     return refusalRecord({
       lease,
       runRef,
-      blockerRefs: ["blocker.assignment.claude_agent_workspace_escape_blocked"],
+      blockerRefs: [
+        "blocker.assignment.claude_agent_workspace_escape_blocked",
+        ...tokenUsageReport.blockerRefs,
+      ],
+      proofRefs: tokenUsageReport.proofRefs,
       resultRef: "result.public.pylon.claude_agent_task.workspace_escape_blocked",
+      resultRefs: tokenUsageReport.resultRefs,
       summaryRef: "summary.public.pylon.claude_agent_task.workspace_escape_blocked",
+      summaryRefs: tokenUsageReport.summaryRefs,
       message: "Local Claude Agent session was stopped: a tool call targeted paths outside the bounded workspace.",
     })
   }
@@ -689,9 +810,15 @@ export async function executeClaudeAgentAssignment(
     return refusalRecord({
       lease,
       runRef,
-      blockerRefs: ["blocker.assignment.claude_agent_budget_exceeded"],
+      blockerRefs: [
+        "blocker.assignment.claude_agent_budget_exceeded",
+        ...tokenUsageReport.blockerRefs,
+      ],
+      proofRefs: tokenUsageReport.proofRefs,
       resultRef: "result.public.pylon.claude_agent_task.budget_exceeded",
+      resultRefs: tokenUsageReport.resultRefs,
       summaryRef: "summary.public.pylon.claude_agent_task.budget_exceeded",
+      summaryRefs: tokenUsageReport.summaryRefs,
       message: "Local Claude Agent session exceeded its turn or wall-clock budget before completing the task.",
     })
   }
@@ -699,48 +826,17 @@ export async function executeClaudeAgentAssignment(
     return refusalRecord({
       lease,
       runRef,
-      blockerRefs: ["blocker.assignment.claude_agent_execution_refused"],
+      blockerRefs: [
+        "blocker.assignment.claude_agent_execution_refused",
+        ...tokenUsageReport.blockerRefs,
+      ],
+      proofRefs: tokenUsageReport.proofRefs,
       resultRef: "result.public.pylon.claude_agent_task.execution_refused",
+      resultRefs: tokenUsageReport.resultRefs,
       summaryRef: "summary.public.pylon.claude_agent_task.execution_refused",
+      summaryRefs: tokenUsageReport.summaryRefs,
       message: "Local Claude Agent session ended with an execution error before completing the task.",
     })
-  }
-
-  // #6391: post the exact own-capacity Claude Agent SDK token usage for this
-  // completed turn so a `token_usage_events` row exists (provider
-  // `pylon-claude-own-capacity`, model `openagents/pylon-claude`). Fail-soft: a
-  // reporter outage must never fail the local coding task. Skipped when the SDK
-  // surfaced no usage (never fabricate a row).
-  if (run.usage != null) {
-    const reporter =
-      options.claudeTurnReporter ??
-      createPylonClaudeTurnReporter({
-        ...(options.agentToken === undefined ? {} : { agentToken: options.agentToken }),
-        ...(options.baseUrl === undefined ? {} : { baseUrl: options.baseUrl }),
-        ...(options.fetch === undefined ? {} : { fetch: options.fetch }),
-      })
-    if (reporter !== undefined) {
-      try {
-        await reporter({
-          assignmentRef: lease.assignmentRef,
-          leaseRef: lease.leaseRef,
-          pylonRef: state.identity.pylonRef,
-          runRef,
-          ...(run.sessionRef === null ? {} : { sessionRef: run.sessionRef }),
-          workspaceRef: materialized.workspaceRef,
-          turnIndex: 1,
-          observedAt: now.toISOString(),
-          usage: {
-            inputTokens: run.usage.inputTokens,
-            cachedInputTokens: run.usage.cachedInputTokens,
-            outputTokens: run.usage.outputTokens,
-          },
-        })
-      } catch {
-        // Fail-soft: token-ingest outage does not abort the local coding task.
-        // The exact token row can be reconciled/retried; the local work stands.
-      }
-    }
   }
 
   const verification = await runCommand({ args: materialized.verificationArgs, cwd: materialized.workspace })
@@ -761,18 +857,22 @@ export async function executeClaudeAgentAssignment(
 
   return {
     artifactRefs: [artifactRef],
-    blockerRefs: passed ? [] : ["blocker.assignment.claude_agent_test_failed"],
+    blockerRefs: [
+      ...(passed ? [] : ["blocker.assignment.claude_agent_test_failed"]),
+      ...tokenUsageReport.blockerRefs,
+    ],
     buildRefs: [commandRef],
     message: passed
       ? `Local Claude Agent completed the bounded coding task: ${run.editedFileCount} file edit(s), ${run.commandCount} command(s), ${run.turnCount} turn(s), verification test passed on this device.`
       : "Local Claude Agent session completed but the verification test command failed; the change is not accepted.",
     previewRefs: [materialized.workspaceRef],
-    proofRefs: [proofRef],
+    proofRefs: [proofRef, ...tokenUsageReport.proofRefs],
     resultRefs: [
       passed
         ? `result.public.pylon.claude_agent_task.${materialized.acceptanceResultRef}_passed`
         : `result.public.pylon.claude_agent_task.${materialized.acceptanceResultRef}_failed`,
       `result.public.pylon.claude_agent_task.edited_files.${run.editedFileCount}`,
+      ...tokenUsageReport.resultRefs,
     ],
     runRefs: [runRef, ...sessionRefs],
     status: passed ? ("accepted" as const) : ("rejected" as const),
@@ -780,6 +880,7 @@ export async function executeClaudeAgentAssignment(
       passed
         ? `summary.public.pylon.claude_agent_task.${materialized.acceptanceResultRef}_passed`
         : `summary.public.pylon.claude_agent_task.${materialized.acceptanceResultRef}_failed`,
+      ...tokenUsageReport.summaryRefs,
     ],
     testRefs: [commandRef],
   }

--- a/apps/pylon/src/claude-agent-task-smoke.ts
+++ b/apps/pylon/src/claude-agent-task-smoke.ts
@@ -96,7 +96,14 @@ const ciFixingRunner: ClaudeAgentRunner = async (input) => {
     join(input.cwd, "sum.ts"),
     "export const sum = (left: number, right: number) => left + right\n",
   )
-  return { outcome: "completed", turnCount: 3, editedFileCount: 1, commandCount: 1, sessionRef: null , usage: null }
+  return {
+    outcome: "completed",
+    turnCount: 3,
+    editedFileCount: 1,
+    commandCount: 1,
+    sessionRef: null,
+    usage: { cachedInputTokens: 0, inputTokens: 1200, outputTokens: 340 },
+  }
 }
 
 function ciHarness(lease: PylonAssignmentLease) {
@@ -129,6 +136,9 @@ function ciHarness(lease: PylonAssignmentLease) {
       if (url.pathname.endsWith("/closeout")) {
         return Response.json({ closeoutRef: `assignment.closeout.${lease.leaseRef}` })
       }
+      if (url.pathname === "/api/pylon/claude/turns") {
+        return Response.json({ tokenUsageEventRef: `token_usage_event.pylon_claude.${lease.leaseRef}` })
+      }
       return Response.json({ errorRef: "error.not_found" }, { status: 404 })
     },
   })
@@ -149,6 +159,7 @@ function smokeResult(
   const ok =
     run.ok === true &&
     closeout?.status === "accepted" &&
+    closeout.blockerRefs.length === 0 &&
     closeout.payoutClaimAllowed === false &&
     closeout.settlementState === "not_applicable" &&
     redactionScan.violations.length === 0
@@ -201,6 +212,7 @@ export async function runClaudeAgentTaskCiSmoke(): Promise<ClaudeAgentTaskSmokeR
     await sendHeartbeat(summary, { baseUrl: harness.baseUrl })
 
     const run = await runNoSpendAssignment(summary, {
+      agentToken: "agent.public.claude_smoke",
       baseUrl: harness.baseUrl,
       claudeAgentRunner: ciFixingRunner,
       claudeAgentProbe: {

--- a/apps/pylon/tests/claude-agent-executor.test.ts
+++ b/apps/pylon/tests/claude-agent-executor.test.ts
@@ -7,12 +7,14 @@ import {
   CLAUDE_AGENT_SUM_REPAIR_FIXTURE_REF,
   CLAUDE_AGENT_TASK_SCHEMA,
   claudeAgentTaskFrom,
+  claudeUsageFrom,
   executeClaudeAgentAssignment,
   toolInputEscapesWorkspace,
   type ClaudeAgentCheckoutRunner,
   type ClaudeAgentRunner,
 } from "../src/claude-agent-executor"
 import { CLAUDE_AGENT_SDK_PACKAGE } from "../src/claude-agent"
+import type { ClaudeTurnReport } from "../src/claude-turn-reporter"
 import { createBootstrapSummary, parseBootstrapArgs } from "../src/bootstrap"
 import { ensurePylonLocalState, assertPublicProjectionSafe } from "../src/state"
 
@@ -78,12 +80,36 @@ const lease = {
   codingAssignment: claudeAgentCodingAssignment,
 }
 
+const successfulClaudeTurnReporter = async (_report: ClaudeTurnReport) => {}
+
 const fixingRunner: ClaudeAgentRunner = async (input) => {
   await writeFile(
     join(input.cwd, "sum.ts"),
     "export const sum = (left: number, right: number) => left + right\n",
   )
-  return { outcome: "completed", turnCount: 3, editedFileCount: 1, commandCount: 1, sessionRef: null , usage: { inputTokens: 1200, cachedInputTokens: 0, outputTokens: 340 } }
+  return {
+    outcome: "completed",
+    turnCount: 3,
+    editedFileCount: 1,
+    commandCount: 1,
+    sessionRef: null,
+    usage: { inputTokens: 1200, cachedInputTokens: 0, outputTokens: 340 },
+  }
+}
+
+const fixingRunnerWithoutUsage: ClaudeAgentRunner = async (input) => {
+  await writeFile(
+    join(input.cwd, "sum.ts"),
+    "export const sum = (left: number, right: number) => left + right\n",
+  )
+  return {
+    outcome: "completed",
+    turnCount: 3,
+    editedFileCount: 1,
+    commandCount: 1,
+    sessionRef: null,
+    usage: null,
+  }
 }
 
 const checkoutRunner: ClaudeAgentCheckoutRunner = async (workspace) => {
@@ -130,6 +156,36 @@ async function withState<T>(fn: (state: Awaited<ReturnType<typeof ensurePylonLoc
 }
 
 describe("claude agent task recognition", () => {
+  test("decodes Claude SDK usage with snake_case or camelCase token fields", () => {
+    expect(
+      claudeUsageFrom({
+        input_tokens: 1200,
+        cache_read_input_tokens: 70,
+        cache_creation_input_tokens: 30,
+        output_tokens: 340,
+      }),
+    ).toEqual({ cachedInputTokens: 100, inputTokens: 1200, outputTokens: 340 })
+    expect(
+      claudeUsageFrom({
+        inputTokens: 800,
+        cacheReadInputTokens: 20,
+        cacheCreationInputTokens: 10,
+        outputTokens: 200,
+      }),
+    ).toEqual({ cachedInputTokens: 30, inputTokens: 800, outputTokens: 200 })
+    expect(
+      claudeUsageFrom({
+        input_tokens: 900,
+        inputTokens: 800,
+        cachedInputTokens: 15,
+        output_tokens: 250,
+        outputTokens: 200,
+      }),
+    ).toEqual({ cachedInputTokens: 15, inputTokens: 900, outputTokens: 250 })
+    expect(claudeUsageFrom({ input_tokens: 0, output_tokens: 0 })).toBeNull()
+    expect(claudeUsageFrom(undefined)).toBeNull()
+  })
+
   test("recognizes the typed work class and passes everything else through", async () => {
     expect(claudeAgentTaskFrom(claudeAgentCodingAssignment)).not.toBeNull()
     expect(claudeAgentTaskFrom({ kind: "job.public.tassadar_executor_trace", tassadar: {} })).toBeNull()
@@ -151,20 +207,78 @@ describe("claude agent task recognition", () => {
 
   test("executes the fixture task, verifies with the real test command, accepts", async () => {
     await withState(async (state) => {
+      const reports: ClaudeTurnReport[] = []
       const record = await executeClaudeAgentAssignment(state, lease, now, {
         claudeAgentRunner: fixingRunner,
         claudeAgentProbe: readyProbe,
+        claudeTurnReporter: async (report) => {
+          reports.push(report)
+        },
       })
       expect(record).not.toBeNull()
       expect(record?.status).toBe("accepted")
       expect(record?.blockerRefs).toEqual([])
       expect(record?.resultRefs).toContain("result.public.pylon.claude_agent_task.fixture_repair_passed")
+      expect(record?.resultRefs).toContain("result.public.pylon.claude_agent_task.token_usage_reported")
+      expect(record?.summaryRefs).toContain("summary.public.pylon.claude_agent_task.token_usage_reported")
       expect(record?.artifactRefs[0]).toStartWith("artifact.pylon.claude_agent_task.patch.")
       expect(record?.testRefs[0]).toStartWith("command.pylon.claude_agent_task.verification.")
+      expect(reports).toHaveLength(1)
+      expect(reports[0]).toMatchObject({
+        assignmentRef: lease.assignmentRef,
+        leaseRef: lease.leaseRef,
+        observedAt: now.toISOString(),
+        pylonRef: state.identity.pylonRef,
+        turnIndex: 1,
+        usage: { cachedInputTokens: 0, inputTokens: 1200, outputTokens: 340 },
+      })
+      expect(reports[0]?.runRef).toStartWith("run.pylon.claude_agent_task.")
+      expect(reports[0]?.workspaceRef).toStartWith("workspace.pylon.claude_agent_task.")
       assertPublicProjectionSafe(record)
       const projected = JSON.stringify(record)
       expect(projected).not.toContain(state.paths.cache)
       expect(projected).not.toContain("bounded fixture workspace")
+    })
+  })
+
+  test("keeps accepted work visible when token reporting fails, with a typed blocker", async () => {
+    await withState(async (state) => {
+      const record = await executeClaudeAgentAssignment(state, lease, now, {
+        claudeAgentRunner: fixingRunner,
+        claudeAgentProbe: readyProbe,
+        claudeTurnReporter: async () => {
+          throw new Error("turn ingest down")
+        },
+      })
+      expect(record?.status).toBe("accepted")
+      expect(record?.blockerRefs).toContain("blocker.assignment.claude_agent_token_usage_report_failed")
+      expect(record?.resultRefs).toContain("result.public.pylon.claude_agent_task.token_usage_report_failed")
+      expect(record?.summaryRefs).toContain("summary.public.pylon.claude_agent_task.token_usage_report_failed")
+      assertPublicProjectionSafe(record)
+    })
+  })
+
+  test("surfaces missing or unconfigured Claude token reporting as public-safe closeout diagnostics", async () => {
+    await withState(async (state) => {
+      const missingUsageRecord = await executeClaudeAgentAssignment(state, lease, now, {
+        claudeAgentRunner: fixingRunnerWithoutUsage,
+        claudeAgentProbe: readyProbe,
+      })
+      expect(missingUsageRecord?.status).toBe("accepted")
+      expect(missingUsageRecord?.blockerRefs).toContain("blocker.assignment.claude_agent_token_usage_missing")
+      expect(missingUsageRecord?.resultRefs).toContain("result.public.pylon.claude_agent_task.token_usage_missing")
+      assertPublicProjectionSafe(missingUsageRecord)
+
+      const unconfiguredRecord = await executeClaudeAgentAssignment(state, lease, now, {
+        claudeAgentRunner: fixingRunner,
+        claudeAgentProbe: readyProbe,
+      })
+      expect(unconfiguredRecord?.status).toBe("accepted")
+      expect(unconfiguredRecord?.blockerRefs).toContain("blocker.assignment.claude_agent_token_usage_reporter_unconfigured")
+      expect(unconfiguredRecord?.resultRefs).toContain(
+        "result.public.pylon.claude_agent_task.token_usage_reporter_unconfigured",
+      )
+      assertPublicProjectionSafe(unconfiguredRecord)
     })
   })
 
@@ -190,6 +304,7 @@ describe("claude agent task recognition", () => {
           checkoutRunner,
           claudeAgentRunner: observingRunner,
           claudeAgentProbe: readyProbe,
+          claudeTurnReporter: successfulClaudeTurnReporter,
         },
       )
 
@@ -217,7 +332,11 @@ describe("claude agent task recognition", () => {
         claudeAgentProbe: readyProbe,
       })
       expect(record?.status).toBe("rejected")
-      expect(record?.blockerRefs).toEqual(["blocker.assignment.claude_agent_test_failed"])
+      expect(record?.blockerRefs).toEqual([
+        "blocker.assignment.claude_agent_test_failed",
+        "blocker.assignment.claude_agent_token_usage_missing",
+      ])
+      expect(record?.resultRefs).toContain("result.public.pylon.claude_agent_task.token_usage_missing")
       assertPublicProjectionSafe(record)
     })
   })
@@ -249,11 +368,12 @@ describe("claude agent task recognition", () => {
           editedFileCount: 0,
           commandCount: 0,
           sessionRef: null,
-          usage: null,
+          usage: { inputTokens: 10, cachedInputTokens: 0, outputTokens: 5 },
         })
         const record = await executeClaudeAgentAssignment(state, lease, now, {
           claudeAgentRunner: runner,
           claudeAgentProbe: readyProbe,
+          claudeTurnReporter: successfulClaudeTurnReporter,
         })
         expect(record?.status).toBe("rejected")
         expect(record?.blockerRefs).toEqual([blocker])
@@ -277,6 +397,7 @@ describe("claude agent task recognition", () => {
       const record = await executeClaudeAgentAssignment(state, lease, now, {
         claudeAgentRunner: fixingRunner,
         claudeAgentProbe: readyProbe,
+        claudeTurnReporter: successfulClaudeTurnReporter,
       })
       const tampered = { ...record, message: `${record?.message} raw prompt follows` }
       expect(() => assertPublicProjectionSafe(tampered)).toThrow()
@@ -297,6 +418,7 @@ describe("claude agent task recognition", () => {
       const record = await executeClaudeAgentAssignment(state, lease, now, {
         claudeAgentRunner: observingRunner,
         claudeAgentProbe: readyProbe,
+        claudeTurnReporter: successfulClaudeTurnReporter,
       })
       expect(record?.status).toBe("accepted")
       expect(workspaceDir).not.toBeNull()
@@ -324,6 +446,7 @@ describe("claude agent task recognition", () => {
         account,
         claudeAgentRunner: observingRunner,
         claudeAgentProbe: readyProbe,
+        claudeTurnReporter: successfulClaudeTurnReporter,
       })
       expect(record?.status).toBe("accepted")
       expect(seenClaudeConfigDir).toBe("/tmp/pylon-claude-account")

--- a/apps/pylon/tests/claude-agent-task-smoke.test.ts
+++ b/apps/pylon/tests/claude-agent-task-smoke.test.ts
@@ -15,6 +15,7 @@ describe("claude agent task smoke (CI-safe leg)", () => {
     expect(result.closeoutStatus).toBe("accepted")
     expect(result.closeoutRef).toContain("assignment.closeout.")
     expect(result.resultRefs).toContain("result.public.pylon.claude_agent_task.fixture_repair_passed")
+    expect(result.resultRefs).toContain("result.public.pylon.claude_agent_task.token_usage_reported")
     expect(result.blockerRefs).toEqual([])
     expect(result.boundaryChecks).toEqual({
       paymentMode: "no-spend",

--- a/docs/fable/2026-07-01-claude-code-parity-and-codex-synergies.md
+++ b/docs/fable/2026-07-01-claude-code-parity-and-codex-synergies.md
@@ -210,7 +210,9 @@ tracked its gaps.
   Decide the ingest route deliberately: the desktop Codex path posts to
   `/api/stats/token-usage/events`; the Pylon Claude lane posts to
   `/api/pylon/claude/turns`. Keeping the desktop-Claude path on the stats route
-  matches the desktop-Codex path; keep exact-only accounting either way.
+  matches the desktop-Codex path; keep exact-only accounting either way. The
+  bounded Pylon-Claude executor now treats a missing/unconfigured/failed turn
+  reporter as a public-safe closeout diagnostic, not as a silent success.
 - **MCP / fleet bridge** (`src/bun/claude-fleet-mcp-bridge.ts`): the Claude
   equivalent of the Codex MCP bridge is *simpler* — no config file to mutate.
   Inject the `khala_fleet` server descriptor directly into `options.mcpServers`

--- a/docs/fable/2026-07-01-episode-245-completion-and-multi-harness-orchestration.md
+++ b/docs/fable/2026-07-01-episode-245-completion-and-multi-harness-orchestration.md
@@ -219,9 +219,22 @@ Deferrable (bounded lane is fine without them):
 3. Execution posture — Claude delegated runs are bounded-workspace
    deny-by-default; only Codex has the owner-local full-access posture.
 4. No PR publisher analogue; local-verification closeouts only.
-5. Observability — no raw-event chunks, no ATIF trace ingest, one
-   cumulative token row per assignment rather than per-turn.
-6. No Claude own-capacity burn runbook.
+5. Observability — no raw-event chunks and no ATIF trace ingest yet. The
+   bounded Pylon-Claude lane does emit an exact assignment-turn token row to
+   `/api/pylon/claude/turns`; closeout now exposes whether that row was
+   reported, missing, unconfigured, or failed to post.
+
+**T9.7 landing note (2026-07-02):** the desktop-fleet slice of Claude closeout
+depth is shipped. `apps/pylon/src/claude-agent-executor.ts` accepts both
+snake_case and camelCase SDK usage fields, attempts the Claude turn reporter for
+every completed SDK session before terminal closeout, and adds public-safe refs
+such as `result.public.pylon.claude_agent_task.token_usage_reported` plus typed
+blockers for `token_usage_missing`, `token_usage_report_failed`, and
+`token_usage_reporter_unconfigured`. The CI smoke now requires the reporter
+route. The posture decision is intentionally conservative: public/fleet Claude
+assignments do not use `bypassPermissions`; PR publishing and raw-event/ATIF
+ingest remain deferred until Claude workers graduate from bounded
+local-verification work to PR delivery.
 
 ### 3.2 Recommended shape: one selector per axis
 

--- a/docs/fable/ROADMAP.md
+++ b/docs/fable/ROADMAP.md
@@ -188,7 +188,7 @@ Source: episode-245 §3.2–3.3; Claude-parity §4.
 | T9.4 | Plan-then-fan-out: Claude plan-mode session (Fable, `permissionMode:'plan'`) emits a typed task DAG → FleetRun work units → Codex dispatch; Claude reviews returned diffs (accept / request-changes / re-plan); deterministic program stays control-flow authority | T8.2, T3.1, T4.1 | MED |
 | T9.5 | Claude second-pass reviewer: structured verdict (`outputFormat: json_schema`) after verify-green, feeding merge policy as advisory signal (verify command remains authority) | T4.3, T8.2 | MED |
 | T9.6 | Cross-harness session catalog: shared local `SessionStore`-style catalog for Khala Code Desktop, merging `codex-sessions.json` + Codex thread list with `claude-sessions.json` + Claude SDK `listSessions`; entries carry harness kind, refs, timestamps, and exact reported totals only, with schema-first RPC/sidebar rendering | T8.2 | MED |
-| T9.7 | Claude-lane closeout depth (deferred until Claude workers do PR delivery): PR publisher analogue, per-turn token rows, raw-event/ATIF observability, full-access posture decision, Claude burn runbook | T9.1 | MED |
+| T9.7 | **SHIPPED for current desktop-fleet push:** Claude closeout exact-token diagnostics: SDK usage decoding accepts snake_case/camelCase, every completed assignment session attempts `/api/pylon/claude/turns`, closeouts carry `token_usage_reported` or typed accounting blockers, and the CI smoke now requires the reporter path. PR publishing, raw-event/ATIF ingest, and public/fleet `bypassPermissions` remain deliberately deferred until Claude PR delivery; bounded Claude stays local-verification only. | T9.1 | MED |
 
 ### WS-10 — One status spine (Orca P2)
 


### PR DESCRIPTION
## Summary
- Decode Claude Agent SDK usage whether it arrives in snake_case or camelCase fields, without fabricating rows when usage is absent.
- Report every completed Claude assignment session through `/api/pylon/claude/turns` before terminal closeout, and add public-safe refs/blockers for reported, missing, unconfigured, and failed token reporting states.
- Tighten the Claude CI smoke and fable docs so T9.7 is explicit: exact-token diagnostics are in the desktop-fleet path; PR publishing, raw-event/ATIF ingest, and public/fleet `bypassPermissions` stay deferred until Claude PR delivery.

Closes #7876

## Validation
- `bun test apps/pylon/tests/claude-agent-executor.test.ts apps/pylon/tests/claude-agent-task-smoke.test.ts`
- `bun run --cwd apps/pylon typecheck`
- `bun run --cwd apps/pylon test` (2052 pass, 3 skip, 0 fail)
- `bun run check:deploy`
