### PR TITLE
Close WS-17 desktop fleet gate

### DIFF
--- a/apps/pylon/scripts/codex-supervisor/replenishment.sh
+++ b/apps/pylon/scripts/codex-supervisor/replenishment.sh
@@ -5,9 +5,9 @@
 # When every backlog issue is locked (closed, already has an open PR, or claimed
 # by another slot), the supervisor must not sit in a long idle backoff. This
 # helper creates or reuses a small fixed set of public, valuable replenishment
-# issues: continual-learning over recent traces, broad codebase audit/review,
-# and test/lint/typecheck sweep work. Dedupe is by exact open issue title under
-# a dedicated label, so repeated LOCKOUT cycles do not spam duplicate issues.
+# issues: desktop-fleet readiness, broad codebase audit/review, and
+# test/lint/typecheck sweep work. Dedupe is by exact open issue title under a
+# dedicated label, so repeated LOCKOUT cycles do not spam duplicate issues.
 #
 # This file performs no work at source time; it only defines functions.
 
@@ -54,7 +54,7 @@ sup_replenishment_label_args() {
 
 sup_replenishment_templates() {
   cat <<'TEMPLATES'
-SG-2 replenish: run GEPA/DSPy continual-learning trace review|#6707|Run the standing GEPA/DSPy continual-learning loop over recent public-safe traces. Inspect current trace/evaluation code and produce a bounded implementation or review improvement. Do not use apps/pylon/scripts/multi-session-campaign.ts. Run the named verification before closeout.
+SG-2 replenish: desktop fleet readiness audit|desktop-fleet|Audit the current desktop-fleet dispatch path end to end: Khala Code fleet tools, Pylon heartbeat/capacity, closeout proof, and exact token accounting. Fix one concrete desktop-fleet blocker if found; otherwise add a focused regression test or public-safe audit note. Run the named verification before closeout.
 SG-2 replenish: audit Pylon clients and Worker API for dispatch waste|audit|Perform a big-context codebase audit over apps/pylon, clients, and apps/openagents.com/workers/api. Look for real dispatch waste, duplicate-work, lockout, stale-base, timeout, and verification gaps. Implement a bounded fix when clear; otherwise add a focused regression test or public-safe audit note. Run the named verification before closeout.
 SG-2 replenish: test lint typecheck sweep for owner-capacity lane|sweep|Run a focused test/lint/typecheck sweep on the owner-capacity Pylon and Worker API lane. Fix real failures in touched code without broad refactors. Do not use apps/pylon/scripts/multi-session-campaign.ts. Run the named verification before closeout.
 TEMPLATES

--- a/clients/khala-cli/README.md
+++ b/clients/khala-cli/README.md
@@ -168,8 +168,9 @@ no long-string pasting:
   the resolved plan first, or `--once` to run one refill round and exit. In
   supervisor mode, sustained all-slot lockout triggers a bounded deduped
   replenishment set instead of escalating into the long refused-work backoff:
-  the standing GEPA/DSPy loop, source audits over Pylon/clients/Worker code, and
-  test/lint/typecheck sweeps.
+  desktop-fleet readiness audits, source audits over Pylon/clients/Worker code,
+  and test/lint/typecheck sweeps. GEPA/DSPy optimizer work is not part of the
+  current desktop-fleet replenishment set.
 - `khala fleet status --live` polls the owner-only
   `/api/operator/fleet/state` endpoint about every five seconds and renders the
   Pace, Fleet, Watchdog, GLM, and Brain/Artanis blocks as a terminal dashboard.

--- a/clients/khala-cli/src/fleet-run.test.ts
+++ b/clients/khala-cli/src/fleet-run.test.ts
@@ -169,8 +169,9 @@ describe("fleet run planning", () => {
     const first = plannedReplenishmentRounds(plan)
     expect(first).toHaveLength(2)
     expect(first.map(round => round.workKind)).toEqual(["replenishment", "replenishment"])
-    expect(first.map(round => round.dedupeKey)).toEqual(["gepa-dspy-6707", "bounded-codebase-audit"])
-    expect(first[0]?.issue).toBe(6707)
+    expect(first.map(round => round.dedupeKey)).toEqual(["desktop-fleet-readiness-audit", "bounded-codebase-audit"])
+    expect(first[0]?.issue).toBeNull()
+    expect(first[0]?.objective).toContain("desktop-fleet dispatch path")
     expect(first[1]?.issue).toBeNull()
     expect(first[1]?.objective).toContain("apps/pylon")
 
@@ -193,7 +194,7 @@ describe("fleet run planning", () => {
       verify: "bun test",
     })
     const dispatched = new Set([
-      "gepa-dspy-6707",
+      "desktop-fleet-readiness-audit",
       "bounded-codebase-audit",
       "test-lint-typecheck-sweep",
     ])

--- a/clients/khala-cli/src/fleet-run.ts
+++ b/clients/khala-cli/src/fleet-run.ts
@@ -82,10 +82,10 @@ type FleetRunSlot = Omit<KhalaFleetRunRound, "ok" | "status" | "assignmentRef">
 
 const REPLENISHMENT_OBJECTIVES = [
   {
-    dedupeKey: "gepa-dspy-6707",
-    issue: 6707,
+    dedupeKey: "desktop-fleet-readiness-audit",
+    issue: null,
     objective:
-      "Advance the standing GEPA/DSPy continual-learning loop from public issue #6707 over recent public-safe traces. Keep the work bounded, avoid duplicate open PRs, and run the named verification.",
+      "Audit the current desktop-fleet dispatch path end to end: Khala Code fleet tools, Pylon heartbeat/capacity, closeout proof, and exact token accounting. Fix one concrete desktop-fleet blocker if found, avoid duplicate open PRs, and run the named verification.",
   },
   {
     dedupeKey: "bounded-codebase-audit",

--- a/docs/afteraction/2026-07-02-fable-ws17-desktop-fleet-closeout.md
+++ b/docs/afteraction/2026-07-02-fable-ws17-desktop-fleet-closeout.md
@@ -1,0 +1,82 @@
+# After-Action: Fable WS-17 Desktop Fleet Closeout - 2026-07-02
+
+## Context
+
+On 2026-07-02 the owner narrowed the active Fable push to "fleet working in
+desktop app ASAP." Mobile companion / push, T16 public-promise ops,
+mobile-dependent AaaS, and GEPA optimizer work are postponed for this push.
+
+PR #8004 recorded that trim in the roadmap. PR #8006 shipped T9.7 Claude
+closeout token diagnostics so every completed Claude assignment either reports
+exact usage or produces a typed accounting blocker. This closeout covers the
+remaining WS-17 issues (#7905, #7906, #7907) under the revised scope.
+
+## Evidence
+
+- `khala fleet status` reported three ready Codex registry accounts:
+  `codex-2`, `codex-b7d4438c`, and `codex-dbbb1972`.
+- `pylon presence heartbeat --base-url https://openagents.com --json` reported
+  `registered=true`, `linked=true`, and `stale=false` for
+  `pylon.33afd48282a649047e3a`, with no blocker refs.
+- `bun run --cwd apps/pylon smoke:fleet-run-live` returned the intended
+  skip-safe unarmed result. No dispatch and no spend occurred.
+- `khala fleet status --live` showed the live watchdog healthy with zero active,
+  ready, busy, or queued live slots and `activeAssignmentCount=0`.
+- A no-dispatch dry-run over the actionable desktop issues
+  `#7956,#7955,#7953,#7931` resolved three target slots across the three ready
+  Codex accounts:
+
+```sh
+khala fleet run --repo OpenAgentsInc/openagents \
+  --issues 7956,7955,7953,7931 \
+  --commit 84880c527bcd38d2ed1ae3f821c2ed78e660b30a \
+  --verify "bun run check:deploy" \
+  --dry-run
+```
+
+## Decision
+
+T17.1 is complete for the current desktop-fleet push. The fleet has enough
+ready local Codex accounts, a fresh hosted heartbeat, skip-safe live-smoke
+behavior, and dry-run slot planning to continue desktop Fleet work honestly.
+
+T17.2, the old clean-2B-day acceptance run, is not run and is not counted as
+complete for live throughput. After the owner trim there were only nine open
+issues total, with four actionable desktop issues in the dry-run set. Running a
+target-15/18 overnight window would either fabricate work, reopen postponed
+scope, or spend owner account budget without a real backlog. That gate is
+postponed until the backlog and owner approval exist again.
+
+T17.3 is complete for the current push through this after-action, the roadmap
+revision, the fleet-management spec update, the cockpit runbook update, and the
+FleetRun fan-out doc update.
+
+## Regressions And Fixtures
+
+No live fleet regression was observed because no armed run was started. The
+important regression class is an acceptance-bound mismatch: a "clean 2B day"
+gate must fail closed when the claimable backlog is below the configured floor.
+
+Future first-class acceptance code should expose this typed blocker:
+
+```txt
+blocker.fleet_run_acceptance.claimable_units_below_floor
+```
+
+The current checked fixture is the active replenishment path: `khala fleet run`
+and the legacy supervisor replenishment templates no longer seed GEPA/DSPy
+optimizer work during desktop-fleet lockout recovery. Replenishment remains
+bounded to desktop-fleet readiness, dispatch waste, and focused test/lint/type
+coverage work.
+
+## Next Live Gate
+
+Revive T17.2 only when all of these are true:
+
+- At least 30 real, claimable, non-duplicate work units exist.
+- `smoke:fleet-run-live` is explicitly armed and green the same day.
+- The owner approves the overnight spend/refill window.
+- The run starts from one chat/Fleet action at target 15-18.
+- Exact token rows, closeouts, claim refs, duplicate-PR checks, and merge
+  verification are the acceptance evidence. Public counter movement alone is
+  not evidence.

--- a/docs/fable/2026-07-01-fleet-fanout-coding-instructions.md
+++ b/docs/fable/2026-07-01-fleet-fanout-coding-instructions.md
@@ -36,6 +36,13 @@ When you are done, all of the following are true and proven:
 4. A supervised overnight acceptance run produces ≥ 2B tokens/day of exact
    accounted usage with **zero duplicate PRs** and 100% verified closeouts.
 
+**July 2 scope correction:** the owner-directed desktop-fleet push closes on
+readiness proof, not a fabricated overnight run. Mobile/push, public-promise,
+AaaS, and GEPA optimizer lanes are postponed. The clean-2B-day target remains
+the future live-capacity gate, but it requires a real >=30-unit claimable
+backlog, an explicitly armed same-day live smoke, and owner approval for the
+overnight spend window.
+
 ## 1. Learn From June 29 Before Writing Code
 
 The stats page (2026-07-01) tells the story: 06/27 1.9B → 06/28 1.7B →
@@ -339,6 +346,13 @@ prerequisites; implement them here if not already landed):
 
 The final acceptance is operational, run by the owner with you supervising:
 
+For the July 2 desktop-fleet closeout, Lane E stops before this overnight run:
+the current tracker was deliberately trimmed below the >=30 claimable-unit
+floor. Treat that as a blocked/postponed acceptance precondition, not as a
+reason to invent replenishment work. The regression fixture to add when the
+acceptance runner becomes first-class is
+`blocker.fleet_run_acceptance.claimable_units_below_floor`.
+
 1. Preflight: `khala fleet status` shows ≥ 3 ready accounts; rate-limit
    meters show fresh budgets; backlog source lists ≥ 30 claimable units;
    `smoke:fleet-run-live` green the same day.
@@ -400,8 +414,9 @@ Check every box before calling this complete:
   approval per run-start, not silent standing authority.
 - Live test tiers are skip-safe by default and env-armed; fixture tiers
   never spend or claim real work.
-- Optimizer candidates (refill/routing parameters are GEPA targets later)
-  never auto-promote; owner-gated admission via the existing Gym path.
+- Optimizer candidates are postponed for the current desktop-fleet push; when
+  reopened later, they never auto-promote and remain owner-gated through the
+  existing Gym path.
 - No GitHub-hosted CI; Tier-1 pre-push + Tier-2 owned-runner patterns.
 
 ## 10. Suggested Issue Breakdown

--- a/docs/fable/ROADMAP.md
+++ b/docs/fable/ROADMAP.md
@@ -14,7 +14,9 @@ flips no promise state and broadens no public copy. The delivery process
 Owner trim (2026-07-02): the current push is desktop fleet working ASAP.
 Mobile companion / push (WS-11), episode/public-promise ops (WS-16),
 GEPA optimizer lanes (T6.15/T9.3), and mobile-dependent AaaS
-productization (T12.6) are postponed / not planned for this push.
+productization (T12.6) are postponed / not planned for this push. WS-17 is
+closed for this push as a desktop-fleet readiness gate, not as a fabricated
+overnight 2B-token run.
 
 ## 0. Reading Guide
 
@@ -54,7 +56,7 @@ WS-12 Artanis (P1/P2 parallel now; P3 needs WS-2+WS-10; P5 postponed)
 WS-13 Foldkit migration (rides behind; cockpit panel first)
 WS-14 Guardrails (continuous from day 1)
 WS-16 Episode 245 (postponed / not planned for current push)
-WS-17 Clean 2B day (needs WS-3,4,5 core + WS-6 live smokes)
+WS-17 Desktop fleet closeout (clean 2B day postponed until backlog returns)
 ```
 
 The two foundations — **WS-1** and **WS-2** — land first and unblock nearly
@@ -264,13 +266,21 @@ current desktop-fleet push.
 | T16.2 | **POSTPONED / not planned for current desktop-fleet push (owner 2026-07-02):** Docs upkeep: keep the §1.1 naming disambiguation near the front of public copy; refresh pre-pivot framing notes (fleet spec, porting audit, ops runbook); file the six `codex.app_server.gap.*` items upstream | — | POSTPONED |
 | T16.3 | **POSTPONED / not planned for current desktop-fleet push (owner 2026-07-02):** Public promise record for "Khala Code wraps your Codex" (through `docs/promises/`, copy-gated) | — | POSTPONED |
 
-### WS-17 — Throughput restoration: the clean 2B day (Lane E; final gate)
+### WS-17 — Throughput restoration: desktop fleet closeout (Lane E; final gate)
+
+Owner-directed closeout (2026-07-02): the old clean-2B-day gate needs a real
+>=30-unit claimable backlog plus owner-approved overnight spend. After the
+desktop-fleet trim, the tracker had only nine open issues total and four
+actionable desktop issues in the dry-run target set. The current push therefore
+closes WS-17 on readiness evidence and postpones the overnight 2B run until the
+backlog exists again. See
+`docs/afteraction/2026-07-02-fable-ws17-desktop-fleet-closeout.md`.
 
 | Task | Description | Deps | Delegable |
 | --- | --- | --- | --- |
-| T17.1 | Preflight: ≥3 ready accounts, fresh budgets, ≥30 claimable units, `smoke:fleet-run-live` green same-day | T6.10 | supervisor |
-| T17.2 | The acceptance run: one chat message, target 15–18, overnight refill window, flags→Inbox; success = ≥2.0B exact tokens/day, ≥15 concurrency ≥6h, duplicate-PR rate 0, 100% closeout coverage, zero unverified merges, Pylon-Claude meaningfully >0 | T17.1 + WS-3/4/5 core | supervisor + owner |
-| T17.3 | After-action doc either way; regressions become fixtures; update fleet-management spec status table + cockpit runbook + FleetRun schema doc | T17.2 | HIGH |
+| T17.1 | **SHIPPED for current desktop-fleet push:** readiness preflight proved 3 ready Codex accounts (`codex-2`, `codex-b7d4438c`, `codex-dbbb1972`), fresh hosted heartbeat for `pylon.33afd48282a649047e3a`, skip-safe unarmed `smoke:fleet-run-live`, healthy read-only live status, and a no-dispatch `khala fleet run` dry-run resolving 3 slots across the actionable issues. The old `>=30 claimable units` bound is postponed because the tracker was deliberately trimmed below that floor. | T6.10 | SHIPPED |
+| T17.2 | **POSTPONED / not planned for current desktop-fleet push:** the old acceptance run (one chat message, target 15–18, overnight refill window, flags->Inbox, >=2.0B exact tokens/day, >=15 concurrency >=6h, duplicate-PR rate 0, 100% closeout coverage, zero unverified merges, Pylon-Claude meaningfully >0) must not run without a real >=30-unit backlog, same-day armed live smoke, and owner approval for overnight spend. | T17.1 + WS-3/4/5 core | POSTPONED |
+| T17.3 | **SHIPPED for current desktop-fleet push:** after-action added; the backlog-floor mismatch is captured as a future acceptance fixture (`blocker.fleet_run_acceptance.claimable_units_below_floor`); fleet-management spec, cockpit runbook, and FleetRun schema/fan-out doc updated; active GEPA replenishment targets removed from desktop-fleet refill paths. | T17.2 revised/postponed | SHIPPED |
 
 ## 3. Parallelization Plan (Who Runs What, Concurrently)
 
@@ -294,7 +304,9 @@ T9.3, and T12.6 from active waves until explicitly reopened.
 - **Wave 3:** T3.5 · T4.5 · T5.6 · T6.5–T6.9 · T6.13 · T6.14 · T8.3 · T8.4 ·
   T9.2 · T9.4 · T9.5 · T9.6 · T13.2 · T13.3 · T15.1 · T14.3.
 - **Wave 4:** T6.10 · T9.7 · T12.5 · T13.4 · T15.2.
-- **Gate:** T17.1 → T17.2 → T17.3 (the clean 2B day).
+- **Gate:** T17.1 → T17.3 closes the current desktop-fleet push; T17.2 clean
+  2B day is postponed until a real backlog and owner-approved overnight window
+  return.
 
 Coordination rules (same as epic #7651's fanout): shared seams (T1.1, T2.1,
 T2.2, T8.1) land first and alone; everything downstream codes against their
@@ -311,7 +323,8 @@ get the strongest worker plus mandatory supervisor review.
   chat behind the pill, status spine end-to-end, `/pro` un-mocked.
 - **M4 — Proof tier**: monkey night green, sustained live smoke green, TLA+
   supervisor properties checked, perf budgets enforced.
-- **M5 — The clean 2B day** (T17.2) with after-action.
+- **M5 — Desktop fleet closeout** (T17.1/T17.3) with after-action now; the
+  clean 2B day (T17.2) remains the later live-capacity milestone.
 - **M6 — Reach**: plan-then-fan-out crossover and Artanis on the spine with
   authority scopes. Mobile companion notify/approve/steer and AaaS demo flow
   remain postponed until explicitly revived after desktop fleet works.

--- a/docs/khala-code/2026-06-30-khala-code-fleet-management-spec.md
+++ b/docs/khala-code/2026-06-30-khala-code-fleet-management-spec.md
@@ -14,6 +14,14 @@ delegation remains the owner-local capacity layer for linked Codex accounts.
 The native `@openagentsinc/khala-tools` runtime is now legacy/fallback for coding
 work, not the center of the default Khala Code execution path.
 
+**July 2 desktop-fleet closeout:** the current implementation push is scoped to
+getting Fleet working in Khala Code Desktop. Mobile/push, public-promise ops,
+mobile-dependent AaaS, and GEPA optimizer lanes are postponed. WS-17 closes on
+desktop-fleet readiness evidence (3 ready Codex accounts, fresh Pylon heartbeat,
+skip-safe live smoke, healthy read-only live status, and dry-run slot planning);
+the old clean-2B-day overnight run waits for a real >=30-unit backlog and owner
+approval.
+
 ## 0. Identity note (read first)
 
 External landscape research conflated two unrelated projects both called
@@ -149,9 +157,9 @@ by advertised slots + system load, not raw process count.
 
 **Gap:** promote the watcher/merge-resolver/refill loop from an operator script
 (`docs/ops/...runbook.md`) into a **first-class, supervised orchestration surface**
-inside Khala Code (start/stop, queue view, per-slot status, refill policy), and
-add the GEPA self-optimization loop for the delegation policy
-(`docs/gepa/2026-06-30-gepa-usage-and-fleet-delegation-optimization-loop.md`).
+inside Khala Code (start/stop, queue view, per-slot status, refill policy).
+GEPA self-optimization for delegation policy is postponed for the current
+desktop-fleet push.
 
 ### 3.5 Local-first adoption ("adopt, don't import")
 
@@ -218,7 +226,8 @@ naming explicitly — most map onto primitives we already have.
   own instructions/memory is powerful but risky; default to **staged write →
   human diff review → approve/reject**, with an explicit per-worker toggle to
   allow auto-memory. This is the safe self-improvement pattern; it pairs with the
-  GEPA delegation loop (offline) for policy-level improvement.
+  future offline delegation-optimization loop after desktop fleet is working and
+  the owner reopens optimizer work.
 - **Event-triggered background workers.** Workers that run on events/schedules in
   the background (not just on demand), surfaced and unblocked through the Inbox.
   We have scheduling + work-intake (`tas/work-intake.ts`); the trigger→run→inbox
@@ -240,8 +249,9 @@ The engine is built; the gaps are surfaces and one orchestration promotion.
 3. **Worker cards** (§3.2) — human-readable scope/credential/tooling/cost/recent-
    runs card over the existing capability + quota + authority data.
 4. **Supervised orchestration surface** (§3.4) — promote the watcher / merge-
-   resolver / refill loop into a first-class start/stop/queue UI; wire the GEPA
-   delegation-optimization loop.
+   resolver / refill loop into a first-class start/stop/queue UI. GEPA
+   delegation optimization is explicitly postponed until desktop fleet is
+   working and the owner reopens that lane.
 5. **Config scanner / adopt-in-place** (§3.5) — scan and adopt skills / MCP /
    instruction files across harnesses, reference-by-default, never clobber.
 6. **Run timeline / trace viewer** (§3.6) — operator view over exact token rows +

--- a/docs/ops/2026-06-29-khala-codex-fleet-manager-runbook.md
+++ b/docs/ops/2026-06-29-khala-codex-fleet-manager-runbook.md
@@ -27,6 +27,33 @@ included because they are the bridge the current Desktop process uses under the
 hood, and because they are the emergency fallback when a manager must get work
 moving before a UI control is finished.
 
+**July 2 WS-17 closeout:** after the owner trim, the active target is desktop
+fleet working ASAP. The mobile/push, T16 public-promise, AaaS, and GEPA
+optimizer lanes are postponed. The current WS-17 preflight evidence is:
+
+- `khala fleet status` found three ready Codex accounts: `codex-2`,
+  `codex-b7d4438c`, and `codex-dbbb1972`.
+- `pylon presence heartbeat --base-url https://openagents.com --json` reported
+  registered, linked, and not stale for `pylon.33afd48282a649047e3a`.
+- `bun run --cwd apps/pylon smoke:fleet-run-live` stayed skip-safe while
+  unarmed; no dispatch or spend occurred.
+- Read-only `khala fleet status --live` showed a healthy watchdog with zero
+  active live slots.
+- The dry-run planner over `#7956,#7955,#7953,#7931` resolved three target slots
+  across three accounts:
+
+```sh
+khala fleet run --repo OpenAgentsInc/openagents \
+  --issues 7956,7955,7953,7931 \
+  --commit 84880c527bcd38d2ed1ae3f821c2ed78e660b30a \
+  --verify "bun run check:deploy" \
+  --dry-run
+```
+
+Do not run the old target-15/18 overnight acceptance gate unless a real
+>=30-unit claimable backlog exists, `smoke:fleet-run-live` is explicitly armed
+and green the same day, and the owner approves the overnight spend window.
+
 ## Current Quick Start: Get Khala Code Desktop Moving
 
 From a clean, current `main` checkout:
@@ -581,6 +608,11 @@ budget, not OpenAgents settlement.
   raw process count, is the gate — check `availableCodexAssignments`, not `ps`.
 
 ## GEPA Delegation Dataset
+
+This section is retained as historical substrate. GEPA delegation optimization
+is postponed for the current desktop-fleet push, and replenishment paths must
+not create or dispatch GEPA/DSPy optimizer work unless the owner explicitly
+reopens that lane.
 
 GD-0 is now a typed public-safe export, not a handwritten scrape. The Worker
 module `apps/openagents.com/workers/api/src/khala-delegation-example-dataset.ts`


### PR DESCRIPTION
## Summary

- revise WS-17 around the owner-directed desktop-fleet closeout instead of pretending the old clean-2B-day gate ran
- add the 2026-07-02 WS-17 after-action and update the fleet spec, runbook, and fan-out instructions
- remove active GEPA/DSPy optimizer replenishment targets from `khala fleet run` and the legacy supervisor refill templates

Closes #7905.
Closes #7907.
Updates #7906 as postponed/not planned for the current desktop-fleet push.

## Verification

- `bun test clients/khala-cli/src/fleet-run.test.ts apps/pylon/tests/fleet-run-live-smoke.test.ts`
- `bash apps/pylon/scripts/codex-supervisor/replenishment.test.sh`
- `git diff --check`
- `bun run check:deploy`
