### PR TITLE
test(khala-qa): cover ThreadItem variant render counts

### DIFF
--- a/packages/khala-qa-harness/src/coverage-ledger.test.ts
+++ b/packages/khala-qa-harness/src/coverage-ledger.test.ts
@@ -47,6 +47,7 @@ describe("Khala Code QA coverage ledger", () => {
     }
     for (const variant of KHALA_CODE_QA_SEED_CORPUS_MANIFEST.coverage.threadItemVariants) {
       expect(ledger.threadItemVariantsRendered).toContain(variant)
+      expect(ledger.threadItemVariantRenderCounts[variant]).toBeGreaterThan(0)
     }
   })
 
@@ -94,6 +95,50 @@ describe("Khala Code QA coverage ledger", () => {
       distinctArgumentShapeCount: 2,
     })
     expect(merged.selectorsClicked).toEqual(["[data-testid=thread-list]"])
+  })
+
+  test("counts repeated ThreadItem variant renders across ledgers", () => {
+    const first = collectKhalaCodeQaCoverageLedger({
+      generatedAt: "2026-07-01T00:00:00.000Z",
+      observations: [{
+        action: { args: [{ threadId: "thread-a", includeTurns: true }], kind: "rpc_call", method: "codexThreadRead" },
+        data: {
+          messages: [
+            { codexItem: { itemType: "agentMessage" } },
+            { harnessItem: { itemType: "commandExecution" } },
+          ],
+        },
+        label: "rpc:codexThreadRead#1",
+        ok: true,
+      }],
+      runId: "run-a",
+    })
+    const second = collectKhalaCodeQaCoverageLedger({
+      generatedAt: "2026-07-02T00:00:00.000Z",
+      observations: [{
+        action: { args: [{ threadId: "thread-b", includeTurns: true }], kind: "rpc_call", method: "codexThreadRead" },
+        data: {
+          messages: [
+            { codexItem: { itemType: "agentMessage" } },
+          ],
+        },
+        label: "rpc:codexThreadRead#1",
+        ok: true,
+      }],
+      runId: "run-b",
+    })
+
+    const merged = mergeKhalaCodeQaCoverageLedgers([first, second])
+
+    expect(first.threadItemVariantRenderCounts).toEqual({
+      agentMessage: 1,
+      commandExecution: 1,
+    })
+    expect(merged.threadItemVariantRenderCounts).toEqual({
+      agentMessage: 2,
+      commandExecution: 1,
+    })
+    expect(merged.threadItemVariantsRendered).toEqual(["agentMessage", "commandExecution"])
   })
 
   test("lists never-exercised coverage classes from the seed corpus manifest", () => {

--- a/packages/khala-qa-harness/src/coverage-ledger.ts
+++ b/packages/khala-qa-harness/src/coverage-ledger.ts
@@ -20,6 +20,7 @@ export type KhalaCodeQaCoverageLedger = {
   readonly hotbarPanelsOpened: readonly string[]
   readonly settingsKeysWritten: readonly string[]
   readonly approvalDecisionKinds: readonly string[]
+  readonly threadItemVariantRenderCounts: Readonly<Record<string, number>>
   readonly threadItemVariantsRendered: readonly string[]
   readonly selectorsClicked: readonly string[]
   readonly screensScreenshotted: readonly string[]
@@ -42,6 +43,7 @@ export type KhalaCodeQaCoverageFrontierReport = {
 
 type MutableRpcCoverage = Map<string, { calls: number; argumentShapes: Set<string> }>
 type MutableSlashCoverage = Map<string, { dispatches: number; availabilityStates: Set<KhalaCodeQaCoverageAvailability> }>
+type MutableCountCoverage = Map<string, number>
 
 const emptyGeneratedAt = "1970-01-01T00:00:00.000Z"
 
@@ -78,6 +80,11 @@ const slashCoverageToObject = (
       dispatches: entry.dispatches,
     },
   ]))
+
+const countCoverageToObject = (
+  coverage: MutableCountCoverage,
+): Readonly<Record<string, number>> =>
+  Object.fromEntries([...coverage.entries()].sort(([left], [right]) => left.localeCompare(right)))
 
 const parseSlashRaw = (raw: unknown): string | undefined => {
   if (typeof raw !== "string") return undefined
@@ -121,12 +128,18 @@ const recordSlash = (
   coverage.set(command, entry)
 }
 
+const recordCount = (
+  coverage: MutableCountCoverage,
+  key: string,
+  increment = 1,
+): void => {
+  coverage.set(key, (coverage.get(key) ?? 0) + increment)
+}
+
 const collectThreadItemVariants = (value: unknown): readonly string[] => {
   if (Array.isArray(value)) return value.flatMap(collectThreadItemVariants)
   if (!isRecord(value)) return []
   const variants = [
-    isRecord(value.codexItem) && typeof value.codexItem.itemType === "string" ? value.codexItem.itemType : undefined,
-    isRecord(value.harnessItem) && typeof value.harnessItem.itemType === "string" ? value.harnessItem.itemType : undefined,
     typeof value.itemType === "string" ? value.itemType : undefined,
   ].filter((variant): variant is string => variant !== undefined)
   return [...variants, ...Object.values(value).flatMap(collectThreadItemVariants)]
@@ -145,6 +158,7 @@ export const createEmptyKhalaCodeQaCoverageLedger = (
   selectorsClicked: [],
   settingsKeysWritten: [],
   slashCommands: {},
+  threadItemVariantRenderCounts: {},
   threadItemVariantsRendered: [],
 })
 
@@ -158,6 +172,7 @@ export const collectKhalaCodeQaCoverageLedger = (input: {
   const hotbarPanelsOpened = new Set<string>()
   const settingsKeysWritten = new Set<string>()
   const approvalDecisionKinds = new Set<string>()
+  const threadItemVariantRenderCounts: MutableCountCoverage = new Map()
   const threadItemVariantsRendered = new Set<string>()
   const selectorsClicked = new Set<string>()
   const screensScreenshotted = new Set<string>()
@@ -192,6 +207,7 @@ export const collectKhalaCodeQaCoverageLedger = (input: {
         approvalDecisionKinds.add(firstArg.action)
       }
       for (const variant of collectThreadItemVariants(observation.data)) {
+        recordCount(threadItemVariantRenderCounts, variant)
         threadItemVariantsRendered.add(variant)
       }
       continue
@@ -220,6 +236,7 @@ export const collectKhalaCodeQaCoverageLedger = (input: {
     selectorsClicked: sorted(selectorsClicked),
     settingsKeysWritten: sorted(settingsKeysWritten),
     slashCommands: slashCoverageToObject(slashCommands),
+    threadItemVariantRenderCounts: countCoverageToObject(threadItemVariantRenderCounts),
     threadItemVariantsRendered: sorted(threadItemVariantsRendered),
   }
 }
@@ -229,6 +246,7 @@ export const mergeKhalaCodeQaCoverageLedgers = (
 ): KhalaCodeQaCoverageLedger => {
   const rpcMethods: MutableRpcCoverage = new Map()
   const slashCommands: MutableSlashCoverage = new Map()
+  const threadItemVariantRenderCounts: MutableCountCoverage = new Map()
   const runIds = new Set<string>()
   const generatedAt = ledgers.map((ledger) => ledger.generatedAt).sort().at(-1) ?? emptyGeneratedAt
   const addSet = <K extends keyof KhalaCodeQaCoverageLedger>(key: K): Set<string> =>
@@ -248,6 +266,9 @@ export const mergeKhalaCodeQaCoverageLedgers = (
       for (const state of entry.availabilityStates) target.availabilityStates.add(state)
       slashCommands.set(command, target)
     }
+    for (const [variant, count] of Object.entries(ledger.threadItemVariantRenderCounts ?? {})) {
+      recordCount(threadItemVariantRenderCounts, variant, count)
+    }
   }
 
   return {
@@ -261,6 +282,7 @@ export const mergeKhalaCodeQaCoverageLedgers = (
     selectorsClicked: sorted(addSet("selectorsClicked")),
     settingsKeysWritten: sorted(addSet("settingsKeysWritten")),
     slashCommands: slashCoverageToObject(slashCommands),
+    threadItemVariantRenderCounts: countCoverageToObject(threadItemVariantRenderCounts),
     threadItemVariantsRendered: sorted(addSet("threadItemVariantsRendered")),
   }
 }

--- a/packages/khala-qa-harness/src/seed-corpus.test.ts
+++ b/packages/khala-qa-harness/src/seed-corpus.test.ts
@@ -57,12 +57,11 @@ describe("Khala Code QA seed scenario corpus", () => {
       "scenario.khala_code.seed.hotbar_settings_panel.v1",
     ])
 
-    for (const variant of KHALA_CODE_QA_THREAD_ITEM_VARIANTS) {
+    const expectedThreadItemScenarioIds = KHALA_CODE_QA_THREAD_ITEM_VARIANTS.map((variant) => {
       const normalized = variant.replace(/[A-Z]/g, (letter) => `_${letter.toLowerCase()}`)
-      expect(idsForGroup("thread_items")).toContain(
-        `scenario.khala_code.seed.thread_item_${normalized}.v1`,
-      )
-    }
+      return `scenario.khala_code.seed.thread_item_${normalized}.v1`
+    })
+    expect(idsForGroup("thread_items")).toEqual(expectedThreadItemScenarioIds)
     expect(KHALA_CODE_QA_THREAD_ITEM_VARIANTS).toEqual(KHALA_CODE_CODEX_PARITY_REQUIRED_THREAD_ITEM_TYPES)
 
     const slashCommandIds = idsForGroup("rpc.slash_commands")


### PR DESCRIPTION
Closes #8028.

### Changes
- Added ThreadItem variant render counts to the Khala QA coverage ledger.
- Merged render counts across multiple coverage ledgers while preserving rendered variant lists.
- Added tests for manifest-covered variants having positive render counts and repeated variant aggregation.
- Updated seed corpus coverage expectations to match the new render-count ledger shape.

### Verification
- `bun run --cwd packages/khala-qa-harness test` passed (exit 0).