### PR TITLE
QA Q6.4: commit GEPA explore policy metrics

### DIFF
--- a/packages/khala-qa-harness/src/explore-policy-gepa.test.ts
+++ b/packages/khala-qa-harness/src/explore-policy-gepa.test.ts
@@ -4,8 +4,10 @@ import { Effect } from "effect"
 import {
   admitKhalaCodeQaGepaExplorePolicyToGym,
   decodeKhalaCodeQaGepaExplorePolicyCandidate,
+  decodeKhalaCodeQaGepaMetricDefinitions,
   decodeKhalaCodeQaScenarioPortfolioPlan,
   evaluateKhalaCodeQaGepaExplorePolicyAutoPromotion,
+  KHALA_CODE_QA_GEPA_EXPLORE_POLICY_METRIC_DEFINITIONS,
   makeKhalaCodeQaGepaExplorePolicyBrain,
   proposeKhalaCodeQaGepaExplorePolicyCandidate,
   rankKhalaCodeQaScenarioPortfolioByYield,
@@ -51,6 +53,10 @@ describe("Khala Code QA GEPA explore policy loop", () => {
 
     expect(decoded.schema).toBe("khala_code_qa_gepa_explore_policy_candidate.v1")
     expect(candidate.admission.state).toBe("admitted")
+    expect(candidate.metricDefinitions.map((metric) => metric.metricRef)).toEqual([
+      "new_coverage_per_action",
+      "confirmed_bugs_per_1000_actions",
+    ])
     expect(candidate.governance).toMatchObject({
       authorityBoundary: "evidence_only",
       autoPromote: false,
@@ -63,6 +69,33 @@ describe("Khala Code QA GEPA explore policy loop", () => {
     expect(promotion).toMatchObject({
       promoted: false,
     })
+  })
+
+  test("commits the explore-policy metric definitions used for candidate scoring", () => {
+    const definitions = decodeKhalaCodeQaGepaMetricDefinitions(
+      KHALA_CODE_QA_GEPA_EXPLORE_POLICY_METRIC_DEFINITIONS,
+    )
+
+    expect(definitions).toEqual([
+      expect.objectContaining({
+        denominator: "total offline explorer actions across admitted source runs",
+        formula: "deduped_new_coverage_refs / total_action_count",
+        metricRef: "new_coverage_per_action",
+        numerator: "deduped coverage refs first reached by the candidate source runs",
+        objective: "maximize",
+        source: "offline_explore_telemetry",
+        unit: "coverage refs per action",
+      }),
+      expect.objectContaining({
+        denominator: "total offline explorer actions across admitted source runs / 1000",
+        formula: "(deduped_confirmed_bug_refs * 1000) / total_action_count",
+        metricRef: "confirmed_bugs_per_1000_actions",
+        numerator: "deduped public-safe confirmed bug refs from the candidate source runs",
+        objective: "maximize",
+        source: "offline_explore_telemetry",
+        unit: "confirmed bugs per 1000 actions",
+      }),
+    ])
   })
 
   test("blocks live or metric-regressed candidates before they can drive exploration", () => {

--- a/packages/khala-qa-harness/src/explore-policy-gepa.ts
+++ b/packages/khala-qa-harness/src/explore-policy-gepa.ts
@@ -13,8 +13,55 @@ export const KHALA_CODE_QA_GEPA_GYM_ADMISSION_SCHEMA =
   "khala_code_qa_gepa_gym_admission.v1" as const
 export const KHALA_CODE_QA_SCENARIO_PORTFOLIO_SCHEMA =
   "khala_code_qa_scenario_portfolio.v1" as const
+export const KHALA_CODE_QA_GEPA_METRIC_DEFINITION_SCHEMA =
+  "khala_code_qa_gepa_metric_definition.v1" as const
 export const KHALA_CODE_QA_GEPA_RELEASE_GATE_REF =
   "khala_code_qa.release_gate.gepa_explore_policy.v1" as const
+
+export const KhalaCodeQaGepaMetricDefinitionSchema = S.Struct({
+  denominator: S.String,
+  formula: S.String,
+  metricRef: S.Literals(["new_coverage_per_action", "confirmed_bugs_per_1000_actions"]),
+  numerator: S.String,
+  objective: S.Literal("maximize"),
+  schema: S.Literal(KHALA_CODE_QA_GEPA_METRIC_DEFINITION_SCHEMA),
+  source: S.Literal("offline_explore_telemetry"),
+  unit: S.String,
+})
+
+export type KhalaCodeQaGepaMetricDefinition = {
+  readonly schema: typeof KHALA_CODE_QA_GEPA_METRIC_DEFINITION_SCHEMA
+  readonly denominator: string
+  readonly formula: string
+  readonly metricRef: "new_coverage_per_action" | "confirmed_bugs_per_1000_actions"
+  readonly numerator: string
+  readonly objective: "maximize"
+  readonly source: "offline_explore_telemetry"
+  readonly unit: string
+}
+
+export const KHALA_CODE_QA_GEPA_EXPLORE_POLICY_METRIC_DEFINITIONS = [
+  {
+    denominator: "total offline explorer actions across admitted source runs",
+    formula: "deduped_new_coverage_refs / total_action_count",
+    metricRef: "new_coverage_per_action",
+    numerator: "deduped coverage refs first reached by the candidate source runs",
+    objective: "maximize",
+    schema: KHALA_CODE_QA_GEPA_METRIC_DEFINITION_SCHEMA,
+    source: "offline_explore_telemetry",
+    unit: "coverage refs per action",
+  },
+  {
+    denominator: "total offline explorer actions across admitted source runs / 1000",
+    formula: "(deduped_confirmed_bug_refs * 1000) / total_action_count",
+    metricRef: "confirmed_bugs_per_1000_actions",
+    numerator: "deduped public-safe confirmed bug refs from the candidate source runs",
+    objective: "maximize",
+    schema: KHALA_CODE_QA_GEPA_METRIC_DEFINITION_SCHEMA,
+    source: "offline_explore_telemetry",
+    unit: "confirmed bugs per 1000 actions",
+  },
+] as const satisfies readonly KhalaCodeQaGepaMetricDefinition[]
 
 export const KhalaCodeQaGepaExplorePolicyParametersSchema = S.Struct({
   actionSelectionHeuristic: S.String,
@@ -110,6 +157,7 @@ export const KhalaCodeQaGepaExplorePolicyCandidateSchema = S.Struct({
     newCoveragePerAction: S.Number,
     score: S.Number,
   }),
+  metricDefinitions: S.Array(KhalaCodeQaGepaMetricDefinitionSchema),
   parameters: KhalaCodeQaGepaExplorePolicyParametersSchema,
   schema: S.Literal(KHALA_CODE_QA_GEPA_EXPLORE_POLICY_SCHEMA),
   sourceRunIds: S.Array(S.String),
@@ -126,6 +174,7 @@ export type KhalaCodeQaGepaExplorePolicyCandidate = {
     readonly newCoveragePerAction: number
     readonly score: number
   }
+  readonly metricDefinitions: readonly KhalaCodeQaGepaMetricDefinition[]
   readonly parameters: KhalaCodeQaGepaExplorePolicyParameters
   readonly sourceRunIds: readonly string[]
 }
@@ -208,6 +257,11 @@ export const decodeKhalaCodeQaGepaExplorePolicyCandidate = (
   input: unknown,
 ): KhalaCodeQaGepaExplorePolicyCandidate =>
   S.decodeUnknownSync(KhalaCodeQaGepaExplorePolicyCandidateSchema)(input) as KhalaCodeQaGepaExplorePolicyCandidate
+
+export const decodeKhalaCodeQaGepaMetricDefinitions = (
+  input: unknown,
+): readonly KhalaCodeQaGepaMetricDefinition[] =>
+  S.decodeUnknownSync(S.Array(KhalaCodeQaGepaMetricDefinitionSchema))(input) as readonly KhalaCodeQaGepaMetricDefinition[]
 
 export const decodeKhalaCodeQaScenarioPortfolioPlan = (
   input: unknown,
@@ -345,6 +399,7 @@ export const proposeKhalaCodeQaGepaExplorePolicyCandidate = (input: {
       newCoveragePerAction: roundMetric(newCoveragePerAction),
       score: roundedScore,
     },
+    metricDefinitions: KHALA_CODE_QA_GEPA_EXPLORE_POLICY_METRIC_DEFINITIONS,
     parameters,
     schema: KHALA_CODE_QA_GEPA_EXPLORE_POLICY_SCHEMA,
     sourceRunIds: dedupe(input.evidence.map((entry) => entry.sourceRunId)),


### PR DESCRIPTION
## Summary
- Add an explicit typed metric-definition contract for the QA GEPA explore-policy loop.
- Attach the committed metric definitions to each offline Gym-admitted explore-policy candidate.
- Cover the new metric registry and candidate metric refs in the QA harness tests.

Closes #8041.

## Verification
- `bun run --cwd packages/khala-qa-harness test` (72 pass)
- `bun run --cwd packages/khala-qa-harness typecheck`
- `bun run check:deploy` (completed successfully)

Pinned base: `main@253a8c33596d54506493f1b668e79365fb031b46`.
