### PR TITLE
Add Claude desktop live smoke harness

### DIFF
--- a/clients/khala-code-desktop/package.json
+++ b/clients/khala-code-desktop/package.json
@@ -12,6 +12,7 @@
     "test": "bun test tests/*.test.ts",
     "smoke:codex-parity-live": "bun scripts/codex-parity-live-smoke.ts",
     "smoke:codex-spawn-live": "bun scripts/live-two-codex-readonly-smoke.ts",
+    "smoke:claude-live": "bun scripts/claude-live-smoke.ts",
     "smoke:composer-visual": "bun scripts/composer-visual-smoke.ts",
     "smoke:composer-visual-preview": "bun scripts/composer-visual-smoke.ts",
     "smoke:cockpit-visual": "bun scripts/cockpit-visual-smoke.ts",

--- a/clients/khala-code-desktop/scripts/claude-live-smoke.ts
+++ b/clients/khala-code-desktop/scripts/claude-live-smoke.ts
@@ -1,0 +1,56 @@
+#!/usr/bin/env bun
+import {
+  CLAUDE_LIVE_SMOKE_DEFAULT_TIMEOUT_MS,
+  CLAUDE_LIVE_SMOKE_HARNESS,
+  runKhalaCodeClaudeLiveSmoke,
+} from "../src/bun/claude-live-smoke.js"
+
+const liveAllowed =
+  Bun.env.KHALA_CODE_DESKTOP_LIVE_CLAUDE_SMOKE === "1" ||
+  process.argv.includes("--allow-live")
+
+if (!liveAllowed) {
+  console.error([
+    "Refusing to launch a live Claude turn without an explicit guard.",
+    "Set KHALA_CODE_DESKTOP_LIVE_CLAUDE_SMOKE=1 or pass --allow-live.",
+  ].join("\n"))
+  process.exit(2)
+}
+
+const timeoutMs = positiveInteger(
+  Bun.env.KHALA_CODE_DESKTOP_LIVE_CLAUDE_TIMEOUT_MS,
+  CLAUDE_LIVE_SMOKE_DEFAULT_TIMEOUT_MS,
+)
+
+console.error(`[live-smoke] harness ${CLAUDE_LIVE_SMOKE_HARNESS}`)
+console.error("[live-smoke] launching one Claude desktop runtime turn")
+console.error(`[live-smoke] timeout ${timeoutMs}ms`)
+
+const summary = await runKhalaCodeClaudeLiveSmoke({
+  env: Bun.env,
+  onEvent: event => {
+    const label = event.type === "tool_event"
+      ? `${event.event.kind} ${(event.event.payload as { readonly name?: string }).name ?? event.event.invocationId}`
+      : event.type
+    console.error(`[live-smoke] ${label}`)
+  },
+  timeoutMs,
+})
+
+console.log(JSON.stringify(summary, null, 2))
+
+if (!summary.ok) {
+  console.error(`[live-smoke] failed: ${summary.failures.join("; ")}`)
+  process.exit(1)
+}
+
+console.error(
+  `[live-smoke] ok: ${summary.approvalRequestCount} approval(s), ` +
+    `${summary.exactTokenRows} exact token row(s), ${summary.totalTokens} token(s)`,
+)
+
+function positiveInteger(raw: string | undefined, fallback: number): number {
+  if (raw === undefined || raw.trim().length === 0) return fallback
+  const parsed = Number.parseInt(raw, 10)
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback
+}

--- a/clients/khala-code-desktop/src/bun/claude-live-smoke.ts
+++ b/clients/khala-code-desktop/src/bun/claude-live-smoke.ts
@@ -1,0 +1,237 @@
+import { readFile } from "node:fs/promises"
+import { join } from "node:path"
+import { homedir } from "node:os"
+
+import { createClaudeAppSdkChatRuntime, type CreateClaudeAppSdkChatRuntimeOptions } from "./claude-app-sdk-chat-runtime.js"
+import { createClaudeApprovalService, type ClaudeApprovalService } from "./claude-approvals.js"
+import { createClaudeSessionStore } from "./claude-session-store.js"
+import { inspectClaudeHarnessStatus, type KhalaCodeDesktopClaudeHarnessStatus } from "./claude-harness-status.js"
+import { createKhalaCodeDesktopClaudeTokenUsageReporter } from "./claude-token-usage-telemetry.js"
+import { khalaCodeConfigFromRuntimeEnv } from "./khala-code-config.js"
+import type { KhalaCodeDesktopChatTurnEvent } from "../shared/rpc.js"
+
+export const CLAUDE_LIVE_SMOKE_HARNESS = "claude_runtime_live_smoke"
+export const CLAUDE_LIVE_SMOKE_DEFAULT_TIMEOUT_MS = 240_000
+export const CLAUDE_LIVE_SMOKE_DEFAULT_PROMPT = [
+  "Khala Code Desktop Claude live smoke.",
+  "Use the Bash tool exactly once to run `pwd`, then reply with one short sentence.",
+  "Do not edit files, create files, delete files, commit, push, or open pull requests.",
+].join("\n")
+
+type ClaudeQueryFn = NonNullable<CreateClaudeAppSdkChatRuntimeOptions["query"]>
+
+export type KhalaCodeClaudeLiveSmokeOptions = {
+  readonly approvalService?: ClaudeApprovalService | undefined
+  readonly env?: Readonly<Record<string, string | undefined>> | undefined
+  readonly localLedgerPath?: string | undefined
+  readonly now?: (() => Date) | undefined
+  readonly onEvent?: ((event: KhalaCodeDesktopChatTurnEvent) => void) | undefined
+  readonly prompt?: string | undefined
+  readonly query?: ClaudeQueryFn | undefined
+  readonly readiness?: KhalaCodeDesktopClaudeHarnessStatus | undefined
+  readonly sleep?: ((ms: number) => Promise<void>) | undefined
+  readonly timeoutMs?: number | undefined
+  readonly workingDirectory?: string | undefined
+}
+
+export type KhalaCodeClaudeLiveSmokeSummary = {
+  readonly approvalRequestCount: number
+  readonly approvedToolNames: readonly string[]
+  readonly eventCount: number
+  readonly exactTokenRows: number
+  readonly failures: readonly string[]
+  readonly finishedAt: string
+  readonly harness: typeof CLAUDE_LIVE_SMOKE_HARNESS
+  readonly ledgerPath: string
+  readonly ok: boolean
+  readonly readiness: KhalaCodeDesktopClaudeHarnessStatus
+  readonly responseRuntimeMode: string | null
+  readonly runtimeBadgeMode: "claude_runtime" | null
+  readonly startedAt: string
+  readonly threadId: string | null
+  readonly toolNames: readonly string[]
+  readonly totalTokens: number
+  readonly turnId: string
+  readonly usageTruth: "exact" | "missing"
+}
+
+export async function runKhalaCodeClaudeLiveSmoke(
+  options: KhalaCodeClaudeLiveSmokeOptions = {},
+): Promise<KhalaCodeClaudeLiveSmokeSummary> {
+  const env = {
+    ...(options.env ?? khalaCodeConfigFromRuntimeEnv().env),
+    KHALA_CODE_DESKTOP_RUNTIME: "claude_runtime",
+  }
+  const sleep = options.sleep ?? ((ms: number) => new Promise<void>(resolve => setTimeout(resolve, ms)))
+  const timeoutMs = options.timeoutMs ?? CLAUDE_LIVE_SMOKE_DEFAULT_TIMEOUT_MS
+  const now = options.now ?? (() => new Date())
+  const startedAt = now().toISOString()
+  const readiness = options.readiness ?? await inspectClaudeHarnessStatus({ env, now })
+  const approvalService = options.approvalService ?? createClaudeApprovalService()
+  const localLedgerPath = options.localLedgerPath ?? defaultClaudeTokenLedgerPath()
+  const runId = now().getTime().toString(36)
+  const turnId = `claude-live-smoke-${runId}`
+  const sessionId = `khala-code-claude-live-smoke-${runId}`
+  const events: KhalaCodeDesktopChatTurnEvent[] = []
+  const approvedToolNames: string[] = []
+  const beforeRows = await exactClaudeTokenRows(localLedgerPath, turnId)
+  let turnSettled = false
+
+  const runtime = createClaudeAppSdkChatRuntime({
+    approvalService,
+    env,
+    onEvent: event => {
+      events.push(event)
+      options.onEvent?.(event)
+    },
+    ...(options.query === undefined ? {} : { query: options.query }),
+    sessionStore: createClaudeSessionStore({ env, path: sessionStorePath(localLedgerPath, turnId) }),
+    tokenUsageReporter: createKhalaCodeDesktopClaudeTokenUsageReporter({
+      env,
+      localLedgerPath,
+    }),
+    workingDirectory: options.workingDirectory ?? process.cwd(),
+  })
+
+  const approvalPump = (async (): Promise<void> => {
+    const seen = new Set<string>()
+    while (!turnSettled) {
+      for (const request of approvalService.pending()) {
+        if (seen.has(request.id)) continue
+        seen.add(request.id)
+        approvedToolNames.push(request.toolName)
+        await approvalService.respond(request.id, {
+          behavior: "allow",
+          decisionClassification: "live_smoke_allow_once",
+          updatedPermissions: request.options.suggestions ?? [],
+        })
+      }
+      await sleep(50)
+    }
+  })()
+
+  let responseRuntimeMode: string | null = null
+  let runtimeBadgeMode: "claude_runtime" | null = null
+  let threadId: string | null = null
+  let toolNames: readonly string[] = []
+  let totalTokens = 0
+  const failures: string[] = readiness.available
+    ? []
+    : [`Claude harness readiness is ${readiness.status}: ${readiness.reason}`]
+
+  try {
+    if (!readiness.available) throw new Error(`Claude harness is not ready (${readiness.status})`)
+    const response = await withTimeout(timeoutMs, runtime.startTurn({
+      messages: [{ body: options.prompt ?? CLAUDE_LIVE_SMOKE_DEFAULT_PROMPT, id: `${turnId}-user`, role: "user" }],
+      sessionId,
+      startNewThread: true,
+      turnId,
+    }))
+    responseRuntimeMode = response.backend.runtimeMode ?? null
+    runtimeBadgeMode = response.backend.runtimeMode === "claude_runtime" ? "claude_runtime" : null
+    threadId = response.backend.threadId ?? null
+    toolNames = response.toolNames
+    totalTokens = usageTotal(response.usage)
+    if (!response.ok) failures.push("Claude runtime returned a failed turn response")
+  } catch (error) {
+    failures.push(error instanceof Error ? error.message : String(error))
+  } finally {
+    turnSettled = true
+    await approvalPump
+  }
+
+  const afterRows = await exactClaudeTokenRows(localLedgerPath, turnId)
+  const exactTokenRows = Math.max(0, afterRows.length - beforeRows.length)
+  if (responseRuntimeMode !== "claude_runtime") {
+    failures.push(`expected response runtimeMode claude_runtime, got ${responseRuntimeMode ?? "missing"}`)
+  }
+  if (runtimeBadgeMode !== "claude_runtime") {
+    failures.push("expected runtime badge mode claude_runtime")
+  }
+  if (approvedToolNames.length < 1) {
+    failures.push("expected canUseTool approval to be exercised at least once")
+  }
+  if (exactTokenRows < 1) {
+    failures.push("expected at least one exact Claude token usage row")
+  }
+  if (totalTokens <= 0) {
+    failures.push("expected positive exact token usage on the Claude turn")
+  }
+
+  return {
+    approvalRequestCount: approvedToolNames.length,
+    approvedToolNames,
+    eventCount: events.length,
+    exactTokenRows,
+    failures,
+    finishedAt: now().toISOString(),
+    harness: CLAUDE_LIVE_SMOKE_HARNESS,
+    ledgerPath: localLedgerPath,
+    ok: failures.length === 0,
+    readiness,
+    responseRuntimeMode,
+    runtimeBadgeMode,
+    startedAt,
+    threadId,
+    toolNames,
+    totalTokens,
+    turnId,
+    usageTruth: exactTokenRows > 0 ? "exact" : "missing",
+  }
+}
+
+async function withTimeout<T>(
+  timeoutMs: number,
+  promise: Promise<T>,
+): Promise<T> {
+  let timeoutId: ReturnType<typeof setTimeout> | undefined
+  const timeout = new Promise<never>((_, reject) => {
+    timeoutId = setTimeout(() => {
+      reject(new Error(`Claude live smoke timed out after ${timeoutMs}ms`))
+    }, timeoutMs)
+  })
+  try {
+    return await Promise.race([promise, timeout])
+  } finally {
+    if (timeoutId !== undefined) clearTimeout(timeoutId)
+  }
+}
+
+function defaultClaudeTokenLedgerPath(): string {
+  return join(homedir(), ".khala-code", "claude-token-usage-events.jsonl")
+}
+
+function sessionStorePath(localLedgerPath: string, turnId: string): string {
+  return join(localLedgerPath, "..", `claude-live-smoke-session-${turnId}.json`)
+}
+
+function usageTotal(usage: { cachedInput: number; input: number; output: number; reasoningOutput: number } | undefined): number {
+  if (usage === undefined) return 0
+  return usage.cachedInput + usage.input + usage.output + usage.reasoningOutput
+}
+
+async function exactClaudeTokenRows(
+  path: string,
+  turnId: string,
+): Promise<readonly Record<string, unknown>[]> {
+  try {
+    const text = await readFile(path, "utf8")
+    return text.split(/\r?\n/u).flatMap(line => {
+      if (line.trim().length === 0) return []
+      try {
+        const row = JSON.parse(line) as Record<string, unknown>
+        const event = row.event
+        if (typeof event !== "object" || event === null || Array.isArray(event)) return []
+        const record = event as Record<string, unknown>
+        const safeMetadata = record.safeMetadata
+        if (record.usageTruth !== "exact") return []
+        if (typeof safeMetadata !== "object" || safeMetadata === null || Array.isArray(safeMetadata)) return []
+        return (safeMetadata as Record<string, unknown>).desktopTurnId === turnId ? [record] : []
+      } catch {
+        return []
+      }
+    })
+  } catch {
+    return []
+  }
+}

--- a/clients/khala-code-desktop/tests/claude-live-smoke.test.ts
+++ b/clients/khala-code-desktop/tests/claude-live-smoke.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { mkdtemp, rm } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+import { runKhalaCodeClaudeLiveSmoke } from "../src/bun/claude-live-smoke"
+
+const tempDirs: string[] = []
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map(dir => rm(dir, { force: true, recursive: true })))
+})
+
+async function tempLedger(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "khala-code-claude-live-smoke-"))
+  tempDirs.push(dir)
+  return join(dir, "claude-token-usage-events.jsonl")
+}
+
+describe("Khala Code Claude live smoke harness", () => {
+  test("exercises canUseTool and proves exact token reporting through the desktop runtime", async () => {
+    const ledgerPath = await tempLedger()
+    const summary = await runKhalaCodeClaudeLiveSmoke({
+      env: {
+        KHALA_CODE_TOKEN_USAGE_REMOTE_DISABLED: "1",
+      },
+      localLedgerPath: ledgerPath,
+      query: input => ({
+        async *[Symbol.asyncIterator]() {
+          const canUseTool = input.options.canUseTool as (
+            toolName: string,
+            toolInput: Record<string, unknown>,
+            options: Record<string, unknown>,
+          ) => Promise<unknown>
+          yield {
+            message: {
+              content: [{ text: "Checking the working directory.", type: "text" }],
+            },
+            session_id: "claude-live-smoke-session",
+            type: "assistant",
+            uuid: "claude-live-smoke-assistant",
+          }
+          await canUseTool("Bash", { command: "pwd" }, {
+            signal: new AbortController().signal,
+            suggestions: [{ rule: "allow", toolName: "Bash" }],
+            title: "Claude wants to run pwd",
+          })
+          yield {
+            message: {
+              content: [{ content: "/repo", tool_use_id: "tool-use-pwd", type: "tool_result" }],
+            },
+            session_id: "claude-live-smoke-session",
+            type: "user",
+            uuid: "claude-live-smoke-tool-result",
+          }
+          yield {
+            model: "claude-sonnet-4",
+            session_id: "claude-live-smoke-session",
+            subtype: "success",
+            type: "result",
+            usage: {
+              cache_read_input_tokens: 2,
+              input_tokens: 7,
+              output_tokens: 11,
+              reasoning_output_tokens: 3,
+            },
+            uuid: "claude-live-smoke-result",
+          }
+        },
+      }),
+      readiness: {
+        available: true,
+        blockerRefs: [],
+        capability: "claude_harness",
+        credentialSourceRef: "credential.source.test",
+        observedAt: "2026-07-02T00:00:00.000Z",
+        reason: "ready",
+        status: "ready",
+      },
+      timeoutMs: 5_000,
+      workingDirectory: "/repo",
+    })
+
+    expect(summary).toMatchObject({
+      approvalRequestCount: 1,
+      exactTokenRows: 1,
+      ok: true,
+      responseRuntimeMode: "claude_runtime",
+      readiness: { status: "ready" },
+      runtimeBadgeMode: "claude_runtime",
+      totalTokens: 23,
+      usageTruth: "exact",
+    })
+    expect(summary.approvedToolNames).toEqual(["Bash"])
+    expect(summary.toolNames).toEqual([])
+    expect(summary.ledgerPath).toBe(ledgerPath)
+  })
+})


### PR DESCRIPTION
## Summary

Closes #8036.

Adds a guarded Khala Code Desktop Claude live smoke harness that:

- forces the desktop harness mode to `claude_runtime` and asserts the returned runtime badge mode
- exercises the Claude SDK `canUseTool` approval callback by auto-approving the live smoke tool request
- verifies an exact Claude token usage row is written through the existing Claude turn reporter path
- exposes the smoke as `bun run --cwd clients/khala-code-desktop smoke:claude-live`

The live script refuses to run unless explicitly armed with `KHALA_CODE_DESKTOP_LIVE_CLAUDE_SMOKE=1` or `--allow-live`.

## Verification

- `bun test clients/khala-code-desktop/tests/claude-live-smoke.test.ts` ✅
- `bun run --cwd clients/khala-code-desktop test` ✅ (517 pass)
- `bun run --cwd clients/khala-code-desktop typecheck` ✅
- `bun run check:deploy` ✅

Note: `check:deploy` prints expected negative-fixture messages from the contract drift guard test, but the command exited 0.