### PR TITLE
[codex] Fix cockpit partial degradation

### DIFF
--- a/clients/khala-code-desktop/src/ui/fleet-status.ts
+++ b/clients/khala-code-desktop/src/ui/fleet-status.ts
@@ -89,6 +89,7 @@ type Handlers = Readonly<{
   onDelegateRun: () => void
   onFleetRunField: (field: keyof FleetRunFormState, value: string) => void
   onFleetRunControl: (verb: KhalaCodeDesktopFleetRunControlRequest["verb"]) => void
+  onFleetRunRetry: () => void
   onFleetWorkerControl: (
     card: KhalaFleetWorkerCard,
     verb: KhalaCodeDesktopFleetWorkerControlRequest["verb"],
@@ -168,9 +169,14 @@ type FleetRunView =
       readonly slots: readonly FleetRunPreviewSlot[]
     }
 
+type ActiveFleetRunError = Readonly<{
+  kind: "fleet_run_control" | "fleet_run_list"
+  message: string
+}>
+
 type ActiveFleetRunView = Readonly<{
   controlInFlight: KhalaCodeDesktopFleetRunControlRequest["verb"] | null
-  error: string | null
+  error: ActiveFleetRunError | null
   objective: string | null
   run: KhalaCodeDesktopFleetRunProjection | null
 }>
@@ -902,6 +908,28 @@ const renderFleetRunResult = (
   container.append(output)
 }
 
+const activeFleetRunErrorLabel = (
+  kind: ActiveFleetRunError["kind"],
+): string =>
+  kind === "fleet_run_list" ? "FleetRun list degraded" : "FleetRun control degraded"
+
+const renderActiveFleetRunError = (
+  container: HTMLElement,
+  error: ActiveFleetRunError,
+  handlers: Handlers,
+): void => {
+  const row = el("div", "khala-fleet-section-error")
+  row.dataset.errorKind = error.kind
+  row.append(
+    badge("degraded", activeFleetRunErrorLabel(error.kind)),
+    el("p", "khala-fleet-section-error-message", error.message),
+  )
+  const retry = iconButton("Retry", "Reload", "khala-fleet-refresh khala-fleet-section-retry")
+  retry.addEventListener("click", handlers.onFleetRunRetry)
+  row.append(retry)
+  container.append(row)
+}
+
 const renderFleetRunHeader = (
   container: HTMLElement,
   activeRun: ActiveFleetRunView,
@@ -909,11 +937,18 @@ const renderFleetRunHeader = (
   handlers: Handlers,
 ): void => {
   const run = activeRun.run
-  if (run === null) return
+  if (run === null && activeRun.error === null) return
 
   const section = el("section", "khala-fleet-section khala-fleet-run-header")
-  section.dataset.state = run.state
+  section.dataset.state = run?.state ?? "degraded"
   section.append(sectionHeader("Active FleetRun", "orchestration store"))
+
+  if (run === null) {
+    const error = activeRun.error
+    if (error !== null) renderActiveFleetRunError(section, error, handlers)
+    container.append(section)
+    return
+  }
 
   const objective = activeRun.objective ?? (
     run.objectiveProjected
@@ -965,7 +1000,7 @@ const renderFleetRunHeader = (
 
   section.append(objectiveNode, chips)
   if (activeRun.error !== null) {
-    section.append(el("p", "khala-fleet-error", activeRun.error))
+    renderActiveFleetRunError(section, activeRun.error, handlers)
   }
   section.append(controls)
   container.append(section)
@@ -1726,6 +1761,7 @@ export const mountFleetPanel = (
       paint()
     },
     onFleetRunControl: verb => onFleetRunControl(verb),
+    onFleetRunRetry: () => void refresh(),
     onFleetWorkerControl: (card, verb) => onFleetWorkerControl(card, verb),
     onFleetRunPreview: () => {
       const preview = fleetRunPreview()
@@ -1840,7 +1876,10 @@ export const mountFleetPanel = (
         activeRun = {
           ...activeRun,
           controlInFlight: null,
-          error: error instanceof Error ? error.message : String(error),
+          error: {
+            kind: "fleet_run_control",
+            message: error instanceof Error ? error.message : String(error),
+          },
         }
         paint()
       }
@@ -2031,29 +2070,59 @@ export const mountFleetPanel = (
     } else {
       syncCockpit()
     }
+
+    const [dataResult, listResult] = await Promise.allSettled([
+      options.fetch(),
+      options.fleetRunList(),
+    ] as const)
+
     try {
-      const [data, list] = await Promise.all([
-        options.fetch(),
-        options.fleetRunList(),
-      ])
-      lastData = data
-      fleetLoadError = null
-      const selected = selectActiveFleetRun(list.runs)
-      activeRun = {
-        controlInFlight: activeRun.controlInFlight,
-        error: null,
-        objective: selected === null
+      if (dataResult.status === "fulfilled") {
+        lastData = dataResult.value
+        fleetLoadError = null
+      } else if (lastData === null) {
+        fleetLoadError = dataResult.reason instanceof Error
+          ? dataResult.reason.message
+          : String(dataResult.reason)
+      }
+
+      if (listResult.status === "fulfilled") {
+        const selected = selectActiveFleetRun(listResult.value.runs)
+        const listError: ActiveFleetRunError | null = listResult.value.ok
           ? null
-          : objectiveByRunRef.get(selected.runRef) ?? (
-              activeRun.run?.runRef === selected.runRef ? activeRun.objective : null
-            ),
-        run: selected,
+          : {
+              kind: "fleet_run_list",
+              message: "fleetRunList returned ok=false.",
+            }
+        activeRun = {
+          controlInFlight: activeRun.controlInFlight,
+          error: listError,
+          objective: selected === null
+            ? null
+            : objectiveByRunRef.get(selected.runRef) ?? (
+                activeRun.run?.runRef === selected.runRef ? activeRun.objective : null
+              ),
+          run: selected,
+        }
+        paint()
+        return
+      }
+
+      const message = listResult.reason instanceof Error
+        ? listResult.reason.message
+        : String(listResult.reason)
+      activeRun = {
+        ...activeRun,
+        controlInFlight: null,
+        error: {
+          kind: "fleet_run_list",
+          message,
+        },
       }
       paint()
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error)
-      if (lastData === null) {
-        fleetLoadError = message
+    } finally {
+      if (dataResult.status === "rejected" && lastData === null) {
+        const message = fleetLoadError ?? "unknown error"
         const errorView: FleetView = { phase: "error", message }
         syncCockpit(errorView)
         render(
@@ -2070,15 +2139,7 @@ export const mountFleetPanel = (
           optimizationRun,
           now(),
         )
-      } else {
-        activeRun = {
-          ...activeRun,
-          controlInFlight: null,
-          error: message,
-        }
-        paint()
       }
-    } finally {
       inFlight = false
       syncCockpit()
     }

--- a/clients/khala-code-desktop/src/ui/styles.css
+++ b/clients/khala-code-desktop/src/ui/styles.css
@@ -2867,6 +2867,29 @@ button {
   font-size: 0.82rem;
   color: var(--oa-color-khala-danger-strong);
 }
+.khala-fleet-section-error {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  min-width: 0;
+  padding: 0.55rem 0.65rem;
+  border: 1px solid color-mix(in srgb, var(--oa-color-khala-warning) 34%, transparent);
+  border-radius: 0.45rem;
+  background: color-mix(in srgb, var(--oa-color-khala-warning) 8%, var(--oa-color-component-surface));
+}
+.khala-fleet-section-error-message {
+  flex: 1 1 14rem;
+  min-width: 0;
+  margin: 0;
+  color: color-mix(in srgb, var(--oa-color-component-text) 78%, transparent);
+  font-size: 0.78rem;
+  line-height: 1.35;
+  overflow-wrap: anywhere;
+}
+.khala-fleet-section-retry {
+  margin-left: auto;
+}
 .khala-fleet-account-list,
 .khala-fleet-assignment-list,
 .khala-fleet-worker-card-list {

--- a/clients/khala-code-desktop/tests/fleet-status.test.ts
+++ b/clients/khala-code-desktop/tests/fleet-status.test.ts
@@ -604,6 +604,63 @@ describe("Fleet status panel", () => {
     expect(root.textContent).toContain("failed1")
   })
 
+  test("keeps account data visible when fleetRunList fails and retries that section", async () => {
+    const root = document.createElement("div")
+    let listCalls = 0
+    const panel = mountFleetPanel(root, {
+      connectAccount: async () => ({
+        ok: false,
+        accountRef: "codex-test",
+        error: "disabled",
+        output: "",
+        userCode: null,
+        verificationUrl: null,
+      }),
+      delegateRun: async () => {
+        throw new Error("delegate runner should not be called")
+      },
+      fetch: async () => status(),
+      fleetRunControl: async () => {
+        throw new Error("fleet run control should not be called")
+      },
+      fleetRunList: async () => {
+        listCalls += 1
+        if (listCalls === 1) throw new Error("fleetRunList failed with 500")
+        return { ok: true, runs: [fleetRunProjection()] }
+      },
+      fleetRunStart: async request => runStartResult(request),
+      fleetWorkerControl: async () => {
+        throw new Error("fleet worker control should not be called")
+      },
+      loadGymDemoProof: () => {
+        throw new Error("gym proof should not be called")
+      },
+      openExternal: async () => false,
+      removeAccount: async () => ({ ok: true }),
+      setAccountPaused: async () => ({ ok: true }),
+      consumeResetCredit: async () => ({ ok: true }),
+      startDelegationOptimization: async () => {
+        throw new Error("optimization should not be called")
+      },
+    })
+
+    await panel.refresh()
+
+    expect(root.textContent).toContain("Worker Codex accounts")
+    expect(root.textContent).toContain("codex-a")
+    expect(root.textContent).toContain("FleetRun list degraded")
+    expect(root.textContent).toContain("fleetRunList failed with 500")
+    expect(root.textContent).toContain("Retry")
+    expect(root.textContent).not.toContain("Could not load fleet status")
+
+    clickButton(root, "Retry")
+    await flushPanelWork()
+
+    expect(listCalls).toBe(2)
+    expect(root.textContent).toContain("fleet.run.public.test")
+    expect(root.textContent).not.toContain("FleetRun list degraded")
+  })
+
   test("wires every FleetRun control transition through mocked RPC and renders returned state", async () => {
     const root = document.createElement("div")
     let currentRun = fleetRunProjection({ state: "running" })

--- a/packages/khala-qa-harness/src/seed-corpus.test.ts
+++ b/packages/khala-qa-harness/src/seed-corpus.test.ts
@@ -160,6 +160,17 @@ describe("Khala Code QA seed scenario corpus", () => {
         ]),
       )
     }
+    const partialDegradationScenario = KHALA_CODE_QA_SEED_SCENARIOS.find((candidate) =>
+      candidate.id === "scenario.khala_code.seed.error_state_single_rpc_failure_partial_degradation.v1"
+    )
+    expect(partialDegradationScenario?.phases[0]?.name).toBe("fleet-panel-partial-degradation")
+    expect(partialDegradationScenario?.phases[0]?.act).toEqual(
+      expect.arrayContaining([
+        { kind: "hotbar", target: "fleet" },
+        { kind: "rpc_call", method: "codexFleetStatus" },
+        { kind: "rpc_call", method: "fleetRunList", args: [{}] },
+      ]),
+    )
     const restartScenario = KHALA_CODE_QA_SEED_SCENARIOS.find((candidate) =>
       candidate.id === "scenario.khala_code.seed.error_state_app_server_crash_restart.v1"
     )

--- a/packages/khala-qa-harness/src/seed-corpus.ts
+++ b/packages/khala-qa-harness/src/seed-corpus.ts
@@ -1173,6 +1173,21 @@ const errorStateAction = (
 const errorStateScenarioPhases = (
   entry: typeof KHALA_CODE_QA_ERROR_STATE_CASES[number],
 ): KhalaCodeQaScenario["phases"] => {
+  if (entry.caseId === "single_rpc_failure_partial_degradation") {
+    return [{
+      name: "fleet-panel-partial-degradation",
+      act: [
+        errorStateArmAction(entry.caseId),
+        { kind: "hotbar", target: "fleet" },
+        { kind: "rpc_call", method: "codexFleetStatus" },
+        { kind: "rpc_call", method: "fleetRunList", args: [{}] },
+      ],
+      expect: [
+        schema("codexFleetStatus"),
+        ...errorStateExpectations(entry.caseId, "fleetRunList"),
+      ],
+    }]
+  }
   if (entry.caseId === "app_server_crash_restart") {
     return [
       {


### PR DESCRIPTION
## Summary

Closes #8042.

- Keep the Khala Code Fleet cockpit from blanking successful `codexFleetStatus` data when `fleetRunList` fails.
- Render a typed degraded chip with an inline retry for the Active FleetRun section.
- Extend the Q4.4 error-state corpus so the single-RPC failure case explicitly exercises successful fleet status plus failed FleetRun list data.

## Verification

- `bun test clients/khala-code-desktop/tests/fleet-status.test.ts packages/khala-qa-harness/src/seed-corpus.test.ts` — 13 pass
- `bun run --cwd clients/khala-code-desktop test` — 517 pass
- `bun run --cwd packages/khala-qa-harness test` — 71 pass
- `bun run --cwd clients/khala-code-desktop typecheck` — pass
- `bun run --cwd packages/khala-qa-harness typecheck` — pass
- `bun run check:deploy` — pass
- `bun run --cwd clients/khala-code-desktop build:ui` — pass
- `bun run --cwd clients/khala-code-desktop smoke:cockpit-visual` — pass