### PR TITLE
Add Claude desktop live smoke

### DIFF
--- a/clients/khala-code-desktop/package.json
+++ b/clients/khala-code-desktop/package.json
@@ -10,6 +10,7 @@
     "build": "bun run build:ui && electrobun build",
     "typecheck": "tsc -p tsconfig.typecheck.json --noEmit",
     "test": "bun test tests/*.test.ts",
+    "smoke:claude-live": "bun scripts/claude-live-smoke.ts",
     "smoke:codex-parity-live": "bun scripts/codex-parity-live-smoke.ts",
     "smoke:codex-spawn-live": "bun scripts/live-two-codex-readonly-smoke.ts",
     "smoke:composer-visual": "bun scripts/composer-visual-smoke.ts",

--- a/clients/khala-code-desktop/scripts/claude-live-smoke.ts
+++ b/clients/khala-code-desktop/scripts/claude-live-smoke.ts
@@ -1,0 +1,10 @@
+#!/usr/bin/env bun
+import { runKhalaCodeClaudeLiveSmoke } from "../src/bun/claude-live-smoke.js"
+
+const args = Bun.argv.slice(2)
+const result = await runKhalaCodeClaudeLiveSmoke({
+  requireLive: args.includes("--require-live"),
+})
+
+console.log(JSON.stringify(result, null, 2))
+if (!result.ok) process.exit(1)

--- a/clients/khala-code-desktop/src/bun/claude-live-smoke.ts
+++ b/clients/khala-code-desktop/src/bun/claude-live-smoke.ts
@@ -1,0 +1,270 @@
+import { randomUUID } from "node:crypto"
+import { readFile, mkdtemp, rm } from "node:fs/promises"
+import { homedir, tmpdir } from "node:os"
+import { join, resolve } from "node:path"
+import { Effect } from "effect"
+
+import type { KhalaCodeDesktopClaudeHarnessStatus } from "./claude-harness-status.js"
+import { inspectClaudeHarnessStatus } from "./claude-harness-status.js"
+import {
+  createClaudeApprovalService,
+  type ClaudeApprovalDecision,
+  type ClaudeApprovalRequest,
+  type ClaudeApprovalService,
+} from "./claude-approvals.js"
+import {
+  createClaudeAppSdkChatRuntime,
+  type CreateClaudeAppSdkChatRuntimeOptions,
+} from "./claude-app-sdk-chat-runtime.js"
+import {
+  createKhalaCodeDesktopClaudeTokenUsageReporter,
+  khalaCodeDesktopClaudeTokenUsageEvent,
+  type KhalaCodeDesktopClaudeTokenUsageReport,
+} from "./claude-token-usage-telemetry.js"
+import { createClaudeSessionStore } from "./claude-session-store.js"
+import { khalaCodeConfigFromRuntimeEnv } from "./khala-code-config.js"
+
+export const KHALA_CODE_CLAUDE_LIVE_SMOKE_HARNESS = "claude_agent_sdk_live_smoke"
+
+export type KhalaCodeClaudeLiveSmokeResult = Readonly<{
+  approvalCount?: number
+  approvalToolNames?: readonly string[]
+  eventCount?: number
+  harness: typeof KHALA_CODE_CLAUDE_LIVE_SMOKE_HARNESS
+  ok: boolean
+  reason?: string
+  required: boolean
+  runtimeMode?: string
+  skipped: boolean
+  status: "failed" | "ok" | "skipped"
+  threadId?: string
+  tokenUsage?: {
+    readonly eventId: string
+    readonly ledgerPath: string
+    readonly provider: string
+    readonly totalTokens: number
+    readonly usageTruth: string
+  }
+  tokenUsageDiagnostics?: readonly string[]
+  turnId?: string
+  turnStatus?: string
+  usedTools?: readonly string[]
+}>
+
+export type RunKhalaCodeClaudeLiveSmokeInput = Readonly<{
+  approvalDecision?: ClaudeApprovalDecision
+  env?: NodeJS.ProcessEnv | Readonly<Record<string, string | undefined>>
+  inspectHarness?: () => Promise<KhalaCodeDesktopClaudeHarnessStatus>
+  prompt?: string
+  query?: CreateClaudeAppSdkChatRuntimeOptions["query"]
+  repoRoot?: string
+  requireLive?: boolean
+  tokenUsageLedgerPath?: string
+  workingDirectory?: string
+}>
+
+const defaultPrompt = [
+  "Khala Claude live smoke:",
+  "Use one read-only local tool to inspect the current working directory name.",
+  "Then answer with one short sentence that includes the word khala-claude-smoke.",
+].join(" ")
+
+const notRequested = (): KhalaCodeClaudeLiveSmokeResult => ({
+  harness: KHALA_CODE_CLAUDE_LIVE_SMOKE_HARNESS,
+  ok: true,
+  reason:
+    "Live Claude smoke not requested. Set KHALA_CODE_DESKTOP_CLAUDE_LIVE_SMOKE=1 or pass --require-live.",
+  required: false,
+  skipped: true,
+  status: "skipped",
+})
+
+const resolveSourceRepositoryRoot = (): string =>
+  resolve(import.meta.dir, "../../../..")
+
+const totalTokensFromEvent = (event: Record<string, unknown>): number => {
+  const tokenCounts = event.tokenCounts
+  if (typeof tokenCounts !== "object" || tokenCounts === null || Array.isArray(tokenCounts)) return 0
+  const totalTokens = (tokenCounts as { readonly totalTokens?: unknown }).totalTokens
+  return typeof totalTokens === "number" && Number.isFinite(totalTokens) ? totalTokens : 0
+}
+
+const createTrackingApprovalService = (
+  decision: ClaudeApprovalDecision,
+  approvals: ClaudeApprovalRequest[],
+): ClaudeApprovalService => {
+  const service = createClaudeApprovalService()
+  return {
+    async canUseTool(toolName, input, options) {
+      const pending = service.canUseTool(toolName, input, options)
+      const item = await service.take()
+      approvals.push(item.request)
+      await service.respond(item.request.id, decision)
+      return pending
+    },
+    pending: service.pending,
+    respond: service.respond,
+    take: service.take,
+  }
+}
+
+const readLedgerEvents = async (path: string): Promise<readonly Record<string, unknown>[]> => {
+  try {
+    const text = await readFile(path, "utf8")
+    return text.split(/\r?\n/u).flatMap(line => {
+      if (line.trim().length === 0) return []
+      try {
+        const row = JSON.parse(line)
+        if (typeof row !== "object" || row === null || Array.isArray(row)) return []
+        const event = (row as { readonly event?: unknown }).event
+        return typeof event === "object" && event !== null && !Array.isArray(event)
+          ? [event as Record<string, unknown>]
+          : []
+      } catch {
+        return []
+      }
+    })
+  } catch {
+    return []
+  }
+}
+
+export async function runKhalaCodeClaudeLiveSmoke(
+  input: RunKhalaCodeClaudeLiveSmokeInput = {},
+): Promise<KhalaCodeClaudeLiveSmokeResult> {
+  const env = input.env ?? khalaCodeConfigFromRuntimeEnv().env
+  const requireLive = input.requireLive === true ||
+    env.KHALA_CODE_DESKTOP_CLAUDE_LIVE_SMOKE === "1"
+  if (!requireLive) return notRequested()
+
+  const harness = await (input.inspectHarness ?? (() => inspectClaudeHarnessStatus({ env: { ...env } })))()
+  if (!harness.available) {
+    return {
+      harness: KHALA_CODE_CLAUDE_LIVE_SMOKE_HARNESS,
+      ok: false,
+      reason: `Explicit live Claude smoke requested, but Claude is unavailable: ${harness.reason}`,
+      required: true,
+      skipped: false,
+      status: "failed",
+    }
+  }
+
+  const tempRoot = input.workingDirectory ?? await mkdtemp(join(tmpdir(), "khala-code-claude-live-"))
+  const ownsTempRoot = input.workingDirectory === undefined
+  const ledgerPath = input.tokenUsageLedgerPath ?? join(homedir(), ".khala-code", "claude-token-usage-events.jsonl")
+  const approvals: ClaudeApprovalRequest[] = []
+  const events: unknown[] = []
+  const reports: KhalaCodeDesktopClaudeTokenUsageReport[] = []
+  const reporter = createKhalaCodeDesktopClaudeTokenUsageReporter({
+    env: {
+      ...env,
+      KHALA_CODE_DESKTOP_RUNTIME: "claude_runtime",
+    },
+    localLedgerPath: ledgerPath,
+  })
+  const approvalDecision = input.approvalDecision ?? {
+    behavior: "allow" as const,
+    decisionClassification: "khala_code_claude_live_smoke",
+  }
+
+  try {
+    const runtime = createClaudeAppSdkChatRuntime({
+      approvalService: createTrackingApprovalService(approvalDecision, approvals),
+      env: {
+        ...env,
+        KHALA_CODE_DESKTOP_RUNTIME: "claude_runtime",
+      },
+      onEvent: event => events.push(event),
+      ...(input.query === undefined ? {} : { query: input.query }),
+      repoRoot: input.repoRoot ?? resolveSourceRepositoryRoot(),
+      sessionStore: createClaudeSessionStore({
+        path: join(tempRoot, "claude-sessions.json"),
+      }),
+      tokenUsageReporter: report => {
+        reports.push(report)
+        return reporter(report).pipe(Effect.asVoid)
+      },
+      workingDirectory: tempRoot,
+    })
+    const sessionId = randomUUID()
+    const turnId = "khala-code-claude-live-smoke-turn"
+    await runtime.startThread({ cwd: tempRoot, sessionId })
+    const response = await runtime.startTurn({
+      cwd: tempRoot,
+      messages: [{
+        body: input.prompt ?? defaultPrompt,
+        id: "khala-code-claude-live-smoke-user",
+        role: "user",
+      }],
+      sessionId,
+      turnId,
+    })
+    const settings = await runtime.claudeSettingsRead()
+    const expectedEvent = reports[0] === undefined ? null : khalaCodeDesktopClaudeTokenUsageEvent(reports[0])
+    const ledgerEvents = await readLedgerEvents(ledgerPath)
+    const ledgerEvent = expectedEvent === null
+      ? undefined
+      : ledgerEvents.find(event => event.eventId === expectedEvent.eventId)
+    const tokenUsageDiagnostics = [
+      ...(settings.errors ?? []),
+      ...(expectedEvent === null ? ["missing_claude_token_usage_report"] : []),
+      ...(ledgerEvent === undefined ? ["missing_claude_token_usage_ledger_event"] : []),
+    ]
+    const runtimeOk = response.backend.runtimeMode === "claude_runtime"
+    const approvalOk = approvals.length > 0
+    const tokenOk = expectedEvent !== null &&
+      ledgerEvent !== undefined &&
+      expectedEvent.usageTruth === "exact" &&
+      totalTokensFromEvent(expectedEvent) > 0 &&
+      tokenUsageDiagnostics.length === 0
+    const ok = response.ok && runtimeOk && approvalOk && tokenOk
+
+    return {
+      approvalCount: approvals.length,
+      approvalToolNames: approvals.map(approval => approval.toolName),
+      eventCount: events.length,
+      harness: KHALA_CODE_CLAUDE_LIVE_SMOKE_HARNESS,
+      ok,
+      ...(ok ? {} : {
+        reason: [
+          response.ok ? null : "Claude runtime turn did not complete successfully.",
+          runtimeOk ? null : `Expected claude_runtime badge, got ${response.backend.runtimeMode ?? "missing"}.`,
+          approvalOk ? null : "Claude canUseTool approval callback was not exercised.",
+          tokenOk ? null : "Claude exact token usage report was not evidenced in the local ledger.",
+        ].filter((item): item is string => item !== null).join(" "),
+      }),
+      required: true,
+      ...(response.backend.runtimeMode === undefined ? {} : { runtimeMode: response.backend.runtimeMode }),
+      skipped: false,
+      status: ok ? "ok" : "failed",
+      ...(response.backend.threadId === undefined ? {} : { threadId: response.backend.threadId }),
+      ...(expectedEvent === null ? {} : {
+        tokenUsage: {
+          eventId: String(expectedEvent.eventId),
+          ledgerPath,
+          provider: String(expectedEvent.provider),
+          totalTokens: totalTokensFromEvent(expectedEvent),
+          usageTruth: String(expectedEvent.usageTruth),
+        },
+      }),
+      tokenUsageDiagnostics,
+      ...(response.backend.turnId === undefined ? {} : { turnId: response.backend.turnId }),
+      ...(response.backend.turnStatus === undefined ? {} : { turnStatus: response.backend.turnStatus }),
+      ...(response.usedTools === undefined ? {} : { usedTools: response.usedTools }),
+    }
+  } catch (error) {
+    return {
+      approvalCount: approvals.length,
+      approvalToolNames: approvals.map(approval => approval.toolName),
+      eventCount: events.length,
+      harness: KHALA_CODE_CLAUDE_LIVE_SMOKE_HARNESS,
+      ok: false,
+      reason: error instanceof Error ? error.message : String(error),
+      required: true,
+      skipped: false,
+      status: "failed",
+    }
+  } finally {
+    if (ownsTempRoot) await rm(tempRoot, { force: true, recursive: true })
+  }
+}

--- a/clients/khala-code-desktop/tests/claude-live-smoke.test.ts
+++ b/clients/khala-code-desktop/tests/claude-live-smoke.test.ts
@@ -1,0 +1,194 @@
+import { afterEach, describe, expect, test } from "bun:test"
+import { mkdtemp, rm } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+import {
+  KHALA_CODE_CLAUDE_LIVE_SMOKE_HARNESS,
+  runKhalaCodeClaudeLiveSmoke,
+} from "../src/bun/claude-live-smoke"
+import type { KhalaCodeDesktopClaudeHarnessStatus } from "../src/bun/claude-harness-status"
+
+const tempDirs: string[] = []
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map(dir => rm(dir, { force: true, recursive: true })))
+})
+
+async function tempDir(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "khala-code-claude-live-smoke-test-"))
+  tempDirs.push(dir)
+  return dir
+}
+
+async function* messages(items: readonly unknown[]): AsyncGenerator<unknown> {
+  for (const item of items) yield item
+}
+
+const readyHarnessStatus = (): KhalaCodeDesktopClaudeHarnessStatus => ({
+  available: true,
+  blockerRefs: [],
+  capability: "claude_harness",
+  credentialSourceRef: "credential.source.claude_agent.local_claude_session",
+  observedAt: "2026-07-02T12:00:00.000Z",
+  reason: "ready",
+  status: "ready",
+})
+
+const unavailableHarnessStatus = (): KhalaCodeDesktopClaudeHarnessStatus => ({
+  available: false,
+  blockerRefs: ["blocker.claude_agent.credentials_missing"],
+  capability: "claude_harness",
+  credentialSourceRef: null,
+  observedAt: "2026-07-02T12:00:00.000Z",
+  reason: "Claude credentials are missing.",
+  status: "credentials_missing",
+})
+
+describe("Khala Code Claude live smoke", () => {
+  test("skips clearly unless the live Claude smoke is explicitly requested", async () => {
+    let inspected = false
+    const result = await runKhalaCodeClaudeLiveSmoke({
+      inspectHarness: async () => {
+        inspected = true
+        return readyHarnessStatus()
+      },
+      requireLive: false,
+    })
+
+    expect(inspected).toBe(false)
+    expect(result).toMatchObject({
+      harness: KHALA_CODE_CLAUDE_LIVE_SMOKE_HARNESS,
+      ok: true,
+      required: false,
+      skipped: true,
+      status: "skipped",
+    })
+    expect(result.reason).toContain("KHALA_CODE_DESKTOP_CLAUDE_LIVE_SMOKE=1")
+  })
+
+  test("fails loudly when required but Claude is unavailable", async () => {
+    const result = await runKhalaCodeClaudeLiveSmoke({
+      inspectHarness: async () => unavailableHarnessStatus(),
+      requireLive: true,
+    })
+
+    expect(result).toMatchObject({
+      harness: KHALA_CODE_CLAUDE_LIVE_SMOKE_HARNESS,
+      ok: false,
+      required: true,
+      skipped: false,
+      status: "failed",
+    })
+    expect(result.reason).toContain("Explicit live Claude smoke requested")
+    expect(result.reason).toContain("Claude credentials are missing")
+  })
+
+  test("runs a Claude runtime turn with approval callback and exact token ledger evidence", async () => {
+    const root = await tempDir()
+    const result = await runKhalaCodeClaudeLiveSmoke({
+      env: {
+        KHALA_CODE_TOKEN_USAGE_REMOTE_DISABLED: "1",
+      },
+      inspectHarness: async () => readyHarnessStatus(),
+      query: input => ({
+        async *[Symbol.asyncIterator]() {
+          const canUseTool = input.options.canUseTool as (
+            toolName: string,
+            input: Record<string, unknown>,
+            options: Record<string, unknown>,
+          ) => Promise<unknown>
+          await canUseTool("Read", { file_path: "README.md" }, {
+            description: "Read a public repository file for the live smoke.",
+            title: "Read README.md",
+          })
+          yield {
+            message: {
+              content: [
+                { id: "tool-use-1", input: { file_path: "README.md" }, name: "Read", type: "tool_use" },
+                { text: "khala-claude-smoke complete", type: "text" },
+              ],
+            },
+            session_id: "claude-live-smoke-session",
+            type: "assistant",
+            uuid: "assistant-live-smoke",
+          }
+          yield {
+            message: {
+              content: [{ content: "ok", tool_use_id: "tool-use-1", type: "tool_result" }],
+            },
+            session_id: "claude-live-smoke-session",
+            type: "user",
+            uuid: "tool-result-live-smoke",
+          }
+          yield {
+            model: "claude-sonnet-4",
+            session_id: "claude-live-smoke-session",
+            subtype: "success",
+            type: "result",
+            usage: {
+              cache_read_input_tokens: 2,
+              input_tokens: 11,
+              output_tokens: 7,
+              reasoning_output_tokens: 3,
+            },
+          }
+        },
+      }),
+      requireLive: true,
+      tokenUsageLedgerPath: join(root, "claude-token-usage-events.jsonl"),
+      workingDirectory: root,
+    })
+
+    expect(result).toMatchObject({
+      approvalCount: 1,
+      approvalToolNames: ["Read"],
+      harness: KHALA_CODE_CLAUDE_LIVE_SMOKE_HARNESS,
+      ok: true,
+      required: true,
+      runtimeMode: "claude_runtime",
+      skipped: false,
+      status: "ok",
+      threadId: "claude-live-smoke-session",
+      tokenUsage: {
+        provider: "pylon-claude-direct-local",
+        totalTokens: 23,
+        usageTruth: "exact",
+      },
+      tokenUsageDiagnostics: [],
+      turnId: "khala-code-claude-live-smoke-turn",
+      turnStatus: "completed",
+      usedTools: ["Read"],
+    })
+    expect(result.tokenUsage?.eventId).toContain("token_usage_event.khala_code_claude_direct_local")
+  })
+
+  test("fails when the Claude turn never exercises canUseTool approval", async () => {
+    const root = await tempDir()
+    const result = await runKhalaCodeClaudeLiveSmoke({
+      env: {
+        KHALA_CODE_TOKEN_USAGE_REMOTE_DISABLED: "1",
+      },
+      inspectHarness: async () => readyHarnessStatus(),
+      query: () => messages([{
+        session_id: "claude-live-smoke-no-approval",
+        subtype: "success",
+        type: "result",
+        usage: {
+          input_tokens: 1,
+          output_tokens: 1,
+        },
+      }]),
+      requireLive: true,
+      tokenUsageLedgerPath: join(root, "claude-token-usage-events.jsonl"),
+      workingDirectory: root,
+    })
+
+    expect(result).toMatchObject({
+      approvalCount: 0,
+      ok: false,
+      status: "failed",
+    })
+    expect(result.reason).toContain("approval callback was not exercised")
+  })
+})


### PR DESCRIPTION
Closes #8036

## Summary
- Adds a skip-safe `smoke:claude-live` desktop command for the Claude Agent SDK runtime.
- The smoke requires explicit arming via `KHALA_CODE_DESKTOP_CLAUDE_LIVE_SMOKE=1` or `--require-live`, asserts the `claude_runtime` backend badge, requires `canUseTool` approval callback exercise, and verifies exact Claude token usage evidence in the durable local reporter ledger.
- Adds deterministic tests for unarmed skip, unavailable Claude readiness, successful fake Claude approval/token evidence, and missing approval failure.

## Live smoke evidence
- Command: `bun run --cwd clients/khala-code-desktop smoke:claude-live -- --require-live`
- Result: `ok: true`, `runtimeMode: claude_runtime`, `approvalCount: 1`, `approvalToolNames: [Bash]`, `turnStatus: completed`
- Exact token event: `token_usage_event.khala_code_claude_direct_local.160281a3a0f611fa968a6d80`
- Provider/model path: `pylon-claude-direct-local`, `usageTruth: exact`, `totalTokens: 133050`

## Verification
- `bun run typecheck` from `clients/khala-code-desktop`
- `bun test tests/claude-live-smoke.test.ts` from `clients/khala-code-desktop`
- `bun run --cwd clients/khala-code-desktop smoke:claude-live` (structured unarmed skip)
- `bun run --cwd clients/khala-code-desktop smoke:claude-live -- --require-live` (armed live smoke green)
- `bun run --cwd clients/khala-code-desktop test` (520 pass)
- `bun run check:deploy`
