### PR TITLE
Fix Khala Code boot RPC degraded states

### DIFF
--- a/clients/khala-code-desktop/src/ui/index.html
+++ b/clients/khala-code-desktop/src/ui/index.html
@@ -18,6 +18,12 @@
       </aside>
       <div class="khala-code-scene" aria-hidden="true"></div>
       <section class="khala-code-thread-shell" aria-label="Khala Code transcript">
+        <div
+          id="boot-degraded-states"
+          class="khala-code-boot-degraded-states"
+          aria-live="polite"
+          hidden
+        ></div>
         <div class="khala-thread-token-meter" id="thread-token-meter">
           <button
             id="thread-token-counter"

--- a/clients/khala-code-desktop/src/ui/main-shell-model.ts
+++ b/clients/khala-code-desktop/src/ui/main-shell-model.ts
@@ -20,8 +20,27 @@ export type KhalaCodeFollowUpDraft = {
   text: string
 }
 
+export type KhalaCodeBootRpcName =
+  | "claudeApprovalPending"
+  | "codexFleetStatus"
+  | "events"
+  | "fleetRunList"
+  | "harnessSettingRead"
+  | "sessionCatalog"
+
+export type KhalaCodeBootDegradedState = {
+  readonly dataLoss: false
+  readonly detail: string
+  readonly kind: "khala_code_boot_rpc_degraded"
+  readonly method: KhalaCodeBootRpcName
+  readonly observedAt: string
+  readonly recoverable: true
+  readonly state: "degraded"
+}
+
 export type KhalaCodeMainShellModel = {
   activeCodexThreadId: string | null
+  bootDegradedStates: KhalaCodeBootDegradedState[]
   claudeApprovalDialogOpen: boolean
   composerAttachmentReceipts: ComposerAttachmentUploadReceipt[]
   composerState: ComposerState
@@ -47,6 +66,14 @@ export type KhalaCodeMainShellModel = {
 
 export type KhalaCodeMainShellMessage =
   | { readonly _tag: "ActiveCodexThreadChanged"; readonly threadId: string | null }
+  | {
+      readonly _tag: "BootRpcDegraded"
+      readonly state: KhalaCodeBootDegradedState
+    }
+  | {
+      readonly _tag: "BootRpcRecovered"
+      readonly method: KhalaCodeBootRpcName
+    }
   | { readonly _tag: "ClaudeApprovalDialogToggled"; readonly open: boolean }
   | {
       readonly _tag: "ComposerAttachmentReceiptPushed"
@@ -102,6 +129,7 @@ export const initialKhalaCodeMainShellModel = (
   }>,
 ): KhalaCodeMainShellModel => ({
   activeCodexThreadId: null,
+  bootDegradedStates: [],
   claudeApprovalDialogOpen: false,
   composerAttachmentReceipts: [],
   composerState: emptyComposerState(),
@@ -132,6 +160,18 @@ export const updateKhalaCodeMainShellModel = (
   switch (message._tag) {
     case "ActiveCodexThreadChanged":
       return { ...model, activeCodexThreadId: message.threadId }
+    case "BootRpcDegraded": {
+      const next = [
+        ...model.bootDegradedStates.filter(item => item.method !== message.state.method),
+        message.state,
+      ].sort((left, right) => left.method.localeCompare(right.method))
+      return { ...model, bootDegradedStates: next }
+    }
+    case "BootRpcRecovered":
+      return {
+        ...model,
+        bootDegradedStates: model.bootDegradedStates.filter(item => item.method !== message.method),
+      }
     case "ClaudeApprovalDialogToggled":
       return { ...model, claudeApprovalDialogOpen: message.open }
     case "ComposerAttachmentReceiptPushed":

--- a/clients/khala-code-desktop/src/ui/main.ts
+++ b/clients/khala-code-desktop/src/ui/main.ts
@@ -51,9 +51,12 @@ import {
   type KhalaCodeDesktopChatTurnEvent,
   type KhalaCodeDesktopFleetLifecycleEvent,
   type KhalaCodeDesktopChatTurnRequest,
+  type KhalaCodeDesktopFleetRunListResult,
+  type KhalaCodeDesktopFleetStatus,
   type KhalaCodeDesktopMessage,
   type KhalaCodeDesktopMessageRole,
   type KhalaCodeDesktopRPCSchema,
+  type KhalaCodeDesktopSessionCatalogResult,
   type KhalaCodeDesktopThreadTokenSummary,
 } from "../shared/rpc"
 import {
@@ -114,6 +117,8 @@ import {
 import {
   initialKhalaCodeMainShellModel,
   updateKhalaCodeMainShellModel,
+  type KhalaCodeBootDegradedState,
+  type KhalaCodeBootRpcName,
   type KhalaCodeFollowUpDraft,
   type KhalaCodeMainShellMessage,
   type KhalaCodeMainShellSlashCommand,
@@ -537,7 +542,17 @@ const decodeChatTurnEvent = (input: unknown): KhalaCodeDesktopChatTurnEvent =>
 
 const startPreviewBridgeEvents = (): void => {
   if (!isKhalaPreviewWindow) return
-  const eventSource = new EventSource("/rpc/events")
+  let eventSource: EventSource
+  try {
+    eventSource = new EventSource("/rpc/events")
+  } catch (error) {
+    recordBootRpcDegradedState("events", error)
+    return
+  }
+  eventSource.addEventListener("open", () => clearBootRpcDegradedState("events"))
+  eventSource.addEventListener("error", () => {
+    recordBootRpcDegradedState("events", new Error("preview event stream unavailable"))
+  })
   eventSource.addEventListener("chatTurnEvent", event => {
     try {
       const payload = JSON.parse((event as MessageEvent<string>).data) as {
@@ -821,6 +836,47 @@ const emptyThreadTokenSummary = (
   usageEventRows: 0,
 })
 
+const degradedSessionCatalog = (
+  state: KhalaCodeBootDegradedState,
+): KhalaCodeDesktopSessionCatalogResult => ({
+  diagnostics: [`qa.boot_rpc.${state.method}.degraded: ${state.detail}`],
+  entries: [],
+  ok: true,
+  schemaVersion: "khala-code-desktop.session-catalog.v1",
+})
+
+const degradedFleetStatus = (
+  state: KhalaCodeBootDegradedState,
+): KhalaCodeDesktopFleetStatus => ({
+  accounts: [],
+  activeAssignments: [],
+  availableCodexAssignments: 0,
+  maxCodexAssignments: 0,
+  observedAt: state.observedAt,
+  ok: false,
+  processes: [],
+  pylon: {
+    message: `qa.boot_rpc.${state.method}.degraded: ${state.detail}`,
+    pylonRef: null,
+    status: "unavailable",
+  },
+  tokenRate: {
+    activeAdjustedTokensPerMinute: null,
+    completedStatus: "not_measured",
+    completedTokenRows: null,
+    completedTokensPerMinute: null,
+    inFlightTokens: null,
+    inFlightTokensPerMinute: null,
+    source: "unavailable",
+    unavailableReason: `qa.boot_rpc.${state.method}.degraded`,
+  },
+})
+
+const degradedFleetRunList = (): KhalaCodeDesktopFleetRunListResult => ({
+  ok: false,
+  runs: [],
+})
+
 const cloneMessages = (
   value: readonly KhalaCodeDesktopMessage[],
 ): KhalaCodeDesktopMessage[] =>
@@ -1006,6 +1062,32 @@ const setShellFollowUpDrafts = (
   drafts: readonly KhalaCodeFollowUpDraft[],
 ): void => dispatchMainShell({ _tag: "FollowUpDraftsChanged", drafts })
 
+const bootFailureDetail = (error: unknown): string =>
+  error instanceof Error ? error.message : typeof error === "string" ? error : "boot RPC failed"
+
+const recordBootRpcDegradedState = (
+  method: KhalaCodeBootRpcName,
+  error: unknown,
+): KhalaCodeBootDegradedState => {
+  const state: KhalaCodeBootDegradedState = {
+    dataLoss: false,
+    detail: bootFailureDetail(error),
+    kind: "khala_code_boot_rpc_degraded",
+    method,
+    observedAt: new Date().toISOString(),
+    recoverable: true,
+    state: "degraded",
+  }
+  dispatchMainShell({ _tag: "BootRpcDegraded", state })
+  renderBootDegradedStates()
+  return state
+}
+
+const clearBootRpcDegradedState = (method: KhalaCodeBootRpcName): void => {
+  dispatchMainShell({ _tag: "BootRpcRecovered", method })
+  renderBootDegradedStates()
+}
+
 const compactTokenFormatter = new Intl.NumberFormat("en-US", {
   maximumFractionDigits: 1,
   notation: "compact",
@@ -1060,7 +1142,9 @@ const refreshHarnessSetting = async (): Promise<void> => {
     shellModel().selectedHarnessMode = setting.mode
     shellModel().harnessEnvOverride = setting.envOverride
     shellModel().lastResponseRuntimeMode = setting.mode
+    clearBootRpcDegradedState("harnessSettingRead")
   } catch {
+    recordBootRpcDegradedState("harnessSettingRead", "harness setting unavailable; using Codex harness defaults")
     shellModel().selectedHarnessMode = "codex_harness"
     shellModel().harnessEnvOverride = null
     shellModel().lastResponseRuntimeMode = "codex_harness"
@@ -2093,8 +2177,31 @@ function renderComposer(): void {
 }
 
 const render = (): void => {
+  renderBootDegradedStates()
   renderMessages()
   renderComposer()
+}
+
+function renderBootDegradedStates(): void {
+  const root = document.getElementById("boot-degraded-states")
+  if (root === null) return
+  const degradedStates = shellModel().bootDegradedStates
+  root.hidden = degradedStates.length === 0
+  root.replaceChildren()
+  root.dataset.state = degradedStates.length === 0 ? "ready" : "degraded"
+  root.dataset.degradedMethods = degradedStates.map(state => state.method).join(" ")
+  root.dataset.degradedCount = String(degradedStates.length)
+  if (degradedStates.length === 0) return
+  for (const state of degradedStates) {
+    const chip = document.createElement("span")
+    chip.className = "khala-code-boot-degraded-chip"
+    chip.dataset.bootRpc = state.method
+    chip.dataset.state = state.state
+    chip.dataset.kind = state.kind
+    chip.title = state.detail
+    chip.textContent = `${state.method}: degraded`
+    root.append(chip)
+  }
 }
 
 const focusComposerInput = (): void => {
@@ -2438,7 +2545,13 @@ const respondToClaudeApprovalRequest = async (
 
 const pollClaudeApprovals = async (): Promise<void> => {
   if (shellModel().claudeApprovalDialogOpen) return
-  const pending = await controls.claudeApprovalPending().catch(() => null)
+  const pending = await controls.claudeApprovalPending().then(result => {
+    clearBootRpcDegradedState("claudeApprovalPending")
+    return result
+  }).catch(error => {
+    recordBootRpcDegradedState("claudeApprovalPending", error)
+    return { ok: false, requests: [] } satisfies Awaited<ReturnType<DesktopRpcRequests["claudeApprovalPending"]>>
+  })
   const request = pending?.requests.find(item => !handledClaudeApprovals.has(item.id))
   if (request === undefined) return
   handledClaudeApprovals.add(request.id)
@@ -2999,6 +3112,7 @@ const controls = {
   appInfo: () => rpc.request.appInfo(),
   attachments: () => shellModel().composerState.doc.attachments.map(attachment => ({ ...attachment })),
   attachmentReceipts: () => shellModel().composerAttachmentReceipts.map(receipt => ({ ...receipt })),
+  bootDegradedStates: () => shellModel().bootDegradedStates.map(state => ({ ...state })),
   clearGymProof: (): GymPaneState => {
     const state = gymPaneStateFromBridgeProof(null)
     gymPanel?.setState(state)
@@ -3327,14 +3441,29 @@ const fleetPanel =
     : mountFleetPanel(fleetPanelEl, {
         delegateRun: request => controls.codexFleetDelegateRun(request),
         fleetRunControl: request => controls.fleetRunControl(request),
-        fleetRunList: request => controls.fleetRunList(request),
+        fleetRunList: async request => {
+          try {
+            const list = await controls.fleetRunList(request)
+            clearBootRpcDegradedState("fleetRunList")
+            return list
+          } catch (error) {
+            recordBootRpcDegradedState("fleetRunList", error)
+            return degradedFleetRunList()
+          }
+        },
         fleetRunStart: request => controls.fleetRunStart(request),
         fleetWorkerControl: request => controls.fleetWorkerControl(request),
         lifecycleNdjson: fleetLifecycleLines.iterable,
         loadGymDemoProof: () => loadGymDemoOptimization(),
         startDelegationOptimization: async () => loadGymDemoOptimization(),
         fetch: async () => {
-          const status = await controls.codexFleetStatus()
+          let status: KhalaCodeDesktopFleetStatus
+          try {
+            status = await controls.codexFleetStatus()
+            clearBootRpcDegradedState("codexFleetStatus")
+          } catch (error) {
+            status = degradedFleetStatus(recordBootRpcDegradedState("codexFleetStatus", error))
+          }
           sidebar?.setFleetCounts(projectKhalaCodeSidebarFleetCounts(status))
           return status
         },
@@ -3528,10 +3657,16 @@ const threadSidebar =
         },
         isThreadStreaming: threadId => shellModel().activeCodexThreadId === threadId && shellModel().pendingTurn,
         listThreads: async request => {
-          const catalog = await cachedSessionCatalog({
-            limit: 50,
-            searchTerm: request.searchTerm,
-          })
+          let catalog: Awaited<ReturnType<DesktopRpcRequests["sessionCatalog"]>>
+          try {
+            catalog = await cachedSessionCatalog({
+              limit: 50,
+              searchTerm: request.searchTerm,
+            })
+            clearBootRpcDegradedState("sessionCatalog")
+          } catch (error) {
+            catalog = degradedSessionCatalog(recordBootRpcDegradedState("sessionCatalog", error))
+          }
           const threads = catalog.entries.map(sessionCatalogEntryToThreadSummary)
           const result = {
             ok: true as const,
@@ -3642,7 +3777,9 @@ const refreshFleetSidebarCounts = async (): Promise<void> => {
   if (sidebar === null) return
   try {
     sidebar.setFleetCounts(projectKhalaCodeSidebarFleetCounts(await controls.codexFleetStatus()))
+    clearBootRpcDegradedState("codexFleetStatus")
   } catch {
+    recordBootRpcDegradedState("codexFleetStatus", "fleet status unavailable")
     sidebar.setFleetCounts(null)
   }
 }

--- a/clients/khala-code-desktop/src/ui/styles.css
+++ b/clients/khala-code-desktop/src/ui/styles.css
@@ -2905,6 +2905,27 @@ button {
   text-transform: uppercase;
   color: var(--oa-color-khala-energy-cyan);
 }
+.khala-code-boot-degraded-states {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  padding: 0.45rem 0.55rem;
+  border-bottom: 1px solid color-mix(in srgb, var(--oa-color-khala-warning) 32%, transparent);
+  background: color-mix(in srgb, var(--oa-color-component-surface) 92%, transparent);
+}
+.khala-code-boot-degraded-chip {
+  display: inline-flex;
+  align-items: center;
+  min-width: 0;
+  max-width: 100%;
+  padding: 0.18rem 0.45rem;
+  border: 1px solid color-mix(in srgb, var(--oa-color-khala-warning) 34%, transparent);
+  border-radius: 0.35rem;
+  color: var(--oa-color-khala-warning);
+  font-size: 0.7rem;
+  line-height: 1.25;
+  overflow-wrap: anywhere;
+}
 .khala-fleet-pylon-message {
   font-size: 0.72rem;
   color: color-mix(in srgb, var(--oa-color-component-text) 55%, transparent);

--- a/clients/khala-code-desktop/tests/app-shell.test.ts
+++ b/clients/khala-code-desktop/tests/app-shell.test.ts
@@ -157,6 +157,35 @@ describe("khala code desktop app shell", () => {
     expect(handlers).toContain("Legacy Khala native runtime handled this turn.")
   })
 
+  test("projects typed degraded states for every boot-time RPC failure", async () => {
+    const html = await Bun.file(new URL("../src/ui/index.html", import.meta.url)).text()
+    const main = await Bun.file(new URL("../src/ui/main.ts", import.meta.url)).text()
+    const model = await Bun.file(new URL("../src/ui/main-shell-model.ts", import.meta.url)).text()
+
+    expect(html).toContain('id="boot-degraded-states"')
+    expect(model).toContain('kind: "khala_code_boot_rpc_degraded"')
+    expect(main).toContain("recordBootRpcDegradedState")
+    expect(main).toContain("bootDegradedStates: () => shellModel().bootDegradedStates")
+
+    for (const method of [
+      "harnessSettingRead",
+      "sessionCatalog",
+      "events",
+      "claudeApprovalPending",
+      "fleetRunList",
+      "codexFleetStatus",
+    ]) {
+      expect(model).toContain(`| "${method}"`)
+      expect(main).toContain(`recordBootRpcDegradedState("${method}"`)
+      expect(main).toContain(`clearBootRpcDegradedState("${method}"`)
+    }
+
+    expect(main).toContain("degradedSessionCatalog(")
+    expect(main).toContain("degradedFleetStatus(")
+    expect(main).toContain("degradedFleetRunList()")
+    expect(main).not.toContain("console.error")
+  })
+
   test("uses the shared blue sci-fi UI tokens and licensed-safe chat fonts", async () => {
     const css = await Bun.file(new URL("../src/ui/styles.css", import.meta.url)).text()
 

--- a/packages/khala-qa-harness/src/seed-corpus.test.ts
+++ b/packages/khala-qa-harness/src/seed-corpus.test.ts
@@ -173,6 +173,19 @@ describe("Khala Code QA seed scenario corpus", () => {
         { kind: "rpc_call", method: "codexThreadResume", args: [{ cwd: "/workspace", sessionId: "desktop-session-fixture", threadId: "thread-fixture" }] },
       ]),
     )
+    const bootFailureScenario = KHALA_CODE_QA_SEED_SCENARIOS.find((candidate) =>
+      candidate.id === "scenario.khala_code.seed.error_state_all_boot_rpcs_failing.v1"
+    )
+    expect(bootFailureScenario?.phases[0]?.name).toBe("exercise-all-boot-rpc-failures")
+    expect(bootFailureScenario?.phases[0]?.act).toEqual(
+      expect.arrayContaining([
+        { kind: "rpc_call", method: "harnessSettingRead" },
+        { kind: "rpc_call", method: "sessionCatalog", args: [{ limit: 10, searchTerm: "fixture" }] },
+        { kind: "rpc_call", method: "claudeApprovalPending" },
+        { kind: "rpc_call", method: "fleetRunList", args: [{}] },
+        { kind: "rpc_call", method: "codexFleetStatus" },
+      ]),
+    )
   })
 
   test("loads every seed scenario and rejects phases without expectations by construction", () => {

--- a/packages/khala-qa-harness/src/seed-corpus.ts
+++ b/packages/khala-qa-harness/src/seed-corpus.ts
@@ -154,6 +154,11 @@ export const KHALA_CODE_QA_ERROR_STATE_CASES = [
     description: "App-server crash, restart, and thread resume preserve the active thread",
     targetMethod: "codexAppServerStatus",
   },
+  {
+    caseId: "all_boot_rpcs_failing",
+    description: "All boot-time RPCs degrade independently without console errors or data loss",
+    targetMethod: "codexFleetStatus",
+  },
 ] as const satisfies readonly {
   readonly caseId: string
   readonly description: string
@@ -1173,6 +1178,30 @@ const errorStateAction = (
 const errorStateScenarioPhases = (
   entry: typeof KHALA_CODE_QA_ERROR_STATE_CASES[number],
 ): KhalaCodeQaScenario["phases"] => {
+  if (entry.caseId === "all_boot_rpcs_failing") {
+    return [{
+      name: "exercise-all-boot-rpc-failures",
+      act: [
+        errorStateArmAction(entry.caseId),
+        { kind: "rpc_call", method: "harnessSettingRead" },
+        { kind: "rpc_call", method: "sessionCatalog", args: [{ limit: 10, searchTerm: "fixture" }] },
+        { kind: "rpc_call", method: "claudeApprovalPending" },
+        { kind: "rpc_call", method: "fleetRunList", args: [{}] },
+        { kind: "rpc_call", method: "codexFleetStatus" },
+      ],
+      expect: [
+        schema("harnessSettingRead"),
+        schema("sessionCatalog"),
+        schema("claudeApprovalPending"),
+        schema("fleetRunList"),
+        schema("codexFleetStatus"),
+        degradedState(entry.caseId),
+        noConsoleErrors(),
+        noDataLoss(entry.caseId),
+        crash(),
+      ],
+    }]
+  }
   if (entry.caseId === "app_server_crash_restart") {
     return [
       {
@@ -1748,7 +1777,9 @@ const fixtureRpcPayload = (
       )
     case "codexFleetStatus":
       return fleetStatus(
-        state.activeErrorStateCase === "pylon_offline" ? state.activeErrorStateCase : null,
+        state.activeErrorStateCase === "pylon_offline" || state.activeErrorStateCase === "all_boot_rpcs_failing"
+          ? state.activeErrorStateCase
+          : null,
       )
     case "codexFleetDelegateRun":
       return fleetDelegateRunResult()
@@ -1760,7 +1791,8 @@ const fixtureRpcPayload = (
     case "fleetRunStatus":
       return { ok: true, run: fleetRun(state.fleetRunState), supervisorActive: state.fleetRunState === "running" }
     case "fleetRunList":
-      return state.activeErrorStateCase === "single_rpc_failure_partial_degradation"
+      return state.activeErrorStateCase === "single_rpc_failure_partial_degradation" ||
+        state.activeErrorStateCase === "all_boot_rpcs_failing"
         ? {
           ok: false,
           runs: [fleetRun(state.fleetRunState, { dataPreservedCase: state.activeErrorStateCase })],
@@ -1806,7 +1838,12 @@ const fixtureRpcPayload = (
       }
     }
     case "claudeApprovalPending":
-      return {
+      return state.activeErrorStateCase === "all_boot_rpcs_failing"
+        ? {
+          ok: false,
+          requests: [],
+        }
+        : {
         ok: true,
         requests: [{
           id: "claude-approval-fixture",
@@ -1830,7 +1867,7 @@ const fixtureRpcPayload = (
       return { ok: true, keyPath: request?.keyPath ?? "model", response: { applied: true }, settings: settingsProjection() }
     }
     case "harnessSettingRead":
-      return harnessSetting("codex_harness")
+      return harnessSetting("codex_harness", undefined, state.activeErrorStateCase === "all_boot_rpcs_failing" ? state.activeErrorStateCase : null)
     case "harnessSettingWrite": {
       const request = args[0] as { readonly mode?: "claude_runtime" | "codex_harness" | "khala_native_runtime" } | undefined
       return harnessSetting(request?.mode ?? "codex_harness", true)
@@ -1887,7 +1924,10 @@ const fixtureRpcPayload = (
       return threadTokenSummary(args[0])
     case "sessionCatalog":
       return sessionCatalog(
-        state.activeErrorStateCase === "corrupt_session_state_recovery" ? state.activeErrorStateCase : null,
+        state.activeErrorStateCase === "corrupt_session_state_recovery" ||
+          state.activeErrorStateCase === "all_boot_rpcs_failing"
+          ? state.activeErrorStateCase
+          : null,
       )
     case "forumRequest":
       return forumResponse(args[0])
@@ -2089,11 +2129,14 @@ const onDeviceDeciderStatus = () => ({
 const harnessSetting = (
   mode: "claude_runtime" | "codex_harness" | "khala_native_runtime",
   saved?: boolean,
+  errorCase: KhalaCodeQaErrorStateCaseId | null = null,
 ) => ({
   envOverride: null,
   mode,
   ok: true,
-  path: "/fixture/khala-code-runtime-mode.json",
+  path: errorCase === null
+    ? "/fixture/khala-code-runtime-mode.json"
+    : `/fixture/khala-code-runtime-mode.json#${errorStateDataPreservedRef(errorCase)}`,
   persistedMode: mode,
   ...(saved === undefined ? {} : { saved }),
 })


### PR DESCRIPTION
## Summary
- Add typed `khala_code_boot_rpc_degraded` shell state for boot-time RPC failures, including `harnessSettingRead`, `sessionCatalog`, `events`, `claudeApprovalPending`, `fleetRunList`, and `codexFleetStatus`.
- Render boot degradation chips and expose them via `khalaCodeDesktop.bootDegradedStates()` for QA automation.
- Add schema-valid degraded fallback payloads and extend the Q4.4 seed corpus with `all_boot_rpcs_failing`.

## Verification
- `bun test clients/khala-code-desktop/tests/app-shell.test.ts packages/khala-qa-harness/src/seed-corpus.test.ts` — 62 pass
- `bun run typecheck:khala-code-desktop` — pass
- `bun run typecheck:khala-qa-harness` — pass
- `bun run test:khala-code-desktop` — 518 pass
- `bun run test:khala-qa-harness` — 71 pass
- `bun run check:deploy` — pass

Closes #8043