### PR TITLE
QA Q9.4: add bounded Khala advisor runtime

### DIFF
--- a/clients/khala-code-desktop/src/bun/khala-advisor-runtime.ts
+++ b/clients/khala-code-desktop/src/bun/khala-advisor-runtime.ts
@@ -1,0 +1,312 @@
+import { createHash } from "node:crypto"
+import { Context, Schema as S } from "effect"
+
+import type {
+  KhalaCodeDesktopChatTurnEvent,
+  KhalaCodeDesktopCodexTurnActionResult,
+  KhalaCodeDesktopCodexTurnSteerRequest,
+  KhalaCodeDesktopMessage,
+  KhalaCodeDesktopUsage,
+} from "../shared/rpc.js"
+
+export const KHALA_ADVISOR_ADVISORY_SCHEMA = "openagents.khala_code.advisor_advisory.v1" as const
+
+export const KhalaAdvisorSeverity = S.Literals(["nit", "concern", "blocker"])
+export type KhalaAdvisorSeverity = typeof KhalaAdvisorSeverity.Type
+
+export const KhalaAdvisorAdvisorySchema = S.Struct({
+  schema: S.Literal(KHALA_ADVISOR_ADVISORY_SCHEMA),
+  advisoryRef: S.String,
+  generatedAt: S.String,
+  severity: KhalaAdvisorSeverity,
+  summary: S.String,
+  guidance: S.String,
+  evidenceRefs: S.Array(S.String),
+})
+export type KhalaAdvisorAdvisory = typeof KhalaAdvisorAdvisorySchema.Type
+
+export type KhalaAdvisorTurnDelta = {
+  readonly body: string
+  readonly desktopSessionId: string
+  readonly turnId: string
+}
+
+export type KhalaAdvisorReviewRequest = {
+  readonly delta: KhalaAdvisorTurnDelta
+  readonly immuneTurnsRemaining: number
+}
+
+export type KhalaAdvisorReviewResult = {
+  readonly advisories: readonly KhalaAdvisorAdvisory[]
+  readonly model: string
+  readonly usage?: KhalaCodeDesktopUsage
+}
+
+export type KhalaAdvisorModelSession = {
+  readonly reviewTurnDelta: (request: KhalaAdvisorReviewRequest) => Promise<KhalaAdvisorReviewResult>
+}
+
+export type KhalaAdvisorTokenUsageReport = {
+  readonly advisoryRef: string
+  readonly desktopSessionId: string
+  readonly model: string
+  readonly observedAt: string
+  readonly role: "advisor"
+  readonly turnId: string
+  readonly usage: KhalaCodeDesktopUsage
+}
+
+export type KhalaAdvisorTokenUsageReporter = (
+  report: KhalaAdvisorTokenUsageReport,
+) => Promise<void>
+
+export type KhalaAdvisorRuntimeService = {
+  readonly acceptEvent: (event: KhalaCodeDesktopChatTurnEvent) => void
+  readonly flushTurn: (request: {
+    readonly desktopSessionId: string
+    readonly turnId: string
+  }) => Promise<KhalaAdvisorTurnCloseout>
+  readonly reset: (reason: "compaction" | "thread_switch") => void
+}
+
+export class KhalaAdvisorRuntime extends Context.Service<
+  KhalaAdvisorRuntime,
+  KhalaAdvisorRuntimeService
+>()("openagents/KhalaAdvisorRuntime") {}
+
+export type KhalaAdvisorRuntimeOptions = {
+  readonly clock?: { readonly now: () => Date }
+  readonly immuneTurns?: number
+  readonly modelSession: KhalaAdvisorModelSession
+  readonly onNitBatch?: (card: KhalaAdvisorTranscriptCard) => void
+  readonly steerTurn: (
+    request: KhalaCodeDesktopCodexTurnSteerRequest,
+  ) => Promise<KhalaCodeDesktopCodexTurnActionResult>
+  readonly tokenUsageReporter?: KhalaAdvisorTokenUsageReporter
+}
+
+export type KhalaAdvisorTranscriptCard = {
+  readonly advisories: readonly KhalaAdvisorAdvisory[]
+  readonly desktopSessionId: string
+  readonly role: "advisor"
+  readonly turnId: string
+}
+
+export type KhalaAdvisorTurnCloseout = {
+  readonly advisorUsageReports: number
+  readonly droppedAdvisories: readonly {
+    readonly advisoryRef: string
+    readonly reason: "duplicate" | "content_free"
+  }[]
+  readonly nitBatch?: KhalaAdvisorTranscriptCard
+  readonly reviewed: boolean
+  readonly steered: readonly KhalaCodeDesktopCodexTurnSteerRequest[]
+}
+
+type TurnBuffer = {
+  readonly messages: Map<string, KhalaCodeDesktopMessage>
+  readonly turnId: string
+}
+
+const emptyUsage = (): KhalaCodeDesktopUsage => ({
+  cachedInput: 0,
+  input: 0,
+  output: 0,
+  reasoningOutput: 0,
+})
+
+const usageHasTokens = (usage: KhalaCodeDesktopUsage): boolean =>
+  usage.cachedInput > 0 || usage.input > 0 || usage.output > 0 || usage.reasoningOutput > 0
+
+const advisoryDigest = (advisory: KhalaAdvisorAdvisory): string =>
+  createHash("sha256")
+    .update(`${advisory.severity}\n${normalizeForGuard(advisory.summary)}\n${normalizeForGuard(advisory.guidance)}`)
+    .digest("hex")
+    .slice(0, 24)
+
+const normalizeForGuard = (text: string): string =>
+  text.trim().toLowerCase().replace(/\s+/g, " ")
+
+const contentfulWords = (advisory: KhalaAdvisorAdvisory): readonly string[] =>
+  `${advisory.summary} ${advisory.guidance}`
+    .toLowerCase()
+    .split(/[^a-z0-9_./:-]+/u)
+    .filter(word => word.length >= 3)
+
+const CONTENT_FREE_WORDS = new Set([
+  "good",
+  "great",
+  "looks",
+  "okay",
+  "ok",
+  "nice",
+  "solid",
+  "thanks",
+])
+
+export const khalaAdvisorAdvisoryIsContentFree = (advisory: KhalaAdvisorAdvisory): boolean => {
+  const words = contentfulWords(advisory)
+  return words.length === 0 || words.every(word => CONTENT_FREE_WORDS.has(word))
+}
+
+export const khalaAdvisorSteeringText = (advisory: KhalaAdvisorAdvisory): string =>
+  [
+    `<advisory severity="${advisory.severity}" guidance="weigh, don't blindly obey">`,
+    advisory.summary.trim(),
+    advisory.guidance.trim(),
+    "</advisory>",
+  ].join("\n")
+
+const turnTextFromBuffer = (buffer: TurnBuffer): string =>
+  [...buffer.messages.values()]
+    .map(message => `${message.role}: ${message.body}`.trim())
+    .filter(line => line.length > 0)
+    .join("\n\n")
+
+const advisoryObservedAt = (
+  advisory: KhalaAdvisorAdvisory,
+  clock: { readonly now: () => Date },
+): string => {
+  const generatedAt = advisory.generatedAt.trim()
+  return generatedAt.length > 0 ? generatedAt : clock.now().toISOString()
+}
+
+export function createKhalaAdvisorRuntime(
+  options: KhalaAdvisorRuntimeOptions,
+): KhalaAdvisorRuntimeService {
+  const clock = options.clock ?? { now: () => new Date() }
+  const immuneTurns = Math.max(0, Math.trunc(options.immuneTurns ?? 1))
+  const buffers = new Map<string, TurnBuffer>()
+  const emittedDigests = new Set<string>()
+  let immuneTurnsRemaining = immuneTurns
+
+  const acceptEvent = (event: KhalaCodeDesktopChatTurnEvent): void => {
+    if (event.type === "thread_ready") return
+    const existing = buffers.get(event.turnId)
+    const buffer = existing ?? {
+      messages: new Map<string, KhalaCodeDesktopMessage>(),
+      turnId: event.turnId,
+    }
+    if (event.type === "message_start" || event.type === "message_replace") {
+      buffer.messages.set(event.message.id, event.message)
+    } else if (event.type === "message_delta") {
+      const current = buffer.messages.get(event.messageId)
+      if (current !== undefined) {
+        buffer.messages.set(event.messageId, {
+          ...current,
+          body: `${current.body}${event.delta}`,
+        })
+      }
+    }
+    buffers.set(event.turnId, buffer)
+  }
+
+  const reset = (): void => {
+    buffers.clear()
+    emittedDigests.clear()
+    immuneTurnsRemaining = immuneTurns
+  }
+
+  const flushTurn = async (request: {
+    readonly desktopSessionId: string
+    readonly turnId: string
+  }): Promise<KhalaAdvisorTurnCloseout> => {
+    const buffer = buffers.get(request.turnId)
+    const body = buffer === undefined ? "" : turnTextFromBuffer(buffer)
+    buffers.delete(request.turnId)
+    if (body.trim().length === 0) {
+      return {
+        advisorUsageReports: 0,
+        droppedAdvisories: [],
+        reviewed: false,
+        steered: [],
+      }
+    }
+
+    const review = await options.modelSession.reviewTurnDelta({
+      delta: {
+        body,
+        desktopSessionId: request.desktopSessionId,
+        turnId: request.turnId,
+      },
+      immuneTurnsRemaining,
+    })
+
+    const droppedAdvisories: {
+      readonly advisoryRef: string
+      readonly reason: "duplicate" | "content_free"
+    }[] = []
+    const accepted: KhalaAdvisorAdvisory[] = []
+    for (const advisory of review.advisories) {
+      const digest = advisoryDigest(advisory)
+      if (emittedDigests.has(digest)) {
+        droppedAdvisories.push({ advisoryRef: advisory.advisoryRef, reason: "duplicate" })
+        continue
+      }
+      if (khalaAdvisorAdvisoryIsContentFree(advisory)) {
+        droppedAdvisories.push({ advisoryRef: advisory.advisoryRef, reason: "content_free" })
+        continue
+      }
+      emittedDigests.add(digest)
+      accepted.push(advisory)
+    }
+
+    let advisorUsageReports = 0
+    if (review.usage !== undefined && usageHasTokens(review.usage)) {
+      for (const advisory of accepted) {
+        await (options.tokenUsageReporter ?? (async () => undefined))({
+          advisoryRef: advisory.advisoryRef,
+          desktopSessionId: request.desktopSessionId,
+          model: review.model,
+          observedAt: advisoryObservedAt(advisory, clock),
+          role: "advisor",
+          turnId: request.turnId,
+          usage: review.usage ?? emptyUsage(),
+        })
+        advisorUsageReports += 1
+      }
+    }
+
+    const nits = accepted.filter(advisory => advisory.severity === "nit")
+    const nitBatch = nits.length === 0
+      ? undefined
+      : {
+        advisories: nits,
+        desktopSessionId: request.desktopSessionId,
+        role: "advisor" as const,
+        turnId: request.turnId,
+      }
+    if (nitBatch !== undefined) options.onNitBatch?.(nitBatch)
+
+    const steered: KhalaCodeDesktopCodexTurnSteerRequest[] = []
+    const urgent = accepted.filter(advisory => advisory.severity !== "nit")
+    for (const advisory of urgent) {
+      if (immuneTurnsRemaining <= 0) break
+      const steerRequest = {
+        clientUserMessageId: advisory.advisoryRef,
+        sessionId: request.desktopSessionId,
+        text: khalaAdvisorSteeringText(advisory),
+        turnId: request.turnId,
+      }
+      const result = await options.steerTurn(steerRequest)
+      if (result.ok) {
+        steered.push(steerRequest)
+        immuneTurnsRemaining -= 1
+      }
+    }
+
+    return {
+      advisorUsageReports,
+      droppedAdvisories,
+      ...(nitBatch === undefined ? {} : { nitBatch }),
+      reviewed: true,
+      steered,
+    }
+  }
+
+  return {
+    acceptEvent,
+    flushTurn,
+    reset,
+  }
+}

--- a/clients/khala-code-desktop/tests/khala-advisor-runtime.test.ts
+++ b/clients/khala-code-desktop/tests/khala-advisor-runtime.test.ts
@@ -1,0 +1,260 @@
+import { describe, expect, test } from "bun:test"
+
+import type {
+  KhalaCodeDesktopChatTurnEvent,
+  KhalaCodeDesktopUsage,
+} from "../src/shared/rpc.js"
+import {
+  createKhalaAdvisorRuntime,
+  KHALA_ADVISOR_ADVISORY_SCHEMA,
+  khalaAdvisorSteeringText,
+  type KhalaAdvisorAdvisory,
+  type KhalaAdvisorReviewRequest,
+  type KhalaAdvisorTokenUsageReport,
+  type KhalaAdvisorTranscriptCard,
+} from "../src/bun/khala-advisor-runtime.js"
+
+const usage: KhalaCodeDesktopUsage = {
+  cachedInput: 1,
+  input: 10,
+  output: 4,
+  reasoningOutput: 2,
+}
+
+const advisory = (
+  advisoryRef: string,
+  severity: KhalaAdvisorAdvisory["severity"],
+  summary: string,
+  guidance = "Patch the affected path before continuing.",
+): KhalaAdvisorAdvisory => ({
+  schema: KHALA_ADVISOR_ADVISORY_SCHEMA,
+  advisoryRef,
+  generatedAt: "2026-07-02T12:00:00.000Z",
+  severity,
+  summary,
+  guidance,
+  evidenceRefs: ["turn.fixture"],
+})
+
+const eventStart = (
+  turnId: string,
+  id: string,
+  body: string,
+): KhalaCodeDesktopChatTurnEvent => ({
+  message: { body, id, role: "assistant" },
+  turnId,
+  type: "message_start",
+})
+
+describe("KhalaAdvisorRuntime", () => {
+  test("consumes turn deltas only and batches nit advisories into transcript cards", async () => {
+    const reviewRequests: KhalaAdvisorReviewRequest[] = []
+    const nitCards: KhalaAdvisorTranscriptCard[] = []
+
+    const runtime = createKhalaAdvisorRuntime({
+      modelSession: {
+        reviewTurnDelta: async request => {
+          reviewRequests.push(request)
+          return {
+            advisories: [
+              advisory("advisor.nit.1", "nit", "Mention the failing assertion in the summary."),
+            ],
+            model: "claude-fixture-advisor",
+            usage,
+          }
+        },
+      },
+      onNitBatch: card => nitCards.push(card),
+      steerTurn: async request => ({
+        desktopSessionId: request.sessionId,
+        desktopTurnId: request.turnId,
+        ok: true,
+      }),
+      tokenUsageReporter: async () => undefined,
+    })
+
+    runtime.acceptEvent(eventStart("turn-1", "assistant-1", "First chunk"))
+    runtime.acceptEvent({
+      delta: " plus streamed delta",
+      messageId: "assistant-1",
+      turnId: "turn-1",
+      type: "message_delta",
+    })
+
+    const closeout = await runtime.flushTurn({
+      desktopSessionId: "session-1",
+      turnId: "turn-1",
+    })
+
+    expect(reviewRequests).toHaveLength(1)
+    expect(reviewRequests[0]?.delta).toEqual({
+      body: "assistant: First chunk plus streamed delta",
+      desktopSessionId: "session-1",
+      turnId: "turn-1",
+    })
+    expect(closeout.steered).toEqual([])
+    expect(closeout.nitBatch?.advisories.map(item => item.advisoryRef)).toEqual(["advisor.nit.1"])
+    expect(nitCards).toHaveLength(1)
+    expect(nitCards[0]?.role).toBe("advisor")
+  })
+
+  test("routes concern and blocker advisories through codex steering with an immune-turn budget", async () => {
+    const steeredTexts: string[] = []
+    const runtime = createKhalaAdvisorRuntime({
+      immuneTurns: 1,
+      modelSession: {
+        reviewTurnDelta: async () => ({
+          advisories: [
+            advisory("advisor.concern.1", "concern", "The migration drops existing rows."),
+            advisory("advisor.blocker.1", "blocker", "The verifier command was weakened."),
+          ],
+          model: "claude-fixture-advisor",
+          usage,
+        }),
+      },
+      steerTurn: async request => {
+        steeredTexts.push(request.text)
+        return {
+          desktopSessionId: request.sessionId,
+          desktopTurnId: request.turnId,
+          ok: true,
+        }
+      },
+      tokenUsageReporter: async () => undefined,
+    })
+
+    runtime.acceptEvent(eventStart("turn-2", "assistant-2", "I changed the verifier."))
+    const closeout = await runtime.flushTurn({
+      desktopSessionId: "session-2",
+      turnId: "turn-2",
+    })
+
+    expect(closeout.steered.map(item => item.clientUserMessageId)).toEqual(["advisor.concern.1"])
+    expect(steeredTexts).toHaveLength(1)
+    expect(steeredTexts[0]).toBe(khalaAdvisorSteeringText(
+      advisory("advisor.concern.1", "concern", "The migration drops existing rows."),
+    ))
+
+    runtime.acceptEvent(eventStart("turn-3", "assistant-3", "Continuing after the first interrupt."))
+    const secondCloseout = await runtime.flushTurn({
+      desktopSessionId: "session-2",
+      turnId: "turn-3",
+    })
+    expect(secondCloseout.steered).toEqual([])
+  })
+
+  test("enforces duplicate and content-free emission guards in code", async () => {
+    const runtime = createKhalaAdvisorRuntime({
+      modelSession: {
+        reviewTurnDelta: async () => ({
+          advisories: [
+            advisory("advisor.concern.1", "concern", "The migration drops existing rows."),
+            advisory("advisor.concern.dup", "concern", "The migration drops existing rows."),
+            advisory("advisor.nit.empty", "nit", "Looks good", "ok"),
+          ],
+          model: "claude-fixture-advisor",
+          usage,
+        }),
+      },
+      steerTurn: async request => ({
+        desktopSessionId: request.sessionId,
+        desktopTurnId: request.turnId,
+        ok: true,
+      }),
+      tokenUsageReporter: async () => undefined,
+    })
+
+    runtime.acceptEvent(eventStart("turn-4", "assistant-4", "Dropped rows."))
+    const closeout = await runtime.flushTurn({
+      desktopSessionId: "session-4",
+      turnId: "turn-4",
+    })
+
+    expect(closeout.droppedAdvisories).toEqual([
+      { advisoryRef: "advisor.concern.dup", reason: "duplicate" },
+      { advisoryRef: "advisor.nit.empty", reason: "content_free" },
+    ])
+    expect(closeout.steered.map(item => item.clientUserMessageId)).toEqual(["advisor.concern.1"])
+  })
+
+  test("reset clears dedupe and restores interrupt budget after compaction or thread switch", async () => {
+    const steered: string[] = []
+    const runtime = createKhalaAdvisorRuntime({
+      immuneTurns: 1,
+      modelSession: {
+        reviewTurnDelta: async () => ({
+          advisories: [
+            advisory("advisor.blocker.1", "blocker", "The verifier command was weakened."),
+          ],
+          model: "claude-fixture-advisor",
+          usage,
+        }),
+      },
+      steerTurn: async request => {
+        steered.push(request.clientUserMessageId ?? "")
+        return {
+          desktopSessionId: request.sessionId,
+          desktopTurnId: request.turnId,
+          ok: true,
+        }
+      },
+      tokenUsageReporter: async () => undefined,
+    })
+
+    runtime.acceptEvent(eventStart("turn-5", "assistant-5", "First blocker."))
+    await runtime.flushTurn({ desktopSessionId: "session-5", turnId: "turn-5" })
+    runtime.acceptEvent(eventStart("turn-6", "assistant-6", "Same blocker before reset."))
+    const beforeReset = await runtime.flushTurn({ desktopSessionId: "session-5", turnId: "turn-6" })
+
+    runtime.reset("compaction")
+    runtime.acceptEvent(eventStart("turn-7", "assistant-7", "Same blocker after reset."))
+    const afterReset = await runtime.flushTurn({ desktopSessionId: "session-5", turnId: "turn-7" })
+
+    expect(beforeReset.droppedAdvisories).toEqual([
+      { advisoryRef: "advisor.blocker.1", reason: "duplicate" },
+    ])
+    expect(afterReset.steered.map(item => item.clientUserMessageId)).toEqual(["advisor.blocker.1"])
+    expect(steered).toEqual(["advisor.blocker.1", "advisor.blocker.1"])
+  })
+
+  test("reports advisor usage as separate exact role usage", async () => {
+    const reports: KhalaAdvisorTokenUsageReport[] = []
+    const runtime = createKhalaAdvisorRuntime({
+      clock: { now: () => new Date("2026-07-02T12:34:56.000Z") },
+      modelSession: {
+        reviewTurnDelta: async () => ({
+          advisories: [
+            advisory("advisor.concern.usage", "concern", "The patch lacks a regression test."),
+          ],
+          model: "claude-fixture-advisor",
+          usage,
+        }),
+      },
+      steerTurn: async request => ({
+        desktopSessionId: request.sessionId,
+        desktopTurnId: request.turnId,
+        ok: true,
+      }),
+      tokenUsageReporter: async report => {
+        reports.push(report)
+      },
+    })
+
+    runtime.acceptEvent(eventStart("turn-8", "assistant-8", "No test was added."))
+    const closeout = await runtime.flushTurn({
+      desktopSessionId: "session-8",
+      turnId: "turn-8",
+    })
+
+    expect(closeout.advisorUsageReports).toBe(1)
+    expect(reports).toEqual([{
+      advisoryRef: "advisor.concern.usage",
+      desktopSessionId: "session-8",
+      model: "claude-fixture-advisor",
+      observedAt: "2026-07-02T12:00:00.000Z",
+      role: "advisor",
+      turnId: "turn-8",
+      usage,
+    }])
+  })
+})


### PR DESCRIPTION
## Summary
- Adds a schema-first KhalaAdvisorRuntime Effect service for advisor advisories.
- Consumes neutral Codex turn deltas, batches nit cards, routes concern/blocker advisories through codexTurnSteer, and enforces dedupe/noise/immune-turn/reset invariants in code.
- Adds advisor role token usage reporting seam and focused regression coverage.

Closes #8055.

## Verification
- `bun test clients/khala-code-desktop/tests/khala-advisor-runtime.test.ts`
- `bun run --cwd clients/khala-code-desktop verify`
- `bun run check:deploy`

Note: `check:deploy` contract-drift guard prints intentional failure-fixture messages while asserting the guard catches them; the command exited 0.