### PR TITLE
Resolve desktop suite flake ledger entry

### DIFF
--- a/clients/khala-code-desktop/tests/flake-quarantine-ledger.test.ts
+++ b/clients/khala-code-desktop/tests/flake-quarantine-ledger.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from "bun:test"
+
+type StaticFlakeLedger = {
+  readonly entries: ReadonlyArray<{
+    readonly id: string
+    readonly status: string
+    readonly trackingIssue: string
+    readonly resolution?: string
+    readonly reproductionEvidence?: {
+      readonly attemptedCommand?: string
+      readonly cleanRuns?: number
+      readonly finalSuiteShape?: {
+        readonly files?: number
+        readonly tests?: number
+        readonly failures?: number
+      }
+    }
+    readonly determinismGuard?: string
+  }>
+}
+
+describe("Khala Code flake quarantine ledger", () => {
+  test("records the #8044 desktop-suite flake as resolved with stress evidence", async () => {
+    const ledger = JSON.parse(
+      await Bun.file(new URL("../../../docs/qa/khala-code-flake-quarantine-ledger.json", import.meta.url)).text(),
+    ) as StaticFlakeLedger
+
+    const entry = ledger.entries.find(
+      candidate => candidate.id === "khala.desktop_suite.single_test_error.2026-07-02",
+    )
+
+    expect(entry).toBeDefined()
+    expect(entry).toMatchObject({
+      status: "resolved",
+      trackingIssue: "https://github.com/OpenAgentsInc/openagents/issues/8044",
+      resolution: "not_reproduced_after_stress",
+      reproductionEvidence: {
+        attemptedCommand: "bun run --cwd clients/khala-code-desktop test",
+        cleanRuns: 42,
+        finalSuiteShape: {
+          files: 67,
+          tests: 526,
+          failures: 0,
+        },
+      },
+      determinismGuard:
+        "clients/khala-code-desktop/tests/cockpit-visual-smoke.test.ts::rate-limit countdown repaints from an injected clock without sleeping",
+    })
+  })
+})

--- a/docs/qa/khala-code-flake-quarantine-ledger.json
+++ b/docs/qa/khala-code-flake-quarantine-ledger.json
@@ -1,18 +1,34 @@
 {
   "schema": "openagents.khala_code.qa_static_flake_quarantine_ledger.v1",
-  "updatedAt": "2026-07-02T00:00:00.000Z",
+  "updatedAt": "2026-07-03T00:55:25.000Z",
   "policy": "retry_once_then_quarantine_no_silent_green",
   "entries": [
     {
       "id": "khala.desktop_suite.single_test_error.2026-07-02",
-      "status": "open",
+      "status": "resolved",
       "firstObservedAt": "2026-07-02",
       "affectedCommand": "bun test tests/*.test.ts",
       "affectedNightlyStep": "desktop-verify",
       "sourceRef": "docs/fable/2026-07-01-khala-code-desktop-qa-framework-design.md#15.2",
       "trackingIssue": "https://github.com/OpenAgentsInc/openagents/issues/8044",
       "quarantineIssue": "https://github.com/OpenAgentsInc/openagents/issues/8015",
-      "notes": "One non-reproducing single-test error in one of three desktop suite runs. Q1.4 adds retry-once quarantine wiring; Q7.3 owns reproduction and fix."
+      "resolvedAt": "2026-07-03T00:55:25.000Z",
+      "resolution": "not_reproduced_after_stress",
+      "reproductionEvidence": {
+        "attemptedCommand": "bun run --cwd clients/khala-code-desktop test",
+        "cleanRuns": 42,
+        "finalSuiteShape": {
+          "files": 67,
+          "tests": 526,
+          "failures": 0
+        },
+        "logRefs": [
+          "var/qa-flake-hunt/desktop-run-1.log",
+          "var/qa-flake-hunt/desktop-run-30.log"
+        ]
+      },
+      "determinismGuard": "clients/khala-code-desktop/tests/cockpit-visual-smoke.test.ts::rate-limit countdown repaints from an injected clock without sleeping",
+      "notes": "Historical anonymous single-test error from one of three 2026-07-02 desktop suite runs. Current pinned suite did not reproduce it across 42 consecutive full-suite runs after dependencies were materialized; the active countdown timing class is covered by an injected-clock regression. Keep any future pass-after-fail under the nightly retry-once quarantine policy instead of treating retry green as success."
     }
   ]
 }


### PR DESCRIPTION
Closes #8044.

## Summary

- Mark the historical 2026-07-02 desktop-suite anonymous single-test error as resolved in the static Q1.4 flake quarantine ledger.
- Record the reproduction campaign outcome: 42 consecutive clean `bun run --cwd clients/khala-code-desktop test` runs on the pinned checkout, final suite shape 526 tests / 67 files before this PR.
- Add a desktop test that pins the #8044 ledger entry, its stress evidence, and the injected-clock determinism guard so the resolved status cannot drift silently.

## Evidence

Reproduction attempt / stress run:

- Initial dependency-materialized suite loop: 12 consecutive clean full desktop-suite runs.
- Quiet stress loop: 30 consecutive clean full desktop-suite runs, logs under ignored local `var/qa-flake-hunt/desktop-run-*.log`.
- No anonymous single-test error reproduced in 42 consecutive full-suite runs.

Verification:

- `bun test clients/khala-code-desktop/tests/flake-quarantine-ledger.test.ts` — 1 pass, 0 fail.
- `bun run --cwd clients/khala-code-desktop test` — 527 pass, 0 fail, 68 files.
- `bun run check:deploy` — passed. Note: the contract-drift guard test prints expected negative-fixture "FAILED" examples while the Vitest file itself passes; the command exited 0.

## Notes

The original issue asked for a reproduced stack. The historical record only names an anonymous single-test error, and this pinned checkout did not reproduce it under repeated full-suite stress. This PR closes the ledger honestly as `not_reproduced_after_stress` while preserving the retry-once quarantine policy for any future pass-after-fail recurrence.