### PR TITLE
[codex] Add judge diff verdict cards

### DIFF
--- a/clients/khala-code-desktop/src/shared/diff-review.ts
+++ b/clients/khala-code-desktop/src/shared/diff-review.ts
@@ -4,6 +4,8 @@ export const KHALA_CODE_DIFF_REVIEW_COMMENT_SCHEMA =
   "openagents.khala_code.diff_review_comment.v1" as const
 export const KHALA_CODE_DIFF_REVIEW_SUBMIT_EVENT =
   "khala-code-diff-review-submit" as const
+export const KHALA_CODE_JUDGE_DIFF_VERDICT_SCHEMA =
+  "openagents.khala_code.judge_diff_verdict.v1" as const
 
 export const KhalaCodeDiffReviewLineKindSchema = S.Literals([
   "add",
@@ -41,6 +43,48 @@ export const KhalaCodeDiffReviewSubmitDetailSchema = S.Struct({
 export type KhalaCodeDiffReviewSubmitDetail =
   typeof KhalaCodeDiffReviewSubmitDetailSchema.Type
 
+export const KhalaCodeJudgeDiffVerdictKindSchema = S.Literals([
+  "accept",
+  "request_changes",
+  "replan",
+])
+export type KhalaCodeJudgeDiffVerdictKind =
+  typeof KhalaCodeJudgeDiffVerdictKindSchema.Type
+
+export const KhalaCodeJudgeDiffFindingPrioritySchema = S.Literals([
+  "P0",
+  "P1",
+  "P2",
+  "P3",
+])
+export type KhalaCodeJudgeDiffFindingPriority =
+  typeof KhalaCodeJudgeDiffFindingPrioritySchema.Type
+
+export const KhalaCodeJudgeDiffVerdictFindingSchema = S.Struct({
+  body: S.String,
+  confidence: S.Number,
+  filePath: S.String,
+  findingRef: S.String,
+  lineEnd: S.optional(S.Number),
+  lineStart: S.Number,
+  priority: KhalaCodeJudgeDiffFindingPrioritySchema,
+  title: S.String,
+})
+export type KhalaCodeJudgeDiffVerdictFinding =
+  typeof KhalaCodeJudgeDiffVerdictFindingSchema.Type
+
+export const KhalaCodeJudgeDiffVerdictSchema = S.Struct({
+  confidence: S.Number,
+  diffRef: S.optional(S.String),
+  findings: S.Array(KhalaCodeJudgeDiffVerdictFindingSchema),
+  schema: S.Literal(KHALA_CODE_JUDGE_DIFF_VERDICT_SCHEMA),
+  summary: S.String,
+  verdict: KhalaCodeJudgeDiffVerdictKindSchema,
+  verifyAuthority: S.Literal("verify_command_required"),
+})
+export type KhalaCodeJudgeDiffVerdict =
+  typeof KhalaCodeJudgeDiffVerdictSchema.Type
+
 export const khalaCodeDiffReviewLineLabel = (
   input: Pick<KhalaCodeDiffReviewComment, "filePath" | "lineNo" | "lineSide">,
 ): string => `${input.filePath}:${input.lineSide === "new" ? "+" : "-"}${input.lineNo}`
@@ -68,3 +112,19 @@ export const khalaCodeDiffReviewSteeringNote = (
   "",
   comment.body,
 ].join("\n")
+
+export const khalaCodeJudgeDiffFindingToReviewDetail = (
+  finding: KhalaCodeJudgeDiffVerdictFinding,
+): Omit<KhalaCodeDiffReviewSubmitDetail, "body"> & { readonly body: string } => ({
+  body: [
+    `Judge finding ${finding.findingRef} (${finding.priority}, confidence ${finding.confidence.toFixed(2)})`,
+    finding.title,
+    "",
+    finding.body,
+  ].join("\n"),
+  filePath: finding.filePath,
+  lineKind: "context",
+  lineNo: finding.lineStart,
+  lineSide: "new",
+  patchRef: `judge.${finding.findingRef}.${finding.filePath}.${finding.lineStart}`,
+})

--- a/clients/khala-code-desktop/src/ui/styles.css
+++ b/clients/khala-code-desktop/src/ui/styles.css
@@ -1513,6 +1513,178 @@ button {
   opacity: 0.54;
 }
 
+.judge-verdict-card {
+  display: grid;
+  gap: 10px;
+  max-width: 52rem;
+  border: 1px solid color-mix(in srgb, var(--oa-color-khala-energy-blue) 36%, transparent);
+  border-radius: 6px;
+  background:
+    linear-gradient(180deg, color-mix(in srgb, var(--oa-color-khala-energy-blue) 8%, transparent), transparent 54%),
+    color-mix(in srgb, var(--oa-color-khala-surface-raised) 84%, transparent);
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--oa-color-khala-energy-cyan) 10%, transparent) inset;
+  color: var(--oa-color-khala-text-primary);
+  padding: 12px;
+}
+
+.judge-verdict-card[data-verdict="accept"] {
+  border-color: color-mix(in srgb, var(--oa-color-khala-success-border) 74%, transparent);
+}
+
+.judge-verdict-card[data-verdict="request_changes"] {
+  border-color: color-mix(in srgb, var(--oa-color-khala-warning) 74%, transparent);
+}
+
+.judge-verdict-card[data-verdict="replan"] {
+  border-color: color-mix(in srgb, var(--oa-color-khala-danger-border) 74%, transparent);
+}
+
+.judge-verdict-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+
+.judge-verdict-role,
+.judge-verdict-kind,
+.judge-verdict-confidence,
+.judge-verdict-priority {
+  display: inline-flex;
+  align-items: center;
+  min-height: 22px;
+  border: 1px solid color-mix(in srgb, var(--oa-color-khala-energy-cyan) 30%, transparent);
+  border-radius: 3px;
+  font-family: var(--oa-font-code);
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0;
+  line-height: 1;
+  padding: 3px 6px;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.judge-verdict-role {
+  color: var(--oa-color-khala-energy-text);
+}
+
+.judge-verdict-kind {
+  color: var(--oa-color-khala-text-primary);
+}
+
+.judge-verdict-card[data-verdict="accept"] .judge-verdict-kind {
+  border-color: color-mix(in srgb, var(--oa-color-khala-success-border) 74%, transparent);
+  color: var(--oa-color-khala-success-strong);
+}
+
+.judge-verdict-card[data-verdict="request_changes"] .judge-verdict-kind {
+  border-color: color-mix(in srgb, var(--oa-color-khala-warning) 74%, transparent);
+  color: var(--oa-color-khala-warning-strong);
+}
+
+.judge-verdict-card[data-verdict="replan"] .judge-verdict-kind {
+  border-color: color-mix(in srgb, var(--oa-color-khala-danger-border) 74%, transparent);
+  color: var(--oa-color-khala-danger-strong);
+}
+
+.judge-verdict-confidence {
+  color: var(--oa-color-khala-text-muted);
+  font-variant-numeric: tabular-nums;
+}
+
+.judge-verdict-summary,
+.judge-verdict-authority,
+.judge-verdict-finding-body {
+  margin: 0;
+  color: var(--oa-color-khala-text-soft);
+  font-size: 0.84rem;
+  line-height: 1.5;
+}
+
+.judge-verdict-authority {
+  color: var(--oa-color-khala-text-muted);
+}
+
+.judge-verdict-findings {
+  display: grid;
+  gap: 8px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.judge-verdict-finding {
+  display: grid;
+  gap: 6px;
+  border: 1px solid color-mix(in srgb, var(--oa-color-khala-border) 74%, transparent);
+  border-radius: 4px;
+  background: color-mix(in srgb, var(--oa-color-khala-void) 38%, transparent);
+  padding: 9px;
+}
+
+.judge-verdict-finding-head {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+}
+
+.judge-verdict-priority {
+  border-color: color-mix(in srgb, var(--oa-color-khala-energy-blue) 42%, transparent);
+  color: var(--oa-color-khala-energy-text);
+}
+
+.judge-verdict-finding[data-priority="P0"] .judge-verdict-priority,
+.judge-verdict-finding[data-priority="P1"] .judge-verdict-priority {
+  border-color: color-mix(in srgb, var(--oa-color-khala-danger-border) 80%, transparent);
+  color: var(--oa-color-khala-danger-strong);
+}
+
+.judge-verdict-finding[data-priority="P2"] .judge-verdict-priority {
+  border-color: color-mix(in srgb, var(--oa-color-khala-warning) 80%, transparent);
+  color: var(--oa-color-khala-warning-strong);
+}
+
+.judge-verdict-finding-title {
+  flex: 1;
+  min-width: min(18rem, 100%);
+  color: var(--oa-color-khala-text-primary);
+  font-size: 0.84rem;
+  font-weight: 700;
+  line-height: 1.35;
+}
+
+.judge-verdict-anchor {
+  color: var(--oa-color-khala-energy-text);
+  font-family: var(--oa-font-code);
+  font-size: 0.74rem;
+  overflow-wrap: anywhere;
+}
+
+.judge-verdict-steer-button {
+  justify-self: start;
+  min-height: 28px;
+  border: 1px solid color-mix(in srgb, var(--oa-color-khala-warning) 74%, transparent);
+  border-radius: 3px;
+  background: color-mix(in srgb, var(--oa-color-khala-surface-warning) 72%, transparent);
+  color: var(--oa-color-khala-warning-strong);
+  cursor: pointer;
+  font: inherit;
+  font-size: 0.74rem;
+  font-weight: 700;
+  line-height: 1;
+  padding: 6px 9px;
+}
+
+.judge-verdict-steer-button:hover,
+.judge-verdict-steer-button:focus-visible {
+  border-color: color-mix(in srgb, var(--oa-color-khala-energy-cyan) 78%, transparent);
+  outline: 1px solid color-mix(in srgb, var(--oa-color-khala-energy-cyan) 36%, transparent);
+}
+
 @media (max-width: 640px) {
   .message-bubble--user {
     max-width: 92%;

--- a/clients/khala-code-desktop/src/ui/transcript-render.ts
+++ b/clients/khala-code-desktop/src/ui/transcript-render.ts
@@ -5,6 +5,7 @@ import {
   tokenizeCode,
   tokenizeCodeLines,
 } from "@openagentsinc/ui/ai-elements/code-highlight"
+import { Schema as S } from "effect"
 import {
   parseMarkdownBlocks,
   parseMarkdownInline,
@@ -19,10 +20,15 @@ import type {
 import type { KhalaCodeDesktopCodexApprovalAction } from "../shared/codex-approval-decisions"
 import {
   KHALA_CODE_DIFF_REVIEW_SUBMIT_EVENT,
+  KHALA_CODE_JUDGE_DIFF_VERDICT_SCHEMA,
+  KhalaCodeJudgeDiffVerdictSchema,
+  khalaCodeJudgeDiffFindingToReviewDetail,
   khalaCodeDiffReviewLineLabel,
   type KhalaCodeDiffReviewLineKind,
   type KhalaCodeDiffReviewLineSide,
   type KhalaCodeDiffReviewSubmitDetail,
+  type KhalaCodeJudgeDiffVerdict,
+  type KhalaCodeJudgeDiffVerdictFinding,
 } from "../shared/diff-review"
 import {
   KHALA_CODE_SOURCE_CONTROL_ACTION_SUBMIT_EVENT,
@@ -55,6 +61,7 @@ export type MessageSegment =
   | { readonly kind: "prose"; readonly text: string }
   | { readonly kind: "code"; readonly text: string; readonly language?: string }
   | { readonly kind: "diff"; readonly text: string }
+  | { readonly kind: "judge-diff-verdict"; readonly verdict: KhalaCodeJudgeDiffVerdict }
 
 export type ToolTranscriptParts = {
   readonly output: string
@@ -224,6 +231,16 @@ const inlineNodes = (parts: readonly MarkdownInlinePart[]): readonly Node[] => {
 
 const appendInlineMarkdown = (element: HTMLElement, text: string): void => {
   element.append(...inlineNodes(parseMarkdownInline(text)))
+}
+
+const decodeJudgeDiffVerdict = (text: string): KhalaCodeJudgeDiffVerdict | null => {
+  const trimmed = text.trim()
+  if (!trimmed.includes(KHALA_CODE_JUDGE_DIFF_VERDICT_SCHEMA)) return null
+  try {
+    return S.decodeUnknownSync(KhalaCodeJudgeDiffVerdictSchema)(JSON.parse(trimmed))
+  } catch {
+    return null
+  }
 }
 
 export const codeBlockElement = (input: {
@@ -489,6 +506,132 @@ const sourceControlActions = (
   return actions
 }
 
+const judgeVerdictLabel = (verdict: KhalaCodeJudgeDiffVerdict["verdict"]): string => {
+  switch (verdict) {
+    case "accept":
+      return "Accept"
+    case "request_changes":
+      return "Request changes"
+    case "replan":
+      return "Replan"
+  }
+}
+
+const judgeFindingLineLabel = (finding: KhalaCodeJudgeDiffVerdictFinding): string => {
+  const range = finding.lineEnd === undefined || finding.lineEnd === finding.lineStart
+    ? String(finding.lineStart)
+    : `${finding.lineStart}-${finding.lineEnd}`
+  return `${finding.filePath}:${range}`
+}
+
+const judgeFindingElement = (
+  root: HTMLElement,
+  finding: KhalaCodeJudgeDiffVerdictFinding,
+  verdictKind: KhalaCodeJudgeDiffVerdict["verdict"],
+): HTMLElement => {
+  const item = document.createElement("li")
+  item.className = "judge-verdict-finding"
+  item.dataset.priority = finding.priority
+
+  const head = document.createElement("div")
+  head.className = "judge-verdict-finding-head"
+
+  const priority = document.createElement("span")
+  priority.className = "judge-verdict-priority"
+  priority.textContent = finding.priority
+
+  const title = document.createElement("span")
+  title.className = "judge-verdict-finding-title"
+  title.textContent = finding.title
+
+  const confidence = document.createElement("span")
+  confidence.className = "judge-verdict-confidence"
+  confidence.textContent = `${Math.round(finding.confidence * 100)}%`
+  confidence.title = "Judge confidence"
+
+  head.append(priority, title, confidence)
+
+  const anchor = document.createElement("div")
+  anchor.className = "judge-verdict-anchor"
+  anchor.textContent = judgeFindingLineLabel(finding)
+
+  const body = document.createElement("p")
+  body.className = "judge-verdict-finding-body"
+  body.textContent = finding.body
+
+  item.append(head, anchor, body)
+
+  if (verdictKind === "request_changes") {
+    const detail = khalaCodeJudgeDiffFindingToReviewDetail(finding)
+    const action = document.createElement("button")
+    action.type = "button"
+    action.className = "judge-verdict-steer-button"
+    action.textContent = "Send to coder"
+    action.title = "Feed this judge finding into the diff-annotation steering loop"
+    action.addEventListener("click", event => {
+      event.preventDefault()
+      event.stopPropagation()
+      root.dispatchEvent(new CustomEvent<KhalaCodeDiffReviewSubmitDetail>(
+        KHALA_CODE_DIFF_REVIEW_SUBMIT_EVENT,
+        {
+          bubbles: true,
+          detail,
+        },
+      ))
+    })
+    item.append(action)
+  }
+
+  return item
+}
+
+export const judgeDiffVerdictElement = (
+  verdict: KhalaCodeJudgeDiffVerdict,
+): HTMLElement => {
+  const root = document.createElement("section")
+  root.className = "judge-verdict-card"
+  root.dataset.verdict = verdict.verdict
+  root.dataset.schema = verdict.schema
+
+  const header = document.createElement("div")
+  header.className = "judge-verdict-header"
+
+  const role = document.createElement("span")
+  role.className = "judge-verdict-role"
+  role.textContent = "Judge"
+
+  const kind = document.createElement("span")
+  kind.className = "judge-verdict-kind"
+  kind.textContent = judgeVerdictLabel(verdict.verdict)
+
+  const confidence = document.createElement("span")
+  confidence.className = "judge-verdict-confidence judge-verdict-confidence--overall"
+  confidence.textContent = `${Math.round(verdict.confidence * 100)}%`
+  confidence.title = "Overall judge confidence"
+
+  header.append(role, kind, confidence)
+
+  const summary = document.createElement("p")
+  summary.className = "judge-verdict-summary"
+  summary.textContent = verdict.summary
+
+  const authority = document.createElement("p")
+  authority.className = "judge-verdict-authority"
+  authority.textContent = "Advisory verdict only. The verify command remains the merge authority."
+
+  root.append(header, summary, authority)
+
+  if (verdict.findings.length > 0) {
+    const findings = document.createElement("ul")
+    findings.className = "judge-verdict-findings"
+    findings.append(...verdict.findings.map(finding =>
+      judgeFindingElement(root, finding, verdict.verdict)))
+    root.append(findings)
+  }
+
+  return root
+}
+
 export const diffElement = (input: {
   readonly patch: string
   readonly language?: string
@@ -667,6 +810,9 @@ export const looksLikeUnifiedDiff = (text: string): boolean => {
 }
 
 export const parseMessageSegments = (text: string): readonly MessageSegment[] => {
+  const verdict = decodeJudgeDiffVerdict(text)
+  if (verdict !== null) return [{ kind: "judge-diff-verdict", verdict }]
+
   if (looksLikeUnifiedDiff(text)) {
     return [{ kind: "diff", text }]
   }
@@ -683,7 +829,10 @@ export const parseMessageSegments = (text: string): readonly MessageSegment[] =>
     }
     const info = (match[1] ?? "").trim().toLowerCase()
     const body = match[2] ?? ""
-    if (info === "diff" || info === "patch" || looksLikeUnifiedDiff(body)) {
+    const bodyVerdict = decodeJudgeDiffVerdict(body)
+    if (bodyVerdict !== null && (info === "" || info === "json")) {
+      segments.push({ kind: "judge-diff-verdict", verdict: bodyVerdict })
+    } else if (info === "diff" || info === "patch" || looksLikeUnifiedDiff(body)) {
       segments.push({ kind: "diff", text: body })
     } else {
       segments.push({
@@ -850,6 +999,7 @@ const codexItemElement = (input: {
     const body = document.createElement("div")
     body.className = "codex-item-card-body"
     body.append(...parseMessageSegments(input.text).map(segment => {
+      if (segment.kind === "judge-diff-verdict") return judgeDiffVerdictElement(segment.verdict)
       if (segment.kind === "diff") return diffElement({ patch: segment.text })
       if (segment.kind === "code") {
         return codeBlockElement({
@@ -988,6 +1138,7 @@ export const renderMessageBody = (
   if (role === "tool") return [toolTranscriptElement(text)]
   if (role === "system") return [plainTextElement(text)]
   return parseMessageSegments(text).map(segment => {
+    if (segment.kind === "judge-diff-verdict") return judgeDiffVerdictElement(segment.verdict)
     if (segment.kind === "diff") return diffElement({ patch: segment.text })
     if (segment.kind === "code") {
       return codeBlockElement({

--- a/clients/khala-code-desktop/tests/app-shell.test.ts
+++ b/clients/khala-code-desktop/tests/app-shell.test.ts
@@ -1773,14 +1773,22 @@ describe("khala code desktop app shell", () => {
     const css = await Bun.file(new URL("../src/ui/styles.css", import.meta.url)).text()
 
     expect(shared).toContain("openagents.khala_code.diff_review_comment.v1")
+    expect(shared).toContain("openagents.khala_code.judge_diff_verdict.v1")
+    expect(shared).toContain("priority")
+    expect(shared).toContain("confidence")
     expect(renderer).toContain("cb-diff-comment-button")
+    expect(renderer).toContain("judge-verdict-card")
+    expect(renderer).toContain("judgeDiffVerdictElement")
     expect(renderer).toContain("KHALA_CODE_DIFF_REVIEW_SUBMIT_EVENT")
+    expect(renderer).toContain("verify command remains the merge authority")
     expect(main).toContain("KhalaCodeDiffReviewSubmitDetailSchema")
     expect(main).toContain("khalaCodeDiffReviewSteeringNote")
     expect(main).toContain("rpc.request.codexTurnSteer")
     expect(main).toContain("stageDiffReviewNoteInComposer")
     expect(css).toContain(".cb-diff-review-editor")
     expect(css).toContain(".cb-diff-review-textarea")
+    expect(css).toContain(".judge-verdict-card")
+    expect(css).toContain(".judge-verdict-steer-button")
   })
 
   test("wires source-control AI actions into the desktop diff review surface", async () => {

--- a/clients/khala-code-desktop/tests/diff-review.test.ts
+++ b/clients/khala-code-desktop/tests/diff-review.test.ts
@@ -5,11 +5,15 @@ import { Schema as S } from "effect"
 import {
   KHALA_CODE_DIFF_REVIEW_COMMENT_SCHEMA,
   KHALA_CODE_DIFF_REVIEW_SUBMIT_EVENT,
+  KHALA_CODE_JUDGE_DIFF_VERDICT_SCHEMA,
   KhalaCodeDiffReviewCommentSchema,
+  KhalaCodeJudgeDiffVerdictSchema,
   khalaCodeDiffReviewComment,
   khalaCodeDiffReviewSteeringNote,
+  khalaCodeJudgeDiffFindingToReviewDetail,
+  type KhalaCodeJudgeDiffVerdict,
 } from "../src/shared/diff-review"
-import { diffElement } from "../src/ui/transcript-render"
+import { diffElement, judgeDiffVerdictElement, parseMessageSegments } from "../src/ui/transcript-render"
 
 let previousDocument: typeof globalThis.document | undefined
 let previousWindow: typeof globalThis.window | undefined
@@ -34,6 +38,30 @@ const restoreDom = (): void => {
 describe("Khala Code diff review annotations", () => {
   beforeEach(installDom)
   afterEach(restoreDom)
+
+  const verdictFixture = (
+    verdict: KhalaCodeJudgeDiffVerdict["verdict"],
+  ): KhalaCodeJudgeDiffVerdict => ({
+    confidence: verdict === "accept" ? 0.91 : verdict === "request_changes" ? 0.84 : 0.72,
+    diffRef: "diff.fixture",
+    findings: verdict === "accept"
+      ? []
+      : [{
+          body: verdict === "replan"
+            ? "The diff solves a different problem than the approved plan."
+            : "The new branch drops the retry guard used by the worker closeout path.",
+          confidence: 0.87,
+          filePath: "src/worker.ts",
+          findingRef: `judge.finding.${verdict}.1`,
+          lineStart: 42,
+          priority: verdict === "replan" ? "P1" : "P2",
+          title: verdict === "replan" ? "Plan no longer matches implementation" : "Retry guard was removed",
+        }],
+    schema: KHALA_CODE_JUDGE_DIFF_VERDICT_SCHEMA,
+    summary: `${verdict} fixture verdict`,
+    verdict,
+    verifyAuthority: "verify_command_required",
+  })
 
   test("formats line comments as structured steering notes", () => {
     const comment = khalaCodeDiffReviewComment({
@@ -90,5 +118,55 @@ describe("Khala Code diff review annotations", () => {
       lineSide: "new",
       patchRef: "diff.src/example.ts.add.1",
     })
+  })
+
+  test("decodes judge verdict fixtures with priority and confidence fields", () => {
+    for (const verdict of ["accept", "request_changes", "replan"] as const) {
+      const fixture = verdictFixture(verdict)
+      expect(S.decodeUnknownSync(KhalaCodeJudgeDiffVerdictSchema)(fixture)).toEqual(fixture)
+      for (const finding of fixture.findings) {
+        expect(finding.priority).toMatch(/^P[0-3]$/)
+        expect(finding.confidence).toBeGreaterThan(0)
+      }
+    }
+  })
+
+  test("renders judge verdict cards for every verdict kind", () => {
+    for (const verdict of ["accept", "request_changes", "replan"] as const) {
+      const root = judgeDiffVerdictElement(verdictFixture(verdict))
+      expect(root.className).toContain("judge-verdict-card")
+      expect(root.dataset.verdict).toBe(verdict)
+      expect(root.textContent).toContain("Judge")
+      expect(root.textContent).toContain("Advisory verdict only")
+      expect(root.textContent).toContain("verify command remains the merge authority")
+    }
+  })
+
+  test("parses judge verdict JSON blocks into transcript verdict segments", () => {
+    const fixture = verdictFixture("request_changes")
+    const segments = parseMessageSegments([
+      "Judge result:",
+      "",
+      "```json",
+      JSON.stringify(fixture),
+      "```",
+    ].join("\n"))
+
+    expect(segments.map(segment => segment.kind)).toEqual(["prose", "judge-diff-verdict"])
+  })
+
+  test("request-change verdict findings feed the diff annotation steering event", () => {
+    const fixture = verdictFixture("request_changes")
+    const root = judgeDiffVerdictElement(fixture)
+    document.body.append(root)
+
+    let submitted: unknown
+    root.addEventListener(KHALA_CODE_DIFF_REVIEW_SUBMIT_EVENT, event => {
+      submitted = (event as CustomEvent<unknown>).detail
+    })
+
+    root.querySelector<HTMLButtonElement>(".judge-verdict-steer-button")?.click()
+
+    expect(submitted).toMatchObject(khalaCodeJudgeDiffFindingToReviewDetail(fixture.findings[0]!))
   })
 })


### PR DESCRIPTION
## Summary

Closes #8054.

- Adds the typed `openagents.khala_code.judge_diff_verdict.v1` schema with verdict kind, P0-P3 priorities, per-finding confidence, file/line anchors, and explicit `verify_command_required` advisory authority.
- Renders judge verdict JSON blocks in the Khala Code desktop transcript as structured cards for `accept`, `request_changes`, and `replan`.
- Routes request-change findings through the existing diff annotation steering event so they stage/send via the same Codex steering path as line comments.

## Verification

- `bun test clients/khala-code-desktop/tests/diff-review.test.ts clients/khala-code-desktop/tests/app-shell.test.ts` passed: 64 tests.
- `bun run --cwd clients/khala-code-desktop verify` passed: architecture scan, typecheck, 530 tests, Vite build, Bun build.
- `bun run check:deploy` passed with exit code 0.

Note: `check:deploy` includes a contract-drift guard fixture test that intentionally prints sample `FAILED` messages while asserting the guard catches those fixtures; the Vitest file passed and the overall command exited 0.