### PR TITLE
QA Q8.4: Public-safety oracle in every mode

### DIFF
--- a/apps/qa-runner/src/khala-desktop-backend.ts
+++ b/apps/qa-runner/src/khala-desktop-backend.ts
@@ -42,7 +42,7 @@ import {
   type NativeDesktopOutcome,
   type NativeDesktopScenario,
 } from "./native-desktop-backend";
-import { assertPublicSafeResult } from "./result";
+import { assertPublicSafeResult, assertPublicSafeTextValues } from "./result";
 import type { Target } from "./target";
 
 const DEFAULT_DESKTOP_CWD = resolve(import.meta.dir, "../../../clients/khala-code-desktop");
@@ -621,6 +621,7 @@ export async function runKhalaDesktopHeadedNativeSmoke(
       visualBaselines,
     };
     assertPublicSafeResult(smokeReport);
+    assertPublicSafeTextValues(smokeReport);
     writeFileSync(smokeReportPath, `${JSON.stringify(smokeReport, null, 2)}\n`);
     return { ...outcome, appPath, executablePath, smokeReportPath, visualBaselines };
   } finally {

--- a/apps/qa-runner/src/native-desktop-backend.test.ts
+++ b/apps/qa-runner/src/native-desktop-backend.test.ts
@@ -175,6 +175,27 @@ describe("runNativeDesktopScenario (fake runtime)", () => {
     expect(existsSync(join(dir, tl.frames[0].screenshot))).toBe(true);
   });
 
+  test("headed artifact metadata trips the public-safety text oracle", async () => {
+    const runtime = makeFakeRuntime({
+      available: true,
+      tree: {
+        app: "FakeApp",
+        nodes: [
+          {
+            role: "AXWindow",
+            title: "Unsafe /Users/operator/.codex/auth.json",
+          },
+        ],
+      },
+    });
+    await expect(
+      runNativeDesktopScenario(
+        { target, scenario: nativeDesktopExample("FakeApp"), artifactDir: dir },
+        { armed: true, runtime },
+      ),
+    ).rejects.toThrow("public_safety_violation");
+  });
+
   test("a wrong assertion FAILS honestly (real red); teardown still runs", async () => {
     const log: FakeLog = { events: [], tornDown: false };
     const runtime = makeFakeRuntime({ available: true, log });
@@ -207,7 +228,7 @@ describe("runNativeDesktopScenario (fake runtime)", () => {
   test("never records the raw typed text (credential) in the result", async () => {
     const runtime = makeFakeRuntime({ available: true });
     const scenario: NativeDesktopScenario = {
-      name: "secret-type",
+      name: "typed-redaction",
       app: "FakeApp",
       steps: [
         { kind: "focus" },

--- a/apps/qa-runner/src/native-desktop-backend.ts
+++ b/apps/qa-runner/src/native-desktop-backend.ts
@@ -35,6 +35,7 @@ import { join } from "node:path";
 
 import {
   assertPublicSafeResult,
+  assertPublicSafeTextValues,
   type QaRunResult,
   type QaRunStep,
 } from "./result";
@@ -314,6 +315,7 @@ export async function runNativeDesktopScenario(
     tree: lastTree ?? { app: input.scenario.app, nodes: [] },
   };
   assertPublicSafeResult(axTreeArtifact);
+  assertPublicSafeTextValues(axTreeArtifact);
   writeFileSync(axTreePath, `${JSON.stringify(axTreeArtifact, null, 2)}\n`);
 
   // ── Artifact 2: timeline (per-step labels + screenshot files) ─────────────
@@ -324,6 +326,7 @@ export async function runNativeDesktopScenario(
     frames,
   };
   assertPublicSafeResult(timelineArtifact);
+  assertPublicSafeTextValues(timelineArtifact);
   writeFileSync(timelinePath, `${JSON.stringify(timelineArtifact, null, 2)}\n`);
 
   // ── Artifact 3: result.json (same public-safe schema as browser/terminal) ──
@@ -347,6 +350,7 @@ export async function runNativeDesktopScenario(
     ...(failure ? { failure } : {}),
   };
   assertPublicSafeResult(result);
+  assertPublicSafeTextValues(result);
   const resultPath = join(input.artifactDir, "result.json");
   writeFileSync(resultPath, `${JSON.stringify(result, null, 2)}\n`);
 

--- a/apps/qa-runner/src/result.ts
+++ b/apps/qa-runner/src/result.ts
@@ -111,6 +111,44 @@ export class PublicSafetyViolation extends Error {
   }
 }
 
+const FORBIDDEN_TEXT_PATTERNS = [
+  /\/Users\//i,
+  /\/home\//i,
+  /~\//,
+  /auth\.json/i,
+  /bearer\s+[a-z0-9._=-]+/i,
+  /sk-[a-z0-9]/i,
+  /raw[_-]?(prompt|trace|log|provider)/i,
+  /provider[_-]?payload/i,
+  /api[_-]?key/i,
+  /credential/i,
+  /secret/i,
+];
+
+export function assertPublicSafeText(text: string, path = "$"): void {
+  for (const pattern of FORBIDDEN_TEXT_PATTERNS) {
+    if (pattern.test(text)) {
+      throw new PublicSafetyViolation(`forbidden text at ${path}`);
+    }
+  }
+}
+
+export function assertPublicSafeTextValues(value: unknown, path = "$"): void {
+  if (typeof value === "string") {
+    assertPublicSafeText(value, path);
+    return;
+  }
+  if (value === null || typeof value !== "object") return;
+  if (Array.isArray(value)) {
+    value.forEach((v, i) => assertPublicSafeTextValues(v, `${path}[${i}]`));
+    return;
+  }
+  for (const [key, v] of Object.entries(value as Record<string, unknown>)) {
+    assertPublicSafeText(key, `${path}.${key}:key`);
+    assertPublicSafeTextValues(v, `${path}.${key}`);
+  }
+}
+
 /**
  * Assert a result (any JSON-like value) carries no forbidden fields. Walks the
  * object graph checking KEYS against the forbidden patterns. Throws

--- a/clients/khala-code-desktop/scripts/cockpit-visual-smoke.ts
+++ b/clients/khala-code-desktop/scripts/cockpit-visual-smoke.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env bun
 import { mkdir, rm, writeFile } from "node:fs/promises"
-import { dirname, join, resolve } from "node:path"
+import { basename, dirname, join, relative, resolve } from "node:path"
 
 import { chromium, type Browser, type Page } from "playwright"
 import {
@@ -26,6 +26,10 @@ import {
   khalaCodeVisualBaselineOptionsFromArgs,
   type KhalaCodeVisualBaselineOptions,
 } from "./visual-baseline-options"
+import {
+  assertKhalaCodePagePublicSafe,
+  assertKhalaCodePublicSafeValue,
+} from "./public-safety-oracle"
 import { installKhalaCodeVisualSmokeRpcMocks } from "./visual-smoke-rpc-mocks"
 
 export type CockpitVisualViewport = Readonly<{
@@ -135,18 +139,17 @@ export async function runCockpitVisualSmoke(
         await page.close()
       }
     }
-    await writeFile(
-      join(options.outDir, "summary.json"),
-      `${JSON.stringify({
-        captures,
-        fixture: {
-          accounts: 3,
-          clock: cockpitClockIso,
-          workers: 18,
-        },
-        harness: COCKPIT_VISUAL_SMOKE_HARNESS,
-      }, null, 2)}\n`,
-    )
+    const summary = {
+      captures,
+      fixture: {
+        accounts: 3,
+        clock: cockpitClockIso,
+        workers: 18,
+      },
+      harness: COCKPIT_VISUAL_SMOKE_HARNESS,
+    }
+    assertKhalaCodePublicSafeValue(summary, "Cockpit visual smoke summary")
+    await writeFile(join(options.outDir, "summary.json"), `${JSON.stringify(summary, null, 2)}\n`)
     return captures
   } finally {
     if (browser !== null) await browser.close()
@@ -221,6 +224,7 @@ async function captureCockpit(
 
   const geometry = await collectCockpitGeometry(page)
   assertCockpitVisualGeometry(geometry)
+  await assertKhalaCodePagePublicSafe(page, "Cockpit visual smoke")
 
   const screenshot = join(
     input.outDir,
@@ -250,7 +254,7 @@ async function captureCockpit(
   return {
     accountCardCount: geometry.accountCards.length,
     geometry,
-    screenshot,
+    screenshot: basename(screenshot),
     visualBaseline,
     viewport: input.viewport.name,
     workerCardCount: geometry.workerCards.length,
@@ -344,14 +348,8 @@ const expectText = async (
   )
 }
 
-const unsafeTextPattern =
-  /\/Users\/|\/home\/|auth\.json|bearer|credential|provider[_-]?payload|raw[_-]?(prompt|trace|log|provider)|secret|sk-[a-z0-9]/i
-
 const assertPagePublicSafe = async (page: Page): Promise<void> => {
-  const text = await page.locator("body").textContent()
-  if (unsafeTextPattern.test(text ?? "")) {
-    throw new Error("Cockpit visual smoke rendered private or raw material")
-  }
+  await assertKhalaCodePagePublicSafe(page, "Cockpit visual smoke")
 }
 
 const cockpitFleetRunListFixture = (): KhalaCodeDesktopFleetRunListResult => ({
@@ -536,12 +534,14 @@ if (import.meta.main) {
       outDir,
       visualBaseline: khalaCodeVisualBaselineOptionsFromArgs(args),
     })
-    console.log(JSON.stringify({
+    const cliSummary = {
       captures,
       harness: COCKPIT_VISUAL_SMOKE_HARNESS,
       ok: true,
-      outDir,
-    }, null, 2))
+      outDir: relative(process.cwd(), outDir) || ".",
+    }
+    assertKhalaCodePublicSafeValue(cliSummary, "Cockpit visual smoke CLI summary")
+    console.log(JSON.stringify(cliSummary, null, 2))
   } catch (error) {
     console.error(error instanceof Error ? error.stack ?? error.message : error)
     process.exit(1)

--- a/clients/khala-code-desktop/scripts/composer-visual-smoke.ts
+++ b/clients/khala-code-desktop/scripts/composer-visual-smoke.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env bun
 import { mkdir, rm, writeFile } from "node:fs/promises"
-import { dirname, join, resolve } from "node:path"
+import { basename, dirname, join, relative, resolve } from "node:path"
 
 import { chromium, type Browser, type Page } from "playwright"
 import {
@@ -18,6 +18,10 @@ import {
   khalaCodeVisualBaselineOptionsFromArgs,
   type KhalaCodeVisualBaselineOptions,
 } from "./visual-baseline-options"
+import {
+  assertKhalaCodePagePublicSafe,
+  assertKhalaCodePublicSafeValue,
+} from "./public-safety-oracle"
 import { installKhalaCodeVisualSmokeRpcMocks } from "./visual-smoke-rpc-mocks"
 
 export type ComposerVisualViewport = Readonly<{
@@ -328,10 +332,12 @@ export async function runComposerVisualSmoke(
       }
     }
     const summaryPath = join(options.outDir, "summary.json")
-    await writeFile(summaryPath, `${JSON.stringify({
+    const summary = {
       harness: COMPOSER_VISUAL_SMOKE_HARNESS,
       results,
-    }, null, 2)}\n`)
+    }
+    assertKhalaCodePublicSafeValue(summary, "Composer visual smoke summary")
+    await writeFile(summaryPath, `${JSON.stringify(summary, null, 2)}\n`)
     return results
   } finally {
     if (browser !== null) await browser.close()
@@ -476,6 +482,7 @@ async function captureTarget(
     reducedMotionProbe,
     input.reducedMotion,
   )
+  await assertKhalaCodePagePublicSafe(page, "Composer visual smoke")
 
   let canvas =
     input.target.canvasSelector === null
@@ -601,10 +608,10 @@ async function captureTarget(
     requireBaseline: input.visualBaseline.requireBaseline,
   })
 
-  return {
+  const result = {
     target: input.target.name,
     viewport: input.viewport.name,
-    screenshot,
+    screenshot: basename(screenshot),
     visualBaseline,
     geometry,
     focus,
@@ -612,6 +619,8 @@ async function captureTarget(
     reducedMotionProbe,
     reducedMotion: input.reducedMotion,
   }
+  assertKhalaCodePublicSafeValue(result, "Composer visual smoke metadata")
+  return result
 }
 
 async function screenshotPixelProbe(
@@ -675,12 +684,14 @@ if (import.meta.main) {
       outDir,
       visualBaseline: khalaCodeVisualBaselineOptionsFromArgs(args),
     })
-    console.log(JSON.stringify({
+    const cliSummary = {
       harness: COMPOSER_VISUAL_SMOKE_HARNESS,
       ok: true,
-      outDir,
+      outDir: relative(process.cwd(), outDir) || ".",
       results,
-    }, null, 2))
+    }
+    assertKhalaCodePublicSafeValue(cliSummary, "Composer visual smoke CLI summary")
+    console.log(JSON.stringify(cliSummary, null, 2))
   } catch (error) {
     console.error(error instanceof Error ? error.stack ?? error.message : error)
     process.exit(1)

--- a/clients/khala-code-desktop/scripts/part2-fleet-gym-visual-smoke.ts
+++ b/clients/khala-code-desktop/scripts/part2-fleet-gym-visual-smoke.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env bun
 import { mkdir, rm, writeFile } from "node:fs/promises"
-import { dirname, join, resolve } from "node:path"
+import { basename, dirname, join, relative, resolve } from "node:path"
 
 import { chromium, type Browser, type Page } from "playwright"
 import {
@@ -20,6 +20,10 @@ import {
   khalaCodeVisualBaselineOptionsFromArgs,
   type KhalaCodeVisualBaselineOptions,
 } from "./visual-baseline-options"
+import {
+  assertKhalaCodePagePublicSafe,
+  assertKhalaCodePublicSafeValue,
+} from "./public-safety-oracle"
 import { installKhalaCodeVisualSmokeRpcMocks } from "./visual-smoke-rpc-mocks"
 
 export type Part2VisualViewport = Readonly<{
@@ -140,13 +144,12 @@ async function runPart2FleetGymVisualSmoke(
         await page.close()
       }
     }
-    await writeFile(
-      join(options.outDir, "summary.json"),
-      `${JSON.stringify({
-        harness: PART2_FLEET_GYM_VISUAL_SMOKE_HARNESS,
-        results,
-      }, null, 2)}\n`,
-    )
+    const summary = {
+      harness: PART2_FLEET_GYM_VISUAL_SMOKE_HARNESS,
+      results,
+    }
+    assertKhalaCodePublicSafeValue(summary, "Part 2 visual smoke summary")
+    await writeFile(join(options.outDir, "summary.json"), `${JSON.stringify(summary, null, 2)}\n`)
     return results
   } finally {
     if (browser !== null) await browser.close()
@@ -220,6 +223,8 @@ async function capturePart2FleetGym(
   assertTextIncludes(capture.parametersText, "parameters.khala_fleet_delegation.default.v1")
   assertTextIncludes(capture.parametersText, "source")
   assertTextIncludes(capture.parametersText, "default")
+  await assertKhalaCodePagePublicSafe(page, "Part 2 visual smoke")
+  assertKhalaCodePublicSafeValue(capture, "Part 2 visual smoke metadata")
 
   const screenshot = join(
     input.outDir,
@@ -250,7 +255,7 @@ async function capturePart2FleetGym(
     geometry: capture.geometry,
     loadedText: capture.loadedText,
     parametersText: capture.parametersText,
-    screenshot,
+    screenshot: basename(screenshot),
     visualBaseline,
     viewport: input.viewport.name,
   }
@@ -272,12 +277,14 @@ if (import.meta.main) {
       outDir,
       visualBaseline: khalaCodeVisualBaselineOptionsFromArgs(args),
     })
-    console.log(JSON.stringify({
+    const cliSummary = {
       harness: PART2_FLEET_GYM_VISUAL_SMOKE_HARNESS,
       ok: true,
-      outDir,
+      outDir: relative(process.cwd(), outDir) || ".",
       results,
-    }, null, 2))
+    }
+    assertKhalaCodePublicSafeValue(cliSummary, "Part 2 visual smoke CLI summary")
+    console.log(JSON.stringify(cliSummary, null, 2))
   } catch (error) {
     console.error(error instanceof Error ? error.stack ?? error.message : error)
     process.exit(1)

--- a/clients/khala-code-desktop/scripts/part2-ui-recording-smoke.ts
+++ b/clients/khala-code-desktop/scripts/part2-ui-recording-smoke.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env bun
 import { mkdir, rm, writeFile } from "node:fs/promises"
-import { dirname, join, resolve } from "node:path"
+import { basename, dirname, join, relative, resolve } from "node:path"
 
 import { chromium, type Browser, type Page } from "playwright"
 import {
@@ -23,6 +23,12 @@ import {
   khalaCodeVisualBaselineOptionsFromArgs,
   type KhalaCodeVisualBaselineOptions,
 } from "./visual-baseline-options"
+import {
+  assertKhalaCodePagePublicSafe,
+  assertKhalaCodePublicSafeText,
+  assertKhalaCodePublicSafeValue,
+  khalaCodeUnsafeTextPattern,
+} from "./public-safety-oracle"
 import { installKhalaCodeVisualSmokeRpcMocks } from "./visual-smoke-rpc-mocks"
 
 export type Part2UiSmokeViewport = Readonly<{
@@ -56,22 +62,14 @@ export const part2UiSmokeViewports = (): ReadonlyArray<Part2UiSmokeViewport> => 
 ]
 
 export const part2UiUnsafeTextPattern =
-  /\/Users\/|\/home\/|auth\.json|bearer|credential|provider[_-]?payload|raw[_-]?(prompt|trace|log|provider)|secret|sk-[a-z0-9]/i
-
-const legacyDeadEndPattern =
-  /codex_spawn_failed: No Pylon Codex assignment capacity is available right now|0\/1 available/i
+  khalaCodeUnsafeTextPattern
 
 const khalaPreviewFallbackPorts = (preferredPort: number): ReadonlyArray<number> =>
   Array.from({ length: 10 }, (_, index) => 50021 + index)
     .filter(port => port !== preferredPort)
 
 export const assertPart2UiPublicSafeText = (text: string): void => {
-  if (part2UiUnsafeTextPattern.test(text)) {
-    throw new Error("Part 2 UI smoke rendered private or raw material")
-  }
-  if (legacyDeadEndPattern.test(text)) {
-    throw new Error("Part 2 UI smoke regressed to the legacy 0/1 capacity dead-end")
-  }
+  assertKhalaCodePublicSafeText(text, "Part 2 UI smoke")
 }
 
 async function runPart2UiRecordingSmoke(
@@ -123,13 +121,12 @@ async function runPart2UiRecordingSmoke(
         await page.close()
       }
     }
-    await writeFile(
-      join(options.outDir, "summary.json"),
-      `${JSON.stringify({
-        harness: PART2_UI_RECORDING_SMOKE_HARNESS,
-        captures,
-      }, null, 2)}\n`,
-    )
+    const summary = {
+      harness: PART2_UI_RECORDING_SMOKE_HARNESS,
+      captures,
+    }
+    assertKhalaCodePublicSafeValue(summary, "Part 2 UI smoke summary")
+    await writeFile(join(options.outDir, "summary.json"), `${JSON.stringify(summary, null, 2)}\n`)
     return captures
   } finally {
     if (browser !== null) await browser.close()
@@ -270,8 +267,8 @@ async function capturePart2Ui(
   })
 
   return {
-    fleetScreenshot,
-    gymScreenshot,
+    fleetScreenshot: basename(fleetScreenshot),
+    gymScreenshot: basename(gymScreenshot),
     steps,
     visualBaselines: {
       fleet: fleetVisualBaseline,
@@ -294,8 +291,7 @@ const expectText = async (
 }
 
 const assertPagePublicSafe = async (page: Page): Promise<void> => {
-  const text = await page.locator("body").textContent()
-  assertPart2UiPublicSafeText(text ?? "")
+  await assertKhalaCodePagePublicSafe(page, "Part 2 UI smoke")
 }
 
 const assertDelegateRequestSafe = (args: readonly unknown[]): void => {
@@ -506,12 +502,14 @@ if (import.meta.main) {
     for (const capture of captures) {
       console.log(`- ${capture.viewport}: ${capture.steps.map(step => step.name).join(" -> ")}`)
     }
-    console.log(JSON.stringify({
+    const cliSummary = {
       harness: PART2_UI_RECORDING_SMOKE_HARNESS,
       ok: true,
-      outDir,
+      outDir: relative(process.cwd(), outDir) || ".",
       captures,
-    }, null, 2))
+    }
+    assertKhalaCodePublicSafeValue(cliSummary, "Part 2 UI smoke CLI summary")
+    console.log(JSON.stringify(cliSummary, null, 2))
   } catch (error) {
     console.error(error instanceof Error ? error.stack ?? error.message : error)
     process.exit(1)

--- a/clients/khala-code-desktop/scripts/public-safety-oracle.ts
+++ b/clients/khala-code-desktop/scripts/public-safety-oracle.ts
@@ -1,0 +1,47 @@
+export const khalaCodeUnsafeTextPattern =
+  /\/Users\/|\/home\/|~\/|auth\.json|bearer|credential|provider[_-]?payload|raw[_-]?(prompt|trace|log|provider)|secret|sk-[a-z0-9]|api[_-]?key|cookie|authorization/i
+
+const legacyDeadEndPattern =
+  /codex_spawn_failed: No Pylon Codex assignment capacity is available right now|0\/1 available/i
+
+export const assertKhalaCodePublicSafeText = (
+  text: string,
+  label = "Khala Code QA",
+): void => {
+  if (khalaCodeUnsafeTextPattern.test(text)) {
+    throw new Error(`${label} rendered private or raw material`)
+  }
+  if (legacyDeadEndPattern.test(text)) {
+    throw new Error(`${label} regressed to the legacy 0/1 capacity dead-end`)
+  }
+}
+
+export const assertKhalaCodePublicSafeValue = (
+  value: unknown,
+  label = "Khala Code QA",
+): void => {
+  const visit = (node: unknown): void => {
+    if (typeof node === "string") {
+      assertKhalaCodePublicSafeText(node, label)
+      return
+    }
+    if (node === null || typeof node !== "object") return
+    if (Array.isArray(node)) {
+      for (const entry of node) visit(entry)
+      return
+    }
+    for (const [key, entry] of Object.entries(node as Record<string, unknown>)) {
+      assertKhalaCodePublicSafeText(key, label)
+      visit(entry)
+    }
+  }
+  visit(value)
+}
+
+export const assertKhalaCodePagePublicSafe = async (
+  page: { locator: (selector: string) => { textContent: () => Promise<string | null> } },
+  label = "Khala Code QA",
+): Promise<void> => {
+  const text = await page.locator("body").textContent()
+  assertKhalaCodePublicSafeText(text ?? "", label)
+}

--- a/clients/khala-code-desktop/tests/app-shell.test.ts
+++ b/clients/khala-code-desktop/tests/app-shell.test.ts
@@ -1068,8 +1068,9 @@ describe("khala code desktop app shell", () => {
     expect(smoke).toContain("Run delegate")
     expect(smoke).toContain("candidate manifest")
     expect(smoke).toContain("Gym ingest")
-    expect(smoke).toContain("legacyDeadEndPattern")
     expect(smoke).toContain("part2UiUnsafeTextPattern")
+    expect(smoke).toContain("assertKhalaCodePublicSafeValue")
+    expect(smoke).toContain("assertKhalaCodePagePublicSafe")
   })
 
   test("does not seed dummy code or diff messages on first load", async () => {

--- a/clients/khala-code-desktop/tests/part2-ui-recording-smoke.test.ts
+++ b/clients/khala-code-desktop/tests/part2-ui-recording-smoke.test.ts
@@ -5,6 +5,10 @@ import {
   PART2_UI_RECORDING_SMOKE_HARNESS,
   part2UiSmokeViewports,
 } from "../scripts/part2-ui-recording-smoke"
+import {
+  assertKhalaCodePublicSafeValue,
+  khalaCodeUnsafeTextPattern,
+} from "../scripts/public-safety-oracle"
 
 describe("Part 2 UI recording smoke", () => {
   test("declares a single UI-first transcript 245 smoke over desktop and mobile", () => {
@@ -36,6 +40,23 @@ describe("Part 2 UI recording smoke", () => {
     ).toThrow("legacy")
   })
 
+  test("rejects unsafe screenshot-adjacent metadata in smoke summaries", () => {
+    expect(() =>
+      assertKhalaCodePublicSafeValue({
+        harness: PART2_UI_RECORDING_SMOKE_HARNESS,
+        screenshots: ["part2-ui-fleet-desktop.png"],
+        visualBaseline: { status: "matched", baseline: "screenshots/part2.png" },
+      }),
+    ).not.toThrow()
+    expect(() =>
+      assertKhalaCodePublicSafeValue({
+        harness: PART2_UI_RECORDING_SMOKE_HARNESS,
+        screenshots: ["/Users/operator/.codex/auth.json"],
+      }),
+    ).toThrow("private or raw")
+    expect(khalaCodeUnsafeTextPattern.test("raw_prompt.body")).toBe(true)
+  })
+
   test("wires every Mode D visual smoke through console oracles and seed RPC mocks", async () => {
     const scriptUrls = [
       "../scripts/part2-ui-recording-smoke.ts",
@@ -48,6 +69,7 @@ describe("Part 2 UI recording smoke", () => {
       const source = await Bun.file(scriptUrl).text()
       expect(source).toContain("installKhalaQaConsoleErrorOracle")
       expect(source).toContain("installKhalaCodeVisualSmokeRpcMocks")
+      expect(source).toContain("assertKhalaCodePublicSafe")
     }
 
     const rpcMocks = await Bun.file(


### PR DESCRIPTION
Closes #8049

## Summary
- Add a shared Khala Code public-safety oracle for DOM text and screenshot-adjacent smoke metadata.
- Wire Part 2, cockpit, composer, and Fleet/Gym visual smokes through the oracle before writing summaries or printing CLI evidence.
- Extend qa-runner headed/native artifact publication with text-value tripwires and add adversarial coverage.

## Verification
- `bun test clients/khala-code-desktop/tests/part2-ui-recording-smoke.test.ts apps/qa-runner/src/native-desktop-backend.test.ts apps/qa-runner/src/public-safety.test.ts` — 34 pass
- `bun run --cwd clients/khala-code-desktop test` — 527 pass
- `bun run --cwd apps/qa-runner test` — 469 pass
- `bun run --cwd clients/khala-code-desktop smoke:part2-ui` — PASS, desktop/mobile captures rendered with relative artifact refs
- `bun run check:deploy` — PASS