### PR TITLE
Add Khala Code architect plan flow

### DIFF
--- a/clients/khala-code-desktop/src/bun/architect-plan-store.ts
+++ b/clients/khala-code-desktop/src/bun/architect-plan-store.ts
@@ -1,0 +1,82 @@
+import { mkdir, readFile, writeFile } from "node:fs/promises"
+import { homedir } from "node:os"
+import { dirname, join } from "node:path"
+import { Schema as S } from "effect"
+
+import type { KhalaCodeDesktopArchitectPlanArtifact } from "../shared/rpc.js"
+
+const ARCHITECT_PLAN_STORE_SCHEMA = "khala-code-desktop.architect-plans.v1"
+
+const StoreFile = S.Struct({
+  schema: S.Literal(ARCHITECT_PLAN_STORE_SCHEMA),
+  plans: S.Record(S.String, S.Unknown),
+})
+
+type StoreFile = typeof StoreFile.Type
+
+type ChatEnv = Readonly<Record<string, string | undefined>>
+
+export type ArchitectPlanStore = Readonly<{
+  get: (
+    sessionId: string,
+    planRef: string,
+  ) => Promise<KhalaCodeDesktopArchitectPlanArtifact | null>
+  path: string
+  put: (
+    artifact: KhalaCodeDesktopArchitectPlanArtifact,
+  ) => Promise<KhalaCodeDesktopArchitectPlanArtifact>
+}>
+
+export const resolveArchitectPlanStorePath = (env: ChatEnv): string => {
+  const override = env.KHALA_CODE_DESKTOP_ARCHITECT_PLAN_STATE_PATH?.trim()
+  if (override !== undefined && override.length > 0) return override
+  const home = env.HOME?.trim() || homedir()
+  return join(home, ".khala-code", "architect-plans.json")
+}
+
+const storeKey = (sessionId: string, planRef: string): string =>
+  `${sessionId}:${planRef}`
+
+const emptyStore = (): StoreFile => ({
+  schema: ARCHITECT_PLAN_STORE_SCHEMA,
+  plans: {},
+})
+
+const readStore = async (path: string): Promise<StoreFile> => {
+  try {
+    return S.decodeUnknownSync(StoreFile)(JSON.parse(await readFile(path, "utf8")))
+  } catch {
+    return emptyStore()
+  }
+}
+
+const writeStore = async (path: string, store: StoreFile): Promise<void> => {
+  await mkdir(dirname(path), { recursive: true })
+  await writeFile(path, `${JSON.stringify(store, null, 2)}\n`, "utf8")
+}
+
+export const createArchitectPlanStore = (
+  input: { readonly env: ChatEnv; readonly path?: string },
+): ArchitectPlanStore => {
+  const path = input.path ?? resolveArchitectPlanStorePath(input.env)
+  return {
+    path,
+    async get(sessionId, planRef) {
+      const store = await readStore(path)
+      const artifact = store.plans[storeKey(sessionId, planRef)]
+      if (artifact === undefined) return null
+      return artifact as KhalaCodeDesktopArchitectPlanArtifact
+    },
+    async put(artifact) {
+      const store = await readStore(path)
+      await writeStore(path, {
+        schema: store.schema,
+        plans: {
+          ...store.plans,
+          [storeKey(artifact.sessionId, artifact.planRef)]: artifact,
+        },
+      })
+      return artifact
+    },
+  }
+}

--- a/clients/khala-code-desktop/src/bun/claude-app-sdk-chat-runtime.ts
+++ b/clients/khala-code-desktop/src/bun/claude-app-sdk-chat-runtime.ts
@@ -333,7 +333,10 @@ export function createClaudeAppSdkChatRuntime(
     (await sessionStore.get(desktopSessionId))?.sessionId ?? null
 
   const startTurn = async (
-    request: KhalaCodeDesktopChatTurnRequest & { readonly cwd?: string },
+    request: KhalaCodeDesktopChatTurnRequest & {
+      readonly claudePermissionMode?: string
+      readonly cwd?: string
+    },
   ): Promise<KhalaCodeDesktopChatTurnResponse> => {
     const desktopTurnId = request.turnId ?? `claude-turn-${Date.now().toString(36)}`
     const prompt = textFromRequest(request)
@@ -358,7 +361,10 @@ export function createClaudeAppSdkChatRuntime(
       canUseTool: approvalService.canUseTool,
       cwd: request.cwd ?? options.workingDirectory,
       includePartialMessages: true,
-      permissionMode: options.env?.KHALA_CODE_DESKTOP_CLAUDE_PERMISSION_MODE ?? "acceptEdits",
+      permissionMode:
+        request.claudePermissionMode ??
+        options.env?.KHALA_CODE_DESKTOP_CLAUDE_PERMISSION_MODE ??
+        "acceptEdits",
       ...(shouldResume ? { resume: threadId } : { sessionId: freshSessionId }),
       env: {
         ...options.env,

--- a/clients/khala-code-desktop/src/bun/codex-app-server-chat-runtime.ts
+++ b/clients/khala-code-desktop/src/bun/codex-app-server-chat-runtime.ts
@@ -125,6 +125,7 @@ export type CodexAppServerChatRuntime = Readonly<{
     request?: KhalaCodeDesktopCodexThreadStartRequest,
   ) => Promise<KhalaCodeDesktopCodexThreadResult>
   startTurn: (request: KhalaCodeDesktopChatTurnRequest & {
+    readonly claudePermissionMode?: string
     readonly cwd?: string
   }) => Promise<KhalaCodeDesktopChatTurnResponse>
   interruptTurn: (

--- a/clients/khala-code-desktop/src/bun/preview-rpc-policy.ts
+++ b/clients/khala-code-desktop/src/bun/preview-rpc-policy.ts
@@ -8,6 +8,8 @@ export const mutatingPreviewRpcMethods = new Set<KhalaCodeDesktopRpcMethodName>(
   "codexAppServerStart",
   "codexAppServerStop",
   "codexApprovalRespond",
+  "architectPlanDecision",
+  "architectPlanRun",
   "codexBackgroundTerminalsClean",
   "codexBackgroundTerminalsTerminate",
   "codexConfigValueWrite",

--- a/clients/khala-code-desktop/src/bun/rpc-handlers.ts
+++ b/clients/khala-code-desktop/src/bun/rpc-handlers.ts
@@ -32,6 +32,9 @@ import type { OnDeviceDeciderSelection } from "../shared/on-device-decider.js"
 import {
   type KhalaCodeDesktopAppInfo,
   type KhalaCodeDesktopChatTurnAttachment,
+  type KhalaCodeDesktopArchitectPlanArtifact,
+  type KhalaCodeDesktopArchitectPlanDecisionResult,
+  type KhalaCodeDesktopArchitectPlanRunResult,
   type KhalaCodeDesktopCodexAppServerActionResult,
   type KhalaCodeDesktopChatTurnEvent,
   type KhalaCodeDesktopChatTurnRequest,
@@ -113,6 +116,13 @@ import {
   createClaudeAppSdkChatRuntime,
   type ClaudeAppSdkChatRuntime,
 } from "./claude-app-sdk-chat-runtime.js"
+import { createArchitectPlanStore } from "./architect-plan-store.js"
+import {
+  claudePlanFanoutDagToWorkSource,
+  claudePlanFanoutPlanModeInstructions,
+  decodeClaudePlanFanoutDag,
+  type ClaudePlanFanoutDag,
+} from "./claude-plan-fanout.js"
 import { readKhalaCodeDesktopSessionCatalog } from "./session-catalog.js"
 import { inspectClaudeHarnessStatus } from "./claude-harness-status.js"
 import {
@@ -918,6 +928,7 @@ export function createKhalaCodeDesktopRpcRequestHandlers(
       }))
   const legacyChatTurn = input.legacyChatTurn ?? runKhalaCodeDesktopChatTurn
   const claudeApprovalService = input.claudeApprovalService ?? createClaudeApprovalService()
+  const architectPlanStore = createArchitectPlanStore({ env: input.env })
   const requireCodexChatRuntime = (): CodexAppServerChatRuntime => {
     if (codexChatRuntime === null) {
       throw new Error("Codex app-server chat runtime is not configured.")
@@ -961,6 +972,159 @@ export function createKhalaCodeDesktopRpcRequestHandlers(
     return { kind: "codex", runtime: requireCodexChatRuntime() }
   }
   let fleetMcpBridgeReady = false
+
+  const architectPlanDispatchMode = (
+    dag: ClaudePlanFanoutDag,
+  ): KhalaCodeDesktopArchitectPlanArtifact["dispatchMode"] =>
+    dag.nodes.length <= 2 ? "in_thread" : "fleet_run"
+
+  const extractArchitectPlanDag = (response: KhalaCodeDesktopChatTurnResponse): ClaudePlanFanoutDag => {
+    const text = response.messages.map(message => message.body).join("\n\n")
+    const fenced = /```(?:json)?\s*([\s\S]*?)```/iu.exec(text)?.[1]?.trim()
+    const candidate = fenced ?? text.slice(text.indexOf("{"), text.lastIndexOf("}") + 1)
+    if (candidate.length === 0) {
+      throw new Error("Claude architect did not return a JSON plan artifact.")
+    }
+    const parsed: unknown = JSON.parse(candidate)
+    return decodeClaudePlanFanoutDag(parsed)
+  }
+
+  const runArchitectPlan = async (
+    request: Parameters<KhalaCodeDesktopRPCSchema["requests"]["architectPlanRun"]>[0],
+  ): Promise<KhalaCodeDesktopArchitectPlanRunResult> => {
+    try {
+      requireNonEmpty("architectPlanRun", "objective", request.objective)
+      const turnId = `architect-plan-${randomUUID()}`
+      const prompt = [
+        claudePlanFanoutPlanModeInstructions(),
+        "",
+        "Return only the JSON object. Keep every field public-safe.",
+        `Session: ${request.sessionId}`,
+        `Objective: ${request.objective}`,
+        request.repo === undefined ? null : `Repo: ${request.repo}`,
+        request.branch === undefined ? null : `Branch: ${request.branch}`,
+        request.baseCommit === undefined ? null : `Base commit: ${request.baseCommit}`,
+        request.verify === undefined ? null : `Verify: ${request.verify}`,
+      ].filter((line): line is string => line !== null).join("\n")
+      const response = await requireClaudeChatRuntime().startTurn({
+        messages: [{ body: prompt, id: `${turnId}-request`, role: "user" }],
+        sessionId: request.sessionId,
+        startNewThread: request.threadId === undefined,
+        ...(request.threadId === undefined ? {} : { threadId: request.threadId }),
+        turnId,
+        cwd: input.workingDirectory,
+        claudePermissionMode: "plan",
+      })
+      const dag = extractArchitectPlanDag(response)
+      const now = new Date().toISOString()
+      const artifact: KhalaCodeDesktopArchitectPlanArtifact = {
+        schema: "openagents.khala_code.architect_plan_artifact.v1",
+        planRef: dag.planRef,
+        sessionId: request.sessionId,
+        createdAt: now,
+        updatedAt: now,
+        status: "pending_approval",
+        architectRole: {
+          role: "architect",
+          harness: "claude",
+          mode: "plan",
+          readOnly: true,
+        },
+        dispatchMode: architectPlanDispatchMode(dag),
+        dag,
+        fleetRunRef: null,
+        coderTurnId: null,
+      }
+      return { ok: true, artifact: await architectPlanStore.put(artifact) }
+    } catch (error) {
+      return {
+        ok: false,
+        error: error instanceof Error ? error.message : String(error),
+      }
+    }
+  }
+
+  const renderCoderPlanPrompt = (artifact: KhalaCodeDesktopArchitectPlanArtifact): string =>
+    [
+      "Execute this approved architect plan in the current Codex thread.",
+      "The Claude architect plan is advisory structure only; obey the deterministic verify command and local safety gates.",
+      "",
+      `Plan ${artifact.planRef}: ${artifact.dag.objective}`,
+      ...artifact.dag.nodes.map((node, index) => [
+        "",
+        `${index + 1}. ${node.title}`,
+        node.objective,
+        node.dependsOn === undefined || node.dependsOn.length === 0
+          ? null
+          : `Depends on: ${node.dependsOn.join(", ")}`,
+        node.verify ?? artifact.dag.verify ?? null,
+      ].filter((line): line is string => line !== null).join("\n")),
+    ].join("\n")
+
+  const decideArchitectPlan = async (
+    request: Parameters<KhalaCodeDesktopRPCSchema["requests"]["architectPlanDecision"]>[0],
+  ): Promise<KhalaCodeDesktopArchitectPlanDecisionResult> => {
+    try {
+      const existing = await architectPlanStore.get(request.sessionId, request.planRef)
+      if (existing === null) return { ok: false, error: "Plan artifact not found." }
+      const now = new Date().toISOString()
+      if (request.decision === "reject") {
+        const rejected = await architectPlanStore.put({
+          ...existing,
+          status: "rejected",
+          updatedAt: now,
+        })
+        return { ok: true, artifact: rejected, message: `Rejected plan ${request.planRef}.` }
+      }
+
+      if (existing.dispatchMode === "fleet_run") {
+        const result = await requireFleetRunSupervisor().start({
+          objective: existing.dag.objective,
+          runRef: `architect-${existing.planRef}`,
+          targetConcurrency: Math.min(5, Math.max(1, existing.dag.nodes.length)),
+          tickImmediately: true,
+          workerKind: "codex",
+          workSource: claudePlanFanoutDagToWorkSource(existing.dag),
+        })
+        const dispatched = await architectPlanStore.put({
+          ...existing,
+          status: "dispatched",
+          updatedAt: now,
+          fleetRunRef: result.run.runRef,
+        })
+        return {
+          ok: true,
+          artifact: dispatched,
+          message: `Approved plan ${request.planRef}; started FleetRun ${result.run.runRef}.`,
+        }
+      }
+
+      const turnId = `architect-coder-${randomUUID()}`
+      await requireCodexChatRuntime().startTurn({
+        messages: [{ body: renderCoderPlanPrompt(existing), id: `${turnId}-request`, role: "user" }],
+        sessionId: request.sessionId,
+        ...(request.threadId === undefined ? { startNewThread: true } : { threadId: request.threadId }),
+        turnId,
+        cwd: input.workingDirectory,
+      })
+      const dispatched = await architectPlanStore.put({
+        ...existing,
+        status: "dispatched",
+        updatedAt: now,
+        coderTurnId: turnId,
+      })
+      return {
+        ok: true,
+        artifact: dispatched,
+        message: `Approved plan ${request.planRef}; dispatched an in-thread Codex turn.`,
+      }
+    } catch (error) {
+      return {
+        ok: false,
+        error: error instanceof Error ? error.message : String(error),
+      }
+    }
+  }
 
   const maybeEnsureFleetMcpBridge = async (): Promise<CodexFleetMcpBridgeEnsureResult | null> => {
     if (input.enableFleetMcpBridge !== true || fleetMcpBridgeReady) return null
@@ -2055,6 +2219,12 @@ export function createKhalaCodeDesktopRpcRequestHandlers(
         run: result.run,
         supervisorActive: result.supervisorActive,
       }
+    },
+    async architectPlanRun(request): Promise<KhalaCodeDesktopArchitectPlanRunResult> {
+      return runArchitectPlan(request)
+    },
+    async architectPlanDecision(request): Promise<KhalaCodeDesktopArchitectPlanDecisionResult> {
+      return decideArchitectPlan(request)
     },
     async fleetRunControl(request): Promise<KhalaCodeDesktopFleetRunControlResult> {
       requireNonEmpty("fleetRunControl", "runRef", request.runRef)

--- a/clients/khala-code-desktop/src/shared/rpc.ts
+++ b/clients/khala-code-desktop/src/shared/rpc.ts
@@ -203,6 +203,11 @@ export type KhalaCodeDesktopFleetRunControlRequest = typeof RpcFleetRunControlRe
 export type KhalaCodeDesktopFleetRunControlResult = typeof RpcFleetRunControlResult.Type
 export type KhalaCodeDesktopFleetRunListRequest = typeof RpcFleetRunListRequest.Type
 export type KhalaCodeDesktopFleetRunListResult = typeof RpcFleetRunListResult.Type
+export type KhalaCodeDesktopArchitectPlanArtifact = typeof RpcArchitectPlanArtifact.Type
+export type KhalaCodeDesktopArchitectPlanRunRequest = typeof RpcArchitectPlanRunRequest.Type
+export type KhalaCodeDesktopArchitectPlanRunResult = typeof RpcArchitectPlanRunResult.Type
+export type KhalaCodeDesktopArchitectPlanDecisionRequest = typeof RpcArchitectPlanDecisionRequest.Type
+export type KhalaCodeDesktopArchitectPlanDecisionResult = typeof RpcArchitectPlanDecisionResult.Type
 export type KhalaCodeDesktopFleetWorkerControlRequest = typeof RpcFleetWorkerControlRequest.Type
 export type KhalaCodeDesktopFleetWorkerControlResult = typeof RpcFleetWorkerControlResult.Type
 export type KhalaCodeDesktopForumRequest = typeof RpcForumRequest.Type
@@ -1634,6 +1639,78 @@ const RpcFleetRunListResult = S.Struct({
   ok: S.Boolean,
   runs: S.Array(RpcFleetRunProjection),
 })
+const RpcArchitectPlanDispatchMode = S.Literals(["in_thread", "fleet_run"])
+const RpcArchitectPlanDagNode = S.Struct({
+  nodeRef: S.String,
+  title: S.String,
+  objective: S.String,
+  dependsOn: S.optional(RpcStringArray),
+  repo: S.optional(S.String),
+  branch: S.optional(S.String),
+  baseCommit: S.optional(S.String),
+  verify: S.optional(S.String),
+  issue: S.optional(S.Number),
+  labels: S.optional(RpcStringArray),
+  evidenceRefs: S.optional(RpcStringArray),
+})
+const RpcArchitectPlanDag = S.Struct({
+  schema: S.Literal("openagents.khala_code.claude_plan_fanout_dag.v1"),
+  planRef: S.String,
+  source: S.Literal("claude_plan_mode"),
+  generatedAt: S.String,
+  objective: S.String,
+  repo: S.optional(S.String),
+  branch: S.optional(S.String),
+  baseCommit: S.optional(S.String),
+  verify: S.optional(S.String),
+  evidenceRefs: S.optional(RpcStringArray),
+  nodes: S.Array(RpcArchitectPlanDagNode),
+})
+const RpcArchitectPlanArtifact = S.Struct({
+  schema: S.Literal("openagents.khala_code.architect_plan_artifact.v1"),
+  planRef: S.String,
+  sessionId: S.String,
+  createdAt: S.String,
+  updatedAt: S.String,
+  status: S.Literals(["pending_approval", "approved", "rejected", "dispatched"]),
+  architectRole: S.Struct({
+    role: S.Literal("architect"),
+    harness: S.Literal("claude"),
+    mode: S.Literal("plan"),
+    readOnly: S.Literal(true),
+  }),
+  dispatchMode: RpcArchitectPlanDispatchMode,
+  dag: RpcArchitectPlanDag,
+  fleetRunRef: RpcStringNull,
+  coderTurnId: RpcStringNull,
+})
+const RpcArchitectPlanRunRequest = S.Struct({
+  sessionId: S.String,
+  objective: S.String,
+  threadId: S.optional(S.String),
+  repo: S.optional(S.String),
+  branch: S.optional(S.String),
+  baseCommit: S.optional(S.String),
+  verify: S.optional(S.String),
+})
+const RpcArchitectPlanRunResult = S.Union([
+  S.Struct({ ok: S.Literal(true), artifact: RpcArchitectPlanArtifact }),
+  S.Struct({ ok: S.Literal(false), error: S.String }),
+])
+const RpcArchitectPlanDecisionRequest = S.Struct({
+  sessionId: S.String,
+  planRef: S.String,
+  decision: S.Literals(["approve", "reject"]),
+  threadId: S.optional(S.String),
+})
+const RpcArchitectPlanDecisionResult = S.Union([
+  S.Struct({
+    ok: S.Literal(true),
+    artifact: RpcArchitectPlanArtifact,
+    message: S.String,
+  }),
+  S.Struct({ ok: S.Literal(false), error: S.String }),
+])
 const RpcFleetWorkerControlVerb = S.Literals(["interrupt", "retry", "flag"])
 const RpcFleetWorkerControlRequest = S.Struct({
   assignmentRef: RpcStringNull,
@@ -1800,6 +1877,8 @@ export const KhalaCodeDesktopRpcMethodSchemas = {
   fleetRunList: { parameters: [optionalParam(RpcFleetRunListRequest)], result: RpcFleetRunListResult },
   fleetRunStart: { parameters: [param(RpcFleetRunStartRequest)], result: RpcFleetRunStartResult },
   fleetRunStatus: { parameters: [param(RpcFleetRunStatusRequest)], result: RpcFleetRunStatusResult },
+  architectPlanRun: { parameters: [param(RpcArchitectPlanRunRequest)], result: RpcArchitectPlanRunResult },
+  architectPlanDecision: { parameters: [param(RpcArchitectPlanDecisionRequest)], result: RpcArchitectPlanDecisionResult },
   fleetWorkerControl: { parameters: [param(RpcFleetWorkerControlRequest)], result: RpcFleetWorkerControlResult },
   forumRequest: { parameters: [param(RpcForumRequest)], result: RpcForumResponse },
   khalaCodePlanCatalog: { parameters: noParams(), result: RpcKhalaCodePlanCatalogResult },
@@ -1955,6 +2034,8 @@ export type KhalaCodeDesktopRPCSchema = {
     fleetRunList(request?: KhalaCodeDesktopFleetRunListRequest): Promise<KhalaCodeDesktopFleetRunListResult>
     fleetRunStart(request: KhalaCodeDesktopFleetRunStartRequest): Promise<KhalaCodeDesktopFleetRunStartResult>
     fleetRunStatus(request: KhalaCodeDesktopFleetRunStatusRequest): Promise<KhalaCodeDesktopFleetRunStatusResult>
+    architectPlanRun(request: KhalaCodeDesktopArchitectPlanRunRequest): Promise<KhalaCodeDesktopArchitectPlanRunResult>
+    architectPlanDecision(request: KhalaCodeDesktopArchitectPlanDecisionRequest): Promise<KhalaCodeDesktopArchitectPlanDecisionResult>
     fleetWorkerControl(request: KhalaCodeDesktopFleetWorkerControlRequest): Promise<KhalaCodeDesktopFleetWorkerControlResult>
     forumRequest(request: KhalaCodeDesktopForumRequest): Promise<KhalaCodeDesktopForumResponse>
     khalaCodePlanCatalog(): Promise<KhalaCodeDesktopPlanCatalogResult>

--- a/clients/khala-code-desktop/src/ui/main-shell-model.ts
+++ b/clients/khala-code-desktop/src/ui/main-shell-model.ts
@@ -8,6 +8,7 @@ import type {
   KhalaCodeDesktopMessage,
   KhalaCodeDesktopRPCSchema,
   KhalaCodeDesktopRuntimeMode,
+  KhalaCodeDesktopArchitectPlanArtifact,
   KhalaCodeDesktopThreadTokenSummary,
 } from "../shared/rpc"
 
@@ -53,6 +54,9 @@ export type KhalaCodeMainShellModel = {
   loadedSlashCommandKey: string
   messages: KhalaCodeDesktopMessage[]
   pendingTurn: boolean
+  architectPlanArtifact: KhalaCodeDesktopArchitectPlanArtifact | null
+  architectPlanMode: boolean
+  architectPlanPending: boolean
   selectedHarnessMode: KhalaCodeDesktopRuntimeMode
   slashCommandLoadInFlight: Promise<void> | null
   slashCommands: KhalaCodeMainShellSlashCommand[]
@@ -103,6 +107,12 @@ export type KhalaCodeMainShellMessage =
     }
   | { readonly _tag: "PendingTurnChanged"; readonly pending: boolean }
   | {
+      readonly _tag: "ArchitectPlanArtifactChanged"
+      readonly artifact: KhalaCodeDesktopArchitectPlanArtifact | null
+    }
+  | { readonly _tag: "ArchitectPlanModeChanged"; readonly enabled: boolean }
+  | { readonly _tag: "ArchitectPlanPendingChanged"; readonly pending: boolean }
+  | {
       readonly _tag: "SlashCommandLoadFinished"
       readonly commands: readonly KhalaCodeMainShellSlashCommand[]
       readonly key: string
@@ -142,6 +152,9 @@ export const initialKhalaCodeMainShellModel = (
   loadedSlashCommandKey: "",
   messages: [],
   pendingTurn: false,
+  architectPlanArtifact: null,
+  architectPlanMode: false,
+  architectPlanPending: false,
   selectedHarnessMode: "codex_harness",
   slashCommandLoadInFlight: null,
   slashCommands: [],
@@ -206,6 +219,12 @@ export const updateKhalaCodeMainShellModel = (
       return { ...model, messages: [...message.messages] }
     case "PendingTurnChanged":
       return { ...model, pendingTurn: message.pending }
+    case "ArchitectPlanArtifactChanged":
+      return { ...model, architectPlanArtifact: message.artifact }
+    case "ArchitectPlanModeChanged":
+      return { ...model, architectPlanMode: message.enabled }
+    case "ArchitectPlanPendingChanged":
+      return { ...model, architectPlanPending: message.pending }
     case "SlashCommandLoadFinished":
       return {
         ...model,

--- a/clients/khala-code-desktop/src/ui/main.ts
+++ b/clients/khala-code-desktop/src/ui/main.ts
@@ -47,6 +47,7 @@ import {
   decodeKhalaCodeDesktopRpcParameters,
   decodeKhalaCodeDesktopRpcResult,
   type KhalaCodeDesktopRpcMethodName,
+  type KhalaCodeDesktopArchitectPlanArtifact,
   type KhalaCodeDesktopChatTurnAttachment,
   type KhalaCodeDesktopChatTurnEvent,
   type KhalaCodeDesktopFleetLifecycleEvent,
@@ -229,6 +230,14 @@ const previewRpc = (): DesktopRpc => ({
       postPreviewRpc<
         Awaited<ReturnType<DesktopRpcRequests["fleetRunStatus"]>>
       >("fleetRunStatus", request),
+    architectPlanRun: request =>
+      postPreviewRpc<
+        Awaited<ReturnType<DesktopRpcRequests["architectPlanRun"]>>
+      >("architectPlanRun", request),
+    architectPlanDecision: request =>
+      postPreviewRpc<
+        Awaited<ReturnType<DesktopRpcRequests["architectPlanDecision"]>>
+      >("architectPlanDecision", request),
     fleetWorkerControl: request =>
       postPreviewRpc<
         Awaited<ReturnType<DesktopRpcRequests["fleetWorkerControl"]>>
@@ -1061,6 +1070,16 @@ const setShellComposerState = (
 const setShellFollowUpDrafts = (
   drafts: readonly KhalaCodeFollowUpDraft[],
 ): void => dispatchMainShell({ _tag: "FollowUpDraftsChanged", drafts })
+
+const setArchitectPlanArtifact = (
+  artifact: KhalaCodeDesktopArchitectPlanArtifact | null,
+): void => dispatchMainShell({ _tag: "ArchitectPlanArtifactChanged", artifact })
+
+const setArchitectPlanMode = (enabled: boolean): void =>
+  dispatchMainShell({ _tag: "ArchitectPlanModeChanged", enabled })
+
+const setArchitectPlanPending = (pending: boolean): void =>
+  dispatchMainShell({ _tag: "ArchitectPlanPendingChanged", pending })
 
 const bootFailureDetail = (error: unknown): string =>
   error instanceof Error ? error.message : typeof error === "string" ? error : "boot RPC failed"
@@ -2038,9 +2057,121 @@ const renderAttachmentRail = (): void => {
   )
 }
 
+const renderArchitectPlanNode = (
+  node: KhalaCodeDesktopArchitectPlanArtifact["dag"]["nodes"][number],
+): HTMLElement => {
+  const item = document.createElement("li")
+  item.className = "khala-architect-plan-node"
+
+  const title = document.createElement("span")
+  title.className = "khala-architect-plan-node-title"
+  title.textContent = node.title
+
+  const objective = document.createElement("span")
+  objective.className = "khala-architect-plan-node-objective"
+  objective.textContent = node.objective
+
+  const meta = document.createElement("span")
+  meta.className = "khala-architect-plan-node-meta"
+  meta.textContent = [
+    node.nodeRef,
+    node.issue === undefined ? null : `#${node.issue}`,
+    node.dependsOn === undefined || node.dependsOn.length === 0
+      ? null
+      : `after ${node.dependsOn.join(", ")}`,
+  ].filter((value): value is string => value !== null).join(" · ")
+
+  item.replaceChildren(title, objective, meta)
+  return item
+}
+
+const decideArchitectPlan = async (decision: "approve" | "reject"): Promise<void> => {
+  const artifact = shellModel().architectPlanArtifact
+  if (artifact === null || shellModel().architectPlanPending) return
+  setArchitectPlanPending(true)
+  renderComposer()
+  try {
+    const activeThreadId = shellModel().activeCodexThreadId
+    const result = await controls.architectPlanDecision({
+      decision,
+      planRef: artifact.planRef,
+      sessionId,
+      ...(activeThreadId === null ? {} : { threadId: activeThreadId }),
+    })
+    if (!result.ok) {
+      appendMessages([{ body: `Architect plan decision failed: ${result.error}`, id: nextMessageId("system"), role: "system" }])
+      return
+    }
+    setArchitectPlanArtifact(result.artifact)
+    appendMessages([{ body: result.message, id: nextMessageId("system"), role: "system" }])
+  } catch (error) {
+    appendMessages([{
+      body: `Architect plan decision failed: ${error instanceof Error ? error.message : String(error)}`,
+      id: nextMessageId("system"),
+      role: "system",
+    }])
+  } finally {
+    setArchitectPlanPending(false)
+    renderComposer()
+    requestAnimationFrame(focusComposerInput)
+  }
+}
+
+const renderArchitectPlanCard = (
+  artifact: KhalaCodeDesktopArchitectPlanArtifact,
+): HTMLElement => {
+  const card = document.createElement("section")
+  card.className = "khala-architect-plan-card"
+  card.dataset.architectPlanRef = artifact.planRef
+  card.dataset.architectPlanStatus = artifact.status
+  card.dataset.architectPlanDispatchMode = artifact.dispatchMode
+
+  const header = document.createElement("div")
+  header.className = "khala-architect-plan-header"
+
+  const title = document.createElement("div")
+  title.className = "khala-architect-plan-title"
+  title.textContent = "Architect plan"
+
+  const status = document.createElement("span")
+  status.className = "khala-architect-plan-status"
+  status.textContent = `${artifact.status.replace(/_/gu, " ")} · ${artifact.dispatchMode.replace("_", "-")}`
+
+  header.replaceChildren(title, status)
+
+  const objective = document.createElement("p")
+  objective.className = "khala-architect-plan-objective"
+  objective.textContent = artifact.dag.objective
+
+  const nodes = document.createElement("ol")
+  nodes.className = "khala-architect-plan-nodes"
+  nodes.replaceChildren(...artifact.dag.nodes.map(renderArchitectPlanNode))
+
+  const actions = document.createElement("div")
+  actions.className = "khala-architect-plan-actions"
+  const approve = document.createElement("button")
+  approve.type = "button"
+  approve.className = "khala-architect-plan-action khala-architect-plan-action--primary"
+  approve.disabled = artifact.status !== "pending_approval" || shellModel().architectPlanPending
+  approve.textContent = artifact.dispatchMode === "fleet_run" ? "Start FleetRun" : "Approve"
+  approve.addEventListener("click", () => void decideArchitectPlan("approve"))
+
+  const reject = document.createElement("button")
+  reject.type = "button"
+  reject.className = "khala-architect-plan-action"
+  reject.disabled = artifact.status !== "pending_approval" || shellModel().architectPlanPending
+  reject.textContent = "Reject"
+  reject.addEventListener("click", () => void decideArchitectPlan("reject"))
+
+  actions.replaceChildren(approve, reject)
+  card.replaceChildren(header, objective, nodes, actions)
+  return card
+}
+
 const renderComposerPreview = (): void => {
-  composerPreview.hidden = true
-  composerPreview.replaceChildren()
+  const artifact = shellModel().architectPlanArtifact
+  composerPreview.hidden = artifact === null
+  composerPreview.replaceChildren(...(artifact === null ? [] : [renderArchitectPlanCard(artifact)]))
 }
 
 const slashCommandPlatform = (): string => {
@@ -2082,13 +2213,35 @@ const slashCommandQuery = (): string | null => {
   return value.slice(1).split(/\s+/)[0]?.toLowerCase() ?? ""
 }
 
+const architectSlashCommand = (): KhalaCodeMainShellSlashCommand => ({
+  aliases: [],
+  availability: shellModel().pendingTurn
+    ? {
+      available: false,
+      reason: "Architect plan mode starts from an idle composer.",
+    }
+    : { available: true },
+  availableDuringTask: false,
+  availableInSideConversation: false,
+  command: "architect",
+  debug: false,
+  description: "Run Claude architect plan mode and render an approvable DAG",
+  dispatch: { action: "architect_plan", kind: "client" },
+  enumName: "Architect",
+  group: "turn_task",
+  supportsInlineArgs: true,
+  visibility: { kind: "always" },
+})
+
 const matchingSlashCommands = (): readonly KhalaCodeMainShellSlashCommand[] => {
   const query = slashCommandQuery()
   if (query === null) return []
-  return shellModel().slashCommands.filter(command =>
+  const local = "architect".includes(query) ? [architectSlashCommand()] : []
+  const remote = shellModel().slashCommands.filter(command =>
     command.command.includes(query) ||
     command.aliases.some(alias => alias.includes(query))
   ).slice(0, 8)
+  return [...local, ...remote].slice(0, 8)
 }
 
 const selectSlashCommand = (command: KhalaCodeMainShellSlashCommand): void => {
@@ -2135,6 +2288,29 @@ function renderSlashCommandPalette(): void {
   )
 }
 
+const renderArchitectPlanModeButton = (): HTMLButtonElement => {
+  const button = document.createElement("button")
+  button.type = "button"
+  button.className = "khala-architect-plan-toggle"
+  button.dataset.active = shellModel().architectPlanMode ? "true" : "false"
+  button.title = "Run next prompt through Claude architect plan mode"
+  button.setAttribute("aria-label", "Toggle architect plan mode")
+  button.setAttribute("aria-pressed", String(shellModel().architectPlanMode))
+  button.disabled = shellModel().pendingTurn || shellModel().architectPlanPending
+
+  const label = document.createElement("span")
+  label.className = "khala-architect-plan-toggle-label"
+  label.textContent = "Plan"
+
+  button.replaceChildren(composerIconElement("model"), label)
+  button.addEventListener("click", () => {
+    setArchitectPlanMode(!shellModel().architectPlanMode)
+    renderComposer()
+    requestAnimationFrame(focusComposerInput)
+  })
+  return button
+}
+
 function renderComposer(): void {
   const status = statusForComposer()
   const sendLabel = buttonLabel(status)
@@ -2155,6 +2331,7 @@ function renderComposer(): void {
     sendLabel
   composerControls.replaceChildren(
     attachButton,
+    renderArchitectPlanModeButton(),
     // renderHarnessPill(),
   )
 
@@ -2167,6 +2344,8 @@ function renderComposer(): void {
   composerA11y.textContent =
     `${statusLabelFor(status)}. ${attachmentCount} attachments. ` +
     `${followUpCount} queued follow-ups. ` +
+    `${shellModel().architectPlanMode ? "Architect plan mode on. " : ""}` +
+    `${shellModel().architectPlanPending ? "Architect plan pending. " : ""}` +
     `${composerInput.value.length} characters.`
 
   renderFollowUpQueue()
@@ -2647,6 +2826,8 @@ const handleSlashCommandClientAction = async (
   result: Awaited<ReturnType<DesktopRpcRequests["slashCommandDispatch"]>>,
 ): Promise<string> => {
   switch (result.action) {
+    case "architect_plan":
+      return "Type /architect followed by a public-safe objective, or use the Plan toggle for the next message."
     case "clear_visible_transcript":
       setShellMessages([])
       setShellFollowUpDrafts([])
@@ -2687,6 +2868,48 @@ const appendSlashCommandResult = async (
     id: nextMessageId("system"),
     role: "system",
   }])
+}
+
+const submitArchitectPlan = async (objective: string): Promise<KhalaCodeDesktopMessage | null> => {
+  if (objective.trim().length === 0) return null
+  shellModel().lastSubmittedDraft = objective
+  shellModel().lastTurnFailed = false
+  setArchitectPlanPending(true)
+  resetComposerDraft()
+  const message = addMessage("user", `/architect ${objective}`)
+  renderComposer()
+  try {
+    const activeThreadId = shellModel().activeCodexThreadId
+    const result = await controls.architectPlanRun({
+      objective,
+      sessionId,
+      ...(activeThreadId === null ? {} : { threadId: activeThreadId }),
+    })
+    if (!result.ok) {
+      appendMessages([{ body: `Architect plan failed: ${result.error}`, id: nextMessageId("system"), role: "system" }])
+      shellModel().lastTurnFailed = true
+      return message
+    }
+    setArchitectPlanArtifact(result.artifact)
+    appendMessages([{
+      body: `Claude architect returned plan ${result.artifact.planRef} with ${result.artifact.dag.nodes.length} nodes.`,
+      id: nextMessageId("system"),
+      role: "system",
+    }])
+  } catch (error) {
+    shellModel().lastTurnFailed = true
+    appendMessages([{
+      body: `Architect plan failed: ${error instanceof Error ? error.message : String(error)}`,
+      id: nextMessageId("system"),
+      role: "system",
+    }])
+  } finally {
+    setArchitectPlanPending(false)
+    setArchitectPlanMode(false)
+    renderComposer()
+    requestAnimationFrame(focusComposerInput)
+  }
+  return message
 }
 
 const submitSlashCommand = async (
@@ -2740,6 +2963,9 @@ const submitComposer = async (): Promise<KhalaCodeDesktopMessage | null> => {
       return null
     }
     if (draftText.startsWith("/")) {
+      if (draftText === "/architect" || draftText.startsWith("/architect ")) {
+        return submitArchitectPlan(draftText.replace(/^\/architect\b/u, "").trim())
+      }
       return submitSlashCommand(draftText, draftText)
     }
     queueFollowUpDraft(draftText)
@@ -2754,7 +2980,21 @@ const submitComposer = async (): Promise<KhalaCodeDesktopMessage | null> => {
   const attachments = [...shellModel().composerState.doc.attachments]
   const body = submittedBody(draftText, attachments)
   if (draftText.startsWith("/")) {
+    if (draftText === "/architect" || draftText.startsWith("/architect ")) {
+      return submitArchitectPlan(draftText.replace(/^\/architect\b/u, "").trim())
+    }
     return submitSlashCommand(draftText, body)
+  }
+  if (shellModel().architectPlanMode) {
+    if (attachments.length > 0) {
+      appendMessages([{
+        body: "Architect plan mode is read-only and accepts text objectives only. Remove attachments or turn plan mode off.",
+        id: nextMessageId("system"),
+        role: "system",
+      }])
+      return null
+    }
+    return submitArchitectPlan(draftText)
   }
   const imageAttachments = await imageAttachmentsForSubmit(attachments)
   shellModel().lastSubmittedDraft = draftText
@@ -3135,6 +3375,10 @@ const controls = {
     rpc.request.fleetRunList(request),
   fleetRunStart: (request: Parameters<DesktopRpcRequests["fleetRunStart"]>[0]) =>
     rpc.request.fleetRunStart(request),
+  architectPlanRun: (request: Parameters<DesktopRpcRequests["architectPlanRun"]>[0]) =>
+    rpc.request.architectPlanRun(request),
+  architectPlanDecision: (request: Parameters<DesktopRpcRequests["architectPlanDecision"]>[0]) =>
+    rpc.request.architectPlanDecision(request),
   fleetWorkerControl: (request: Parameters<DesktopRpcRequests["fleetWorkerControl"]>[0]) =>
     rpc.request.fleetWorkerControl(request),
   forumRequest: (request: Parameters<DesktopRpcRequests["forumRequest"]>[0]) =>

--- a/clients/khala-code-desktop/src/ui/styles.css
+++ b/clients/khala-code-desktop/src/ui/styles.css
@@ -881,6 +881,39 @@ button {
   box-shadow: 0 0 0 1px color-mix(in srgb, var(--oa-color-khala-energy-cyan) 68%, transparent);
 }
 
+.khala-architect-plan-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 5px;
+  height: 32px;
+  border: 1px solid color-mix(in srgb, var(--oa-color-khala-energy-blue) 42%, transparent);
+  border-radius: 2px;
+  background: color-mix(in srgb, var(--oa-color-khala-surface-active) 58%, transparent);
+  color: color-mix(in srgb, var(--oa-color-khala-text-body) 88%, transparent);
+  cursor: pointer;
+  font-family: var(--oa-font-code);
+  font-size: 0.75rem;
+  line-height: 1;
+  padding: 0 9px;
+}
+
+.khala-architect-plan-toggle[data-active="true"],
+.khala-architect-plan-toggle:hover,
+.khala-architect-plan-toggle:focus-visible {
+  border-color: color-mix(in srgb, var(--oa-color-khala-energy-cyan) 74%, transparent);
+  background:
+    linear-gradient(180deg, color-mix(in srgb, var(--oa-color-khala-energy-cyan) 12%, transparent), transparent 70%),
+    color-mix(in srgb, var(--oa-color-khala-surface-active) 76%, transparent);
+  color: var(--oa-color-khala-text-bright);
+  outline: none;
+}
+
+.khala-architect-plan-toggle:disabled {
+  cursor: not-allowed;
+  opacity: 0.52;
+}
+
 #composer-input {
   min-height: 3.45rem;
   width: 100%;
@@ -1179,6 +1212,106 @@ button {
 
 .khala-code-composer-preview {
   max-height: 12rem;
+}
+
+.khala-architect-plan-card {
+  display: grid;
+  gap: 9px;
+  max-height: 12rem;
+  overflow: auto;
+  border: 1px solid color-mix(in srgb, var(--oa-color-khala-energy-blue) 42%, transparent);
+  border-radius: 4px;
+  background:
+    linear-gradient(180deg, color-mix(in srgb, var(--oa-color-khala-energy-cyan) 7%, transparent), transparent 54%),
+    color-mix(in srgb, var(--oa-color-khala-void) 72%, transparent);
+  color: var(--oa-color-khala-text-body);
+  padding: 10px;
+}
+
+.khala-architect-plan-header,
+.khala-architect-plan-actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.khala-architect-plan-title {
+  color: var(--oa-color-khala-text-bright);
+  font-family: var(--oa-font-code);
+  font-size: 0.78rem;
+  font-weight: 700;
+}
+
+.khala-architect-plan-status,
+.khala-architect-plan-node-meta {
+  color: color-mix(in srgb, var(--oa-color-khala-energy-soft) 84%, transparent);
+  font-family: var(--oa-font-code);
+  font-size: 0.7rem;
+}
+
+.khala-architect-plan-objective {
+  margin: 0;
+  color: color-mix(in srgb, var(--oa-color-khala-text-body) 92%, transparent);
+  font-size: 0.78rem;
+  line-height: 1.4;
+}
+
+.khala-architect-plan-nodes {
+  display: grid;
+  gap: 6px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.khala-architect-plan-node {
+  display: grid;
+  gap: 3px;
+  padding: 7px;
+  border: 1px solid color-mix(in srgb, var(--oa-color-khala-border) 84%, transparent);
+  border-radius: 3px;
+  background: color-mix(in srgb, var(--oa-color-khala-surface-raised) 58%, transparent);
+}
+
+.khala-architect-plan-node-title {
+  color: var(--oa-color-khala-text-primary);
+  font-size: 0.78rem;
+  font-weight: 700;
+}
+
+.khala-architect-plan-node-objective {
+  color: var(--oa-color-khala-text-body);
+  font-size: 0.75rem;
+  line-height: 1.35;
+}
+
+.khala-architect-plan-action {
+  height: 26px;
+  border: 1px solid color-mix(in srgb, var(--oa-color-khala-energy-blue) 38%, transparent);
+  border-radius: 2px;
+  background: color-mix(in srgb, var(--oa-color-khala-surface-active) 62%, transparent);
+  color: var(--oa-color-khala-text-body);
+  cursor: pointer;
+  font-family: var(--oa-font-code);
+  font-size: 0.72rem;
+  padding: 0 8px;
+}
+
+.khala-architect-plan-action--primary {
+  border-color: color-mix(in srgb, var(--oa-color-khala-energy-cyan) 68%, transparent);
+  color: var(--oa-color-khala-text-bright);
+}
+
+.khala-architect-plan-action:hover,
+.khala-architect-plan-action:focus-visible {
+  border-color: color-mix(in srgb, var(--oa-color-khala-energy-cyan) 88%, transparent);
+  outline: none;
+}
+
+.khala-architect-plan-action:disabled {
+  cursor: not-allowed;
+  opacity: 0.54;
 }
 
 .cb {

--- a/clients/khala-code-desktop/tests/app-shell.test.ts
+++ b/clients/khala-code-desktop/tests/app-shell.test.ts
@@ -124,6 +124,31 @@ describe("khala code desktop app shell", () => {
     expect(html).not.toContain("Pylons")
   })
 
+  test("wires the architect plan-first composer surface", async () => {
+    const main = await Bun.file(new URL("../src/ui/main.ts", import.meta.url)).text()
+    const model = await Bun.file(new URL("../src/ui/main-shell-model.ts", import.meta.url)).text()
+    const rpc = await Bun.file(new URL("../src/shared/rpc.ts", import.meta.url)).text()
+    const css = await Bun.file(new URL("../src/ui/styles.css", import.meta.url)).text()
+
+    expect(rpc).toContain("architectPlanRun")
+    expect(rpc).toContain("architectPlanDecision")
+    expect(rpc).toContain("openagents.khala_code.architect_plan_artifact.v1")
+    expect(model).toContain("architectPlanArtifact")
+    expect(model).toContain("architectPlanMode")
+    expect(model).toContain("architectPlanPending")
+    expect(main).toContain("architectSlashCommand")
+    expect(main).toContain('command: "architect"')
+    expect(main).toContain('action: "architect_plan"')
+    expect(main).toContain("renderArchitectPlanModeButton")
+    expect(main).toContain("submitArchitectPlan")
+    expect(main).toContain('draftText.startsWith("/architect ")')
+    expect(main).toContain("renderArchitectPlanCard")
+    expect(main).toContain("architectPlanDecision")
+    expect(css).toContain(".khala-architect-plan-toggle")
+    expect(css).toContain(".khala-architect-plan-card")
+    expect(css).toContain(".khala-architect-plan-actions")
+  })
+
   test("keeps backend runtime hooks while visible composer selectors stay commented out", async () => {
     const main = await Bun.file(new URL("../src/ui/main.ts", import.meta.url)).text()
     const css = await Bun.file(new URL("../src/ui/styles.css", import.meta.url)).text()

--- a/clients/khala-code-desktop/tests/rpc-handlers.test.ts
+++ b/clients/khala-code-desktop/tests/rpc-handlers.test.ts
@@ -513,6 +513,217 @@ describe("Khala Code desktop RPC handlers", () => {
     })
   })
 
+  test("runs Claude architect plan mode and persists an approvable plan artifact", async () => {
+    const root = await mkdtemp(join(tmpdir(), "khala-code-architect-plan-"))
+    tempDirs.push(root)
+    let observedPermissionMode: string | undefined
+    const handlers = createKhalaCodeDesktopRpcRequestHandlers({
+      appleFmReadiness: () => {
+        throw new Error("not used")
+      },
+      claudeChatRuntime: throwingClaudeChatRuntime({
+        startTurn: async request => {
+          observedPermissionMode = request.claudePermissionMode
+          return {
+            backend: {
+              kind: "claude_app_sdk",
+              model: "claude-app-sdk",
+              runtimeMode: "claude_runtime",
+              threadId: "claude-plan-thread",
+              turnId: request.turnId ?? "claude-plan-turn",
+            },
+            messages: [{
+              id: "claude-plan-message",
+              role: "assistant",
+              body: JSON.stringify({
+                schema: "openagents.khala_code.claude_plan_fanout_dag.v1",
+                planRef: "plan.q9_2.small",
+                source: "claude_plan_mode",
+                generatedAt: "2026-07-02T18:00:00.000Z",
+                objective: "Plan a bounded implementation for issue #8053.",
+                repo: "OpenAgentsInc/openagents",
+                branch: "main",
+                baseCommit: "80986c141c64f0d2ecb9dea373f9d148c74054b6",
+                verify: "bun run check:deploy",
+                nodes: [{
+                  nodeRef: "node.ui",
+                  title: "Wire plan card",
+                  objective: "Add the plan-mode card and approval controls.",
+                  issue: 8053,
+                }],
+              }),
+            }],
+            ok: true,
+            toolNames: [],
+            usedTools: [],
+          }
+        },
+      }),
+      env: { HOME: root },
+      onDeviceDeciderStatus: () => {
+        throw new Error("not used")
+      },
+      workingDirectory: process.cwd(),
+    })
+
+    const result = await handlers.architectPlanRun({
+      objective: "Plan issue #8053",
+      sessionId: "desktop-session-plan",
+    })
+
+    expect(result.ok).toBe(true)
+    if (!result.ok) throw new Error(result.error)
+    expect(observedPermissionMode).toBe("plan")
+    expect(result.artifact).toMatchObject({
+      planRef: "plan.q9_2.small",
+      sessionId: "desktop-session-plan",
+      status: "pending_approval",
+      dispatchMode: "in_thread",
+      architectRole: {
+        role: "architect",
+        harness: "claude",
+        mode: "plan",
+        readOnly: true,
+      },
+    })
+    expect(await readFile(join(root, ".khala-code", "architect-plans.json"), "utf8"))
+      .toContain("plan.q9_2.small")
+  })
+
+  test("rejects and approves persisted architect plans through typed dispatch paths", async () => {
+    const root = await mkdtemp(join(tmpdir(), "khala-code-architect-decision-"))
+    tempDirs.push(root)
+    const codexTurns: string[] = []
+    const fleetStarts: KhalaCodeDesktopFleetRunStartRequest[] = []
+    const run = fleetRunProjection({ runRef: "architect-plan.q9_2.large" })
+    const planBody = (planRef: string, nodeCount: number) => JSON.stringify({
+      schema: "openagents.khala_code.claude_plan_fanout_dag.v1",
+      planRef,
+      source: "claude_plan_mode",
+      generatedAt: "2026-07-02T18:00:00.000Z",
+      objective: `Plan ${planRef}.`,
+      nodes: Array.from({ length: nodeCount }, (_, index) => ({
+        nodeRef: `node.${index + 1}`,
+        title: `Node ${index + 1}`,
+        objective: `Do bounded work ${index + 1}.`,
+        ...(index === 0 ? {} : { dependsOn: [`node.${index}`] }),
+      })),
+    })
+    const handlers = createKhalaCodeDesktopRpcRequestHandlers({
+      appleFmReadiness: () => {
+        throw new Error("not used")
+      },
+      claudeChatRuntime: throwingClaudeChatRuntime({
+        startTurn: async request => ({
+          backend: {
+            kind: "claude_app_sdk",
+            model: "claude-app-sdk",
+            runtimeMode: "claude_runtime",
+            threadId: "claude-plan-thread",
+            turnId: request.turnId ?? "claude-plan-turn",
+          },
+          messages: [{
+            id: "claude-plan-message",
+            role: "assistant",
+            body: request.messages[0]?.body.includes("large") === true
+              ? planBody("plan.q9_2.large", 3)
+              : planBody("plan.q9_2.small", 1),
+          }],
+          ok: true,
+          toolNames: [],
+          usedTools: [],
+        }),
+      }),
+      codexChatRuntime: throwingCodexChatRuntime({
+        startTurn: async request => {
+          codexTurns.push(request.messages[0]?.body ?? "")
+          return {
+            backend: {
+              kind: "codex_app_server",
+              model: "gpt-5.1-codex",
+              runtimeMode: "codex_harness",
+              threadId: request.threadId ?? "thread-codex-plan",
+              turnId: request.turnId ?? "turn-codex-plan",
+            },
+            messages: [{ id: "codex-plan-result", role: "assistant", body: "accepted" }],
+            ok: true,
+            toolNames: [],
+            usedTools: [],
+          }
+        },
+      }),
+      env: { HOME: root },
+      fleetRunSupervisor: {
+        control: async () => {
+          throw new Error("not used")
+        },
+        list: async () => [],
+        start: async request => {
+          fleetStarts.push(request)
+          return { run, supervisorStarted: true }
+        },
+        status: async () => ({ run, supervisorActive: true }),
+      },
+      onDeviceDeciderStatus: () => {
+        throw new Error("not used")
+      },
+      workingDirectory: process.cwd(),
+    })
+
+    const small = await handlers.architectPlanRun({
+      objective: "small plan",
+      sessionId: "desktop-session-plan",
+    })
+    if (!small.ok) throw new Error(small.error)
+    await expect(handlers.architectPlanDecision({
+      decision: "reject",
+      planRef: small.artifact.planRef,
+      sessionId: "desktop-session-plan",
+    })).resolves.toMatchObject({
+      ok: true,
+      artifact: { status: "rejected" },
+    })
+
+    const smallApproved = await handlers.architectPlanRun({
+      objective: "small plan",
+      sessionId: "desktop-session-plan-2",
+    })
+    if (!smallApproved.ok) throw new Error(smallApproved.error)
+    await expect(handlers.architectPlanDecision({
+      decision: "approve",
+      planRef: smallApproved.artifact.planRef,
+      sessionId: "desktop-session-plan-2",
+      threadId: "thread-existing",
+    })).resolves.toMatchObject({
+      ok: true,
+      artifact: { coderTurnId: expect.stringContaining("architect-coder-"), status: "dispatched" },
+    })
+    expect(codexTurns[0]).toContain("Execute this approved architect plan")
+
+    const large = await handlers.architectPlanRun({
+      objective: "large plan",
+      sessionId: "desktop-session-plan-3",
+    })
+    if (!large.ok) throw new Error(large.error)
+    await expect(handlers.architectPlanDecision({
+      decision: "approve",
+      planRef: large.artifact.planRef,
+      sessionId: "desktop-session-plan-3",
+    })).resolves.toMatchObject({
+      ok: true,
+      artifact: { dispatchMode: "fleet_run", fleetRunRef: "architect-plan.q9_2.large" },
+    })
+    expect(fleetStarts[0]).toMatchObject({
+      objective: "Plan plan.q9_2.large.",
+      targetConcurrency: 3,
+      workerKind: "codex",
+      workSource: {
+        kind: "plan_dag",
+        planRef: "plan.q9_2.large",
+      },
+    })
+  })
+
   test("answers native desktop status probes instead of falling through", async () => {
     const qaSamples: KhalaCodeDesktopQaMetricSample[] = []
     const handlers = createKhalaCodeDesktopRpcRequestHandlers({


### PR DESCRIPTION
## Summary
- add a plan-first `/architect` chat flow that runs Claude in read-only plan mode and persists a typed plan artifact
- add approve/reject actions that either dispatch small plans in-thread or escalate larger DAGs to FleetRun
- add desktop RPC contract, preview policy, UI state, styling, and deterministic tests for the new path

Closes #8053

## Verification
- `cd clients/khala-code-desktop && bun run verify`
- `bun run check:deploy`

Pinned base: `main@80986c141c64f0d2ecb9dea373f9d148c74054b6`.
