### PR TITLE
Gate fixture RPC responses on schema drift

### DIFF
--- a/packages/khala-qa-harness/src/runner.ts
+++ b/packages/khala-qa-harness/src/runner.ts
@@ -496,27 +496,48 @@ const evaluateOracle = (
   observations: ReadonlyArray<KhalaCodeQaObservation>,
 ): KhalaCodeQaOracleOutcome => {
   if (expectation.oracle === "schema") {
-    const schemaObservation = [...observations].reverse().find((observation) => {
+    const schemaObservations = observations.filter((observation) => {
       if (observation.action.kind !== "rpc_call") return false
       if (expectation.query === undefined) return true
       return observation.action.method === expectation.query || `rpc:${observation.action.method}` === expectation.query
     })
-    const data = schemaObservation?.data as
-      | { readonly oracle?: { readonly decoded?: boolean; readonly unknownFields?: ReadonlyArray<unknown> } }
-      | undefined
-    const decoded = data?.oracle?.decoded === true
-    const unknownFields = data?.oracle?.unknownFields ?? []
-    const ok = schemaObservation?.ok === true && decoded && unknownFields.length === 0
+    const oracleReports = schemaObservations.map((observation) => {
+      const data = observation.data as
+        | { readonly oracle?: { readonly decoded?: boolean; readonly unknownFields?: ReadonlyArray<unknown> } }
+        | undefined
+      return {
+        decoded: data?.oracle?.decoded === true,
+        label: observation.label,
+        method: observation.action.kind === "rpc_call" ? observation.action.method : "unknown",
+        observationOk: observation.ok,
+        unknownFields: data?.oracle?.unknownFields ?? [],
+      }
+    })
+    const ok = schemaObservations.length > 0 &&
+      oracleReports.every((report) =>
+        report.observationOk === true &&
+        report.decoded &&
+        report.unknownFields.length === 0
+      )
+    const failedReports = oracleReports.filter((report) =>
+      report.observationOk !== true ||
+      !report.decoded ||
+      report.unknownFields.length > 0
+    )
     return {
-      data: data?.oracle,
+      data: {
+        query: expectation.query,
+        checkedResponses: oracleReports.length,
+        failures: failedReports,
+      },
       ok,
       oracle: "schema",
       phaseName,
-      summary: schemaObservation === undefined
+      summary: schemaObservations.length === 0
         ? "no RPC observation available for schema oracle"
-        : decoded && unknownFields.length === 0
-          ? "RPC response decoded with no unknown fields"
-          : "RPC response failed schema oracle",
+        : failedReports.length === 0
+          ? `${oracleReports.length} RPC response(s) decoded with no unknown fields`
+          : `RPC response schema oracle failed for ${failedReports.map((report) => report.label).join(", ")}`,
       verdict: ok ? "CONFIRMED" : "REFUTED",
     }
   }
@@ -647,6 +668,37 @@ const evaluateOracle = (
   }
 }
 
+const schemaGateExpectationsForFixturePhase = (
+  explicitExpectations: ReadonlyArray<KhalaCodeQaOracleExpectation>,
+  observations: ReadonlyArray<KhalaCodeQaObservation>,
+): ReadonlyArray<KhalaCodeQaOracleExpectation> => {
+  const rpcMethods = [...new Set(observations.flatMap((observation) =>
+    observation.action.kind === "rpc_call" ? [observation.action.method] : []
+  ))]
+  if (rpcMethods.length === 0) return []
+
+  const explicitSchemaExpectations = explicitExpectations.filter((expectation) =>
+    expectation.oracle === "schema"
+  )
+  if (explicitSchemaExpectations.some((expectation) => expectation.query === undefined)) {
+    return []
+  }
+
+  const coveredQueries = new Set(explicitSchemaExpectations.flatMap((expectation) =>
+    expectation.query === undefined ? [] : [expectation.query]
+  ))
+  return rpcMethods
+    .filter((method) =>
+      !coveredQueries.has(method) &&
+      !coveredQueries.has(`rpc:${method}`)
+    )
+    .map((method) => ({
+      id: "fixture-schema-gate",
+      oracle: "schema" as const,
+      query: method,
+    }))
+}
+
 export const runKhalaCodeQaScenario = (input: {
   readonly driver: KhalaCodeQaDriver
   readonly scenario: KhalaCodeQaScenario
@@ -713,7 +765,13 @@ export const runKhalaCodeQaScenario = (input: {
         )
         observations.push(metricsObservation)
       }
-      const oracles = phase.expect.map((expectation) =>
+      const expectations = input.scenario.backend === "fixture"
+        ? [
+            ...phase.expect,
+            ...schemaGateExpectationsForFixturePhase(phase.expect, observations),
+          ]
+        : phase.expect
+      const oracles = expectations.map((expectation) =>
         evaluateOracle(phase.name, expectation, observations),
       )
       phaseOutcomes.push({

--- a/packages/khala-qa-harness/src/scenario-runner.test.ts
+++ b/packages/khala-qa-harness/src/scenario-runner.test.ts
@@ -89,6 +89,19 @@ describe("Khala Code QA scenario DSL", () => {
     }
   })
 
+  test("allows fixture RPC phases to rely on the automatic schema gate", () => {
+    const decoded = decodeKhalaCodeQaScenario({
+      ...fixtureScenario,
+      phases: [{
+        act: [{ kind: "rpc_call", method: "appInfo" }],
+        expect: [{ oracle: "crash" }],
+        name: "schema-less-rpc",
+      }],
+    })
+
+    expect("_tag" in decoded).toBe(false)
+  })
+
   test("rejects a scenario without phases", () => {
     const decoded = decodeKhalaCodeQaScenario({
       ...fixtureScenario,
@@ -217,6 +230,74 @@ describe("Khala Code QA RPC driver and runner", () => {
     expect(report.status).toBe("fail")
     expect(report.commitments.verdict).toBe("REFUTED")
     expect(report.phaseOutcomes[0]?.oracles[0]?.ok).toBe(false)
+  })
+
+  test("blocks synthetic response drift with unknown fields", async () => {
+    const driver = makeKhalaCodeRpcQaDriver({
+      fetch: (() =>
+        Promise.resolve(jsonResponse({
+          app: "Khala Code Desktop",
+          ok: true,
+          observedAt: "2026-07-01T00:00:00.000Z",
+          syntheticDrift: true,
+        }))) as KhalaCodeRpcFetch,
+    })
+
+    const report = await Effect.runPromise(
+      runKhalaCodeQaScenario({
+        driver,
+        scenario: loadKhalaCodeQaScenario(fixtureScenario),
+      }),
+    )
+
+    expect(report.status).toBe("fail")
+    expect(report.commitments.verdict).toBe("REFUTED")
+    expect(report.phaseOutcomes[0]?.oracles[0]).toMatchObject({
+      ok: false,
+      oracle: "schema",
+      verdict: "REFUTED",
+    })
+    expect(JSON.stringify(report.phaseOutcomes[0]?.oracles[0]?.data)).toContain("syntheticDrift")
+  })
+
+  test("automatically gates fixture RPC phases without explicit schema expectations", async () => {
+    const scenario = loadKhalaCodeQaScenario({
+      ...fixtureScenario,
+      commitments: [
+        {
+          claim: "schema-less fixture phase still blocks drift",
+          evidence: "run-pass",
+          id: "run.pass",
+        },
+      ],
+      phases: [{
+        act: [{ kind: "rpc_call", method: "appInfo" }],
+        expect: [{ oracle: "crash" }],
+        name: "implicit-schema-gate",
+      }],
+    })
+    const driver = makeKhalaCodeRpcQaDriver({
+      fetch: (() =>
+        Promise.resolve(jsonResponse({
+          app: "Khala Code Desktop",
+          ok: true,
+          observedAt: "2026-07-01T00:00:00.000Z",
+          syntheticDrift: true,
+        }))) as KhalaCodeRpcFetch,
+    })
+
+    const report = await Effect.runPromise(runKhalaCodeQaScenario({ driver, scenario }))
+
+    expect(report.status).toBe("fail")
+    expect(report.phaseOutcomes[0]?.oracles.map((oracle) => oracle.oracle)).toEqual([
+      "crash",
+      "schema",
+    ])
+    expect(report.phaseOutcomes[0]?.oracles[1]).toMatchObject({
+      ok: false,
+      oracle: "schema",
+      verdict: "REFUTED",
+    })
   })
 
   test("keeps unobserved commitments inconclusive", async () => {


### PR DESCRIPTION
Closes #8047

## Summary

- Tightens the QA runner schema oracle so it evaluates every matching RPC observation, not just the latest one.
- Adds an automatic fixture-tier schema gate for RPC phases that rely on other explicit oracles such as perf, consistency, or invariants.
- Adds synthetic drift coverage proving an unknown RPC response field fails the fixture run like any other merge-blocking test.

## Verification

- `bun run --cwd packages/khala-qa-harness test` — 80 pass, 0 fail
- `bun run --cwd packages/khala-qa-harness typecheck` — pass
- `bun run check:deploy` — pass

Pinned base used: `main@80986c141c64f0d2ecb9dea373f9d148c74054b6`.