### PR TITLE
Add QA Swarm customer-one engagement report

### DIFF
--- a/apps/openagents.com/apps/web/src/page/qa-swarm.test.ts
+++ b/apps/openagents.com/apps/web/src/page/qa-swarm.test.ts
@@ -111,9 +111,20 @@ describe('QA Swarm route', () => {
     expect(rendered).toContain('Verdict wall')
     expect(rendered).toContain('Coverage + frontier')
     expect(rendered).toContain('Perf budgets')
+    expect(rendered).toContain('Findings ledger')
+    expect(rendered).toContain('Caught')
+    expect(rendered).toContain('Filed')
+    expect(rendered).toContain('Fixed')
+    expect(rendered).toContain('Distilled')
+    expect(rendered).toContain('Case-study seed')
+    expect(rendered).toContain('/qa/qa-run.khala-code-nightly.latest')
+    expect(rendered).toContain('artifact.qa_swarm.weekly_report.khala_code.latest')
+    expect(rendered).toContain('artifact.khala_code.qa_status_surface.latest')
+    expect(rendered).toContain('Cockpit blanks when one startup RPC fails')
     expect(rendered).toContain('Videos and traces')
     expect(rendered).toContain('/trace/24c6fea6-b271-46c6-a9a9-bc614440e9ef')
     expect(rendered).toContain('/docs/qa/khala-code-mechanical-corpus')
+    expect(rendered).toContain('/docs/qa/qa-swarm-khala-code-standing-engagement')
     expect(rendered).toContain('artifact.qa_swarm.target.opaque.customer_one')
     expect(rendered).not.toMatch(/\/Users\/|bearer|token|secret/i)
   })
@@ -153,6 +164,20 @@ describe('QA Swarm projection schema and redaction', () => {
       maxAgeHours: 24,
       mode: 'artifact_snapshot',
     })
+    expect(sampleQaSwarmRunProjection.engagement).toMatchObject({
+      cadence: 'weekly',
+      reportHref: '/qa/qa-run.khala-code-nightly.latest',
+      status: 'standing_customer_one',
+    })
+    expect(sampleQaSwarmRunProjection.findingsLedger).toMatchObject({
+      caughtCount: 3,
+      filedIssueCount: 3,
+      fixedCount: 2,
+      distilledRegressionCount: 1,
+    })
+    expect(sampleQaSwarmRunProjection.caseStudy.href).toBe(
+      '/docs/qa/qa-swarm-khala-code-standing-engagement',
+    )
     expect(lookupQaSwarmRunProjection(QA_SWARM_SAMPLE_RUN_REF)).toEqual(
       sampleQaSwarmRunProjection,
     )

--- a/apps/openagents.com/apps/web/src/page/qa-swarm.ts
+++ b/apps/openagents.com/apps/web/src/page/qa-swarm.ts
@@ -6,6 +6,7 @@ import type { PublicHeaderAuthState } from './publicHeader'
 import * as PublicHeader from './publicHeader'
 import {
   type QaSwarmCoverageFrontierItem,
+  type QaSwarmFindingsLedgerProjection,
   type QaSwarmPerfBudgetItem,
   type QaSwarmRunProjection,
   type QaSwarmVerdict,
@@ -296,6 +297,86 @@ const perfRow = <Message>(item: QaSwarmPerfBudgetItem): Html => {
   )
 }
 
+const ledgerStatusClass = (
+  status: QaSwarmFindingsLedgerProjection['rows'][number]['status'],
+): string => {
+  switch (status) {
+    case 'caught':
+      return 'text-[var(--oa-color-khala-warning-strong)]'
+    case 'filed':
+      return 'text-[var(--oa-color-khala-energy-cyan)]'
+    case 'fixed':
+      return 'text-[var(--oa-color-khala-success-strong)]'
+    case 'distilled':
+      return 'text-[var(--oa-color-khala-text-bright)]'
+  }
+}
+
+const findingsLedger = <Message>(
+  ledger: QaSwarmFindingsLedgerProjection,
+): Html => {
+  const h = html<Message>()
+  return h.section([Ui.className<Message>(panel)], [
+    h.div([Ui.className<Message>('grid gap-4')], [
+      label<Message>('Findings ledger'),
+      h.div(
+        [Ui.className<Message>('grid gap-3 sm:grid-cols-4')],
+        [
+          metric<Message>('Caught', String(ledger.caughtCount), 'Observed findings'),
+          metric<Message>('Filed', String(ledger.filedIssueCount), 'Strict issues'),
+          metric<Message>('Fixed', String(ledger.fixedCount), 'Closed regressions'),
+          metric<Message>(
+            'Distilled',
+            String(ledger.distilledRegressionCount),
+            'Regression tests',
+          ),
+        ],
+      ),
+      h.ul(
+        [Ui.className<Message>('grid gap-3 p-0')],
+        ledger.rows.map(item =>
+          h.li(
+            [
+              Ui.className<Message>(
+                'grid gap-3 border border-[var(--oa-color-khala-border)] bg-[var(--oa-color-khala-surface)] p-3 sm:grid-cols-[1fr_auto]',
+              ),
+            ],
+            [
+              h.div([Ui.className<Message>('grid gap-1')], [
+                h.span(
+                  [
+                    Ui.className<Message>(
+                      'text-sm font-semibold text-[var(--oa-color-khala-text-bright)]',
+                    ),
+                  ],
+                  [item.label],
+                ),
+                h.span(
+                  [
+                    Ui.className<Message>(
+                      `break-all text-xs text-[var(--oa-color-khala-text-dim)] ${mono}`,
+                    ),
+                  ],
+                  [item.findingRef, ' -> ', item.issueRef, ' -> ', item.testRef],
+                ),
+              ]),
+              h.span(
+                [
+                  Ui.className<Message>(
+                    `text-xs font-semibold uppercase leading-none tracking-wide ${ledgerStatusClass(item.status)} ${mono}`,
+                  ),
+                ],
+                [item.status],
+              ),
+            ],
+          ),
+        ),
+      ),
+      code<Message>(ledger.ledgerRef),
+    ]),
+  ])
+}
+
 const runArticle = <Message>(projection: QaSwarmRunProjection): Html => {
   const h = html<Message>()
 
@@ -365,6 +446,23 @@ const runArticle = <Message>(projection: QaSwarmRunProjection): Html => {
                 ),
                 code<Message>(projection.target.ref),
               ]),
+              h.div([Ui.className<Message>('grid gap-1')], [
+                label<Message>('Weekly report'),
+                h.a(
+                  [
+                    h.Href(projection.engagement.reportHref),
+                    Ui.className<Message>(
+                      `khala-focus text-[var(--oa-color-khala-text-bright)] underline decoration-[var(--oa-color-khala-border-strong)] underline-offset-4 hover:text-[var(--oa-color-khala-energy-cyan)] hover:decoration-[var(--oa-color-khala-energy-cyan)] ${mono}`,
+                    ),
+                  ],
+                  [projection.engagement.reportHref],
+                ),
+                code<Message>(projection.engagement.reportRef),
+              ]),
+              h.div([Ui.className<Message>('grid gap-1')], [
+                label<Message>('Source artifact'),
+                code<Message>(projection.engagement.sourceArtifactRef),
+              ]),
             ],
           ),
         ],
@@ -405,6 +503,8 @@ const runArticle = <Message>(projection: QaSwarmRunProjection): Html => {
           ),
         ]),
       ]),
+
+      findingsLedger<Message>(projection.findingsLedger),
 
       h.section([Ui.className<Message>('grid gap-4 lg:grid-cols-2')], [
         h.div([Ui.className<Message>(panel)], [
@@ -477,6 +577,23 @@ const runArticle = <Message>(projection: QaSwarmRunProjection): Html => {
               ),
             ),
           ),
+        ]),
+      ]),
+
+      h.section([Ui.className<Message>(panel)], [
+        h.div([Ui.className<Message>('grid gap-3')], [
+          label<Message>('Case study seed'),
+          h.a(
+            [
+              h.Href(projection.caseStudy.href),
+              Ui.className<Message>(
+                'khala-focus text-lg font-semibold text-[var(--oa-color-khala-text-bright)] underline decoration-[var(--oa-color-khala-border-strong)] underline-offset-4 hover:text-[var(--oa-color-khala-energy-cyan)] hover:decoration-[var(--oa-color-khala-energy-cyan)]',
+              ),
+            ],
+            [projection.caseStudy.title],
+          ),
+          h.p([Ui.className<Message>(body)], [projection.caseStudy.summary]),
+          code<Message>(projection.caseStudy.receiptRef),
         ]),
       ]),
 

--- a/apps/openagents.com/apps/web/src/page/qa-swarm/projection.ts
+++ b/apps/openagents.com/apps/web/src/page/qa-swarm/projection.ts
@@ -64,11 +64,52 @@ export class QaSwarmDistilledTestRef extends S.Class<QaSwarmDistilledTestRef>(
   receiptRef: S.String,
 }) {}
 
+export class QaSwarmEngagementProjection extends S.Class<QaSwarmEngagementProjection>(
+  'QaSwarmEngagementProjection',
+)({
+  cadence: S.Literal('weekly'),
+  reportHref: S.String,
+  reportRef: S.String,
+  sourceArtifactRef: S.String,
+  status: S.Literal('standing_customer_one'),
+}) {}
+
+export class QaSwarmFindingsLedgerProjection extends S.Class<QaSwarmFindingsLedgerProjection>(
+  'QaSwarmFindingsLedgerProjection',
+)({
+  caughtCount: S.Number,
+  distilledRegressionCount: S.Number,
+  filedIssueCount: S.Number,
+  fixedCount: S.Number,
+  ledgerRef: S.String,
+  rows: S.Array(
+    S.Struct({
+      findingRef: S.String,
+      issueRef: S.String,
+      label: S.String,
+      status: S.Literals(['caught', 'filed', 'fixed', 'distilled']),
+      testRef: S.String,
+    }),
+  ),
+}) {}
+
+export class QaSwarmCaseStudyProjection extends S.Class<QaSwarmCaseStudyProjection>(
+  'QaSwarmCaseStudyProjection',
+)({
+  href: S.String,
+  receiptRef: S.String,
+  summary: S.String,
+  title: S.String,
+}) {}
+
 export class QaSwarmRunProjection extends S.Class<QaSwarmRunProjection>(
   'QaSwarmRunProjection',
 )({
+  caseStudy: QaSwarmCaseStudyProjection,
   coverageFrontier: S.Array(QaSwarmCoverageFrontierItem),
   distilledTests: S.Array(QaSwarmDistilledTestRef),
+  engagement: QaSwarmEngagementProjection,
+  findingsLedger: QaSwarmFindingsLedgerProjection,
   generatedAt: S.String,
   nightlyArtifactRef: S.String,
   opaqueTargetRefs: S.Array(S.String),
@@ -90,7 +131,8 @@ export class QaSwarmRunProjection extends S.Class<QaSwarmRunProjection>(
   videoRefs: S.Array(QaSwarmVideoRef),
 }) {}
 
-export const QA_SWARM_SAMPLE_RUN_REF = 'qa-run.khala-code-nightly.2026-07-02'
+export const QA_SWARM_SAMPLE_RUN_REF = 'qa-run.khala-code-nightly.latest'
+export const QA_SWARM_SEED_RUN_REF = 'qa-run.khala-code-nightly.2026-07-02'
 
 const PRIVATE_MATERIAL_PATTERN =
   /(@|\/Users\/|\/home\/|access[_-]?token|api[_-]?key|auth\.json|bearer|cookie|customer[_-]?(email|name|phone|prompt|record|value)|email[_-]?(address|body|html|raw|text)|gho_[A-Za-z0-9_]+|ghp_[A-Za-z0-9_]+|github\.com\/[^:/]+\/private|invoice[_-]?(id|raw)|lnbc|lntb|lnbcrt|macaroon|mnemonic|oauth|payment[_-]?(hash|id|invoice|preimage|proof|raw|secret)|payout[_-]?(address|destination|private|raw|target)|preimage|private[_-]?(archive|customer|dataset|key|prompt|source|trace|wallet)|provider[_-]?(account|credential|grant|payload|secret|token)|raw[_-]?(artifact|auth|customer|dataset|email|invoice|log|model|payment|payload|payout|prompt|provider|record|repo|runner|run[_-]?log|source|state|target|telemetry|text|trace)|recovery[_-]?phrase|runner[_-]?(payload|secret|token)|secret|seed[_-]?phrase|sk-[a-z0-9]|source[_-]?(archive|raw)|wallet[._-]?(key|material|mnemonic|payment|preimage|secret|seed))/i
@@ -125,6 +167,18 @@ export const assertQaSwarmPublicProjection = (
 
   assertPublicRefs([decoded.projectionRef], 'projectionRef')
   assertPublicRefs([decoded.nightlyArtifactRef], 'nightlyArtifactRef')
+  assertPublicRefs([decoded.engagement.reportRef], 'engagement.reportRef')
+  assertPublicRefs([decoded.engagement.sourceArtifactRef], 'engagement.sourceArtifactRef')
+  assertPublicRefs([decoded.findingsLedger.ledgerRef], 'findingsLedger.ledgerRef')
+  assertPublicRefs(
+    decoded.findingsLedger.rows.flatMap(item => [
+      item.findingRef,
+      item.issueRef,
+      item.testRef,
+    ]),
+    'findingsLedger.rows',
+  )
+  assertPublicRefs([decoded.caseStudy.receiptRef], 'caseStudy.receiptRef')
   assertPublicRefs(decoded.opaqueTargetRefs, 'opaqueTargetRefs')
   assertPublicRefs(decoded.publicSafetyRefs, 'publicSafetyRefs')
   assertPublicRefs(decoded.traceRefs, 'traceRefs')
@@ -158,6 +212,13 @@ export const assertQaSwarmPublicProjection = (
 
 export const sampleQaSwarmRunProjection = assertQaSwarmPublicProjection(
   new QaSwarmRunProjection({
+    caseStudy: {
+      href: '/docs/qa/qa-swarm-khala-code-standing-engagement',
+      receiptRef: 'artifact.qa_swarm.case_study.khala_code.20260702',
+      summary:
+        'The first audit session caught two main-branch regressions in stale visual smokes and one cockpit robustness bug before the standing loop was automated.',
+      title: 'Case-study seed: the first Khala Code QA Swarm audit',
+    },
     coverageFrontier: [
       {
         current: 42,
@@ -190,6 +251,43 @@ export const sampleQaSwarmRunProjection = assertQaSwarmPublicProjection(
         receiptRef: 'test.qa_swarm.khala_code.error_states.20260702',
       },
     ],
+    engagement: {
+      cadence: 'weekly',
+      reportHref: '/qa/qa-run.khala-code-nightly.latest',
+      reportRef: 'artifact.qa_swarm.weekly_report.khala_code.latest',
+      sourceArtifactRef: 'artifact.khala_code.qa_status_surface.latest',
+      status: 'standing_customer_one',
+    },
+    findingsLedger: {
+      caughtCount: 3,
+      distilledRegressionCount: 1,
+      filedIssueCount: 3,
+      fixedCount: 2,
+      ledgerRef: 'artifact.qa_swarm.findings_ledger.khala_code.20260702',
+      rows: [
+        {
+          findingRef: 'artifact.qa_swarm.finding.visual_fleet_run_rpc.20260702',
+          issueRef: 'artifact.qa_swarm.issue.visual_fleet_run_rpc.20260702',
+          label: 'Fleet-run RPC visual smoke stale fixture',
+          status: 'fixed',
+          testRef: 'test.qa_swarm.khala_code.visual_fleet_run_rpc.20260702',
+        },
+        {
+          findingRef: 'artifact.qa_swarm.finding.foldkit_cockpit_visual.20260702',
+          issueRef: 'artifact.qa_swarm.issue.foldkit_cockpit_visual.20260702',
+          label: 'Foldkit cockpit landing visual smoke stale fixture',
+          status: 'fixed',
+          testRef: 'test.qa_swarm.khala_code.foldkit_cockpit_visual.20260702',
+        },
+        {
+          findingRef: 'artifact.qa_swarm.finding.cockpit_failed_rpc_blank.20260702',
+          issueRef: 'artifact.qa_swarm.issue.cockpit_failed_rpc_blank.20260702',
+          label: 'Cockpit blanks when one startup RPC fails',
+          status: 'filed',
+          testRef: 'test.qa_swarm.khala_code.error_state_pending.20260702',
+        },
+      ],
+    },
     generatedAt: '2026-07-02T17:00:00.000Z',
     nightlyArtifactRef: 'artifact.qa_swarm.khala_code.nightly.20260702',
     opaqueTargetRefs: ['artifact.qa_swarm.target.opaque.customer_one'],
@@ -278,4 +376,6 @@ export const sampleQaSwarmRunProjection = assertQaSwarmPublicProjection(
 export const lookupQaSwarmRunProjection = (
   runRef: string,
 ): QaSwarmRunProjection | null =>
-  runRef === QA_SWARM_SAMPLE_RUN_REF ? sampleQaSwarmRunProjection : null
+  runRef === QA_SWARM_SAMPLE_RUN_REF || runRef === QA_SWARM_SEED_RUN_REF
+    ? sampleQaSwarmRunProjection
+    : null

--- a/apps/openagents.com/apps/web/src/route-table.ts
+++ b/apps/openagents.com/apps/web/src/route-table.ts
@@ -746,7 +746,7 @@ export const routeTable = {
   QaSwarm: {
     surface: 'spaDocument',
     serverDocument: QA_SWARM,
-    examplePaths: ['/qa/qa-run.khala-code-nightly.2026-07-02'],
+    examplePaths: ['/qa/qa-run.khala-code-nightly.latest'],
     requiresAuthBootstrap: false,
     loggedInGate: 'open',
     inLoggedOutUnion: true,

--- a/docs/qa/qa-swarm-khala-code-standing-engagement.md
+++ b/docs/qa/qa-swarm-khala-code-standing-engagement.md
@@ -1,0 +1,99 @@
+# QA Swarm at Khala Code: Customer-One Standing Engagement
+
+Date: 2026-07-02
+Status: public-safe case-study seed and weekly-report contract for issue #8066.
+This document does not flip a product promise green, publish a price, or claim
+hosted QA Swarm self-service is generally available.
+
+## Stable Report URL
+
+The customer-one engagement report is the QA Swarm run projection for Khala Code:
+
+- Stable share URL: `/qa/qa-run.khala-code-nightly.latest`
+- Seed snapshot alias: `/qa/qa-run.khala-code-nightly.2026-07-02`
+- Projection schema: `openagents.qa_swarm.run_projection.v1`
+- Source artifact: `artifact.khala_code.qa_status_surface.latest`
+- Weekly report ref: `artifact.qa_swarm.weekly_report.khala_code.latest`
+
+The latest URL is the stable link for the standing engagement. The dated alias is
+the public-safe seed snapshot from the 2026-07-02 audit session. Future nightly
+or weekly automation may refresh the latest projection, but it must keep the same
+redaction and evidence rules: every visible count comes from the nightly status
+surface, trace/video receipts, coverage frontier, perf budgets, filed issue refs,
+or distilled regression refs.
+
+## Engagement Contract
+
+QA Swarm customer one is Khala Code Desktop. The engagement packages the existing
+Khala Code QA loop as a weekly report:
+
+- Run the Khala Code nightly QA matrix and merge its public-safe artifacts into
+  the Q1.5 status surface.
+- Publish a QA Swarm run projection at the stable share URL.
+- Carry a findings ledger with the lifecycle `caught -> filed -> fixed ->
+  distilled`.
+- Link only dereferenceable public-safe receipts: artifact refs, trace refs,
+  coverage/frontier refs, perf refs, test refs, and strict issue refs.
+- Keep raw logs, local paths, account identifiers, provider payloads, customer
+  records, and private traces out of the projection.
+
+The report is allowed to say what the evidence shows for Khala Code. It is not
+allowed to imply third-party hosted runs, pricing, settlement, or self-serve
+availability before those lanes pass their own gates.
+
+## Case-Study Seed: 2026-07-02 Audit Session
+
+The first useful evidence came before the standing loop was fully automated. On
+2026-07-02, the QA framework parts were run against Khala Code and immediately
+found three concrete items:
+
+| Finding | Lifecycle state | Public-safe receipt |
+| --- | --- | --- |
+| Fleet-run RPC visual smoke stale fixture | fixed | `artifact.qa_swarm.finding.visual_fleet_run_rpc.20260702` |
+| Foldkit cockpit landing visual smoke stale fixture | fixed | `artifact.qa_swarm.finding.foldkit_cockpit_visual.20260702` |
+| Cockpit blanks when one startup RPC fails | filed | `artifact.qa_swarm.finding.cockpit_failed_rpc_blank.20260702` |
+
+That is the honest case-study claim: the first audit pass caught two
+main-branch regression-test gaps and one product robustness bug. The two stale
+visual-smoke gaps were fixed in the audit landing commits recorded by
+`ROADMAP_QA.md`; the cockpit degradation remains a tracked product fix in the
+QA roadmap until its regression scenario lands.
+
+## Findings Ledger
+
+Current seed counts:
+
+| Metric | Count | Meaning |
+| --- | ---: | --- |
+| Caught | 3 | Observed findings from the audit session |
+| Filed | 3 | Findings represented by strict issue or roadmap refs |
+| Fixed | 2 | Findings already closed by committed fixes |
+| Distilled regressions | 1 | Deterministic regression coverage represented in the seed projection |
+
+The ledger is intentionally conservative. A finding only moves forward when the
+next receipt exists. Counter movement, screenshots without trace refs, or agent
+summaries without artifacts do not advance a row.
+
+## Copy Gate
+
+Allowed public wording:
+
+> QA Swarm's customer-one engagement is Khala Code itself. The weekly report
+> shows the current nightly verdicts, coverage frontier, perf-budget status,
+> findings ledger, videos, traces, and distilled regression refs at a stable
+> share URL.
+
+Disallowed until separately gated:
+
+- "QA Swarm is generally available."
+- "Hosted QA Swarm runs are self-serve."
+- "The weekly report proves every Khala Code workflow is covered."
+- Any price, SLA, settlement, or third-party customer claim.
+
+## Verification
+
+For this seed, the implementation evidence is:
+
+- Web route: `/qa/qa-run.khala-code-nightly.latest`
+- Projection test: `apps/openagents.com/apps/web/src/page/qa-swarm.test.ts`
+- Full deploy gate for the issue PR: `bun run check:deploy`


### PR DESCRIPTION
Closes #8066.

## Summary

- Adds the stable Khala Code customer-one QA Swarm report ref at `/qa/qa-run.khala-code-nightly.latest`, with the dated 2026-07-02 seed alias still accepted.
- Extends the public-safe QA Swarm projection/page with the weekly engagement source artifact, findings ledger counts, row lifecycle refs, and case-study seed link.
- Commits the public-safe case-study/runbook doc for the 2026-07-02 audit session, including the allowed/disallowed copy gate.

## Verification

- `bun run --cwd apps/openagents.com/apps/web test -- src/page/qa-swarm.test.ts` ✅ 1 file / 7 tests passed
- `bun run --cwd apps/openagents.com/apps/web typecheck` ✅ passed
- `bun run check:deploy` ✅ passed

## Public-safety notes

- The projection uses opaque customer-one refs and existing public-safe artifact/test/trace ref patterns.
- The case study explicitly avoids product-promise, pricing, settlement, third-party hosted-run, and self-serve availability claims.