### PR TITLE
Add QA target adapter onboarding contract

### DIFF
--- a/apps/qa-runner/README.md
+++ b/apps/qa-runner/README.md
@@ -216,6 +216,12 @@ QA_TARGET_URL=https://staging.openagents.com bun run --cwd apps/qa-runner run-on
 
 Default target is `https://openagents.com`.
 
+For third-party/customer apps, use the minimal Target adapter contract:
+[`docs/target-adapter-onboarding.md`](docs/target-adapter-onboarding.md). It
+documents the schema, auth/fresh-identity/restart checklist, a worked public
+fixture example, and the external-production rule: prod is read-only and
+mutating steps are refused by the runner before browser interaction.
+
 ## Cost / time envelope
 
 The demo is one headless chromium session of a handful of steps: a few seconds

--- a/apps/qa-runner/docs/target-adapter-onboarding.md
+++ b/apps/qa-runner/docs/target-adapter-onboarding.md
@@ -1,0 +1,170 @@
+# Third-Party Target Adapter Onboarding
+
+Status: adapter contract for QA Swarm third-party onboarding (#8069). This is
+not product-promise copy; it is the integration contract a customer app must
+satisfy before a swarm run can honestly claim coverage.
+
+## Contract
+
+A Target adapter is a public-safe JSON-shaped record that tells `qa-runner` how
+to point one scenario corpus at a customer app without bespoke integration code.
+It covers four things:
+
+- **Auth**: whether the app needs no auth, env-supplied auth, device login, or a
+  seeded test account.
+- **Fresh identity**: every run must start from an isolated browser context and,
+  for authenticated apps, a non-human test identity that can be reset or safely
+  discarded.
+- **Restart**: the runner may optionally restart a local/preview target by a
+  command or HTTP hook. Production targets normally set `none`.
+- **Production policy**: external production targets are read-only. The runner
+  refuses mutating steps before touching the browser.
+
+The code schema lives in `src/target-adapter.ts` as
+`TargetAdapterContract`:
+
+```ts
+{
+  schemaVersion: "openagents.qa_runner.target_adapter.v1",
+  id: string,
+  displayName: string,
+  target: {
+    name: string,
+    baseUrl: string,
+    environment: "local" | "preview" | "staging" | "prod" | "fixture",
+    owner: "first-party" | "external",
+    capabilities: Array<"browser" | "terminal">,
+    restrictions?: Array<"read-only">
+  },
+  auth: {
+    kind: "none" | "env" | "device" | "seeded-test-account",
+    loginUrl?: string,
+    envVars?: string[],
+    freshIdentity: {
+      required: boolean,
+      strategy: string
+    }
+  },
+  restart: {
+    kind: "none" | "command" | "http",
+    command?: string,
+    url?: string
+  },
+  prodReadOnly: {
+    policy: "read-only" | "blocked",
+    allowedStepKinds: string[],
+    blockedStepKinds: string[],
+    notes?: string
+  },
+  scenarioSeeds: Array<{
+    id: string,
+    title: string,
+    startPath: string,
+    commitment: string
+  }>,
+  checklist: string[]
+}
+```
+
+`targetFromAdapter()` converts the adapter into the runner `Target`. If
+`target.owner` is `external` and `target.environment` is `prod`, it always adds
+the `read-only` restriction even when the adapter omits it. If the adapter sets
+`prodReadOnly.policy` to `blocked`, the run fails before a browser session can
+start.
+
+## Checklist
+
+Before a third-party app is accepted for a QA Swarm run:
+
+- The adapter decodes with `decodeTargetAdapterContract`.
+- The base URL is the exact app surface to test; no private local paths appear
+  in the adapter or artifacts.
+- Auth uses a test identity, not a human operator account.
+- Fresh identity is explicit: new browser context plus reset/seed strategy for
+  any server-side state the scenario can touch.
+- Production is read-only for external targets. Allowed steps are observation
+  only: `navigate`, `wait-for`, `screenshot`, and `assert`.
+- Mutating steps such as `click` and `type` are blocked on external production
+  targets. Run writable flows against local, preview, staging, fixture, or a
+  dedicated seeded test environment.
+- Restart hooks are absent for production unless the target owner explicitly
+  supplies a safe read-only refresh endpoint.
+- Scenario seeds name commitments that can be confirmed from public-safe run
+  receipts: result JSON, video, trace refs, screenshots, coverage ledger rows,
+  and distilled tests.
+- Artifacts pass the public-safety tripwire. Do not include raw prompts,
+  credentials, cookies, provider payloads, private repo data, or customer
+  secrets.
+
+## Worked Example: Public Fixture App
+
+This example uses a public read-only fixture target. It is intentionally not an
+OpenAgents-owned surface, so it exercises the external-production rule without
+creating customer data.
+
+```ts
+import {
+  TARGET_ADAPTER_SCHEMA_VERSION,
+  decodeTargetAdapterContract,
+  targetFromAdapter,
+} from "@openagentsinc/qa-runner/target-adapter";
+
+const adapter = decodeTargetAdapterContract({
+  schemaVersion: TARGET_ADAPTER_SCHEMA_VERSION,
+  id: "fixture-public-todo-prod",
+  displayName: "Fixture Public Todo",
+  target: {
+    name: "public-todo-prod",
+    baseUrl: "https://example.com",
+    environment: "prod",
+    owner: "external",
+    capabilities: ["browser"]
+  },
+  auth: {
+    kind: "none",
+    freshIdentity: {
+      required: true,
+      strategy: "fresh anonymous browser context per run; no persisted cookies"
+    }
+  },
+  restart: { kind: "none" },
+  prodReadOnly: {
+    policy: "read-only",
+    allowedStepKinds: ["navigate", "wait-for", "screenshot", "assert"],
+    blockedStepKinds: ["click", "type"],
+    notes: "External production is observed only; writable flows use staging."
+  },
+  scenarioSeeds: [
+    {
+      id: "home-renders",
+      title: "Home page renders",
+      startPath: "/",
+      commitment: "The target home page renders public text."
+    }
+  ],
+  checklist: [
+    "Auth does not reuse a human account.",
+    "Every production run is read-only.",
+    "Artifacts contain only public-safe refs."
+  ]
+});
+
+const target = targetFromAdapter(adapter);
+// target.restrictions contains "read-only"; click/type are refused by runner policy.
+```
+
+End-to-end flow:
+
+1. Decode the adapter and convert it with `targetFromAdapter`.
+2. Generate an initial scenario corpus from `scenarioSeeds`.
+3. Run the read-only smoke against production: navigate to `/`, wait for public
+   text, screenshot, and assert.
+4. Run writable exploratory flows only against a fixture/staging adapter with a
+   fresh seeded identity.
+5. Distill confirmed findings into committed `*.e2e.test.ts` scenarios and add
+   the run receipts to the coverage ledger.
+
+For a real customer app, the only adapter-specific parts should be the base URL,
+auth seed/reset details, optional restart hook, and the first scenario seeds.
+The runner behavior stays the same.
+

--- a/apps/qa-runner/package.json
+++ b/apps/qa-runner/package.json
@@ -35,6 +35,7 @@
     "./byo": "./src/byo.ts",
     "./byo-model": "./src/byo-model.ts",
     "./target": "./src/target.ts",
+    "./target-adapter": "./src/target-adapter.ts",
     "./brain": "./src/brain.ts",
     "./backend": "./src/backend.ts",
     "./runner": "./src/runner.ts",
@@ -65,7 +66,8 @@
     "scripts/build.ts",
     "README.md",
     "LICENSE",
-    "docs/oss-quickstart.md"
+    "docs/oss-quickstart.md",
+    "docs/target-adapter-onboarding.md"
   ],
   "publishConfig": {
     "access": "public"
@@ -89,7 +91,7 @@
     "evals": "bun run src/evals-run.ts",
     "pr-comment": "bun run src/pr-comment-run.ts",
     "trace:fixture": "bun run src/trace-fixture.ts",
-    "test": "bun test src/byo-model.test.ts src/byo.test.ts src/runner.test.ts src/runner-hardening.test.ts src/timeouts.test.ts src/shard.test.ts src/public-safety.test.ts src/brain.test.ts src/backend.test.ts src/terminal-backend.test.ts src/container-backend.test.ts src/native-desktop-backend.test.ts src/khala-desktop-backend.test.ts src/khala-action.test.ts src/khala-driver.test.ts src/khala-config.test.ts src/khala-openrouter.test.ts src/session-trace.test.ts src/distiller.test.ts src/skill-candidate.test.ts src/receipt.test.ts src/run-settlement.test.ts src/khala-session.test.ts src/compose/build-plan.test.ts src/compose/ffmpeg.test.ts src/evals.test.ts src/pr-comment.test.ts src/control-auth.test.ts src/artifacts.test.ts src/control.test.ts src/api-server.test.ts src/failure-learning.test.ts src/failure-learning-gepa.test.ts src/target-registry.test.ts src/target-registry-run.test.ts src/cf-browser-backend.test.ts src/cf-browser-video.test.ts src/cf-sandbox-backend.test.ts src/atif.test.ts src/atif-html.test.ts src/codex-to-atif.test.ts src/redaction.test.ts src/claude-code-to-atif.test.ts src/publish-trace.test.ts src/trace-fixture.test.ts src/publish-trace-e2e.verify.test.ts generated/khala-code-packaged-seeded-bug.e2e.test.ts",
+    "test": "bun test src/byo-model.test.ts src/byo.test.ts src/runner.test.ts src/runner-hardening.test.ts src/timeouts.test.ts src/shard.test.ts src/public-safety.test.ts src/brain.test.ts src/backend.test.ts src/terminal-backend.test.ts src/container-backend.test.ts src/native-desktop-backend.test.ts src/khala-desktop-backend.test.ts src/khala-action.test.ts src/khala-driver.test.ts src/khala-config.test.ts src/khala-openrouter.test.ts src/session-trace.test.ts src/distiller.test.ts src/skill-candidate.test.ts src/receipt.test.ts src/run-settlement.test.ts src/khala-session.test.ts src/compose/build-plan.test.ts src/compose/ffmpeg.test.ts src/evals.test.ts src/pr-comment.test.ts src/control-auth.test.ts src/artifacts.test.ts src/control.test.ts src/api-server.test.ts src/failure-learning.test.ts src/failure-learning-gepa.test.ts src/target-registry.test.ts src/target-registry-run.test.ts src/target-adapter.test.ts src/cf-browser-backend.test.ts src/cf-browser-video.test.ts src/cf-sandbox-backend.test.ts src/atif.test.ts src/atif-html.test.ts src/codex-to-atif.test.ts src/redaction.test.ts src/claude-code-to-atif.test.ts src/publish-trace.test.ts src/trace-fixture.test.ts src/publish-trace-e2e.verify.test.ts generated/khala-code-packaged-seeded-bug.e2e.test.ts",
     "typecheck": "tsc --noEmit -p tsconfig.json",
     "playwright:install": "playwright install --with-deps chromium",
     "atif:emit": "bun run src/atif-emit.ts",

--- a/apps/qa-runner/src/index.ts
+++ b/apps/qa-runner/src/index.ts
@@ -30,6 +30,23 @@ export {
   type TargetCapability,
   type TargetRestriction,
 } from "./target";
+export {
+  TARGET_ADAPTER_SCHEMA_VERSION,
+  TargetAdapterContract,
+  decodeTargetAdapterContract,
+  targetFromAdapter,
+  type TargetAdapterAuth,
+  type TargetAdapterAuthKind,
+  type TargetAdapterContract as TargetAdapterContractType,
+  type TargetAdapterEnvironment,
+  type TargetAdapterOwner,
+  type TargetAdapterProdPolicy,
+  type TargetAdapterProdReadOnly,
+  type TargetAdapterRestart,
+  type TargetAdapterRestartKind,
+  type TargetAdapterScenarioSeed,
+  type TargetAdapterTarget,
+} from "./target-adapter";
 
 // Brains — the pluggable decision-makers (scripted is deterministic-now).
 export {

--- a/apps/qa-runner/src/target-adapter.test.ts
+++ b/apps/qa-runner/src/target-adapter.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, test } from "bun:test";
+
+import { type BrainStep } from "./brain";
+import { checkStepAllowed, isReadOnly } from "./target";
+import {
+  decodeTargetAdapterContract,
+  targetFromAdapter,
+  TARGET_ADAPTER_SCHEMA_VERSION,
+  type TargetAdapterContract,
+} from "./target-adapter";
+
+const publicTodoAdapter = (): TargetAdapterContract => ({
+  schemaVersion: TARGET_ADAPTER_SCHEMA_VERSION,
+  id: "fixture-public-todo-prod",
+  displayName: "Fixture Public Todo",
+  target: {
+    name: "public-todo-prod",
+    baseUrl: "https://example.com",
+    environment: "prod",
+    owner: "external",
+    capabilities: ["browser"],
+  },
+  auth: {
+    kind: "none",
+    freshIdentity: {
+      required: true,
+      strategy: "fresh anonymous browser context per run; no persisted cookies",
+    },
+  },
+  restart: { kind: "none" },
+  prodReadOnly: {
+    policy: "read-only",
+    allowedStepKinds: ["navigate", "wait-for", "screenshot", "assert"],
+    blockedStepKinds: ["click", "type"],
+  },
+  scenarioSeeds: [
+    {
+      id: "home-renders",
+      title: "Home page renders",
+      startPath: "/",
+      commitment: "The target home page renders public text.",
+    },
+  ],
+  checklist: [
+    "Auth does not reuse a human account.",
+    "Every production run is read-only.",
+    "Artifacts contain only public-safe refs.",
+  ],
+});
+
+describe("Target adapter contract (#8069)", () => {
+  test("decodes the minimal third-party adapter schema", () => {
+    const decoded = decodeTargetAdapterContract(publicTodoAdapter());
+    expect(decoded.schemaVersion).toBe("openagents.qa_runner.target_adapter.v1");
+    expect(decoded.target.environment).toBe("prod");
+    expect(decoded.auth.freshIdentity.required).toBe(true);
+    expect(decoded.scenarioSeeds[0]!.id).toBe("home-renders");
+  });
+
+  test("external prod adapters are forced read-only even when restriction is omitted", () => {
+    const target = targetFromAdapter(publicTodoAdapter());
+    expect(isReadOnly(target)).toBe(true);
+    expect(checkStepAllowed(target, "navigate").allowed).toBe(true);
+
+    const decision = checkStepAllowed(target, "click");
+    expect(decision.allowed).toBe(false);
+    if (!decision.allowed) {
+      expect(decision.reason).toContain("read-only");
+      expect(decision.reason).toContain("click");
+    }
+  });
+
+  test("blocked external prod adapters fail before a run can start", () => {
+    const adapter: TargetAdapterContract = {
+      ...publicTodoAdapter(),
+      prodReadOnly: {
+        ...publicTodoAdapter().prodReadOnly,
+        policy: "blocked",
+      },
+    };
+    expect(() => targetFromAdapter(adapter)).toThrow(/blocked by policy/);
+  });
+
+  test("worked fixture scenario exposes the allowed read-only step set", () => {
+    const target = targetFromAdapter(publicTodoAdapter());
+    const readOnlySteps: ReadonlyArray<BrainStep> = [
+      { kind: "navigate", url: "/", label: "open public homepage" },
+      { kind: "screenshot", label: "capture public homepage" },
+      {
+        kind: "assert",
+        label: "public page has text",
+        check: { kind: "text-contains", selector: "body", value: "Example" },
+      },
+    ];
+
+    for (const step of readOnlySteps) {
+      expect(checkStepAllowed(target, step.kind).allowed).toBe(true);
+    }
+    expect(checkStepAllowed(target, "type").allowed).toBe(false);
+  });
+});
+

--- a/apps/qa-runner/src/target-adapter.ts
+++ b/apps/qa-runner/src/target-adapter.ts
@@ -1,0 +1,138 @@
+// Third-party Target adapter contract (#8069).
+//
+// A Target adapter is the minimal public-safe description QA Swarm needs to run
+// an arbitrary customer app: where the app lives, how auth/fresh identity are
+// prepared, whether the app can be restarted, and which production policy must
+// be enforced. The adapter is data, not bespoke integration code.
+
+import { Schema as S } from "effect";
+import {
+  makeTarget,
+  type Target,
+  type TargetCapability,
+  type TargetRestriction,
+} from "./target";
+
+export const TARGET_ADAPTER_SCHEMA_VERSION =
+  "openagents.qa_runner.target_adapter.v1" as const;
+
+export const TargetAdapterEnvironment = S.Literals([
+  "local",
+  "preview",
+  "staging",
+  "prod",
+  "fixture",
+]);
+export type TargetAdapterEnvironment = typeof TargetAdapterEnvironment.Type;
+
+export const TargetAdapterOwner = S.Literals(["first-party", "external"]);
+export type TargetAdapterOwner = typeof TargetAdapterOwner.Type;
+
+export const TargetAdapterAuthKind = S.Literals([
+  "none",
+  "env",
+  "device",
+  "seeded-test-account",
+]);
+export type TargetAdapterAuthKind = typeof TargetAdapterAuthKind.Type;
+
+export const TargetAdapterRestartKind = S.Literals([
+  "none",
+  "command",
+  "http",
+]);
+export type TargetAdapterRestartKind = typeof TargetAdapterRestartKind.Type;
+
+export const TargetAdapterProdPolicy = S.Literals(["read-only", "blocked"]);
+export type TargetAdapterProdPolicy = typeof TargetAdapterProdPolicy.Type;
+
+export const TargetAdapterTarget = S.Struct({
+  name: S.String,
+  baseUrl: S.String,
+  environment: TargetAdapterEnvironment,
+  owner: TargetAdapterOwner,
+  capabilities: S.Array(S.Literals(["browser", "terminal"])),
+  restrictions: S.optional(S.Array(S.Literal("read-only"))),
+});
+export type TargetAdapterTarget = typeof TargetAdapterTarget.Type;
+
+export const TargetAdapterAuth = S.Struct({
+  kind: TargetAdapterAuthKind,
+  loginUrl: S.optional(S.String),
+  envVars: S.optional(S.Array(S.String)),
+  freshIdentity: S.Struct({
+    required: S.Boolean,
+    strategy: S.String,
+  }),
+});
+export type TargetAdapterAuth = typeof TargetAdapterAuth.Type;
+
+export const TargetAdapterRestart = S.Struct({
+  kind: TargetAdapterRestartKind,
+  command: S.optional(S.String),
+  url: S.optional(S.String),
+});
+export type TargetAdapterRestart = typeof TargetAdapterRestart.Type;
+
+export const TargetAdapterProdReadOnly = S.Struct({
+  policy: TargetAdapterProdPolicy,
+  allowedStepKinds: S.Array(S.String),
+  blockedStepKinds: S.Array(S.String),
+  notes: S.optional(S.String),
+});
+export type TargetAdapterProdReadOnly = typeof TargetAdapterProdReadOnly.Type;
+
+export const TargetAdapterScenarioSeed = S.Struct({
+  id: S.String,
+  title: S.String,
+  startPath: S.String,
+  commitment: S.String,
+});
+export type TargetAdapterScenarioSeed = typeof TargetAdapterScenarioSeed.Type;
+
+export const TargetAdapterContract = S.Struct({
+  schemaVersion: S.Literal(TARGET_ADAPTER_SCHEMA_VERSION),
+  id: S.String,
+  displayName: S.String,
+  target: TargetAdapterTarget,
+  auth: TargetAdapterAuth,
+  restart: TargetAdapterRestart,
+  prodReadOnly: TargetAdapterProdReadOnly,
+  scenarioSeeds: S.Array(TargetAdapterScenarioSeed),
+  checklist: S.Array(S.String),
+});
+export type TargetAdapterContract = typeof TargetAdapterContract.Type;
+
+export const decodeTargetAdapterContract =
+  S.decodeUnknownSync(TargetAdapterContract);
+
+const unique = <T>(values: ReadonlyArray<T>): ReadonlyArray<T> => [...new Set(values)];
+
+const isExternalProd = (adapter: TargetAdapterContract): boolean =>
+  adapter.target.owner === "external" && adapter.target.environment === "prod";
+
+/**
+ * Convert an adapter into the runner's existing Target model. Enforcement rule:
+ * an external production adapter is always read-only. If the adapter declares
+ * `blocked`, it is rejected before any run can start.
+ */
+export function targetFromAdapter(adapter: TargetAdapterContract): Target {
+  if (isExternalProd(adapter) && adapter.prodReadOnly.policy === "blocked") {
+    throw new Error(
+      `target adapter "${adapter.id}" points at external prod and is blocked by policy`,
+    );
+  }
+
+  const restrictions = unique<TargetRestriction>([
+    ...(adapter.target.restrictions ?? []),
+    ...(isExternalProd(adapter) ? ["read-only" as const] : []),
+  ]);
+
+  return makeTarget({
+    name: adapter.target.name,
+    baseUrl: adapter.target.baseUrl,
+    capabilities: adapter.target.capabilities as ReadonlyArray<TargetCapability>,
+    restrictions,
+  });
+}
+


### PR DESCRIPTION
## Summary
- adds a typed `TargetAdapterContract` for third-party QA Swarm targets, including auth, fresh identity, restart, scenario seeds, and production policy fields
- enforces external production adapters as read-only through `targetFromAdapter`, reusing the existing runner restriction path before browser interaction
- documents the onboarding checklist and worked public fixture example, and links it from the qa-runner README

Closes #8069

## Verification
- `bun test apps/qa-runner/src/target-adapter.test.ts apps/qa-runner/src/target-registry.test.ts apps/qa-runner/src/target-registry-run.test.ts`
- `bun run --cwd apps/qa-runner typecheck`
- `bun run check:deploy`
- `bun run --cwd apps/qa-runner test`

All commands completed green in the bounded checkout.

## FleetRun evidence
- assigned issue: #8069
- base: `main@1422b4a8440fd16bf1505cd052583f9bc4bed28e`
- commit: `6db3e165d0`
