### PR TITLE
QA Swarm QS10: hosted run receipts and exact metering

### DIFF
--- a/NEEDS_OWNER.md
+++ b/NEEDS_OWNER.md
@@ -44,3 +44,17 @@ NEEDS-OWNER: Review
 `docs/fable/2026-07-02-qs7-rhys-sales-motion-owner-review.md`, approve or edit
 the public-safe artifact packet, and explicitly authorize the outward-facing
 `RhysSullivan/executor` PR only after the real audit receipts exist.
+
+## QA Swarm Hosted-Run Engagement Arming
+
+Source issue: OpenAgentsInc/openagents#8070
+
+The QS10 contract now models hosted-run receipts, exact-only metering rows, and
+engagement receipts through the existing business quick-win lifecycle. The
+settlement/payment seam is intentionally inert unless the owner explicitly arms
+it.
+
+NEEDS-OWNER: Decide when QA Swarm hosted-run engagement receipts may evidence
+`buyer_paid` / `provider_settled` refs, which checkout/payment source is
+approved for those refs, and what operator review is required before any paid
+QA Swarm engagement is represented as paid or settled.

--- a/apps/openagents.com/workers/api/src/qa-swarm-hosted-run-receipt.test.ts
+++ b/apps/openagents.com/workers/api/src/qa-swarm-hosted-run-receipt.test.ts
@@ -1,0 +1,192 @@
+import { describe, expect, test } from 'vitest'
+
+import {
+  QA_SWARM_OWNER_ARM_TOKEN,
+  QaSwarmHostedRunReceiptInvariantError,
+  buildQaSwarmEngagementReceipt,
+  buildQaSwarmHostedRunMeteringRow,
+  buildQaSwarmHostedRunReceipt,
+  publicQaSwarmHostedRunReceiptProjection,
+} from './qa-swarm-hosted-run-receipt'
+
+const runRef = 'qa-run.khala-code-nightly.20260702'
+
+const exactMeteringRow = () =>
+  buildQaSwarmHostedRunMeteringRow({
+    rowRef: 'metering.qa_swarm.khala_code.20260702.turn_1',
+    runRef,
+    source: 'provider_usage',
+    usageTruth: 'exact',
+    inputTokens: 100,
+    outputTokens: 20,
+    reasoningTokens: 7,
+    cacheReadTokens: 3,
+  })
+
+const hostedRunReceipt = () =>
+  buildQaSwarmHostedRunReceipt({
+    receiptRef: 'receipt.qa_swarm.hosted_run.khala_code.20260702',
+    runRef,
+    projectionRef: 'projection.qa_swarm.run.khala_code.20260702',
+    verdict: 'warning',
+    traceRefs: ['trace.qa_swarm.khala_code.seed_corpus.20260702'],
+    coverageRefs: ['coverage.qa_swarm.khala_code.seed_corpus.20260702'],
+    videoRefs: ['video.qa_swarm.khala_code.seed_corpus.20260702'],
+    distilledTestRefs: ['test.qa_swarm.khala_code.distilled.20260702'],
+    meteringRows: [exactMeteringRow()],
+    publicSafetyRefs: ['redaction.qa_swarm.public_projection.reviewed.20260702'],
+  })
+
+describe('qa-swarm-hosted-run-receipt', () => {
+  test('builds a hosted run receipt with trace, coverage, and exact metering refs', () => {
+    const receipt = hostedRunReceipt()
+
+    expect(receipt.receiptKind).toBe('qa_swarm_hosted_run')
+    expect(receipt.traceRefs).toEqual([
+      'trace.qa_swarm.khala_code.seed_corpus.20260702',
+    ])
+    expect(receipt.coverageRefs).toEqual([
+      'coverage.qa_swarm.khala_code.seed_corpus.20260702',
+    ])
+    expect(receipt.meteringRowRefs).toEqual([
+      'metering.qa_swarm.khala_code.20260702.turn_1',
+    ])
+    expect(receipt.exactTokenTotal).toBe(130)
+    expect(receipt.settlement).toEqual({
+      state: 'inert_owner_armed_required',
+      movedMoney: false,
+      ownerArmingRef: 'NEEDS_OWNER.qa_swarm_hosted_run_engagement_arming',
+    })
+  })
+
+  test('rejects hosted run receipts without trace or coverage refs', () => {
+    const base = {
+      receiptRef: 'receipt.qa_swarm.hosted_run.khala_code.20260702',
+      runRef,
+      projectionRef: 'projection.qa_swarm.run.khala_code.20260702',
+      verdict: 'passed' as const,
+      traceRefs: ['trace.qa_swarm.khala_code.seed_corpus.20260702'],
+      coverageRefs: ['coverage.qa_swarm.khala_code.seed_corpus.20260702'],
+      meteringRows: [exactMeteringRow()],
+      publicSafetyRefs: [
+        'redaction.qa_swarm.public_projection.reviewed.20260702',
+      ],
+    }
+
+    expect(() =>
+      buildQaSwarmHostedRunReceipt({ ...base, traceRefs: [] }),
+    ).toThrow(QaSwarmHostedRunReceiptInvariantError)
+    expect(() =>
+      buildQaSwarmHostedRunReceipt({ ...base, coverageRefs: [] }),
+    ).toThrow(QaSwarmHostedRunReceiptInvariantError)
+  })
+
+  test('rejects estimated, missing, synthetic, or mismatched usage rows', () => {
+    expect(() =>
+      buildQaSwarmHostedRunMeteringRow({
+        rowRef: 'metering.qa_swarm.khala_code.20260702.estimated',
+        runRef,
+        source: 'runner_report',
+        usageTruth: 'estimated',
+        inputTokens: 100,
+        outputTokens: 20,
+      }),
+    ).toThrow(/exact-only/)
+
+    expect(() =>
+      buildQaSwarmHostedRunMeteringRow({
+        rowRef: 'metering.qa_swarm.khala_code.20260702.synthetic',
+        runRef,
+        source: 'runner_report',
+        usageTruth: 'synthetic',
+        inputTokens: 100,
+        outputTokens: 20,
+      }),
+    ).toThrow(/exact-only/)
+
+    expect(() =>
+      buildQaSwarmHostedRunMeteringRow({
+        rowRef: 'metering.qa_swarm.khala_code.20260702.bad_total',
+        runRef,
+        source: 'provider_usage',
+        usageTruth: 'exact',
+        inputTokens: 100,
+        outputTokens: 20,
+        totalTokens: 999,
+      }),
+    ).toThrow(/totalTokens/)
+  })
+
+  test('requires metering rows to belong to the same run', () => {
+    const row = buildQaSwarmHostedRunMeteringRow({
+      rowRef: 'metering.qa_swarm.other.20260702.turn_1',
+      runRef: 'qa-run.other-target.20260702',
+      source: 'provider_usage',
+      usageTruth: 'exact',
+      inputTokens: 1,
+      outputTokens: 1,
+    })
+
+    expect(() =>
+      buildQaSwarmHostedRunReceipt({
+        receiptRef: 'receipt.qa_swarm.hosted_run.khala_code.20260702',
+        runRef,
+        projectionRef: 'projection.qa_swarm.run.khala_code.20260702',
+        verdict: 'passed',
+        traceRefs: ['trace.qa_swarm.khala_code.seed_corpus.20260702'],
+        coverageRefs: ['coverage.qa_swarm.khala_code.seed_corpus.20260702'],
+        meteringRows: [row],
+        publicSafetyRefs: [
+          'redaction.qa_swarm.public_projection.reviewed.20260702',
+        ],
+      }),
+    ).toThrow(/not qa-run\.khala-code-nightly\.20260702/)
+  })
+
+  test('bridges engagement receipts through quick-win lifecycle while settlement stays inert by default', () => {
+    const engagement = buildQaSwarmEngagementReceipt({
+      signupId: 'business_signup.qa_swarm.example.001',
+      hostedRunReceipt: hostedRunReceipt(),
+      quickWinScopedRef: 'scope.qa_swarm.audit.example.001',
+      outcomeAcceptedRef: 'acceptance.qa_swarm.audit.example.001',
+      buyerPaidRef: 'payment.qa_swarm.audit.example.001',
+      providerSettledRef: 'settlement.qa_swarm.audit.example.001',
+    })
+
+    expect(engagement.paymentMode).toBe('inert_until_owner_armed')
+    expect(engagement.movedMoney).toBe(false)
+    expect(engagement.businessQuickWinReceipt.paidQuickWin).toBe(false)
+    expect(engagement.businessQuickWinReceipt.unevidencedStateIds).toContain(
+      'buyer_paid',
+    )
+    expect(engagement.businessQuickWinReceipt.unevidencedStateIds).toContain(
+      'provider_settled',
+    )
+  })
+
+  test('owner arming may evidence payment refs but still does not move money', () => {
+    const engagement = buildQaSwarmEngagementReceipt({
+      signupId: 'business_signup.qa_swarm.example.001',
+      hostedRunReceipt: hostedRunReceipt(),
+      quickWinScopedRef: 'scope.qa_swarm.audit.example.001',
+      outcomeAcceptedRef: 'acceptance.qa_swarm.audit.example.001',
+      buyerPaidRef: 'payment.qa_swarm.audit.example.001',
+      providerSettledRef: 'settlement.qa_swarm.audit.example.001',
+      ownerArmToken: QA_SWARM_OWNER_ARM_TOKEN,
+    })
+
+    expect(engagement.businessQuickWinReceipt.paidQuickWin).toBe(true)
+    expect(engagement.businessQuickWinReceipt.evidencedStateCount).toBe(6)
+    expect(engagement.paymentMode).toBe('inert_until_owner_armed')
+    expect(engagement.movedMoney).toBe(false)
+  })
+
+  test('public hosted-run projection keeps refs and drops nothing private', () => {
+    const projection = publicQaSwarmHostedRunReceiptProjection(hostedRunReceipt())
+
+    expect(projection.exactTokenTotal).toBe(130)
+    expect(projection.traceRefs).toHaveLength(1)
+    expect(JSON.stringify(projection)).not.toContain('business_signup')
+    expect(JSON.stringify(projection)).not.toContain('payment.qa_swarm')
+  })
+})

--- a/apps/openagents.com/workers/api/src/qa-swarm-hosted-run-receipt.ts
+++ b/apps/openagents.com/workers/api/src/qa-swarm-hosted-run-receipt.ts
@@ -1,0 +1,335 @@
+import { Schema as S } from 'effect'
+
+import {
+  buildBusinessQuickWinReceipt,
+  type BusinessQuickWinReceipt,
+} from './business-quick-win-receipt'
+
+export const QA_SWARM_HOSTED_RUN_RECEIPT_SCHEMA_VERSION =
+  'openagents.qa_swarm.hosted_run_receipt.v1'
+
+export const QA_SWARM_HOSTED_RUN_METERING_SCHEMA_VERSION =
+  'openagents.qa_swarm.hosted_run_metering.v1'
+
+export const QA_SWARM_ENGAGEMENT_RECEIPT_SCHEMA_VERSION =
+  'openagents.qa_swarm.engagement_receipt.v1'
+
+export const QA_SWARM_OWNER_ARM_TOKEN = 'owner.arm.qa_swarm_engagement.v1'
+
+const PUBLIC_REF_PATTERN =
+  /^[a-z][a-z0-9_-]*(\.[a-z0-9][a-z0-9_-]*){2,}$/i
+
+const PRIVATE_REF_PATTERN =
+  /(@|\/Users\/|\/home\/|access[_-]?token|api[_-]?key|auth\.json|bearer|cookie|customer[_-]?(email|name|phone|prompt|record|value)|email[_-]?(address|body|html|raw|text)|gho_[A-Za-z0-9_]+|ghp_[A-Za-z0-9_]+|invoice[_-]?(id|raw)|lnbc|lntb|lnbcrt|macaroon|mnemonic|oauth|payment[_-]?(hash|id|invoice|preimage|proof|raw|secret)|payout[_-]?(address|destination|private|raw|target)|preimage|private[_-]?(archive|customer|dataset|key|prompt|source|trace|wallet)|provider[_-]?(credential|grant|payload|secret|token)|raw[_-]?(artifact|auth|customer|dataset|invoice|log|payment|payload|payout|prompt|provider|record|runner|run[_-]?log|source|state|target|telemetry|text|trace)|recovery[_-]?phrase|secret|seed[_-]?phrase|sk-[a-z0-9]|wallet[._-]?(key|material|mnemonic|payment|preimage|secret|seed))/i
+
+export const QaSwarmHostedRunVerdict = S.Literals([
+  'passed',
+  'failed',
+  'warning',
+  'inconclusive',
+])
+export type QaSwarmHostedRunVerdict = typeof QaSwarmHostedRunVerdict.Type
+
+export const QaSwarmUsageTruth = S.Literals(['exact'])
+export type QaSwarmUsageTruth = typeof QaSwarmUsageTruth.Type
+
+export const QaSwarmMeteringSource = S.Literals([
+  'runner_report',
+  'provider_usage',
+  'ledger_reconciliation',
+])
+export type QaSwarmMeteringSource = typeof QaSwarmMeteringSource.Type
+
+export const QaSwarmHostedRunMeteringRow = S.Struct({
+  schemaVersion: S.Literal(QA_SWARM_HOSTED_RUN_METERING_SCHEMA_VERSION),
+  rowRef: S.String,
+  runRef: S.String,
+  provider: S.Literal('qa-swarm-hosted-run'),
+  model: S.Literal('openagents/qa-swarm-hosted-run'),
+  usageTruth: QaSwarmUsageTruth,
+  demandKind: S.Literal('hosted_run'),
+  demandSource: S.Literal('qa_swarm_hosted_run'),
+  source: QaSwarmMeteringSource,
+  inputTokens: S.Number,
+  outputTokens: S.Number,
+  reasoningTokens: S.Number,
+  cacheReadTokens: S.Number,
+  totalTokens: S.Number,
+})
+export type QaSwarmHostedRunMeteringRow =
+  typeof QaSwarmHostedRunMeteringRow.Type
+
+export const QaSwarmHostedRunReceipt = S.Struct({
+  schemaVersion: S.Literal(QA_SWARM_HOSTED_RUN_RECEIPT_SCHEMA_VERSION),
+  receiptKind: S.Literal('qa_swarm_hosted_run'),
+  receiptRef: S.String,
+  runRef: S.String,
+  projectionRef: S.String,
+  verdict: QaSwarmHostedRunVerdict,
+  traceRefs: S.Array(S.String),
+  coverageRefs: S.Array(S.String),
+  videoRefs: S.Array(S.String),
+  distilledTestRefs: S.Array(S.String),
+  meteringRowRefs: S.Array(S.String),
+  exactTokenTotal: S.Number,
+  publicSafetyRefs: S.Array(S.String),
+  settlement: S.Struct({
+    state: S.Literal('inert_owner_armed_required'),
+    movedMoney: S.Literal(false),
+    ownerArmingRef: S.Literal('NEEDS_OWNER.qa_swarm_hosted_run_engagement_arming'),
+  }),
+})
+export type QaSwarmHostedRunReceipt = typeof QaSwarmHostedRunReceipt.Type
+
+export class QaSwarmHostedRunReceiptInvariantError extends S.TaggedErrorClass<QaSwarmHostedRunReceiptInvariantError>()(
+  'QaSwarmHostedRunReceiptInvariantError',
+  { reason: S.String },
+) {
+  override get message() {
+    return this.reason
+  }
+}
+
+export type QaSwarmHostedRunMeteringInput = Readonly<{
+  rowRef: string
+  runRef: string
+  source: QaSwarmMeteringSource
+  usageTruth: 'exact' | 'estimated' | 'synthetic' | 'missing'
+  inputTokens: number
+  outputTokens: number
+  reasoningTokens?: number
+  cacheReadTokens?: number
+  totalTokens?: number
+}>
+
+export type QaSwarmHostedRunReceiptInput = Readonly<{
+  receiptRef: string
+  runRef: string
+  projectionRef: string
+  verdict: QaSwarmHostedRunVerdict
+  traceRefs: ReadonlyArray<string>
+  coverageRefs: ReadonlyArray<string>
+  videoRefs?: ReadonlyArray<string>
+  distilledTestRefs?: ReadonlyArray<string>
+  meteringRows: ReadonlyArray<QaSwarmHostedRunMeteringRow>
+  publicSafetyRefs: ReadonlyArray<string>
+}>
+
+export type QaSwarmEngagementReceipt = Readonly<{
+  schemaVersion: typeof QA_SWARM_ENGAGEMENT_RECEIPT_SCHEMA_VERSION
+  receiptKind: 'qa_swarm_engagement'
+  hostedRunReceiptRef: string
+  businessQuickWinReceipt: BusinessQuickWinReceipt
+  paymentMode: 'inert_until_owner_armed'
+  movedMoney: false
+}>
+
+export type QaSwarmEngagementReceiptInput = Readonly<{
+  signupId: string
+  hostedRunReceipt: QaSwarmHostedRunReceipt
+  quickWinScopedRef: string
+  outcomeAcceptedRef?: string | null
+  buyerPaidRef?: string | null
+  providerSettledRef?: string | null
+  ownerArmToken?: string
+}>
+
+const trimmedOrNull = (value: string | null | undefined): string | null => {
+  if (value === undefined || value === null) {
+    return null
+  }
+  const trimmed = value.trim()
+  return trimmed === '' ? null : trimmed
+}
+
+const requirePublicRef = (value: string, field: string): string => {
+  const ref = trimmedOrNull(value)
+  if (ref === null) {
+    throw new QaSwarmHostedRunReceiptInvariantError({
+      reason: `${field} is required.`,
+    })
+  }
+  if (!PUBLIC_REF_PATTERN.test(ref) || PRIVATE_REF_PATTERN.test(ref)) {
+    throw new QaSwarmHostedRunReceiptInvariantError({
+      reason: `${field} must be a public-safe dereferenceable ref.`,
+    })
+  }
+  return ref
+}
+
+const requirePublicRefs = (
+  values: ReadonlyArray<string>,
+  field: string,
+): ReadonlyArray<string> => {
+  if (values.length === 0) {
+    throw new QaSwarmHostedRunReceiptInvariantError({
+      reason: `${field} must include at least one dereferenceable ref.`,
+    })
+  }
+  return values.map((value, index) => requirePublicRef(value, `${field}[${index}]`))
+}
+
+const requireNonNegativeInteger = (value: number, field: string): number => {
+  if (!Number.isInteger(value) || value < 0) {
+    throw new QaSwarmHostedRunReceiptInvariantError({
+      reason: `${field} must be a non-negative integer.`,
+    })
+  }
+  return value
+}
+
+export const buildQaSwarmHostedRunMeteringRow = (
+  input: QaSwarmHostedRunMeteringInput,
+): QaSwarmHostedRunMeteringRow => {
+  if (input.usageTruth !== 'exact') {
+    throw new QaSwarmHostedRunReceiptInvariantError({
+      reason: `hosted QA Swarm metering is exact-only; got ${input.usageTruth}.`,
+    })
+  }
+
+  const inputTokens = requireNonNegativeInteger(
+    input.inputTokens,
+    'inputTokens',
+  )
+  const outputTokens = requireNonNegativeInteger(
+    input.outputTokens,
+    'outputTokens',
+  )
+  const reasoningTokens = requireNonNegativeInteger(
+    input.reasoningTokens ?? 0,
+    'reasoningTokens',
+  )
+  const cacheReadTokens = requireNonNegativeInteger(
+    input.cacheReadTokens ?? 0,
+    'cacheReadTokens',
+  )
+  const computedTotal =
+    inputTokens + outputTokens + reasoningTokens + cacheReadTokens
+  const totalTokens = requireNonNegativeInteger(
+    input.totalTokens ?? computedTotal,
+    'totalTokens',
+  )
+
+  if (totalTokens !== computedTotal) {
+    throw new QaSwarmHostedRunReceiptInvariantError({
+      reason: 'totalTokens must equal input + output + reasoning + cacheRead.',
+    })
+  }
+
+  return {
+    schemaVersion: QA_SWARM_HOSTED_RUN_METERING_SCHEMA_VERSION,
+    rowRef: requirePublicRef(input.rowRef, 'rowRef'),
+    runRef: requirePublicRef(input.runRef, 'runRef'),
+    provider: 'qa-swarm-hosted-run',
+    model: 'openagents/qa-swarm-hosted-run',
+    usageTruth: 'exact',
+    demandKind: 'hosted_run',
+    demandSource: 'qa_swarm_hosted_run',
+    source: input.source,
+    inputTokens,
+    outputTokens,
+    reasoningTokens,
+    cacheReadTokens,
+    totalTokens,
+  }
+}
+
+export const buildQaSwarmHostedRunReceipt = (
+  input: QaSwarmHostedRunReceiptInput,
+): QaSwarmHostedRunReceipt => {
+  const runRef = requirePublicRef(input.runRef, 'runRef')
+  const meteringRows = input.meteringRows
+  if (meteringRows.length === 0) {
+    throw new QaSwarmHostedRunReceiptInvariantError({
+      reason: 'meteringRows must include at least one exact usage row.',
+    })
+  }
+  const mismatched = meteringRows.find(row => row.runRef !== runRef)
+  if (mismatched !== undefined) {
+    throw new QaSwarmHostedRunReceiptInvariantError({
+      reason: `metering row ${mismatched.rowRef} is for ${mismatched.runRef}, not ${runRef}.`,
+    })
+  }
+  const exactTokenTotal = meteringRows.reduce(
+    (sum, row) => sum + row.totalTokens,
+    0,
+  )
+
+  return {
+    schemaVersion: QA_SWARM_HOSTED_RUN_RECEIPT_SCHEMA_VERSION,
+    receiptKind: 'qa_swarm_hosted_run',
+    receiptRef: requirePublicRef(input.receiptRef, 'receiptRef'),
+    runRef,
+    projectionRef: requirePublicRef(input.projectionRef, 'projectionRef'),
+    verdict: input.verdict,
+    traceRefs: requirePublicRefs(input.traceRefs, 'traceRefs'),
+    coverageRefs: requirePublicRefs(input.coverageRefs, 'coverageRefs'),
+    videoRefs: (input.videoRefs ?? []).map((value, index) =>
+      requirePublicRef(value, `videoRefs[${index}]`),
+    ),
+    distilledTestRefs: (input.distilledTestRefs ?? []).map((value, index) =>
+      requirePublicRef(value, `distilledTestRefs[${index}]`),
+    ),
+    meteringRowRefs: meteringRows.map(row => row.rowRef),
+    exactTokenTotal,
+    publicSafetyRefs: requirePublicRefs(
+      input.publicSafetyRefs,
+      'publicSafetyRefs',
+    ),
+    settlement: {
+      state: 'inert_owner_armed_required',
+      movedMoney: false,
+      ownerArmingRef: 'NEEDS_OWNER.qa_swarm_hosted_run_engagement_arming',
+    },
+  }
+}
+
+export const buildQaSwarmEngagementReceipt = (
+  input: QaSwarmEngagementReceiptInput,
+): QaSwarmEngagementReceipt => {
+  const ownerArmed = input.ownerArmToken === QA_SWARM_OWNER_ARM_TOKEN
+  const buyerPaidRef = ownerArmed ? input.buyerPaidRef : null
+  const providerSettledRef = ownerArmed ? input.providerSettledRef : null
+  const outcomeAcceptedRef = trimmedOrNull(input.outcomeAcceptedRef)
+  const quickWinInput = {
+    signupId: input.signupId,
+    offeringPromiseId: 'qa_swarm.hosted_runs.v1',
+    quickWinSummary: 'Hosted QA Swarm run engagement.',
+    quickWinScopedRef: input.quickWinScopedRef,
+    deliveredEvidenceRef: input.hostedRunReceipt.receiptRef,
+    ...(outcomeAcceptedRef === null ? {} : { outcomeAcceptedRef }),
+    ...(buyerPaidRef === null || buyerPaidRef === undefined
+      ? {}
+      : { buyerPaidRef }),
+    ...(providerSettledRef === null || providerSettledRef === undefined
+      ? {}
+      : { providerSettledRef }),
+    publicCaveatRef:
+      'caveat.qa_swarm.engagement_settlement_inert_until_owner_armed',
+  }
+
+  return {
+    schemaVersion: QA_SWARM_ENGAGEMENT_RECEIPT_SCHEMA_VERSION,
+    receiptKind: 'qa_swarm_engagement',
+    hostedRunReceiptRef: input.hostedRunReceipt.receiptRef,
+    businessQuickWinReceipt: buildBusinessQuickWinReceipt(quickWinInput),
+    paymentMode: 'inert_until_owner_armed',
+    movedMoney: false,
+  }
+}
+
+export const publicQaSwarmHostedRunReceiptProjection = (
+  receipt: QaSwarmHostedRunReceipt,
+) => ({
+  receiptKind: receipt.receiptKind,
+  receiptRef: receipt.receiptRef,
+  runRef: receipt.runRef,
+  projectionRef: receipt.projectionRef,
+  verdict: receipt.verdict,
+  traceRefs: receipt.traceRefs,
+  coverageRefs: receipt.coverageRefs,
+  meteringRowRefs: receipt.meteringRowRefs,
+  exactTokenTotal: receipt.exactTokenTotal,
+  publicSafetyRefs: receipt.publicSafetyRefs,
+  settlement: receipt.settlement,
+})


### PR DESCRIPTION
Closes #8070

## Summary
- Add a typed QA Swarm hosted-run receipt contract with required trace, coverage, public-safety, and exact metering refs.
- Add exact-only hosted-run metering rows that reject estimated/synthetic/missing usage and inconsistent totals.
- Bridge QA Swarm engagement receipts into the existing business quick-win lifecycle while keeping payment/settlement inert unless owner-armed.
- Add the required `NEEDS_OWNER.md` arming entry for paid/settled hosted-run engagement refs.

## Verification
- `bun run --cwd apps/openagents.com/workers/api test -- src/qa-swarm-hosted-run-receipt.test.ts` — PASS (1 file, 7 tests)
- `bun run --cwd apps/openagents.com/workers/api typecheck` — PASS
- `bun run check:deploy` — PASS

Note: `check:deploy` includes a contract-drift guard fixture test that intentionally prints sample "FAILED" lines while asserting the guard catches fixture drift; the command exited 0 and all listed suites passed.
