### PR TITLE
Add QA Swarm hosted run composition

### DIFF
--- a/apps/qa-runner/README.md
+++ b/apps/qa-runner/README.md
@@ -143,6 +143,15 @@ bun run --cwd apps/qa-runner serve
 # (no Chrome/network/spend) by default; real runs gated by QA_CONTROL_ARM_REAL=1.
 QA_CONTROL_TOKENS="raynor:tok_demo_secret" bun run --cwd apps/qa-runner api
 #   curl quick-start a third party can follow: docs/control-api-quickstart.md
+
+# QA Swarm hosted-run composition (#8065): one command emits the QS2
+# openagents.qa_swarm.run_projection.v1 artifact plus /qa/{runRef} share URL.
+# Fixture tier is no-spend by default; live tiers are skip-safe unless armed.
+bun run --cwd apps/qa-runner qa -- swarm run \
+  --target https://openagents.com \
+  --out ./runs/qa-swarm \
+  --max-workers 2 \
+  --max-runs 1
 ```
 
 ## QA Control API (#6196): everything over HTTP
@@ -155,6 +164,14 @@ Worker), running the existing engine **in-process** with an in-memory job store.
 Auth is a **Khala agent bearer token**; a deterministic **mock path** runs with
 no Chrome/network/spend; real runs are owner-gated. Full curl walkthrough:
 [`docs/control-api-quickstart.md`](docs/control-api-quickstart.md).
+
+`POST /swarm-runs` composes the same control-plane runner into a QA Swarm run:
+fixture-tier fanout, FleetRun-style worker/run caps, skip-safe live tier rows
+for GCE Tier-2 and CF Browser Rendering, and an
+`openagents.qa_swarm.run_projection.v1` artifact with a `/qa/{runRef}` share
+URL. `GET /swarm-runs/:id` returns the projection and tier statuses. Real runs
+still require `QA_CONTROL_ARM_REAL=1`; unarmed live requests fail closed with
+`not_armed`.
 
 ## Artifacts (`result.json` + receipt)
 

--- a/apps/qa-runner/docs/control-api-quickstart.md
+++ b/apps/qa-runner/docs/control-api-quickstart.md
@@ -129,6 +129,37 @@ curl -s $B/evals/$EID -H "Authorization: Bearer $T"
 #                   "deltas": [...], "decisionGrade": false } }
 ```
 
+## Submit a QA Swarm run → fetch the projection
+
+One API call starts the hosted-run composition: qa-runner control fanout,
+FleetRun-style caps, the nightly-matrix projection vocabulary, and a
+`/qa/{runRef}` share URL. The fixture tier is no-spend by default; GCE Tier-2
+and CF Browser Rendering live tiers are represented as skip-safe tier rows
+unless the daemon is armed and a live runner receipt is attached.
+
+```bash
+SID=$(curl -s -X POST $B/swarm-runs \
+  -H "Authorization: Bearer $T" -H "content-type: application/json" \
+  -d '{
+    "target": "https://openagents.com",
+    "targetName": "openagents.com",
+    "maxWorkers": 2,
+    "maxRuns": 1
+  }' | grep -o '"id": "[^"]*"' | head -1 | sed 's/.*"id": "//;s/"//')
+
+curl -s $B/swarm-runs/$SID -H "Authorization: Bearer $T"
+# { "object": "qa_control.swarm_run_artifacts",
+#   "qaShareUrl": "https://openagents.com/qa/qa-run.swarm.openagents.com.<id>",
+#   "swarm": {
+#     "projection": { "schemaVersion": "openagents.qa_swarm.run_projection.v1", ... },
+#     "tiers": [
+#       { "backend": "fixture", "status": "passed", ... },
+#       { "backend": "gce-tier-2", "status": "skipped", ... },
+#       { "backend": "cf-browser-rendering", "status": "skipped", ... }
+#     ]
+#   } }
+```
+
 ## Real (gated) runs
 
 A `real` run drives **real Chrome against the live Target** and is **owner-gated**:
@@ -154,6 +185,8 @@ QA_CONTROL_TOKENS="raynor:tok_demo_secret" bun run api
 | `GET` | `/runs/:id/artifacts` | bearer | video + committed test + `result.json` (+ `verify`/`receipt`) + `/pro` link |
 | `POST` | `/evals` | bearer | submit a ≥2-variant comparison → `202` |
 | `GET` | `/evals/:id` | bearer | comparison + `/pro/evals/:id` link |
+| `POST` | `/swarm-runs` | bearer | submit a QA Swarm hosted-run composition → `202` |
+| `GET` | `/swarm-runs/:id` | bearer | QA Swarm projection + `/qa/{runRef}` share URL + tier statuses |
 
 OpenAI-compatible shapes where they fit: errors use the
 `{ error: { message, type, code } }` envelope; submit/status responses carry a

--- a/apps/qa-runner/src/api-server.test.ts
+++ b/apps/qa-runner/src/api-server.test.ts
@@ -155,6 +155,70 @@ describe("full eval flow over HTTP", () => {
   });
 });
 
+describe("full QA Swarm flow over HTTP", () => {
+  test("POST /swarm-runs -> GET /swarm-runs/:id projection", async () => {
+    const handler = mkHandler();
+    const submit = await handler(
+      req("POST", "/swarm-runs", {
+        token: TOKEN,
+        body: {
+          maxRuns: 1,
+          maxWorkers: 1,
+          target: "https://example.test",
+          targetName: "Example Target",
+        },
+      }),
+    );
+    expect(submit.status).toBe(202);
+    const job = (await submit.json()) as { id: string; object: string; qaShareUrl: string };
+    expect(job.object).toBe("qa_control.swarm_run");
+    expect(job.qaShareUrl).toContain("/qa/");
+
+    let status = "queued";
+    let body: {
+      object: string;
+      status: string;
+      qaShareUrl: string | null;
+      swarm: {
+        projection: { schemaVersion: string; verdict: string };
+        tiers: Array<{ backend: string; status: string }>;
+      } | null;
+    } = {
+      object: "",
+      status,
+      qaShareUrl: null,
+      swarm: null,
+    };
+    for (let i = 0; i < 50; i++) {
+      const s = await handler(req("GET", `/swarm-runs/${job.id}`, { token: TOKEN }));
+      body = (await s.json()) as typeof body;
+      status = body.status;
+      if (status === "succeeded" || status === "failed") break;
+      await new Promise((r) => setTimeout(r, 20));
+    }
+
+    expect(body.object).toBe("qa_control.swarm_run_artifacts");
+    expect(status).toBe("succeeded");
+    expect(body.qaShareUrl).toContain("/qa/");
+    expect(body.swarm).not.toBeNull();
+    expect(body.swarm!.projection.schemaVersion).toBe("openagents.qa_swarm.run_projection.v1");
+    expect(body.swarm!.tiers.some(tier => tier.backend === "cf-browser-rendering" && tier.status === "skipped")).toBe(true);
+  });
+
+  test("real swarm run is refused with 403 not_armed when unarmed", async () => {
+    const handler = mkHandler();
+    const res = await handler(
+      req("POST", "/swarm-runs", {
+        token: TOKEN,
+        body: { real: true, target: "https://openagents.com" },
+      }),
+    );
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as { error: { code: string } };
+    expect(body.error.code).toBe("not_armed");
+  });
+});
+
 describe("routing", () => {
   test("unknown route => 404", async () => {
     const res = await mkHandler()(req("GET", "/nope", { token: TOKEN }));

--- a/apps/qa-runner/src/api-server.ts
+++ b/apps/qa-runner/src/api-server.ts
@@ -14,6 +14,9 @@
 //                               present), and the /pro/runs/:id link
 //   POST /evals              -> submit a variant comparison (>= 2 variants)
 //   GET  /evals/:id          -> the comparison + /pro/evals/:id link
+//   POST /swarm-runs         -> compose qa-runner fanout into a QA Swarm
+//                               projection + /qa/{runRef} share URL
+//   GET  /swarm-runs/:id     -> swarm run projection/status
 //   GET  /healthz            -> liveness (no auth)
 //
 // OpenAI-compatible shapes where they fit: a 401 returns an OpenAI-style
@@ -33,6 +36,7 @@ import {
   type ControlOptions,
   type SubmitEvalInput,
   type SubmitRunInput,
+  type SubmitSwarmRunInput,
 } from "./control";
 import {
   allowlistFromEnv,
@@ -110,6 +114,20 @@ export function makeFetchHandler(options: ApiServerOptions): (req: Request) => P
         const input = (await readJson(req)) as SubmitEvalInput;
         const job = control.submitEval(input ?? {});
         return json(202, { object: "qa_control.eval", ...job });
+      }
+
+      // POST /swarm-runs
+      if (path === "/swarm-runs" && method === "POST") {
+        const input = (await readJson(req)) as SubmitSwarmRunInput;
+        const job = control.submitSwarmRun(input ?? {});
+        return json(202, { object: "qa_control.swarm_run", ...job });
+      }
+
+      // GET /swarm-runs/:id
+      const swarmMatch = /^\/swarm-runs\/([^/]+)$/.exec(path);
+      if (swarmMatch && method === "GET") {
+        const res = control.swarmRunArtifacts(decodeURIComponent(swarmMatch[1]!));
+        return json(200, { object: "qa_control.swarm_run_artifacts", ...res });
       }
 
       // GET /evals/:id

--- a/apps/qa-runner/src/byo.test.ts
+++ b/apps/qa-runner/src/byo.test.ts
@@ -7,17 +7,46 @@
 //   - it distills the session into a COMMITTED, runnable e2e test file,
 //   - the run requires no OpenAgents secret / login / token.
 
-import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { runCommand } from "./byo";
+import { runCommand, runSwarmCommand } from "./byo";
 
 let dir: string;
 let emit: string;
 beforeEach(() => {
   dir = mkdtempSync(join(tmpdir(), "qa-byo-test-"));
   emit = join(dir, "generated", "byo.e2e.test.ts");
+});
+
+describe("qa swarm run (fixture hosted-run composition)", () => {
+  test("emits a QA Swarm projection and share URL without model credentials", async () => {
+    const code = await runSwarmCommand([
+      "--target",
+      "https://example.test",
+      "--target-name",
+      "Example Target",
+      "--out",
+      dir,
+      "--max-workers",
+      "1",
+      "--max-runs",
+      "1",
+    ]);
+    expect(code).toBe(0);
+
+    // The command's generated id is time-based, so assert by walking the one
+    // created swarm artifact directory rather than pinning the id.
+    const child = readdirSync(dir).find(name => name.startsWith("swarm_"));
+    expect(child).toBeDefined();
+    expect(existsSync(join(dir, child!, "qa-swarm-projection.json"))).toBe(true);
+    const projection = JSON.parse(
+      readFileSync(join(dir, child!, "qa-swarm-projection.json"), "utf8"),
+    ) as { schemaVersion: string; verdict: string };
+    expect(projection.schemaVersion).toBe("openagents.qa_swarm.run_projection.v1");
+    expect(projection.verdict).toBe("warning");
+  });
 });
 afterEach(() => {
   rmSync(dir, { recursive: true, force: true });

--- a/apps/qa-runner/src/byo.ts
+++ b/apps/qa-runner/src/byo.ts
@@ -40,6 +40,7 @@ import { dirname, join, resolve } from "node:path";
 import { Effect } from "effect";
 import { localBackend } from "./backend";
 import { makeByoChatClient, resolveByoModelConfig, ByoModelConfigError } from "./byo-model";
+import { QaControl } from "./control";
 import { assessCandidate, distill } from "./distiller";
 import { makeFakeChromium } from "./fake-chromium";
 import type { ChatClient } from "./khala-driver";
@@ -73,6 +74,7 @@ const HELP = `qa — OSS, local-first, BYO-model autonomous QA runner
 
 USAGE
   qa run [options]
+  qa swarm run --target <url> [--out <dir>] [--max-workers <n>] [--max-runs <n>]
 
 OPTIONS
   --url <url>          Target dev/prod server to drive (required for a real run).
@@ -89,6 +91,11 @@ OPTIONS
   --fake-model         Deterministic, no-network, no-key, no-OpenAgents proof of
                        the loop. Drives a canned /login scenario against a fake
                        page; still emits a real video + a committed e2e test.
+
+SWARM
+  qa swarm run --target <url> composes the control API runner fanout into an
+  openagents.qa_swarm.run_projection.v1 artifact and a /qa/{runRef} share URL.
+  Fixture tier is default and no-spend; real tiers require QA_CONTROL_ARM_REAL=1.
 
 NO OPENAGENTS LOGIN IS REQUIRED. Khala is the default dogfood backend; overrides remain BYO.
 `;
@@ -212,6 +219,67 @@ async function runCommand(argv: ReadonlyArray<string>): Promise<number> {
   return ok ? 0 : 1;
 }
 
+async function runSwarmCommand(argv: ReadonlyArray<string>): Promise<number> {
+  const args = parseArgs(argv);
+  const target = typeof args.target === "string" ? args.target : undefined;
+  if (!target) {
+    console.error("error: qa swarm run requires --target <url>.\n");
+    console.error(HELP);
+    return 2;
+  }
+  const storeDir = typeof args.out === "string" ? args.out : "./runs/qa-swarm";
+  const maxWorkers = typeof args["max-workers"] === "string" ? Number(args["max-workers"]) : 2;
+  const maxRuns = typeof args["max-runs"] === "string" ? Number(args["max-runs"]) : 1;
+  const real = args.real === true;
+  const includeLiveTiers = args["include-live-tiers"] === true;
+  const targetName = typeof args["target-name"] === "string" ? args["target-name"] : target;
+  const proBaseUrl = typeof args["share-base-url"] === "string"
+    ? args["share-base-url"]
+    : "https://openagents.com";
+
+  const control = new QaControl({
+    allowReal: process.env.QA_CONTROL_ARM_REAL === "1",
+    defaultTokenBudget: Number(process.env.QA_CONTROL_TOKEN_BUDGET ?? 0),
+    proBaseUrl,
+    storeDir,
+  });
+
+  let job;
+  try {
+    job = control.submitSwarmRun({
+      includeLiveTiers,
+      maxRuns,
+      maxWorkers,
+      real,
+      target,
+      targetName,
+    });
+  } catch (error) {
+    console.error(error instanceof Error ? `error: ${error.message}` : String(error));
+    return 2;
+  }
+
+  console.log("=== qa swarm run ===");
+  console.log(`target:      ${target}`);
+  console.log(`mode:        ${real ? "real" : "fixture"}`);
+  console.log(`job:         ${job.id}`);
+  console.log(`worker cap:  ${maxWorkers}`);
+  console.log(`run cap:     ${maxRuns}`);
+
+  const done = await control.wait(job.id);
+  const artifacts = control.swarmRunArtifacts(job.id);
+  console.log(`status:      ${done.status}`);
+  console.log(`share URL:   ${artifacts.qaShareUrl ?? "(not ready)"}`);
+  if (artifacts.swarm) {
+    console.log(`projection:  ${artifacts.swarm.projectionPath}`);
+    console.log(`verdict:     ${artifacts.swarm.projection.verdict}`);
+    for (const tier of artifacts.swarm.tiers) {
+      console.log(`  [${tier.status}] ${tier.backend}${tier.reason ? ` — ${tier.reason}` : ""}`);
+    }
+  }
+  return done.status === "succeeded" ? 0 : 1;
+}
+
 async function main(): Promise<void> {
   const argv = process.argv.slice(2);
   const [command, ...rest] = argv;
@@ -222,6 +290,9 @@ async function main(): Promise<void> {
   if (command === "run") {
     process.exit(await runCommand(rest));
   }
+  if (command === "swarm" && rest[0] === "run") {
+    process.exit(await runSwarmCommand(rest.slice(1)));
+  }
   console.error(`error: unknown command "${command}"\n`);
   console.error(HELP);
   process.exit(2);
@@ -231,4 +302,4 @@ if (import.meta.main) {
   await main();
 }
 
-export { runCommand };
+export { runCommand, runSwarmCommand };

--- a/apps/qa-runner/src/control.test.ts
+++ b/apps/qa-runner/src/control.test.ts
@@ -7,6 +7,7 @@ import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { NotArmedError, BadRequestError, NotFoundError, QaControl } from "./control";
 import type { FetchLike } from "./publish-trace";
+import { QA_SWARM_RUN_PROJECTION_SCHEMA } from "./swarm";
 
 let dir: string;
 beforeEach(() => {
@@ -104,6 +105,50 @@ describe("submitEval (mock path)", () => {
   test("rejects < 2 variants", () => {
     const control = mkControl();
     expect(() => control.submitEval({ variants: [{ id: "only" }] })).toThrow(BadRequestError);
+  });
+});
+
+describe("submitSwarmRun (fixture path)", () => {
+  test("composes qa-runner fanout into a QA Swarm projection and share URL", async () => {
+    const control = mkControl();
+    const job = control.submitSwarmRun({
+      maxRuns: 2,
+      maxWorkers: 2,
+      target: "https://example.test",
+      targetName: "Example Target",
+    });
+    expect(job.kind).toBe("swarm");
+    expect(job.mode).toBe("mock");
+    expect(job.qaShareUrl).toContain("https://openagents.com/qa/qa-run.swarm.example.test");
+
+    const done = await control.wait(job.id);
+    expect(done.status).toBe("succeeded");
+
+    const artifacts = control.swarmRunArtifacts(job.id);
+    expect(artifacts.qaShareUrl).toContain("/qa/");
+    expect(artifacts.swarm).not.toBeNull();
+    expect(artifacts.swarm!.projection.schemaVersion).toBe(QA_SWARM_RUN_PROJECTION_SCHEMA);
+    expect(artifacts.swarm!.projection.verdict).toBe("warning");
+    expect(artifacts.swarm!.childRunIds.length).toBe(2);
+    expect(artifacts.swarm!.tiers.some(tier => tier.backend === "gce-tier-2" && tier.status === "skipped")).toBe(true);
+    expect(artifacts.swarm!.tiers.some(tier => tier.backend === "cf-browser-rendering" && tier.status === "skipped")).toBe(true);
+    expect(existsSync(artifacts.swarm!.projectionPath)).toBe(true);
+  });
+
+  test("rejects missing target and invalid caps", () => {
+    const control = mkControl();
+    // @ts-expect-error intentionally missing target
+    expect(() => control.submitSwarmRun({})).toThrow(BadRequestError);
+    expect(() =>
+      control.submitSwarmRun({ target: "https://example.test", maxWorkers: 0 }),
+    ).toThrow(BadRequestError);
+  });
+
+  test("real swarm runs are refused unless armed", () => {
+    const control = mkControl({ allowReal: false });
+    expect(() =>
+      control.submitSwarmRun({ real: true, target: "https://openagents.com" }),
+    ).toThrow(NotArmedError);
   });
 });
 

--- a/apps/qa-runner/src/control.ts
+++ b/apps/qa-runner/src/control.ts
@@ -49,6 +49,13 @@ import {
 } from "./publish-trace";
 import { makeTarget, type Target } from "./target";
 import { TARGET_REGISTRY, isTargetName } from "./target-registry";
+import {
+  readQaSwarmRunSummary,
+  swarmRunRefFor,
+  writeQaSwarmRunSummary,
+  type QaSwarmRunArtifactsResponse,
+  type SubmitSwarmRunInput,
+} from "./swarm";
 
 // Resolve a control-API `target` field to a base URL: a registry NAME
 // (dev/staging/prod/selfhost) -> its baseUrl; a full http(s) URL -> as-is;
@@ -68,7 +75,7 @@ const resolveControlBaseUrl = (target?: string): string => {
 // Public-safe job model (what GET /runs/:id and GET /evals/:id project)
 // ---------------------------------------------------------------------------
 
-export type JobKind = "run" | "eval";
+export type JobKind = "run" | "eval" | "swarm";
 export type JobStatus = "queued" | "running" | "succeeded" | "failed";
 
 /** How a job executed: deterministic mock vs a real (spend-capable-class) run. */
@@ -122,6 +129,8 @@ export interface Job {
    * when publishing is not armed.
    */
   readonly variantTraceUrls?: Readonly<Record<string, string>>;
+  readonly childRunIds?: readonly string[];
+  readonly qaShareUrl?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -177,6 +186,8 @@ export interface SubmitEvalVariant {
   readonly scenario?: ControlScenario;
 }
 
+export type { SubmitSwarmRunInput } from "./swarm";
+
 // ---------------------------------------------------------------------------
 // Errors (mapped to HTTP status by the server)
 // ---------------------------------------------------------------------------
@@ -190,6 +201,12 @@ export class NotArmedError extends Error {
 export class NotFoundError extends Error {
   readonly _tag = "NotFoundError";
 }
+
+const positiveInt = (value: number | undefined, fallback: number, field: string): number => {
+  if (value === undefined) return fallback;
+  if (Number.isInteger(value) && value > 0) return value;
+  throw new BadRequestError(`${field} must be a positive integer`);
+};
 
 // ---------------------------------------------------------------------------
 // The control plane
@@ -408,6 +425,92 @@ export class QaControl {
     return this.get(id);
   }
 
+  // ── submit a hosted QA Swarm composition ─────────────────────────────────
+
+  submitSwarmRun(input: SubmitSwarmRunInput): Job {
+    if (!input.target || !/^https?:\/\//i.test(input.target)) {
+      throw new BadRequestError("qa swarm run requires --target <http(s) URL>");
+    }
+    const scenario = input.scenario ?? "login-regression";
+    if (!isControlScenario(scenario)) {
+      throw new BadRequestError(`unknown scenario "${scenario}"`);
+    }
+    const real = input.real === true;
+    if (real && !this.allowReal) {
+      throw new NotArmedError(
+        "real QA Swarm runs are not armed on this daemon: set QA_CONTROL_ARM_REAL=1. " +
+          "The fixture tier runs without arming.",
+      );
+    }
+
+    const mode: JobMode = real ? "real" : "mock";
+    const id = this.genId("swarm");
+    const createdAt = this.now().toISOString();
+    const tokenBudget = real ? (input.tokenBudget ?? this.defaultTokenBudget) : 0;
+    const maxWorkers = positiveInt(input.maxWorkers, 2, "maxWorkers");
+    const maxRuns = positiveInt(input.maxRuns, 1, "maxRuns");
+    const runRef = swarmRunRefFor({ id, target: input.target, runRef: input.runRef });
+    const targetName = input.targetName ?? input.target;
+    const artifactDir = join(this.options.storeDir, id);
+    mkdirSync(artifactDir, { recursive: true });
+
+    const job: Job = {
+      id,
+      kind: "swarm",
+      status: "queued",
+      mode,
+      scenario,
+      targetName,
+      createdAt,
+      qaShareUrl: `${this.proBaseUrl}/qa/${runRef}`,
+      receipt: { mode, spendCapable: real, tokenBudget, tokensSpent: 0 },
+    };
+    this.jobs.set(id, job);
+    this.set(id, { artifactDir: id });
+
+    this.inflight.set(
+      id,
+      this.execute(id, async () => {
+        const childJobs: Job[] = [];
+        for (let i = 0; i < maxRuns; i++) {
+          const child = this.submitRun({
+            real,
+            scenario,
+            target: input.target,
+            targetName,
+            tokenBudget,
+          });
+          childJobs.push(child);
+          this.set(id, { childRunIds: childJobs.map(childJob => childJob.id) });
+          if (childJobs.length >= maxWorkers || i === maxRuns - 1) {
+            await Promise.all(childJobs.map(childJob => this.wait(childJob.id)));
+          }
+        }
+
+        const completedChildJobs = childJobs.map(childJob => this.get(childJob.id));
+        const summary = writeQaSwarmRunSummary({
+          artifactDir,
+          childJobs: completedChildJobs,
+          generatedAt: this.now().toISOString(),
+          includeLiveTiers: input.includeLiveTiers === true,
+          maxRuns,
+          maxWorkers,
+          proBaseUrl: this.proBaseUrl,
+          runRef,
+          storeDir: this.options.storeDir,
+          target: input.target,
+          targetName,
+          tokenBudget,
+        });
+        this.set(id, {
+          childRunIds: summary.childRunIds,
+          qaShareUrl: summary.shareUrl,
+        });
+      }),
+    );
+    return this.get(id);
+  }
+
   // ── status + artifacts ────────────────────────────────────────────────────
 
   /** Snapshot a job's status (throws NotFoundError if unknown). */
@@ -463,6 +566,21 @@ export class QaControl {
       proUrl: `${this.proBaseUrl}/pro/evals/${id}`,
       jobReceipt: job.receipt,
       comparison,
+    };
+  }
+
+  swarmRunArtifacts(id: string): QaSwarmRunArtifactsResponse {
+    const job = this.get(id);
+    if (job.kind !== "swarm") throw new BadRequestError(`job ${id} is not a swarm run`);
+    const dir = join(this.options.storeDir, id);
+    const swarm = readQaSwarmRunSummary(dir);
+    return {
+      jobId: id,
+      status: job.status,
+      qaShareUrl: swarm?.shareUrl ?? job.qaShareUrl ?? null,
+      proUrl: `${this.proBaseUrl}/pro/swarm-runs/${id}`,
+      jobReceipt: job.receipt,
+      swarm,
     };
   }
 

--- a/apps/qa-runner/src/swarm.ts
+++ b/apps/qa-runner/src/swarm.ts
@@ -1,0 +1,332 @@
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import type { Job, JobReceipt, JobStatus, SubmitRunInput } from "./control";
+
+export const QA_SWARM_RUN_PROJECTION_SCHEMA = "openagents.qa_swarm.run_projection.v1";
+
+export type QaSwarmVerdict = "passed" | "failed" | "warning" | "inconclusive";
+export type QaSwarmTierStatus = "scheduled" | "running" | "passed" | "failed" | "skipped";
+
+export interface SubmitSwarmRunInput {
+  readonly target: string;
+  readonly targetName?: string;
+  readonly title?: string;
+  readonly runRef?: string;
+  readonly scenario?: SubmitRunInput["scenario"];
+  readonly real?: boolean;
+  readonly tokenBudget?: number;
+  readonly maxWorkers?: number;
+  readonly maxRuns?: number;
+  readonly includeLiveTiers?: boolean;
+}
+
+export interface QaSwarmRunTier {
+  readonly backend: "fixture" | "gce-tier-2" | "cf-browser-rendering";
+  readonly jobId?: string;
+  readonly reason?: string;
+  readonly status: QaSwarmTierStatus;
+}
+
+export interface QaSwarmRunProjection {
+  readonly coverageFrontier: ReadonlyArray<{
+    readonly current: number;
+    readonly frontier: number;
+    readonly label: string;
+    readonly receiptRef: string;
+  }>;
+  readonly distilledTests: ReadonlyArray<{
+    readonly href: string;
+    readonly label: string;
+    readonly receiptRef: string;
+  }>;
+  readonly generatedAt: string;
+  readonly nightlyArtifactRef: string;
+  readonly opaqueTargetRefs: readonly string[];
+  readonly perfBudgets: ReadonlyArray<{
+    readonly actualMs: number;
+    readonly budgetMs: number;
+    readonly label: string;
+    readonly receiptRef: string;
+    readonly verdict: QaSwarmVerdict;
+  }>;
+  readonly projectionRef: string;
+  readonly publicSafetyRefs: readonly string[];
+  readonly runRef: string;
+  readonly schemaVersion: typeof QA_SWARM_RUN_PROJECTION_SCHEMA;
+  readonly staleness: {
+    readonly contractVersion: "projection_staleness.v1";
+    readonly maxAgeHours: number;
+    readonly mode: "artifact_snapshot";
+  };
+  readonly target: {
+    readonly label: string;
+    readonly ref: string;
+    readonly visibility: "public" | "opaque";
+  };
+  readonly title: string;
+  readonly traceRefs: readonly string[];
+  readonly verdict: QaSwarmVerdict;
+  readonly verdictWall: ReadonlyArray<{
+    readonly label: string;
+    readonly receiptRef: string;
+    readonly summary: string;
+    readonly verdict: QaSwarmVerdict;
+  }>;
+  readonly videoRefs: ReadonlyArray<{
+    readonly label: string;
+    readonly posterRef: string;
+    readonly traceHref: string;
+    readonly videoRef: string;
+  }>;
+}
+
+export interface QaSwarmRunSummary {
+  readonly runRef: string;
+  readonly shareUrl: string;
+  readonly projectionPath: string;
+  readonly projection: QaSwarmRunProjection;
+  readonly caps: {
+    readonly maxWorkers: number;
+    readonly maxRuns: number;
+    readonly tokenBudget: number;
+  };
+  readonly tiers: readonly QaSwarmRunTier[];
+  readonly childRunIds: readonly string[];
+}
+
+export interface QaSwarmRunArtifactsResponse {
+  readonly jobId: string;
+  readonly status: JobStatus;
+  readonly proUrl: string;
+  readonly qaShareUrl: string | null;
+  readonly jobReceipt: JobReceipt;
+  readonly swarm: QaSwarmRunSummary | null;
+}
+
+const PRIVATE_MATERIAL_PATTERN =
+  /(@|\/Users\/|\/home\/|access[_-]?token|api[_-]?key|auth\.json|bearer|cookie|customer[_-]?(email|name|phone|prompt|record|value)|email[_-]?(address|body|html|raw|text)|gho_[A-Za-z0-9_]+|ghp_[A-Za-z0-9_]+|invoice[_-]?(id|raw)|lnbc|lntb|lnbcrt|macaroon|mnemonic|oauth|payment[_-]?(hash|id|invoice|preimage|proof|raw|secret)|payout[_-]?(address|destination|private|raw|target)|preimage|private[_-]?(archive|customer|dataset|key|prompt|source|trace|wallet)|provider[_-]?(account|credential|grant|payload|secret|token)|raw[_-]?(artifact|auth|customer|dataset|email|invoice|log|model|payment|payload|payout|prompt|provider|record|repo|runner|run[_-]?log|source|state|target|telemetry|text|trace)|recovery[_-]?phrase|runner[_-]?(payload|secret|token)|secret|seed[_-]?phrase|sk-[a-z0-9]|source[_-]?(archive|raw)|wallet[._-]?(key|material|mnemonic|payment|preimage|secret|seed))/i;
+
+const PUBLIC_REF_PATTERN =
+  /^(artifact|coverage|frontier|perf|poster|projection|qa-run|redaction|test|trace|video)\.[a-z0-9][a-z0-9._-]*$/i;
+
+const slug = (value: string): string =>
+  value
+    .trim()
+    .toLowerCase()
+    .replace(/^https?:\/\//, "")
+    .replace(/[^a-z0-9._-]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 64) || "target";
+
+const isPublicRef = (value: string): boolean =>
+  PUBLIC_REF_PATTERN.test(value) && !PRIVATE_MATERIAL_PATTERN.test(value);
+
+const assertPublicRefs = (refs: readonly string[], field: string): void => {
+  const unsafe = refs.find(ref => !isPublicRef(ref));
+  if (unsafe !== undefined) {
+    throw new Error(`Unsafe QA Swarm projection ref in ${field}: ${unsafe}`);
+  }
+};
+
+export const assertQaSwarmProjectionPublicSafe = (
+  projection: QaSwarmRunProjection,
+): QaSwarmRunProjection => {
+  if (PRIVATE_MATERIAL_PATTERN.test(JSON.stringify(projection))) {
+    throw new Error("QA Swarm projection contains private material");
+  }
+  assertPublicRefs([projection.projectionRef], "projectionRef");
+  assertPublicRefs([projection.nightlyArtifactRef], "nightlyArtifactRef");
+  assertPublicRefs(projection.opaqueTargetRefs, "opaqueTargetRefs");
+  assertPublicRefs(projection.publicSafetyRefs, "publicSafetyRefs");
+  assertPublicRefs(projection.traceRefs, "traceRefs");
+  assertPublicRefs(projection.verdictWall.map(item => item.receiptRef), "verdictWall.receiptRef");
+  assertPublicRefs(
+    projection.coverageFrontier.map(item => item.receiptRef),
+    "coverageFrontier.receiptRef",
+  );
+  assertPublicRefs(projection.perfBudgets.map(item => item.receiptRef), "perfBudgets.receiptRef");
+  assertPublicRefs(
+    projection.videoRefs.flatMap(item => [item.videoRef, item.posterRef]),
+    "videoRefs",
+  );
+  assertPublicRefs(
+    projection.distilledTests.map(item => item.receiptRef),
+    "distilledTests.receiptRef",
+  );
+  assertPublicRefs([projection.target.ref], "target.ref");
+  return projection;
+};
+
+export const swarmRunRefFor = (input: Readonly<{
+  id: string;
+  target: string;
+  runRef?: string | undefined;
+}>): string => input.runRef ?? `qa-run.swarm.${slug(input.target)}.${slug(input.id)}`;
+
+const runVerdict = (job: Job, resultStatus: string | undefined): QaSwarmVerdict => {
+  if (job.status === "failed") return "failed";
+  if (job.status !== "succeeded") return "inconclusive";
+  if (resultStatus === "pass") return "passed";
+  if (resultStatus === "fail") return "failed";
+  return "inconclusive";
+};
+
+const readRunStatus = (storeDir: string, jobId: string): string | undefined => {
+  const path = join(storeDir, jobId, "result.json");
+  if (!existsSync(path)) return undefined;
+  const parsed = JSON.parse(readFileSync(path, "utf8")) as { status?: unknown };
+  return typeof parsed.status === "string" ? parsed.status : undefined;
+};
+
+export const writeQaSwarmRunSummary = (input: Readonly<{
+  artifactDir: string;
+  childJobs: readonly Job[];
+  generatedAt: string;
+  includeLiveTiers: boolean;
+  maxRuns: number;
+  maxWorkers: number;
+  proBaseUrl: string;
+  runRef: string;
+  storeDir: string;
+  target: string;
+  targetName: string;
+  tokenBudget: number;
+}>): QaSwarmRunSummary => {
+  const targetSlug = slug(input.targetName || input.target);
+  const childRunIds = input.childJobs.map(job => job.id);
+  const childVerdicts = input.childJobs.map(job =>
+    runVerdict(job, readRunStatus(input.storeDir, job.id)),
+  );
+  const failedCount = childVerdicts.filter(verdict => verdict === "failed").length;
+  const inconclusiveCount = childVerdicts.filter(verdict => verdict === "inconclusive").length;
+  const passedCount = childVerdicts.filter(verdict => verdict === "passed").length;
+  const fixtureVerdict: QaSwarmVerdict =
+    failedCount > 0 ? "failed" : inconclusiveCount > 0 ? "inconclusive" : "passed";
+  const overallVerdict: QaSwarmVerdict =
+    fixtureVerdict === "passed" && !input.includeLiveTiers ? "warning" : fixtureVerdict;
+
+  const projection = assertQaSwarmProjectionPublicSafe({
+    coverageFrontier: [
+      {
+        current: passedCount,
+        frontier: Math.max(input.maxRuns, passedCount + failedCount + inconclusiveCount),
+        label: "Fixture scenario fanout",
+        receiptRef: `coverage.qa_swarm.${targetSlug}.${slug(input.runRef)}`,
+      },
+    ],
+    distilledTests: [
+      {
+        href: "/docs/qa/khala-code-mechanical-corpus",
+        label: "Nightly matrix recipe",
+        receiptRef: `test.qa_swarm.${targetSlug}.nightly_matrix_recipe.${slug(input.runRef)}`,
+      },
+    ],
+    generatedAt: input.generatedAt,
+    nightlyArtifactRef: `artifact.qa_swarm.${targetSlug}.nightly_matrix.${slug(input.runRef)}`,
+    opaqueTargetRefs: [`artifact.qa_swarm.target.opaque.${targetSlug}`],
+    perfBudgets: [
+      {
+        actualMs: input.childJobs.length,
+        budgetMs: input.maxRuns,
+        label: "Run cap usage",
+        receiptRef: `perf.qa_swarm.${targetSlug}.run_cap.${slug(input.runRef)}`,
+        verdict: input.childJobs.length <= input.maxRuns ? "passed" : "failed",
+      },
+      {
+        actualMs: Math.min(input.maxWorkers, input.childJobs.length),
+        budgetMs: input.maxWorkers,
+        label: "Worker cap usage",
+        receiptRef: `perf.qa_swarm.${targetSlug}.worker_cap.${slug(input.runRef)}`,
+        verdict: "passed",
+      },
+    ],
+    projectionRef: `projection.qa_swarm.run.${targetSlug}.${slug(input.runRef)}`,
+    publicSafetyRefs: [`redaction.qa_swarm.public_projection.${targetSlug}.${slug(input.runRef)}`],
+    runRef: input.runRef,
+    schemaVersion: QA_SWARM_RUN_PROJECTION_SCHEMA,
+    staleness: {
+      contractVersion: "projection_staleness.v1",
+      maxAgeHours: 24,
+      mode: "artifact_snapshot",
+    },
+    target: {
+      label: input.targetName,
+      ref: `artifact.qa_swarm.target.opaque.${targetSlug}`,
+      visibility: "opaque",
+    },
+    title: `QA Swarm hosted run: ${input.targetName}`,
+    traceRefs: childRunIds.map(jobId => `trace.qa_swarm.${targetSlug}.${slug(jobId)}`),
+    verdict: overallVerdict,
+    verdictWall: [
+      {
+        label: "Fixture-tier fanout",
+        receiptRef: `artifact.qa_swarm.verdict.fixture_fanout.${targetSlug}.${slug(input.runRef)}`,
+        summary: `${passedCount}/${input.childJobs.length} fixture shard(s) passed under owned-runner caps.`,
+        verdict: fixtureVerdict,
+      },
+      {
+        label: "Live owned-runner tiers",
+        receiptRef: `artifact.qa_swarm.verdict.live_tiers.${targetSlug}.${slug(input.runRef)}`,
+        summary: input.includeLiveTiers
+          ? "Live tiers requested; runner evidence is represented by the tier statuses."
+          : "GCE Tier-2 and CF Browser Rendering tiers were skipped safely for this fixture run.",
+        verdict: input.includeLiveTiers ? "inconclusive" : "warning",
+      },
+    ],
+    videoRefs: childRunIds.map(jobId => ({
+      label: `Fixture shard ${jobId}`,
+      posterRef: `poster.qa_swarm.${targetSlug}.${slug(jobId)}`,
+      traceHref: `/trace/${slug(jobId)}`,
+      videoRef: `video.qa_swarm.${targetSlug}.${slug(jobId)}`,
+    })),
+  });
+
+  const tiers: readonly QaSwarmRunTier[] = [
+    ...input.childJobs.map(job => ({
+      backend: "fixture" as const,
+      jobId: job.id,
+      status: job.status === "succeeded"
+        ? readRunStatus(input.storeDir, job.id) === "pass" ? "passed" as const : "failed" as const
+        : job.status === "failed" ? "failed" as const : "running" as const,
+    })),
+    {
+      backend: "gce-tier-2",
+      reason: input.includeLiveTiers
+        ? "live tier requested; external runner receipt not attached in fixture composition"
+        : "skip-safe fixture tier: set includeLiveTiers with an armed daemon for live evidence",
+      status: "skipped",
+    },
+    {
+      backend: "cf-browser-rendering",
+      reason: input.includeLiveTiers
+        ? "live tier requested; CF Browser Rendering receipt not attached in fixture composition"
+        : "skip-safe fixture tier: set includeLiveTiers with an armed daemon for live evidence",
+      status: "skipped",
+    },
+  ];
+
+  const summary: QaSwarmRunSummary = {
+    caps: {
+      maxRuns: input.maxRuns,
+      maxWorkers: input.maxWorkers,
+      tokenBudget: input.tokenBudget,
+    },
+    childRunIds,
+    projection,
+    projectionPath: join(input.artifactDir, "qa-swarm-projection.json"),
+    runRef: input.runRef,
+    shareUrl: `${input.proBaseUrl}/qa/${input.runRef}`,
+    tiers,
+  };
+
+  writeFileSync(summary.projectionPath, `${JSON.stringify(projection, null, 2)}\n`);
+  writeFileSync(join(input.artifactDir, "qa-swarm-run.json"), `${JSON.stringify(summary, null, 2)}\n`);
+  return summary;
+};
+
+export const readQaSwarmRunSummary = (artifactDir: string): QaSwarmRunSummary | null => {
+  const path = join(artifactDir, "qa-swarm-run.json");
+  if (!existsSync(path)) return null;
+  return JSON.parse(readFileSync(path, "utf8")) as QaSwarmRunSummary;
+};


### PR DESCRIPTION
Closes #8065.

## Summary
- Adds qa-runner QA Swarm composition with `qa swarm run --target <url>` and the typed `POST /swarm-runs` / `GET /swarm-runs/:id` control API.
- Emits `openagents.qa_swarm.run_projection.v1`, `/qa/{runRef}` share URL, public-safe refs, worker/run caps, and skip-safe live tier rows for GCE Tier-2 and CF Browser Rendering.
- Documents the one-command and one-API-call flows, with fixture tier no-spend by default and live runs gated by `QA_CONTROL_ARM_REAL=1`.

## Verification
- `bun run --cwd apps/qa-runner typecheck`
- `bun run --cwd apps/qa-runner test` — 475 pass, 0 fail
- `bun run check:deploy` — passed
- CLI smoke: `bun run --cwd apps/qa-runner qa -- swarm run --target https://example.test --out <tmp> --max-workers 1 --max-runs 1` — passed; emitted projection + `/qa/qa-run.swarm.example.test...` share URL

## FleetRun Evidence
- Fixture/no-spend local worker run; no raw private prompts, credentials, or local auth material included.
- Exact token accounting closeout is handled by the supervising FleetRun assignment closeout for this worker session.
