### PR TITLE
QA Swarm Arbiter board projection

### DIFF
--- a/apps/openagents.com/apps/web/package.json
+++ b/apps/openagents.com/apps/web/package.json
@@ -17,6 +17,7 @@
     "@effect/platform-browser": "4.0.0-beta.70",
     "@openagentsinc/autopilot-control-protocol": "workspace:*",
     "@openagentsinc/autopilot-ui": "workspace:*",
+    "@openagentsinc/arbiter-effect": "workspace:*",
     "@openagentsinc/design-tokens": "workspace:*",
     "@openagentsinc/mcp-contract": "workspace:*",
     "@openagentsinc/mullet-schema": "workspace:*",

--- a/apps/openagents.com/apps/web/src/page/qa-swarm.test.ts
+++ b/apps/openagents.com/apps/web/src/page/qa-swarm.test.ts
@@ -109,6 +109,10 @@ describe('QA Swarm route', () => {
     expect(rendered).toContain('Khala Code nightly QA swarm')
     expect(rendered).toContain('QA Swarm run')
     expect(rendered).toContain('Verdict wall')
+    expect(rendered).toContain('Arbiter swarm board')
+    expect(rendered).toContain('data-link-id="scenario-to-target"')
+    expect(rendered).toContain('data-status="evidence_backed"')
+    expect(rendered).toContain('QA Swarm board text mirror')
     expect(rendered).toContain('Coverage + frontier')
     expect(rendered).toContain('Perf budgets')
     expect(rendered).toContain('Findings ledger')
@@ -181,6 +185,9 @@ describe('QA Swarm projection schema and redaction', () => {
     expect(lookupQaSwarmRunProjection(QA_SWARM_SAMPLE_RUN_REF)).toEqual(
       sampleQaSwarmRunProjection,
     )
+    expect(sampleQaSwarmRunProjection.boardGraph.schemaVersion).toBe(
+      'openagents.arbiter.graph_spec.v0',
+    )
   })
 
   test('keeps non-owner targets opaque and public-safe', () => {
@@ -199,5 +206,23 @@ describe('QA Swarm projection schema and redaction', () => {
         traceRefs: ['/Users/operator/private/raw-trace.json'],
       }),
     ).toThrow(/private material|Unsafe QA Swarm projection ref/)
+  })
+
+  test('board projection refuses evidence-backed links without receipts', () => {
+    const broken = {
+      ...sampleQaSwarmRunProjection,
+      boardGraph: {
+        ...sampleQaSwarmRunProjection.boardGraph,
+        links: sampleQaSwarmRunProjection.boardGraph.links.map(link =>
+          link.id === 'scenario-to-target'
+            ? { ...link, status: 'evidence_backed' as const, evidenceRefs: [] }
+            : link,
+        ),
+      },
+    }
+
+    expect(() =>
+      assertQaSwarmPublicProjection(broken),
+    ).toThrow(/lit without receipt/)
   })
 })

--- a/apps/openagents.com/apps/web/src/page/qa-swarm.ts
+++ b/apps/openagents.com/apps/web/src/page/qa-swarm.ts
@@ -1,3 +1,4 @@
+import { arbiterGraphFigure } from '@openagentsinc/arbiter-effect/foldkit'
 import type { Html } from 'foldkit/html'
 import { html } from 'foldkit/html'
 
@@ -493,6 +494,28 @@ const runArticle = <Message>(projection: QaSwarmRunProjection): Html => {
           ),
         ],
       ),
+
+      h.section([Ui.className<Message>(panel)], [
+        h.div([Ui.className<Message>('grid gap-4')], [
+          label<Message>('Arbiter swarm board'),
+          h.div(
+            [
+              Ui.className<Message>(
+                'min-w-0 overflow-hidden border border-[var(--oa-color-khala-border)] bg-[var(--oa-color-khala-surface)] p-3',
+              ),
+            ],
+            [
+              arbiterGraphFigure<Message>({
+                spec: projection.boardGraph,
+                options: {
+                  layout: { height: 395 },
+                  mirrorLabel: 'QA Swarm board text mirror',
+                },
+              }),
+            ],
+          ),
+        ]),
+      ]),
 
       h.section([Ui.className<Message>(panel)], [
         h.div([Ui.className<Message>('grid gap-4')], [

--- a/apps/openagents.com/apps/web/src/page/qa-swarm/projection.ts
+++ b/apps/openagents.com/apps/web/src/page/qa-swarm/projection.ts
@@ -1,3 +1,5 @@
+import { GraphSpec } from '@openagentsinc/arbiter-effect/core'
+import { buildQaSwarmBoardGraphSpec } from '@openagentsinc/arbiter-effect/qa-swarm'
 import { Schema as S } from 'effect'
 
 export const QaSwarmVerdict = S.Literals([
@@ -105,6 +107,7 @@ export class QaSwarmCaseStudyProjection extends S.Class<QaSwarmCaseStudyProjecti
 export class QaSwarmRunProjection extends S.Class<QaSwarmRunProjection>(
   'QaSwarmRunProjection',
 )({
+  boardGraph: GraphSpec,
   caseStudy: QaSwarmCaseStudyProjection,
   coverageFrontier: S.Array(QaSwarmCoverageFrontierItem),
   distilledTests: S.Array(QaSwarmDistilledTestRef),
@@ -138,7 +141,7 @@ const PRIVATE_MATERIAL_PATTERN =
   /(@|\/Users\/|\/home\/|access[_-]?token|api[_-]?key|auth\.json|bearer|cookie|customer[_-]?(email|name|phone|prompt|record|value)|email[_-]?(address|body|html|raw|text)|gho_[A-Za-z0-9_]+|ghp_[A-Za-z0-9_]+|github\.com\/[^:/]+\/private|invoice[_-]?(id|raw)|lnbc|lntb|lnbcrt|macaroon|mnemonic|oauth|payment[_-]?(hash|id|invoice|preimage|proof|raw|secret)|payout[_-]?(address|destination|private|raw|target)|preimage|private[_-]?(archive|customer|dataset|key|prompt|source|trace|wallet)|provider[_-]?(account|credential|grant|payload|secret|token)|raw[_-]?(artifact|auth|customer|dataset|email|invoice|log|model|payment|payload|payout|prompt|provider|record|repo|runner|run[_-]?log|source|state|target|telemetry|text|trace)|recovery[_-]?phrase|runner[_-]?(payload|secret|token)|secret|seed[_-]?phrase|sk-[a-z0-9]|source[_-]?(archive|raw)|wallet[._-]?(key|material|mnemonic|payment|preimage|secret|seed))/i
 
 const PUBLIC_REF_PATTERN =
-  /^(artifact|coverage|frontier|perf|poster|projection|qa-run|redaction|test|trace|video)\.[a-z0-9][a-z0-9._-]*$/i
+  /^(artifact|check|coverage|frontier|openagents|perf|poster|projection|qa-run|redaction|test|trace|video)\.[a-z0-9][a-z0-9._-]*$/i
 
 const isPublicRef = (value: string): boolean =>
   PUBLIC_REF_PATTERN.test(value) && !PRIVATE_MATERIAL_PATTERN.test(value)
@@ -202,6 +205,17 @@ export const assertQaSwarmPublicProjection = (
     decoded.distilledTests.map(item => item.receiptRef),
     'distilledTests.receiptRef',
   )
+  assertPublicRefs(decoded.boardGraph.evidenceRefs, 'boardGraph.evidenceRefs')
+  assertPublicRefs(decoded.boardGraph.sourceRefs, 'boardGraph.sourceRefs')
+  assertPublicRefs(
+    decoded.boardGraph.links.flatMap(item => item.evidenceRefs),
+    'boardGraph.links.evidenceRefs',
+  )
+  for (const link of decoded.boardGraph.links) {
+    if (link.status === 'evidence_backed' && link.evidenceRefs.length === 0) {
+      throw new Error(`QA Swarm board link lit without receipt: ${link.id}`)
+    }
+  }
 
   if (decoded.target.visibility === 'opaque') {
     assertPublicRefs([decoded.target.ref], 'target.ref')
@@ -210,166 +224,171 @@ export const assertQaSwarmPublicProjection = (
   return decoded
 }
 
+const sampleQaSwarmRunProjectionFields = {
+  caseStudy: {
+    href: '/docs/qa/qa-swarm-khala-code-standing-engagement',
+    receiptRef: 'artifact.qa_swarm.case_study.khala_code.20260702',
+    summary:
+      'The first audit session caught two main-branch regressions in stale visual smokes and one cockpit robustness bug before the standing loop was automated.',
+    title: 'Case-study seed: the first Khala Code QA Swarm audit',
+  },
+  coverageFrontier: [
+    {
+      current: 42,
+      frontier: 58,
+      label: 'Seed corpus coverage',
+      receiptRef: 'coverage.qa_swarm.khala_code.seed_corpus.20260702',
+    },
+    {
+      current: 17,
+      frontier: 24,
+      label: 'Desktop state frontier',
+      receiptRef: 'frontier.qa_swarm.khala_code.desktop_state.20260702',
+    },
+    {
+      current: 9,
+      frontier: 13,
+      label: 'Regression tests distilled',
+      receiptRef: 'test.qa_swarm.khala_code.distilled.20260702',
+    },
+  ],
+  distilledTests: [
+    {
+      href: '/docs/qa/khala-code-mechanical-corpus',
+      label: 'Mechanical corpus',
+      receiptRef: 'test.qa_swarm.khala_code.mechanical_corpus.20260702',
+    },
+    {
+      href: '/docs/qa/khala-code-error-state-corpus',
+      label: 'Error-state corpus',
+      receiptRef: 'test.qa_swarm.khala_code.error_states.20260702',
+    },
+  ],
+  engagement: {
+    cadence: 'weekly',
+    reportHref: '/qa/qa-run.khala-code-nightly.latest',
+    reportRef: 'artifact.qa_swarm.weekly_report.khala_code.latest',
+    sourceArtifactRef: 'artifact.khala_code.qa_status_surface.latest',
+    status: 'standing_customer_one',
+  },
+  findingsLedger: {
+    caughtCount: 3,
+    distilledRegressionCount: 1,
+    filedIssueCount: 3,
+    fixedCount: 2,
+    ledgerRef: 'artifact.qa_swarm.findings_ledger.khala_code.20260702',
+    rows: [
+      {
+        findingRef: 'artifact.qa_swarm.finding.visual_fleet_run_rpc.20260702',
+        issueRef: 'artifact.qa_swarm.issue.visual_fleet_run_rpc.20260702',
+        label: 'Fleet-run RPC visual smoke stale fixture',
+        status: 'fixed',
+        testRef: 'test.qa_swarm.khala_code.visual_fleet_run_rpc.20260702',
+      },
+      {
+        findingRef: 'artifact.qa_swarm.finding.foldkit_cockpit_visual.20260702',
+        issueRef: 'artifact.qa_swarm.issue.foldkit_cockpit_visual.20260702',
+        label: 'Foldkit cockpit landing visual smoke stale fixture',
+        status: 'fixed',
+        testRef: 'test.qa_swarm.khala_code.foldkit_cockpit_visual.20260702',
+      },
+      {
+        findingRef: 'artifact.qa_swarm.finding.cockpit_failed_rpc_blank.20260702',
+        issueRef: 'artifact.qa_swarm.issue.cockpit_failed_rpc_blank.20260702',
+        label: 'Cockpit blanks when one startup RPC fails',
+        status: 'filed',
+        testRef: 'test.qa_swarm.khala_code.error_state_pending.20260702',
+      },
+    ],
+  },
+  generatedAt: '2026-07-02T17:00:00.000Z',
+  nightlyArtifactRef: 'artifact.qa_swarm.khala_code.nightly.20260702',
+  opaqueTargetRefs: ['artifact.qa_swarm.target.opaque.customer_one'],
+  perfBudgets: [
+    {
+      actualMs: 82,
+      budgetMs: 100,
+      label: 'Thread switch p95',
+      receiptRef: 'perf.qa_swarm.khala_code.thread_switch_p95.20260702',
+      verdict: 'passed',
+    },
+    {
+      actualMs: 441,
+      budgetMs: 500,
+      label: 'Lifecycle to card p95',
+      receiptRef: 'perf.qa_swarm.khala_code.lifecycle_card_p95.20260702',
+      verdict: 'passed',
+    },
+    {
+      actualMs: 1030,
+      budgetMs: 1000,
+      label: '25-agent tick p95',
+      receiptRef: 'perf.qa_swarm.khala_code.tick_p95.20260702',
+      verdict: 'warning',
+    },
+  ],
+  projectionRef: 'projection.qa_swarm.run.khala_code.20260702',
+  publicSafetyRefs: [
+    'redaction.qa_swarm.public_projection.reviewed.20260702',
+  ],
+  runRef: QA_SWARM_SAMPLE_RUN_REF,
+  schemaVersion: 'openagents.qa_swarm.run_projection.v1',
+  staleness: {
+    contractVersion: 'projection_staleness.v1',
+    maxAgeHours: 24,
+    mode: 'artifact_snapshot',
+  },
+  target: {
+    label: 'Khala Code Desktop',
+    ref: 'artifact.qa_swarm.target.opaque.customer_one',
+    visibility: 'opaque',
+  },
+  title: 'Khala Code nightly QA swarm',
+  traceRefs: [
+    'trace.public.qa_swarm.khala_code.seed_corpus.20260702',
+    'trace.public.qa_swarm.khala_code.desktop_frontier.20260702',
+  ],
+  verdict: 'warning',
+  verdictWall: [
+    {
+      label: 'Login and workspace routing',
+      receiptRef: 'artifact.qa_swarm.verdict.login_workspace.20260702',
+      summary: 'Core public entrypoints passed the mechanical flow.',
+      verdict: 'passed',
+    },
+    {
+      label: 'Desktop command palette',
+      receiptRef: 'artifact.qa_swarm.verdict.command_palette.20260702',
+      summary: 'Explorer found one latency budget warning, no correctness failure.',
+      verdict: 'warning',
+    },
+    {
+      label: 'Trace and video archive',
+      receiptRef: 'artifact.qa_swarm.verdict.trace_video.20260702',
+      summary: 'Trace, screenshot, and video refs are dereferenceable public receipts.',
+      verdict: 'passed',
+    },
+  ],
+  videoRefs: [
+    {
+      label: 'Seed corpus replay',
+      posterRef: 'poster.qa_swarm.khala_code.seed_corpus.20260702',
+      traceHref: '/trace/24c6fea6-b271-46c6-a9a9-bc614440e9ef',
+      videoRef: 'video.qa_swarm.khala_code.seed_corpus.20260702',
+    },
+    {
+      label: 'Desktop frontier replay',
+      posterRef: 'poster.qa_swarm.khala_code.desktop_frontier.20260702',
+      traceHref: '/trace/db838bdc-3bc6-48a5-8715-a6669f6b10c5',
+      videoRef: 'video.qa_swarm.khala_code.desktop_frontier.20260702',
+    },
+  ],
+} as const
+
 export const sampleQaSwarmRunProjection = assertQaSwarmPublicProjection(
   new QaSwarmRunProjection({
-    caseStudy: {
-      href: '/docs/qa/qa-swarm-khala-code-standing-engagement',
-      receiptRef: 'artifact.qa_swarm.case_study.khala_code.20260702',
-      summary:
-        'The first audit session caught two main-branch regressions in stale visual smokes and one cockpit robustness bug before the standing loop was automated.',
-      title: 'Case-study seed: the first Khala Code QA Swarm audit',
-    },
-    coverageFrontier: [
-      {
-        current: 42,
-        frontier: 58,
-        label: 'Seed corpus coverage',
-        receiptRef: 'coverage.qa_swarm.khala_code.seed_corpus.20260702',
-      },
-      {
-        current: 17,
-        frontier: 24,
-        label: 'Desktop state frontier',
-        receiptRef: 'frontier.qa_swarm.khala_code.desktop_state.20260702',
-      },
-      {
-        current: 9,
-        frontier: 13,
-        label: 'Regression tests distilled',
-        receiptRef: 'test.qa_swarm.khala_code.distilled.20260702',
-      },
-    ],
-    distilledTests: [
-      {
-        href: '/docs/qa/khala-code-mechanical-corpus',
-        label: 'Mechanical corpus',
-        receiptRef: 'test.qa_swarm.khala_code.mechanical_corpus.20260702',
-      },
-      {
-        href: '/docs/qa/khala-code-error-state-corpus',
-        label: 'Error-state corpus',
-        receiptRef: 'test.qa_swarm.khala_code.error_states.20260702',
-      },
-    ],
-    engagement: {
-      cadence: 'weekly',
-      reportHref: '/qa/qa-run.khala-code-nightly.latest',
-      reportRef: 'artifact.qa_swarm.weekly_report.khala_code.latest',
-      sourceArtifactRef: 'artifact.khala_code.qa_status_surface.latest',
-      status: 'standing_customer_one',
-    },
-    findingsLedger: {
-      caughtCount: 3,
-      distilledRegressionCount: 1,
-      filedIssueCount: 3,
-      fixedCount: 2,
-      ledgerRef: 'artifact.qa_swarm.findings_ledger.khala_code.20260702',
-      rows: [
-        {
-          findingRef: 'artifact.qa_swarm.finding.visual_fleet_run_rpc.20260702',
-          issueRef: 'artifact.qa_swarm.issue.visual_fleet_run_rpc.20260702',
-          label: 'Fleet-run RPC visual smoke stale fixture',
-          status: 'fixed',
-          testRef: 'test.qa_swarm.khala_code.visual_fleet_run_rpc.20260702',
-        },
-        {
-          findingRef: 'artifact.qa_swarm.finding.foldkit_cockpit_visual.20260702',
-          issueRef: 'artifact.qa_swarm.issue.foldkit_cockpit_visual.20260702',
-          label: 'Foldkit cockpit landing visual smoke stale fixture',
-          status: 'fixed',
-          testRef: 'test.qa_swarm.khala_code.foldkit_cockpit_visual.20260702',
-        },
-        {
-          findingRef: 'artifact.qa_swarm.finding.cockpit_failed_rpc_blank.20260702',
-          issueRef: 'artifact.qa_swarm.issue.cockpit_failed_rpc_blank.20260702',
-          label: 'Cockpit blanks when one startup RPC fails',
-          status: 'filed',
-          testRef: 'test.qa_swarm.khala_code.error_state_pending.20260702',
-        },
-      ],
-    },
-    generatedAt: '2026-07-02T17:00:00.000Z',
-    nightlyArtifactRef: 'artifact.qa_swarm.khala_code.nightly.20260702',
-    opaqueTargetRefs: ['artifact.qa_swarm.target.opaque.customer_one'],
-    perfBudgets: [
-      {
-        actualMs: 82,
-        budgetMs: 100,
-        label: 'Thread switch p95',
-        receiptRef: 'perf.qa_swarm.khala_code.thread_switch_p95.20260702',
-        verdict: 'passed',
-      },
-      {
-        actualMs: 441,
-        budgetMs: 500,
-        label: 'Lifecycle to card p95',
-        receiptRef: 'perf.qa_swarm.khala_code.lifecycle_card_p95.20260702',
-        verdict: 'passed',
-      },
-      {
-        actualMs: 1030,
-        budgetMs: 1000,
-        label: '25-agent tick p95',
-        receiptRef: 'perf.qa_swarm.khala_code.tick_p95.20260702',
-        verdict: 'warning',
-      },
-    ],
-    projectionRef: 'projection.qa_swarm.run.khala_code.20260702',
-    publicSafetyRefs: [
-      'redaction.qa_swarm.public_projection.reviewed.20260702',
-    ],
-    runRef: QA_SWARM_SAMPLE_RUN_REF,
-    schemaVersion: 'openagents.qa_swarm.run_projection.v1',
-    staleness: {
-      contractVersion: 'projection_staleness.v1',
-      maxAgeHours: 24,
-      mode: 'artifact_snapshot',
-    },
-    target: {
-      label: 'Khala Code Desktop',
-      ref: 'artifact.qa_swarm.target.opaque.customer_one',
-      visibility: 'opaque',
-    },
-    title: 'Khala Code nightly QA swarm',
-    traceRefs: [
-      'trace.public.qa_swarm.khala_code.seed_corpus.20260702',
-      'trace.public.qa_swarm.khala_code.desktop_frontier.20260702',
-    ],
-    verdict: 'warning',
-    verdictWall: [
-      {
-        label: 'Login and workspace routing',
-        receiptRef: 'artifact.qa_swarm.verdict.login_workspace.20260702',
-        summary: 'Core public entrypoints passed the mechanical flow.',
-        verdict: 'passed',
-      },
-      {
-        label: 'Desktop command palette',
-        receiptRef: 'artifact.qa_swarm.verdict.command_palette.20260702',
-        summary: 'Explorer found one latency budget warning, no correctness failure.',
-        verdict: 'warning',
-      },
-      {
-        label: 'Trace and video archive',
-        receiptRef: 'artifact.qa_swarm.verdict.trace_video.20260702',
-        summary: 'Trace, screenshot, and video refs are dereferenceable public receipts.',
-        verdict: 'passed',
-      },
-    ],
-    videoRefs: [
-      {
-        label: 'Seed corpus replay',
-        posterRef: 'poster.qa_swarm.khala_code.seed_corpus.20260702',
-        traceHref: '/trace/24c6fea6-b271-46c6-a9a9-bc614440e9ef',
-        videoRef: 'video.qa_swarm.khala_code.seed_corpus.20260702',
-      },
-      {
-        label: 'Desktop frontier replay',
-        posterRef: 'poster.qa_swarm.khala_code.desktop_frontier.20260702',
-        traceHref: '/trace/db838bdc-3bc6-48a5-8715-a6669f6b10c5',
-        videoRef: 'video.qa_swarm.khala_code.desktop_frontier.20260702',
-      },
-    ],
+    ...sampleQaSwarmRunProjectionFields,
+    boardGraph: buildQaSwarmBoardGraphSpec(sampleQaSwarmRunProjectionFields),
   }),
 )
 

--- a/apps/openagents.com/apps/web/src/styles.css
+++ b/apps/openagents.com/apps/web/src/styles.css
@@ -98,6 +98,191 @@ body:has([data-forum-shell]) #root {
   --color-public-landing-warning: #ffd54a;
 }
 
+@layer components {
+  [data-route='qa-swarm'] .khala-gym-graph {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr);
+    gap: 0.75rem;
+    min-width: 0;
+    margin: 0;
+  }
+
+  [data-route='qa-swarm'] .khala-gym-graph-svg {
+    display: block;
+    width: 100%;
+    min-width: 0;
+    max-width: 100%;
+    height: auto;
+    aspect-ratio: 1480 / 395;
+    overflow: hidden;
+  }
+
+  [data-route='qa-swarm'] .khala-gym-edge {
+    fill: none;
+    stroke: color-mix(
+      in srgb,
+      var(--oa-color-khala-border-strong) 45%,
+      transparent
+    );
+    stroke-width: 2;
+    vector-effect: non-scaling-stroke;
+  }
+
+  [data-route='qa-swarm'] .khala-gym-edge[data-status='inactive'] {
+    stroke-dasharray: 3 7;
+  }
+
+  [data-route='qa-swarm'] .khala-gym-edge[data-status='active'] {
+    stroke: var(--oa-color-khala-energy-line);
+    stroke-dasharray: 8 10;
+  }
+
+  [data-route='qa-swarm'] .khala-gym-edge[data-status='blocked'] {
+    stroke: var(--oa-color-khala-warning);
+    stroke-dasharray: 2 7;
+  }
+
+  [data-route='qa-swarm'] .khala-gym-edge[data-status='evidence_backed'] {
+    stroke: var(--oa-color-khala-energy-cyan);
+    stroke-dasharray: 10 12;
+    filter: drop-shadow(
+      0 0 5px
+        color-mix(
+          in srgb,
+          var(--oa-color-khala-energy-cyan) 42%,
+          transparent
+        )
+    );
+  }
+
+  [data-route='qa-swarm']
+    .khala-gym-graph-svg[data-reduced-motion='false']
+    .khala-gym-edge[data-status='active'],
+  [data-route='qa-swarm']
+    .khala-gym-graph-svg[data-reduced-motion='false']
+    .khala-gym-edge[data-status='evidence_backed'] {
+    animation: qa-swarm-edge-flow 18s linear infinite;
+  }
+
+  [data-route='qa-swarm'] .khala-gym-edge-label {
+    fill: var(--oa-color-khala-text-faint);
+    font-size: 0.68rem;
+    text-anchor: middle;
+  }
+
+  [data-route='qa-swarm'] .khala-gym-edge-label[data-status='blocked'] {
+    fill: var(--oa-color-khala-warning);
+  }
+
+  [data-route='qa-swarm'] .khala-gym-node-card {
+    fill: var(--oa-color-khala-surface-raised);
+    stroke: color-mix(
+      in srgb,
+      var(--oa-color-khala-energy-cyan) 20%,
+      transparent
+    );
+    stroke-width: 1;
+  }
+
+  [data-route='qa-swarm'] .khala-gym-node[data-status='complete'] .khala-gym-node-card,
+  [data-route='qa-swarm']
+    .khala-gym-node[data-status='proposal_ready']
+    .khala-gym-node-card {
+    stroke: color-mix(
+      in srgb,
+      var(--oa-color-khala-energy-cyan) 52%,
+      transparent
+    );
+    filter: drop-shadow(
+      0 0 8px
+        color-mix(
+          in srgb,
+          var(--oa-color-khala-energy-cyan) 14%,
+          transparent
+        )
+    );
+  }
+
+  [data-route='qa-swarm'] .khala-gym-node[data-status='active'] .khala-gym-node-card {
+    stroke: var(--oa-color-khala-energy-line);
+  }
+
+  [data-route='qa-swarm'] .khala-gym-node[data-status='blocked'] .khala-gym-node-card {
+    stroke: var(--oa-color-khala-warning);
+  }
+
+  [data-route='qa-swarm'] .khala-gym-node-label {
+    fill: var(--oa-color-khala-text-bright);
+    font-size: 0.78rem;
+    font-weight: 700;
+  }
+
+  [data-route='qa-swarm'] .khala-gym-node-status {
+    fill: var(--oa-color-khala-energy-soft);
+    font-size: 0.62rem;
+    letter-spacing: 0;
+    text-transform: uppercase;
+  }
+
+  [data-route='qa-swarm'] .khala-gym-node-datum {
+    fill: var(--oa-color-khala-text-muted);
+    font-size: 0.64rem;
+  }
+
+  [data-route='qa-swarm'] .khala-gym-node-ref {
+    fill: var(--oa-color-khala-text-faint);
+    font-size: 0.58rem;
+  }
+
+  [data-route='qa-swarm'] .khala-gym-graph-mirror {
+    min-width: 0;
+    max-height: 9rem;
+    overflow: auto;
+    border: 1px solid var(--oa-color-khala-border);
+    background: var(--oa-color-khala-surface-muted);
+  }
+
+  [data-route='qa-swarm'] .khala-gym-graph-mirror-list {
+    display: grid;
+    gap: 0.35rem;
+    margin: 0;
+    padding: 0.65rem 0.8rem 0.65rem 1.7rem;
+  }
+
+  [data-route='qa-swarm'] .khala-gym-graph-mirror-row {
+    color: var(--oa-color-khala-text-muted);
+    font-size: 0.7rem;
+    line-height: 1.45;
+  }
+
+  [data-route='qa-swarm'] .khala-gym-graph-mirror-flow {
+    color: var(--oa-color-khala-text-bright);
+  }
+
+  [data-route='qa-swarm'] .khala-gym-graph-mirror-status {
+    margin-left: 0.45rem;
+    color: var(--oa-color-khala-energy-soft);
+  }
+
+  [data-route='qa-swarm'] .khala-gym-graph-mirror-refs {
+    display: block;
+    color: var(--oa-color-khala-text-faint);
+    overflow-wrap: anywhere;
+  }
+}
+
+@keyframes qa-swarm-edge-flow {
+  to {
+    stroke-dashoffset: -88;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  [data-route='qa-swarm'] .khala-gym-edge {
+    animation: none;
+  }
+}
+
 @layer base {
   @font-face {
     font-family: 'Berkeley Mono';

--- a/bun.lock
+++ b/bun.lock
@@ -131,6 +131,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@effect/platform-browser": "4.0.0-beta.70",
+        "@openagentsinc/arbiter-effect": "workspace:*",
         "@openagentsinc/autopilot-control-protocol": "workspace:*",
         "@openagentsinc/autopilot-ui": "workspace:*",
         "@openagentsinc/design-tokens": "workspace:*",

--- a/clients/khala-code-desktop/src/ui/qa-swarm-panel.ts
+++ b/clients/khala-code-desktop/src/ui/qa-swarm-panel.ts
@@ -1,0 +1,61 @@
+import { GraphSpec } from "@openagentsinc/arbiter-effect/core"
+import { arbiterGraphFigure } from "@openagentsinc/arbiter-effect/foldkit"
+import {
+  buildQaSwarmBoardGraphSpec,
+  type QaSwarmBoardRunProjection,
+} from "@openagentsinc/arbiter-effect/qa-swarm"
+import type { Html } from "foldkit/html"
+import { html } from "foldkit/html"
+
+export type KhalaCodeQaSwarmPanelState = Readonly<{
+  boardGraph: GraphSpec
+  generatedAt: string
+  runRef: string
+  status: string
+  title: string
+}>
+
+export const khalaCodeQaSwarmPanelStateFromRunProjection = (
+  projection: QaSwarmBoardRunProjection,
+): KhalaCodeQaSwarmPanelState => ({
+  boardGraph: buildQaSwarmBoardGraphSpec(projection),
+  generatedAt: projection.generatedAt,
+  runRef: projection.runRef,
+  status: projection.verdict,
+  title: projection.title,
+})
+
+export const khalaCodeQaSwarmPanelView = <Message>(
+  state: KhalaCodeQaSwarmPanelState,
+): Html => {
+  const h = html<Message>()
+
+  return h.section([
+    h.Class("khala-qa-swarm-panel"),
+    h.DataAttribute("component", "khala-code-qa-swarm-panel"),
+    h.DataAttribute("status", state.status),
+  ], [
+    h.header([h.Class("khala-qa-swarm-header")], [
+      h.div([h.Class("khala-qa-swarm-title-group")], [
+        h.h2([h.Class("khala-qa-swarm-title")], ["QA Swarm"]),
+        h.p([h.Class("khala-qa-swarm-subtitle")], [state.title]),
+      ]),
+      h.div([h.Class("khala-qa-swarm-meta")], [
+        h.span([h.Class("khala-qa-swarm-status")], [state.status]),
+        h.span([h.Class("khala-qa-swarm-run-ref")], [state.runRef]),
+      ]),
+    ]),
+    h.div([h.Class("khala-qa-swarm-board")], [
+      arbiterGraphFigure<Message>({
+        spec: state.boardGraph,
+        options: {
+          layout: { height: 395 },
+          mirrorLabel: "QA Swarm board text mirror",
+        },
+      }),
+    ]),
+    h.p([h.Class("khala-qa-swarm-boundary")], [
+      `Generated ${state.generatedAt}. Edges light only when the GraphSpec carries a dereferenceable receipt ref.`,
+    ]),
+  ])
+}

--- a/clients/khala-code-desktop/src/ui/styles.css
+++ b/clients/khala-code-desktop/src/ui/styles.css
@@ -4236,6 +4236,62 @@ button {
   overflow-wrap: anywhere;
 }
 
+.khala-qa-swarm-panel {
+  display: grid;
+  gap: 0.95rem;
+  min-width: 0;
+  color: var(--oa-color-component-text);
+}
+.khala-qa-swarm-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+}
+.khala-qa-swarm-title-group {
+  display: grid;
+  gap: 0.25rem;
+}
+.khala-qa-swarm-title {
+  margin: 0;
+  color: var(--oa-color-khala-text-primary);
+  font-size: 1rem;
+  font-weight: 700;
+  line-height: 1.15;
+}
+.khala-qa-swarm-subtitle,
+.khala-qa-swarm-boundary {
+  margin: 0;
+  color: color-mix(in srgb, var(--oa-color-component-text) 66%, transparent);
+  font-size: 0.78rem;
+  line-height: 1.5;
+}
+.khala-qa-swarm-meta {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 0.45rem;
+}
+.khala-qa-swarm-status,
+.khala-qa-swarm-run-ref {
+  border: 1px solid var(--oa-color-component-border);
+  background: color-mix(in srgb, var(--oa-color-khala-void) 22%, transparent);
+  padding: 0.28rem 0.45rem;
+  color: var(--oa-color-khala-energy-soft);
+  font-size: 0.68rem;
+  line-height: 1;
+}
+.khala-qa-swarm-run-ref {
+  color: color-mix(in srgb, var(--oa-color-component-text) 62%, transparent);
+}
+.khala-qa-swarm-board {
+  min-width: 0;
+  overflow: hidden;
+  border: 1px solid var(--oa-color-component-border);
+  background: color-mix(in srgb, var(--oa-color-khala-void) 18%, transparent);
+  padding: 0.75rem;
+}
+
 @keyframes khala-gym-edge-flow {
   to {
     stroke-dashoffset: -88;

--- a/clients/khala-code-desktop/tests/qa-swarm-panel.test.ts
+++ b/clients/khala-code-desktop/tests/qa-swarm-panel.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, test } from "bun:test"
+
+import {
+  khalaCodeQaSwarmPanelStateFromRunProjection,
+  khalaCodeQaSwarmPanelView,
+} from "../src/ui/qa-swarm-panel"
+import type { QaSwarmBoardRunProjection } from "@openagentsinc/arbiter-effect/qa-swarm"
+
+const projection = (): QaSwarmBoardRunProjection => ({
+  coverageFrontier: [
+    {
+      current: 42,
+      frontier: 58,
+      label: "Seed corpus coverage",
+      receiptRef: "coverage.qa_swarm.khala_code.seed_corpus.desktop",
+    },
+    {
+      current: 17,
+      frontier: 24,
+      label: "Desktop state frontier",
+      receiptRef: "frontier.qa_swarm.khala_code.desktop_state.desktop",
+    },
+  ],
+  distilledTests: [
+    {
+      href: "/docs/qa/khala-code-mechanical-corpus",
+      label: "Mechanical corpus",
+      receiptRef: "test.qa_swarm.khala_code.mechanical_corpus.desktop",
+    },
+  ],
+  generatedAt: "2026-07-02T17:00:00.000Z",
+  perfBudgets: [
+    {
+      actualMs: 82,
+      budgetMs: 100,
+      label: "Thread switch p95",
+      receiptRef: "perf.qa_swarm.khala_code.thread_switch_p95.desktop",
+      verdict: "passed",
+    },
+  ],
+  projectionRef: "projection.qa_swarm.run.khala_code.desktop",
+  publicSafetyRefs: [
+    "check.public_projection.qa_swarm_board.no_receipt_no_lit_edge",
+  ],
+  runRef: "qa-run.khala-code-nightly.desktop",
+  target: {
+    label: "Khala Code Desktop",
+    ref: "artifact.qa_swarm.target.opaque.customer_one",
+    visibility: "opaque",
+  },
+  title: "Khala Code nightly QA swarm",
+  traceRefs: ["trace.public.qa_swarm.khala_code.seed_corpus.desktop"],
+  verdict: "warning",
+  verdictWall: [
+    {
+      label: "Login and workspace routing",
+      receiptRef: "artifact.qa_swarm.verdict.login_workspace.desktop",
+      summary: "Core entrypoints passed.",
+      verdict: "passed",
+    },
+    {
+      label: "Desktop command palette",
+      receiptRef: "artifact.qa_swarm.verdict.command_palette.desktop",
+      summary: "Explorer found one warning.",
+      verdict: "warning",
+    },
+  ],
+})
+
+describe("Khala Code QA Swarm panel", () => {
+  test("consumes the shared QA Swarm Arbiter GraphSpec projection", () => {
+    const state = khalaCodeQaSwarmPanelStateFromRunProjection(projection())
+
+    expect(state.boardGraph.schemaVersion).toBe("openagents.arbiter.graph_spec.v0")
+    expect(state.boardGraph.nodes.map(node => node.id)).toContain("scenario-runner")
+    expect(state.boardGraph.links.find(link => link.id === "scenario-to-target")?.status)
+      .toBe("evidence_backed")
+  })
+
+  test("exposes a read-only desktop panel view with accessible graph mirror", () => {
+    const view = khalaCodeQaSwarmPanelView(
+      khalaCodeQaSwarmPanelStateFromRunProjection(projection()),
+    )
+
+    expect(view).not.toBeNull()
+    expect(JSON.stringify(view)).toContain("khala-code-qa-swarm-panel")
+    expect(JSON.stringify(view)).toContain("QA Swarm board text mirror")
+  })
+
+  test("counter-only receipts remain inactive in the desktop projection", () => {
+    const state = khalaCodeQaSwarmPanelStateFromRunProjection({
+      ...projection(),
+      perfBudgets: [
+        {
+          actualMs: 1,
+          budgetMs: 2,
+          label: "Counter-only p95",
+          receiptRef: "counter.khala_tokens_served.total=123",
+          verdict: "passed",
+        },
+      ],
+    })
+
+    expect(state.boardGraph.links.find(link => link.id === "perf-to-target")?.status)
+      .toBe("inactive")
+    expect(JSON.stringify(state)).not.toContain("counter.khala_tokens_served")
+  })
+})

--- a/packages/arbiter-effect/package.json
+++ b/packages/arbiter-effect/package.json
@@ -9,7 +9,8 @@
   "exports": {
     ".": "./src/index.ts",
     "./core": "./src/core.ts",
-    "./foldkit": "./src/foldkit.ts"
+    "./foldkit": "./src/foldkit.ts",
+    "./qa-swarm": "./src/qa-swarm.ts"
   },
   "files": [
     "src",

--- a/packages/arbiter-effect/src/foldkit.ts
+++ b/packages/arbiter-effect/src/foldkit.ts
@@ -17,6 +17,7 @@ import {
 export type ArbiterGraphRenderOptions = Readonly<{
   reducedMotion?: boolean
   layout?: Partial<GraphLayout>
+  mirrorLabel?: string
 }>
 
 export type ArbiterGraphRenderOutput = Readonly<{
@@ -112,6 +113,7 @@ const renderNode = (node: GraphNode, layout: GraphLayout): string => {
 const renderMirror = (
   spec: GraphSpec,
   nodes: ReadonlyMap<string, GraphNode>,
+  label = "Gym graph text mirror",
 ): string => {
   const rows = spec.links
     .map(link => {
@@ -130,7 +132,7 @@ const renderMirror = (
     .join("")
 
   return [
-    `<div class="khala-gym-graph-mirror" aria-label="Gym graph text mirror">`,
+    `<div class="khala-gym-graph-mirror" aria-label="${escapeHtml(label)}">`,
     `<ol class="khala-gym-graph-mirror-list">${rows}</ol>`,
     "</div>",
   ].join("")
@@ -157,7 +159,7 @@ export const renderArbiterGraphHtml = (
     `<g class="khala-gym-node-layer">${renderedNodes}</g>`,
     "</svg>",
   ].join("")
-  const mirrorHtml = renderMirror(graph, nodes)
+  const mirrorHtml = renderMirror(graph, nodes, options.mirrorLabel)
   const renderedHtml = [
     `<figure class="khala-gym-graph" data-status="${escapeHtml(graph.status)}">`,
     svg,
@@ -256,10 +258,11 @@ const foldkitMirror = <Message>(
   h: ReturnType<typeof html<Message>>,
   spec: GraphSpec,
   nodes: ReadonlyMap<string, GraphNode>,
+  label = "Gym graph text mirror",
 ): Html =>
   h.div([
     h.Class("khala-gym-graph-mirror"),
-    h.AriaLabel("Gym graph text mirror"),
+    h.AriaLabel(label),
   ], [
     h.ol([
       h.Class("khala-gym-graph-mirror-list"),
@@ -318,6 +321,6 @@ export const arbiterGraphFigure = <Message>(
         h.Class("khala-gym-node-layer"),
       ], graph.nodes.map(node => foldkitNode(h, node, layout))),
     ]),
-    foldkitMirror(h, graph, nodes),
+    foldkitMirror(h, graph, nodes, input.options?.mirrorLabel),
   ])
 }

--- a/packages/arbiter-effect/src/index.ts
+++ b/packages/arbiter-effect/src/index.ts
@@ -1,2 +1,3 @@
 export * from "./core"
 export * from "./foldkit"
+export * from "./qa-swarm"

--- a/packages/arbiter-effect/src/qa-swarm.test.ts
+++ b/packages/arbiter-effect/src/qa-swarm.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, test } from "bun:test"
+
+import {
+  buildQaSwarmBoardGraphSpec,
+  QaSwarmBoardProjectionSchemaVersion,
+  type QaSwarmBoardRunProjection,
+} from "./qa-swarm"
+
+const projection = (
+  overrides: Partial<QaSwarmBoardRunProjection> = {},
+): QaSwarmBoardRunProjection => ({
+  coverageFrontier: [
+    {
+      current: 42,
+      frontier: 58,
+      label: "Seed corpus coverage",
+      receiptRef: "coverage.qa_swarm.khala_code.seed_corpus.20260702",
+    },
+    {
+      current: 17,
+      frontier: 24,
+      label: "Desktop state frontier",
+      receiptRef: "frontier.qa_swarm.khala_code.desktop_state.20260702",
+    },
+  ],
+  distilledTests: [
+    {
+      href: "/docs/qa/khala-code-mechanical-corpus",
+      label: "Mechanical corpus",
+      receiptRef: "test.qa_swarm.khala_code.mechanical_corpus.20260702",
+    },
+  ],
+  generatedAt: "2026-07-02T17:00:00.000Z",
+  perfBudgets: [
+    {
+      actualMs: 82,
+      budgetMs: 100,
+      label: "Thread switch p95",
+      receiptRef: "perf.qa_swarm.khala_code.thread_switch_p95.20260702",
+      verdict: "passed",
+    },
+  ],
+  projectionRef: "projection.qa_swarm.run.khala_code.20260702",
+  publicSafetyRefs: [
+    "check.public_projection.qa_swarm_board.no_receipt_no_lit_edge",
+  ],
+  runRef: "qa-run.khala-code-nightly.2026-07-02",
+  target: {
+    label: "Khala Code Desktop",
+    ref: "artifact.qa_swarm.target.opaque.customer_one",
+    visibility: "opaque",
+  },
+  title: "Khala Code nightly QA swarm",
+  traceRefs: ["trace.public.qa_swarm.khala_code.seed_corpus.20260702"],
+  verdict: "warning",
+  verdictWall: [
+    {
+      label: "Login and workspace routing",
+      receiptRef: "artifact.qa_swarm.verdict.login_workspace.20260702",
+      summary: "Core entrypoints passed.",
+      verdict: "passed",
+    },
+    {
+      label: "Desktop command palette",
+      receiptRef: "artifact.qa_swarm.verdict.command_palette.20260702",
+      summary: "Explorer found one warning.",
+      verdict: "warning",
+    },
+  ],
+  ...overrides,
+})
+
+describe("QA Swarm Arbiter board projection", () => {
+  test("maps a QA run projection into Arbiter GraphSpec nodes and links", () => {
+    const graph = buildQaSwarmBoardGraphSpec(projection())
+
+    expect(graph.schemaVersion).toBe("openagents.arbiter.graph_spec.v0")
+    expect(graph.sourceRefs).toContain(QaSwarmBoardProjectionSchemaVersion)
+    expect(graph.nodes.map(node => node.id)).toEqual([
+      "scenario-runner",
+      "seeded-monkey",
+      "llm-explorer",
+      "perf-probe",
+      "headed-ax",
+      "target-surface",
+      "oracle-families",
+      "verdict-wall",
+      "distiller",
+      "public-safe-share",
+    ])
+    expect(graph.links.every(link => link.status === "evidence_backed")).toBe(
+      true,
+    )
+  })
+
+  test("does not light edges from missing or counter-only receipts", () => {
+    const graph = buildQaSwarmBoardGraphSpec(
+      projection({
+        distilledTests: [],
+        perfBudgets: [
+          {
+            actualMs: 1,
+            budgetMs: 2,
+            label: "Counter-only p95",
+            receiptRef: "counter.khala_tokens_served.total=123",
+            verdict: "passed",
+          },
+        ],
+      }),
+    )
+
+    const perfLink = graph.links.find(link => link.id === "perf-to-target")
+    const distilledLink = graph.links.find(link => link.id === "verdict-to-distiller")
+
+    expect(perfLink?.status).toBe("inactive")
+    expect(perfLink?.evidenceRefs).toEqual([])
+    expect(distilledLink?.status).toBe("inactive")
+    expect(JSON.stringify(graph)).not.toContain("counter.khala_tokens_served")
+  })
+
+  test("ignores unmodeled raw private fields", () => {
+    const graph = buildQaSwarmBoardGraphSpec({
+      ...projection(),
+      rawPrompt: "Bearer sk-local /Users/operator/.codex/auth.json",
+    } as unknown as QaSwarmBoardRunProjection)
+
+    expect(JSON.stringify(graph)).not.toMatch(/Bearer|sk-local|\/Users\/|auth\.json/)
+  })
+})

--- a/packages/arbiter-effect/src/qa-swarm.ts
+++ b/packages/arbiter-effect/src/qa-swarm.ts
@@ -1,0 +1,454 @@
+import {
+  ArbiterGraphSpecSchemaVersion,
+  graphLinkStatusForRefs,
+  isDereferenceableGraphRef,
+  type GraphDatum,
+  type GraphLink,
+  type GraphNode,
+  type GraphPin,
+  type GraphPinDirection,
+  type GraphSpec,
+} from "./core"
+
+export const QaSwarmBoardProjectionSchemaVersion =
+  "openagents.qa_swarm.board_graph_projection.v1"
+
+export type QaSwarmBoardVerdict =
+  | "passed"
+  | "failed"
+  | "warning"
+  | "inconclusive"
+
+export type QaSwarmBoardVerdictItem = Readonly<{
+  label: string
+  receiptRef: string
+  summary: string
+  verdict: QaSwarmBoardVerdict
+}>
+
+export type QaSwarmBoardCoverageItem = Readonly<{
+  current: number
+  frontier: number
+  label: string
+  receiptRef: string
+}>
+
+export type QaSwarmBoardPerfItem = Readonly<{
+  actualMs: number
+  budgetMs: number
+  label: string
+  receiptRef: string
+  verdict: QaSwarmBoardVerdict
+}>
+
+export type QaSwarmBoardDistilledTest = Readonly<{
+  href: string
+  label: string
+  receiptRef: string
+}>
+
+export type QaSwarmBoardRunProjection = Readonly<{
+  coverageFrontier: ReadonlyArray<QaSwarmBoardCoverageItem>
+  distilledTests: ReadonlyArray<QaSwarmBoardDistilledTest>
+  generatedAt: string
+  perfBudgets: ReadonlyArray<QaSwarmBoardPerfItem>
+  projectionRef: string
+  publicSafetyRefs: ReadonlyArray<string>
+  runRef: string
+  target: Readonly<{
+    label: string
+    ref: string
+    visibility: "public" | "opaque"
+  }>
+  title: string
+  traceRefs: ReadonlyArray<string>
+  verdict: QaSwarmBoardVerdict
+  verdictWall: ReadonlyArray<QaSwarmBoardVerdictItem>
+}>
+
+const uniqueRefs = (
+  refs: ReadonlyArray<string | null | undefined>,
+): ReadonlyArray<string> =>
+  [...new Set(refs.flatMap(ref => {
+    if (ref === null || ref === undefined) return []
+    const trimmed = ref.trim()
+    return trimmed.length === 0 ? [] : [trimmed]
+  }))].sort()
+
+const dereferenceableRefs = (
+  refs: ReadonlyArray<string | null | undefined>,
+): ReadonlyArray<string> =>
+  uniqueRefs(refs).filter(isDereferenceableGraphRef)
+
+const pin = (
+  direction: GraphPinDirection,
+  id: string,
+  name: string,
+  type: string,
+): GraphPin => ({
+  direction,
+  id,
+  name,
+  type,
+})
+
+const datum = (
+  label: string,
+  value: string | number | boolean | undefined,
+  evidenceRefs: ReadonlyArray<string>,
+  unit?: string,
+): ReadonlyArray<GraphDatum> =>
+  value === undefined
+    ? []
+    : [{
+        label,
+        value,
+        evidenceRefs,
+        ...(unit === undefined ? {} : { unit }),
+      }]
+
+const node = (input: {
+  id: string
+  label: string
+  kind: string
+  status: GraphNode["status"]
+  inputs?: ReadonlyArray<GraphPin>
+  outputs?: ReadonlyArray<GraphPin>
+  datum?: ReadonlyArray<GraphDatum>
+  evidenceRefs?: ReadonlyArray<string>
+  blockerRefs?: ReadonlyArray<string>
+  caveatRefs?: ReadonlyArray<string>
+  x: number
+  y: number
+}): GraphNode => ({
+  id: input.id,
+  label: input.label,
+  kind: input.kind,
+  status: input.status,
+  inputs: [...(input.inputs ?? [])],
+  outputs: [...(input.outputs ?? [])],
+  datum: [...(input.datum ?? [])],
+  evidenceRefs: [...(input.evidenceRefs ?? [])],
+  blockerRefs: [...(input.blockerRefs ?? [])],
+  caveatRefs: [...(input.caveatRefs ?? [])],
+  position: { x: input.x, y: input.y },
+})
+
+const link = (input: {
+  id: string
+  label: string
+  fromNodeId: string
+  fromPinId: string
+  toNodeId: string
+  toPinId: string
+  evidenceRefs?: ReadonlyArray<string>
+  blockerRefs?: ReadonlyArray<string>
+  caveatRefs?: ReadonlyArray<string>
+}): GraphLink => {
+  const evidenceRefs = dereferenceableRefs(input.evidenceRefs ?? [])
+  const blockerRefs = uniqueRefs(input.blockerRefs ?? [])
+  return {
+    id: input.id,
+    label: input.label,
+    status: graphLinkStatusForRefs(evidenceRefs, blockerRefs),
+    from: { nodeId: input.fromNodeId, pinId: input.fromPinId },
+    to: { nodeId: input.toNodeId, pinId: input.toPinId },
+    evidenceRefs,
+    blockerRefs,
+    caveatRefs: uniqueRefs(input.caveatRefs ?? []),
+  }
+}
+
+const firstVerdictRef = (
+  projection: QaSwarmBoardRunProjection,
+  needle: RegExp,
+): string | undefined =>
+  projection.verdictWall.find(item => needle.test(item.label))?.receiptRef
+
+const boardStatus = (
+  verdict: QaSwarmBoardVerdict,
+): GraphNode["status"] => {
+  switch (verdict) {
+    case "failed":
+      return "blocked"
+    case "passed":
+      return "complete"
+    case "warning":
+      return "active"
+    case "inconclusive":
+      return "idle"
+  }
+}
+
+export const buildQaSwarmBoardGraphSpec = (
+  projection: QaSwarmBoardRunProjection,
+): GraphSpec => {
+  const scenarioRefs = dereferenceableRefs([
+    firstVerdictRef(projection, /login|workspace|scenario/i),
+    ...projection.traceRefs,
+  ])
+  const monkeyRefs = dereferenceableRefs(
+    projection.coverageFrontier
+      .filter(item => /seed|monkey|corpus/i.test(item.label))
+      .map(item => item.receiptRef),
+  )
+  const explorerRefs = dereferenceableRefs(
+    projection.coverageFrontier
+      .filter(item => /frontier|desktop|explor/i.test(item.label))
+      .map(item => item.receiptRef),
+  )
+  const perfRefs = dereferenceableRefs(
+    projection.perfBudgets.map(item => item.receiptRef),
+  )
+  const headedAxRefs = dereferenceableRefs([
+    firstVerdictRef(projection, /command|palette|headed|ax|desktop/i),
+  ])
+  const oracleRefs = dereferenceableRefs([
+    ...projection.verdictWall.map(item => item.receiptRef),
+    ...projection.coverageFrontier.map(item => item.receiptRef),
+    ...projection.perfBudgets.map(item => item.receiptRef),
+  ])
+  const verdictRefs = dereferenceableRefs(
+    projection.verdictWall.map(item => item.receiptRef),
+  )
+  const distilledRefs = dereferenceableRefs(
+    projection.distilledTests.map(item => item.receiptRef),
+  )
+  const safetyRefs = uniqueRefs(projection.publicSafetyRefs)
+  const allEvidenceRefs = dereferenceableRefs([
+    projection.projectionRef,
+    projection.target.ref,
+    ...projection.traceRefs,
+    ...projection.verdictWall.map(item => item.receiptRef),
+    ...projection.coverageFrontier.map(item => item.receiptRef),
+    ...projection.perfBudgets.map(item => item.receiptRef),
+    ...projection.distilledTests.map(item => item.receiptRef),
+    ...projection.publicSafetyRefs,
+  ])
+  const graphStatus = boardStatus(projection.verdict)
+
+  const nodes: ReadonlyArray<GraphNode> = [
+    node({
+      id: "scenario-runner",
+      label: "Scenario runner",
+      kind: "qa_agent",
+      status: scenarioRefs.length > 0 ? "complete" : "idle",
+      outputs: [pin("output", "run", "run", "qa.scenario.receipt")],
+      datum: datum("traces", projection.traceRefs.length, scenarioRefs),
+      evidenceRefs: scenarioRefs,
+      x: 40,
+      y: 45,
+    }),
+    node({
+      id: "seeded-monkey",
+      label: "Seeded monkey",
+      kind: "qa_agent",
+      status: monkeyRefs.length > 0 ? "complete" : "idle",
+      outputs: [pin("output", "coverage", "coverage", "qa.coverage.receipt")],
+      datum: datum("coverage rows", projection.coverageFrontier.length, monkeyRefs),
+      evidenceRefs: monkeyRefs,
+      x: 40,
+      y: 155,
+    }),
+    node({
+      id: "llm-explorer",
+      label: "LLM explorer",
+      kind: "qa_agent",
+      status: explorerRefs.length > 0 ? "complete" : "idle",
+      outputs: [pin("output", "frontier", "frontier", "qa.frontier.receipt")],
+      datum: datum("frontier", projection.coverageFrontier.length, explorerRefs),
+      evidenceRefs: explorerRefs,
+      x: 40,
+      y: 265,
+    }),
+    node({
+      id: "perf-probe",
+      label: "Perf probe",
+      kind: "qa_agent",
+      status: perfRefs.length > 0 ? "complete" : "idle",
+      outputs: [pin("output", "budget", "budget", "qa.perf.receipt")],
+      datum: datum("budgets", projection.perfBudgets.length, perfRefs),
+      evidenceRefs: perfRefs,
+      x: 255,
+      y: 45,
+    }),
+    node({
+      id: "headed-ax",
+      label: "Headed AX",
+      kind: "qa_agent",
+      status: headedAxRefs.length > 0 ? "complete" : "idle",
+      outputs: [pin("output", "desktop", "desktop", "qa.ax.receipt")],
+      datum: datum("driver", "native", headedAxRefs),
+      evidenceRefs: headedAxRefs,
+      x: 255,
+      y: 265,
+    }),
+    node({
+      id: "target-surface",
+      label: projection.target.label,
+      kind: "target_surface",
+      status: allEvidenceRefs.length > 0 ? "complete" : "idle",
+      inputs: [
+        pin("input", "run", "run", "qa.scenario.receipt"),
+        pin("input", "coverage", "coverage", "qa.coverage.receipt"),
+        pin("input", "frontier", "frontier", "qa.frontier.receipt"),
+        pin("input", "budget", "budget", "qa.perf.receipt"),
+        pin("input", "desktop", "desktop", "qa.ax.receipt"),
+      ],
+      outputs: [pin("output", "observed", "observed", "qa.observed.receipt")],
+      datum: datum("target", projection.target.visibility, allEvidenceRefs),
+      evidenceRefs: dereferenceableRefs([projection.target.ref, ...allEvidenceRefs]),
+      x: 470,
+      y: 155,
+    }),
+    node({
+      id: "oracle-families",
+      label: "Oracle families",
+      kind: "oracle_stage",
+      status: oracleRefs.length > 0 ? "complete" : "idle",
+      inputs: [pin("input", "observed", "observed", "qa.observed.receipt")],
+      outputs: [pin("output", "verdict", "verdict", "qa.verdict.receipt")],
+      datum: datum("checks", projection.verdictWall.length, oracleRefs),
+      evidenceRefs: oracleRefs,
+      x: 685,
+      y: 155,
+    }),
+    node({
+      id: "verdict-wall",
+      label: "Verdict wall",
+      kind: "verdict_stage",
+      status: graphStatus,
+      inputs: [pin("input", "verdict", "verdict", "qa.verdict.receipt")],
+      outputs: [pin("output", "finding", "finding", "qa.finding.receipt")],
+      datum: datum("verdict", projection.verdict, verdictRefs),
+      evidenceRefs: verdictRefs,
+      x: 900,
+      y: 155,
+    }),
+    node({
+      id: "distiller",
+      label: "Distiller",
+      kind: "distiller_stage",
+      status: distilledRefs.length > 0 ? "complete" : "idle",
+      inputs: [pin("input", "finding", "finding", "qa.finding.receipt")],
+      outputs: [pin("output", "test", "test", "qa.distilled_test.receipt")],
+      datum: datum("merged tests", projection.distilledTests.length, distilledRefs),
+      evidenceRefs: distilledRefs,
+      x: 1115,
+      y: 155,
+    }),
+    node({
+      id: "public-safe-share",
+      label: "Share URL",
+      kind: "public_projection",
+      status: safetyRefs.length > 0 ? "complete" : "idle",
+      inputs: [pin("input", "test", "test", "qa.distilled_test.receipt")],
+      datum: datum("schema", QaSwarmBoardProjectionSchemaVersion, safetyRefs),
+      evidenceRefs: dereferenceableRefs(safetyRefs),
+      caveatRefs: safetyRefs.filter(ref => !isDereferenceableGraphRef(ref)),
+      x: 1330,
+      y: 155,
+    }),
+  ]
+
+  const links: ReadonlyArray<GraphLink> = [
+    link({
+      id: "scenario-to-target",
+      label: "scenario receipts",
+      fromNodeId: "scenario-runner",
+      fromPinId: "run",
+      toNodeId: "target-surface",
+      toPinId: "run",
+      evidenceRefs: scenarioRefs,
+    }),
+    link({
+      id: "monkey-to-target",
+      label: "seed coverage",
+      fromNodeId: "seeded-monkey",
+      fromPinId: "coverage",
+      toNodeId: "target-surface",
+      toPinId: "coverage",
+      evidenceRefs: monkeyRefs,
+    }),
+    link({
+      id: "explorer-to-target",
+      label: "frontier",
+      fromNodeId: "llm-explorer",
+      fromPinId: "frontier",
+      toNodeId: "target-surface",
+      toPinId: "frontier",
+      evidenceRefs: explorerRefs,
+    }),
+    link({
+      id: "perf-to-target",
+      label: "p95 budgets",
+      fromNodeId: "perf-probe",
+      fromPinId: "budget",
+      toNodeId: "target-surface",
+      toPinId: "budget",
+      evidenceRefs: perfRefs,
+    }),
+    link({
+      id: "headed-ax-to-target",
+      label: "desktop receipts",
+      fromNodeId: "headed-ax",
+      fromPinId: "desktop",
+      toNodeId: "target-surface",
+      toPinId: "desktop",
+      evidenceRefs: headedAxRefs,
+    }),
+    link({
+      id: "target-to-oracles",
+      label: "observed run",
+      fromNodeId: "target-surface",
+      fromPinId: "observed",
+      toNodeId: "oracle-families",
+      toPinId: "observed",
+      evidenceRefs: oracleRefs,
+    }),
+    link({
+      id: "oracles-to-verdict",
+      label: "verdict receipts",
+      fromNodeId: "oracle-families",
+      fromPinId: "verdict",
+      toNodeId: "verdict-wall",
+      toPinId: "verdict",
+      evidenceRefs: verdictRefs,
+    }),
+    link({
+      id: "verdict-to-distiller",
+      label: "merged tests",
+      fromNodeId: "verdict-wall",
+      fromPinId: "finding",
+      toNodeId: "distiller",
+      toPinId: "finding",
+      evidenceRefs: distilledRefs,
+    }),
+    link({
+      id: "distiller-to-share",
+      label: "public mirror",
+      fromNodeId: "distiller",
+      fromPinId: "test",
+      toNodeId: "public-safe-share",
+      toPinId: "test",
+      evidenceRefs: [...distilledRefs, ...safetyRefs],
+    }),
+  ]
+
+  return {
+    schemaVersion: ArbiterGraphSpecSchemaVersion,
+    title: `QA Swarm board - ${projection.title}`,
+    generatedAt: projection.generatedAt,
+    status: graphStatus,
+    nodes,
+    links,
+    evidenceRefs: allEvidenceRefs,
+    blockerRefs: [],
+    caveatRefs: safetyRefs.filter(ref => !isDereferenceableGraphRef(ref)),
+    sourceRefs: uniqueRefs([
+      projection.runRef,
+      projection.projectionRef,
+      QaSwarmBoardProjectionSchemaVersion,
+    ]),
+  }
+}


### PR DESCRIPTION
Closes #8063.

## Summary

- Adds a shared `@openagentsinc/arbiter-effect/qa-swarm` builder that maps QA Swarm run projections into Arbiter `GraphSpec` nodes/typed pins/receipt-bound links.
- Renders the shared board on the `/qa/{runRef}` share page and adds a Khala Code Desktop QA Swarm panel wrapper that consumes the same projection.
- Enforces and tests the evidence-binding rule: missing receipts and counter-only refs do not light edges; accessible text mirrors are emitted with QA-specific labels.

## Verification

- `bun test src/qa-swarm.test.ts src/foldkit.test.ts` from `packages/arbiter-effect` — 11 passed.
- `bun test tests/qa-swarm-panel.test.ts` from `clients/khala-code-desktop` — 3 passed.
- `bunx vitest run src/page/qa-swarm.test.ts` from `apps/openagents.com/apps/web` — 8 passed.
- `bun run typecheck` from `packages/arbiter-effect` — passed.
- `bun run typecheck` from `clients/khala-code-desktop` — passed.
- `bun run typecheck` from `apps/openagents.com/apps/web` — passed.
- `bun run check:deploy` from repo root — passed on the final tree: web block 22 files / 567 tests passed; worker block 13 files / 239 tests passed.

## FleetRun Evidence

- Assigned issue: #8063 only.
- Branch: `issue-8063-qa-swarm-arbiter-board`.
- Commit: `5f899a8a9a`.
- Claim/ref accounting: this PR contains only the bounded checkout changes for the assigned issue; downstream FleetRun token accounting remains with the assignment closeout system, not in public PR text.