### PR TITLE
Add Planner/Coder/Judge QA regime coverage

### DIFF
--- a/packages/khala-qa-harness/package.json
+++ b/packages/khala-qa-harness/package.json
@@ -26,6 +26,7 @@
     "test": "bun test src/*.test.ts",
     "lag:sweep": "bun src/lag-profiling-sweep.ts",
     "smoke:real-bridge": "bun src/real-bridge-smoke.ts",
+    "smoke:architect-coder-judge-live": "bun src/architect-coder-judge-live-smoke.ts",
     "monkey:night": "bun src/monkey-night.ts --runs 100 --steps 64",
     "monkey:smoke": "bun test src/monkey-explorer.test.ts --test-name-pattern 'bounded fixture smoke'",
     "typecheck": "tsc -p tsconfig.json --noEmit"

--- a/packages/khala-qa-harness/src/architect-coder-judge-live-smoke.ts
+++ b/packages/khala-qa-harness/src/architect-coder-judge-live-smoke.ts
@@ -1,0 +1,85 @@
+const schema = "openagents.khala_code.architect_coder_judge_live_smoke.v1" as const
+
+type SmokeEvidence = {
+  readonly schema: typeof schema
+  readonly ok: boolean
+  readonly mode: "env_armed" | "skip_safe_default"
+  readonly observedAt: string
+  readonly publicSafe: true
+  readonly refs: readonly string[]
+  readonly status: "pass" | "skip"
+  readonly summary: string
+}
+
+const armed = process.env.KHALA_CODE_ARCHITECT_CODER_JUDGE_LIVE_SMOKE === "1"
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  value !== null && typeof value === "object" && !Array.isArray(value)
+
+const stringArray = (value: unknown): readonly string[] =>
+  Array.isArray(value) ? value.filter((entry): entry is string => typeof entry === "string") : []
+
+const fail = (summary: string): never => {
+  console.error(JSON.stringify({
+    schema,
+    ok: false,
+    mode: "env_armed",
+    observedAt: new Date().toISOString(),
+    publicSafe: true,
+    refs: [],
+    status: "fail",
+    summary,
+  }, null, 2))
+  process.exit(1)
+}
+
+const validateArchivedEvidence = async (path: string): Promise<SmokeEvidence> => {
+  if (path.trim().length === 0) {
+    fail("KHALA_CODE_ARCHITECT_CODER_JUDGE_LIVE_EVIDENCE_JSON is required when the live smoke is armed.")
+  }
+  const raw = await Bun.file(path).text().catch((error) =>
+    fail(`Could not read KHALA_CODE_ARCHITECT_CODER_JUDGE_LIVE_EVIDENCE_JSON: ${error instanceof Error ? error.message : String(error)}`)
+  )
+  const parsed = JSON.parse(raw) as unknown
+  if (!isRecord(parsed)) fail("Archived evidence must be a JSON object.")
+  const record = parsed as Record<string, unknown>
+  const roles = stringArray(record.roles)
+  const exactTokenRoles = stringArray(record.exactTokenRoles)
+  const refs = stringArray(record.refs)
+  for (const role of ["architect", "coder", "judge"]) {
+    if (!roles.includes(role)) fail(`Archived evidence is missing role ${role}.`)
+    if (!exactTokenRoles.includes(role)) fail(`Archived evidence is missing exact token rows for role ${role}.`)
+  }
+  if (record.publicSafe !== true) fail("Archived evidence must declare publicSafe=true.")
+  if (record.judgeVerdict !== "accept" && record.judgeVerdict !== "request_changes" && record.judgeVerdict !== "replan") {
+    fail("Archived evidence must include judgeVerdict accept|request_changes|replan.")
+  }
+  return {
+    schema,
+    ok: true,
+    mode: "env_armed",
+    observedAt: new Date().toISOString(),
+    publicSafe: true,
+    refs,
+    status: "pass",
+    summary: "Architect/Coder/Judge archived live evidence validated with exact per-role token rows and public-safe projection metadata.",
+  }
+}
+
+const evidence: SmokeEvidence = armed
+  ? await validateArchivedEvidence(process.env.KHALA_CODE_ARCHITECT_CODER_JUDGE_LIVE_EVIDENCE_JSON ?? "")
+  : {
+      schema,
+      ok: true,
+      mode: "skip_safe_default",
+      observedAt: new Date().toISOString(),
+      publicSafe: true,
+      refs: [
+        "env.KHALA_CODE_ARCHITECT_CODER_JUDGE_LIVE_SMOKE.required",
+        "nightly.skip_safe.default",
+      ],
+      status: "skip",
+      summary: "Architect/Coder/Judge live smoke skipped by default; set KHALA_CODE_ARCHITECT_CODER_JUDGE_LIVE_SMOKE=1 for an owner-armed run.",
+    }
+
+console.log(JSON.stringify(evidence, null, 2))

--- a/packages/khala-qa-harness/src/coverage-ledger.test.ts
+++ b/packages/khala-qa-harness/src/coverage-ledger.test.ts
@@ -77,6 +77,15 @@ describe("Khala Code QA coverage ledger", () => {
     expect(ledger.fleetRunControlVerbs).toEqual([...KHALA_CODE_QA_SEED_CORPUS_MANIFEST.coverage.fleetRunControlVerbs].sort())
     expect(ledger.inboxRoutingFlagKinds).toEqual([...KHALA_CODE_QA_SEED_CORPUS_MANIFEST.coverage.inboxRoutingFlagKinds].sort())
     expect(ledger.errorStateCasesExercised).toEqual([...KHALA_CODE_QA_ERROR_STATE_CASE_IDS].sort())
+    expect(ledger.plannerCoderJudge).toEqual({
+      advisorAdvisorySeverities: ["blocker", "concern", "nit"],
+      advisorGuardRefs: ["dedupe_guard", "interrupt_budget"],
+      architectPlanDecisions: ["approve", "reject"],
+      judgeVerdictKinds: ["accept", "replan", "request_changes"],
+      liveSmokeModes: ["skip_safe_default"],
+      modelRoleRegistryRoles: ["advisor", "architect", "coder", "judge"],
+      roleEconomicsRoleRefs: ["advisor", "architect", "coder", "judge"],
+    })
     expect(ledger.crossModeSurfacesExercised).toEqual(
       [...KHALA_CODE_QA_SEED_CORPUS_MANIFEST.coverage.crossModeSurfaces].sort(),
     )
@@ -204,6 +213,13 @@ describe("Khala Code QA coverage ledger", () => {
     expect(frontier.missing.fleetRunControlVerbs).toEqual(["drain", "pause", "resume", "stop"])
     expect(frontier.missing.inboxRoutingFlagKinds).toEqual(["flag", "interrupt", "retry"])
     expect(frontier.missing.errorStateCases).toEqual([...KHALA_CODE_QA_ERROR_STATE_CASE_IDS].sort())
+    expect(frontier.missing.plannerCoderJudgeAdvisorAdvisorySeverities).toEqual(["blocker", "concern", "nit"])
+    expect(frontier.missing.plannerCoderJudgeAdvisorGuardRefs).toEqual(["dedupe_guard", "interrupt_budget"])
+    expect(frontier.missing.plannerCoderJudgeArchitectPlanDecisions).toEqual(["approve", "reject"])
+    expect(frontier.missing.plannerCoderJudgeJudgeVerdictKinds).toEqual(["accept", "replan", "request_changes"])
+    expect(frontier.missing.plannerCoderJudgeLiveSmokeModes).toEqual(["skip_safe_default"])
+    expect(frontier.missing.plannerCoderJudgeModelRoleRegistryRoles).toEqual(["advisor", "architect", "coder", "judge"])
+    expect(frontier.missing.plannerCoderJudgeRoleEconomicsRoleRefs).toEqual(["advisor", "architect", "coder", "judge"])
     expect(frontier.missing.crossModeSurfaces).toEqual(
       [...KHALA_CODE_QA_SEED_CORPUS_MANIFEST.coverage.crossModeSurfaces].sort(),
     )

--- a/packages/khala-qa-harness/src/coverage-ledger.ts
+++ b/packages/khala-qa-harness/src/coverage-ledger.ts
@@ -39,6 +39,15 @@ export type KhalaCodeQaCoverageLedger = {
   readonly errorStateCasesExercised: readonly string[]
   readonly threadItemVariantRenderCounts: Readonly<Record<string, number>>
   readonly threadItemVariantsRendered: readonly string[]
+  readonly plannerCoderJudge: {
+    readonly advisorAdvisorySeverities: readonly string[]
+    readonly advisorGuardRefs: readonly string[]
+    readonly architectPlanDecisions: readonly string[]
+    readonly judgeVerdictKinds: readonly string[]
+    readonly liveSmokeModes: readonly string[]
+    readonly modelRoleRegistryRoles: readonly string[]
+    readonly roleEconomicsRoleRefs: readonly string[]
+  }
   readonly selectorsClicked: readonly string[]
   readonly screensScreenshotted: readonly string[]
 }
@@ -57,6 +66,13 @@ export type KhalaCodeQaCoverageFrontierReport = {
     readonly fleetRunControlVerbs: readonly string[]
     readonly inboxRoutingFlagKinds: readonly string[]
     readonly errorStateCases: readonly string[]
+    readonly plannerCoderJudgeAdvisorAdvisorySeverities: readonly string[]
+    readonly plannerCoderJudgeAdvisorGuardRefs: readonly string[]
+    readonly plannerCoderJudgeArchitectPlanDecisions: readonly string[]
+    readonly plannerCoderJudgeJudgeVerdictKinds: readonly string[]
+    readonly plannerCoderJudgeLiveSmokeModes: readonly string[]
+    readonly plannerCoderJudgeModelRoleRegistryRoles: readonly string[]
+    readonly plannerCoderJudgeRoleEconomicsRoleRefs: readonly string[]
     readonly threadItemVariants: readonly string[]
     readonly selectors: readonly string[]
     readonly slashCommandAvailabilityStates: readonly string[]
@@ -68,6 +84,15 @@ type MutableRpcCoverage = Map<string, { calls: number; argumentShapes: Set<strin
 type MutableRpcGroupCoverage = Map<string, { calls: number; methods: Set<string> }>
 type MutableSlashCoverage = Map<string, { dispatches: number; availabilityStates: Set<KhalaCodeQaCoverageAvailability> }>
 type MutableCountCoverage = Map<string, number>
+type MutablePlannerCoderJudgeCoverage = {
+  advisorAdvisorySeverities: string[]
+  advisorGuardRefs: string[]
+  architectPlanDecisions: string[]
+  judgeVerdictKinds: string[]
+  liveSmokeModes: string[]
+  modelRoleRegistryRoles: string[]
+  roleEconomicsRoleRefs: string[]
+}
 
 const emptyGeneratedAt = "1970-01-01T00:00:00.000Z"
 
@@ -311,6 +336,97 @@ const collectErrorStateCaseIds = (value: unknown): readonly string[] => {
   return [...direct, ...refs]
 }
 
+const collectPlannerCoderJudgeCoverage = (value: unknown): {
+  readonly advisorAdvisorySeverities: readonly string[]
+  readonly advisorGuardRefs: readonly string[]
+  readonly architectPlanDecisions: readonly string[]
+  readonly judgeVerdictKinds: readonly string[]
+  readonly liveSmokeModes: readonly string[]
+  readonly modelRoleRegistryRoles: readonly string[]
+  readonly roleEconomicsRoleRefs: readonly string[]
+} => {
+  if (Array.isArray(value)) {
+    return mergePlannerCoderJudgeCoverage(value.map(collectPlannerCoderJudgeCoverage))
+  }
+  if (!isRecord(value)) return emptyPlannerCoderJudgeCoverage()
+  const body = typeof value.body === "string" ? value.body : ""
+  const bodyHas = (needle: string): boolean => body.includes(needle)
+  const direct = {
+    advisorAdvisorySeverities: [
+      value.schema === "openagents.khala_code.advisor_advisory.v1" && typeof value.severity === "string"
+        ? value.severity
+        : undefined,
+      ...["blocker", "concern", "nit"].filter((severity) =>
+        bodyHas(`advisor_advisory:${severity}`)
+      ),
+    ].filter((entry): entry is string => entry !== undefined),
+    advisorGuardRefs: [
+      Array.isArray(value.droppedAdvisories) ? "dedupe_guard" : undefined,
+      typeof value.immuneTurnsRemaining === "number" ? "interrupt_budget" : undefined,
+      ...["dedupe_guard", "interrupt_budget"].filter((guardRef) =>
+        bodyHas(`advisor_guard:${guardRef}`)
+      ),
+    ].filter((entry): entry is string => entry !== undefined),
+    architectPlanDecisions: [
+      typeof value.decision === "string" && (value.decision === "approve" || value.decision === "reject")
+        ? value.decision
+        : undefined,
+    ].filter((entry): entry is string => entry !== undefined),
+    judgeVerdictKinds: [
+      value.schema === "openagents.khala_code.judge_diff_verdict.v1" && typeof value.verdict === "string"
+        ? value.verdict
+        : undefined,
+      ...["accept", "request_changes", "replan"].filter((verdict) =>
+        bodyHas(`judge_verdict:${verdict}`)
+      ),
+    ].filter((entry): entry is string => entry !== undefined),
+    liveSmokeModes: [
+      value.schema === "openagents.khala_code.architect_coder_judge_live_smoke.v1" && typeof value.mode === "string"
+        ? value.mode
+        : undefined,
+      ...["skip_safe_default", "env_armed"].filter((mode) =>
+        bodyHas(`architect_coder_judge_live_smoke:${mode}`)
+      ),
+    ].filter((entry): entry is string => entry !== undefined),
+    modelRoleRegistryRoles: isRecord(value.registry) && isRecord(value.registry.roles)
+      ? Object.keys(value.registry.roles)
+      : isRecord(value.roles)
+        ? Object.keys(value.roles)
+        : [],
+    roleEconomicsRoleRefs: Array.isArray(value.roleEconomics)
+      ? value.roleEconomics.flatMap((entry) =>
+        isRecord(entry) && typeof entry.roleRef === "string" ? [entry.roleRef] : []
+      )
+      : [],
+  }
+  return mergePlannerCoderJudgeCoverage([
+    direct,
+    ...Object.values(value).map(collectPlannerCoderJudgeCoverage),
+  ])
+}
+
+const emptyPlannerCoderJudgeCoverage = (): MutablePlannerCoderJudgeCoverage => ({
+  advisorAdvisorySeverities: [],
+  advisorGuardRefs: [],
+  architectPlanDecisions: [],
+  judgeVerdictKinds: [],
+  liveSmokeModes: [],
+  modelRoleRegistryRoles: [],
+  roleEconomicsRoleRefs: [],
+})
+
+const mergePlannerCoderJudgeCoverage = (
+  entries: readonly (MutablePlannerCoderJudgeCoverage | KhalaCodeQaCoverageLedger["plannerCoderJudge"])[],
+): MutablePlannerCoderJudgeCoverage => ({
+  advisorAdvisorySeverities: [...sorted(entries.flatMap((entry) => entry.advisorAdvisorySeverities))],
+  advisorGuardRefs: [...sorted(entries.flatMap((entry) => entry.advisorGuardRefs))],
+  architectPlanDecisions: [...sorted(entries.flatMap((entry) => entry.architectPlanDecisions))],
+  judgeVerdictKinds: [...sorted(entries.flatMap((entry) => entry.judgeVerdictKinds))],
+  liveSmokeModes: [...sorted(entries.flatMap((entry) => entry.liveSmokeModes))],
+  modelRoleRegistryRoles: [...sorted(entries.flatMap((entry) => entry.modelRoleRegistryRoles))],
+  roleEconomicsRoleRefs: [...sorted(entries.flatMap((entry) => entry.roleEconomicsRoleRefs))],
+})
+
 const collectArmedErrorStateCases = (args: readonly unknown[] | undefined): readonly string[] => {
   const sample = args?.[0]
   if (!isRecord(sample) || !isRecord(sample.context)) return []
@@ -332,6 +448,7 @@ export const createEmptyKhalaCodeQaCoverageLedger = (
   hotbarPanelsOpened: [],
   inboxRoutingFlagKinds: [],
   errorStateCasesExercised: [],
+  plannerCoderJudge: emptyPlannerCoderJudgeCoverage(),
   rpcGroups: {},
   rpcMethods: {},
   runIds: options.runId === undefined ? [] : [options.runId],
@@ -361,6 +478,7 @@ export const collectKhalaCodeQaCoverageLedger = (input: {
   const errorStateCasesExercised = new Set<string>()
   const threadItemVariantRenderCounts: MutableCountCoverage = new Map()
   const threadItemVariantsRendered = new Set<string>()
+  const plannerCoderJudge = emptyPlannerCoderJudgeCoverage()
   const selectorsClicked = new Set<string>()
   const screensScreenshotted = new Set<string>()
 
@@ -410,6 +528,18 @@ export const collectKhalaCodeQaCoverageLedger = (input: {
       if (action.method === "fleetWorkerControl" && isRecord(firstArg) && typeof firstArg.verb === "string") {
         inboxRoutingFlagKinds.add(firstArg.verb)
       }
+      if (action.method === "architectPlanDecision" && isRecord(firstArg) && typeof firstArg.decision === "string") {
+        plannerCoderJudge.architectPlanDecisions.push(firstArg.decision)
+      }
+      if (
+        action.method === "qaMetricSample" &&
+        isRecord(firstArg) &&
+        isRecord(firstArg.context) &&
+        firstArg.context.schema === "openagents.khala_code.architect_coder_judge_live_smoke.v1" &&
+        typeof firstArg.context.mode === "string"
+      ) {
+        plannerCoderJudge.liveSmokeModes.push(firstArg.context.mode)
+      }
       for (const caseId of collectArmedErrorStateCases(action.args)) {
         errorStateCasesExercised.add(caseId)
       }
@@ -420,6 +550,14 @@ export const collectKhalaCodeQaCoverageLedger = (input: {
         recordCount(threadItemVariantRenderCounts, variant)
         threadItemVariantsRendered.add(variant)
       }
+      const pcj = collectPlannerCoderJudgeCoverage(observation.data)
+      plannerCoderJudge.advisorAdvisorySeverities.push(...pcj.advisorAdvisorySeverities)
+      plannerCoderJudge.advisorGuardRefs.push(...pcj.advisorGuardRefs)
+      plannerCoderJudge.architectPlanDecisions.push(...pcj.architectPlanDecisions)
+      plannerCoderJudge.judgeVerdictKinds.push(...pcj.judgeVerdictKinds)
+      plannerCoderJudge.liveSmokeModes.push(...pcj.liveSmokeModes)
+      plannerCoderJudge.modelRoleRegistryRoles.push(...pcj.modelRoleRegistryRoles)
+      plannerCoderJudge.roleEconomicsRoleRefs.push(...pcj.roleEconomicsRoleRefs)
       continue
     }
 
@@ -447,6 +585,7 @@ export const collectKhalaCodeQaCoverageLedger = (input: {
     hotbarPanelsOpened: sorted(hotbarPanelsOpened),
     inboxRoutingFlagKinds: sorted(inboxRoutingFlagKinds),
     errorStateCasesExercised: sorted(errorStateCasesExercised),
+    plannerCoderJudge: mergePlannerCoderJudgeCoverage([plannerCoderJudge]),
     rpcGroups: rpcGroupCoverageToObject(rpcGroups),
     rpcMethods: rpcCoverageToObject(rpcMethods),
     runIds: [input.runId],
@@ -467,6 +606,9 @@ export const mergeKhalaCodeQaCoverageLedgers = (
   const rpcMethods: MutableRpcCoverage = new Map()
   const slashCommands: MutableSlashCoverage = new Map()
   const threadItemVariantRenderCounts: MutableCountCoverage = new Map()
+  const plannerCoderJudge = mergePlannerCoderJudgeCoverage(ledgers.map((ledger) =>
+    ledger.plannerCoderJudge ?? emptyPlannerCoderJudgeCoverage()
+  ))
   const runIds = new Set<string>()
   const generatedAt = ledgers.map((ledger) => ledger.generatedAt).sort().at(-1) ?? emptyGeneratedAt
   const addSet = <K extends keyof KhalaCodeQaCoverageLedger>(key: K): Set<string> =>
@@ -505,6 +647,7 @@ export const mergeKhalaCodeQaCoverageLedgers = (
     hotbarPanelsOpened: sorted(addSet("hotbarPanelsOpened")),
     inboxRoutingFlagKinds: sorted(addSet("inboxRoutingFlagKinds")),
     errorStateCasesExercised: sorted(addSet("errorStateCasesExercised")),
+    plannerCoderJudge,
     rpcGroups: rpcGroupCoverageToObject(rpcGroups),
     rpcMethods: rpcCoverageToObject(rpcMethods),
     runIds: sorted(runIds),
@@ -542,6 +685,27 @@ export const khalaCodeQaCoverageFrontierReport = (input: {
     )),
     errorStateCases: sorted(input.manifest.coverage.errorStateCases.filter((item) =>
       !input.ledger.errorStateCasesExercised.includes(item)
+    )),
+    plannerCoderJudgeAdvisorAdvisorySeverities: sorted(input.manifest.coverage.plannerCoderJudge.advisorAdvisorySeverities.filter((item) =>
+      !input.ledger.plannerCoderJudge.advisorAdvisorySeverities.includes(item)
+    )),
+    plannerCoderJudgeAdvisorGuardRefs: sorted(input.manifest.coverage.plannerCoderJudge.advisorGuardRefs.filter((item) =>
+      !input.ledger.plannerCoderJudge.advisorGuardRefs.includes(item)
+    )),
+    plannerCoderJudgeArchitectPlanDecisions: sorted(input.manifest.coverage.plannerCoderJudge.architectPlanDecisions.filter((item) =>
+      !input.ledger.plannerCoderJudge.architectPlanDecisions.includes(item)
+    )),
+    plannerCoderJudgeJudgeVerdictKinds: sorted(input.manifest.coverage.plannerCoderJudge.judgeVerdictKinds.filter((item) =>
+      !input.ledger.plannerCoderJudge.judgeVerdictKinds.includes(item)
+    )),
+    plannerCoderJudgeLiveSmokeModes: sorted(input.manifest.coverage.plannerCoderJudge.liveSmokeModes.filter((item) =>
+      !input.ledger.plannerCoderJudge.liveSmokeModes.includes(item)
+    )),
+    plannerCoderJudgeModelRoleRegistryRoles: sorted(input.manifest.coverage.plannerCoderJudge.modelRoleRegistryRoles.filter((item) =>
+      !input.ledger.plannerCoderJudge.modelRoleRegistryRoles.includes(item)
+    )),
+    plannerCoderJudgeRoleEconomicsRoleRefs: sorted(input.manifest.coverage.plannerCoderJudge.roleEconomicsRoleRefs.filter((item) =>
+      !input.ledger.plannerCoderJudge.roleEconomicsRoleRefs.includes(item)
     )),
     rpcGroups: sorted(input.manifest.coverage.rpcGroups.filter((item) =>
       input.ledger.rpcGroups[item] === undefined

--- a/packages/khala-qa-harness/src/real-bridge-smoke.ts
+++ b/packages/khala-qa-harness/src/real-bridge-smoke.ts
@@ -248,6 +248,8 @@ const realBridgeInProcessOnlyScenarioIds = new Set([
   "scenario.khala_code.seed.rpc_fleet_run_lifecycle.v1",
   "scenario.khala_code.seed.rpc_forum_panel_lifecycle.v1",
   "scenario.khala_code.seed.rpc_inbox_routing_lifecycle.v1",
+  "scenario.khala_code.seed.planner_coder_judge_judge_verdict_cards.v1",
+  "scenario.khala_code.seed.planner_coder_judge_advisor_guards.v1",
 ])
 
 const isRealBridgeTransportValidSeedScenario = (scenario: KhalaCodeQaScenario): boolean =>

--- a/packages/khala-qa-harness/src/runner.ts
+++ b/packages/khala-qa-harness/src/runner.ts
@@ -422,6 +422,34 @@ const evaluateNoDataLossInvariant = (
   }
 }
 
+const stringifyPublicFixtureValue = (value: unknown): string => {
+  try {
+    return JSON.stringify(value)
+  } catch {
+    return String(value)
+  }
+}
+
+const evaluateFixtureEvidenceInvariant = (
+  phaseName: string,
+  expectation: KhalaCodeQaOracleExpectation,
+  observations: ReadonlyArray<KhalaCodeQaObservation>,
+): KhalaCodeQaOracleOutcome => {
+  const match = expectation.match
+  const haystack = stringifyPublicFixtureValue(observedValues(observations))
+  const ok = match === undefined ? observations.every((observation) => observation.ok) : haystack.includes(match)
+  return {
+    data: { id: expectation.id, match, observed: ok },
+    ok,
+    oracle: "invariant",
+    phaseName,
+    summary: ok
+      ? `${expectation.id ?? "fixture evidence"} was observed`
+      : `${expectation.id ?? "fixture evidence"} was not observed`,
+    verdict: ok ? "CONFIRMED" : "REFUTED",
+  }
+}
+
 const verifyCommitments = (input: {
   readonly commitments: ReadonlyArray<KhalaCodeQaCommitment>
   readonly phaseOutcomes: ReadonlyArray<KhalaCodeQaPhaseOutcome>
@@ -567,6 +595,17 @@ const evaluateOracle = (
 
   if (expectation.oracle === "invariant" && expectation.id === "no-data-loss") {
     return evaluateNoDataLossInvariant(phaseName, expectation, observations)
+  }
+
+  if (
+    expectation.oracle === "invariant" &&
+    (expectation.id === "advisor-advisory-severity" ||
+      expectation.id === "advisor-dedupe-guard" ||
+      expectation.id === "advisor-interrupt-budget" ||
+      expectation.id === "judge-verdict-card" ||
+      expectation.id === "role-economics-exact-rows")
+  ) {
+    return evaluateFixtureEvidenceInvariant(phaseName, expectation, observations)
   }
 
   if (expectation.oracle === "consistency") {

--- a/packages/khala-qa-harness/src/seed-corpus.test.ts
+++ b/packages/khala-qa-harness/src/seed-corpus.test.ts
@@ -94,6 +94,22 @@ describe("Khala Code QA seed scenario corpus", () => {
     expect(idsForGroup("cross_mode")).toEqual([
       "scenario.khala_code.seed.cross_mode_consistency.v1",
     ])
+    expect(idsForGroup("planner_coder_judge")).toEqual([
+      "scenario.khala_code.seed.planner_coder_judge_role_registry.v1",
+      "scenario.khala_code.seed.planner_coder_judge_plan_card_decisions.v1",
+      "scenario.khala_code.seed.planner_coder_judge_judge_verdict_cards.v1",
+      "scenario.khala_code.seed.planner_coder_judge_advisor_guards.v1",
+      "scenario.khala_code.seed.planner_coder_judge_role_economics_and_live_smoke.v1",
+    ])
+    expect(KHALA_CODE_QA_SEED_CORPUS_MANIFEST.coverage.plannerCoderJudge).toEqual({
+      advisorAdvisorySeverities: ["blocker", "concern", "nit"],
+      advisorGuardRefs: ["dedupe_guard", "interrupt_budget"],
+      architectPlanDecisions: ["approve", "reject"],
+      judgeVerdictKinds: ["accept", "request_changes", "replan"],
+      liveSmokeModes: ["skip_safe_default"],
+      modelRoleRegistryRoles: ["advisor", "architect", "coder", "judge"],
+      roleEconomicsRoleRefs: ["advisor", "architect", "coder", "judge"],
+    })
     const crossModeScenario = KHALA_CODE_QA_SEED_SCENARIOS.find((candidate) =>
       candidate.id === "scenario.khala_code.seed.cross_mode_consistency.v1"
     )

--- a/packages/khala-qa-harness/src/seed-corpus.ts
+++ b/packages/khala-qa-harness/src/seed-corpus.ts
@@ -11,6 +11,7 @@ import {
   khalaCodeDesktopSlashCommandsWithAvailability,
   type KhalaCodeDesktopSlashCommand,
 } from "../../../clients/khala-code-desktop/src/shared/codex-slash-commands.js"
+import { defaultKhalaCodeModelRoleRegistry } from "../../../clients/khala-code-desktop/src/shared/model-roles.js"
 import {
   evaluateKhalaCodeQaMetricBudgets,
   khalaCodeQaMetricBudgets,
@@ -53,6 +54,7 @@ export type SeedCorpusGroup =
   | "rpc.plans_billing"
   | "rpc.headless_events"
   | "rpc.qa_metrics"
+  | "planner_coder_judge"
   | "hotbar"
   | "cross_mode"
   | "error_states"
@@ -79,6 +81,15 @@ export type KhalaCodeQaSeedCorpusManifest = Readonly<{
     fleetRunControlVerbs: readonly string[]
     hotbarPanels: readonly string[]
     inboxRoutingFlagKinds: readonly string[]
+    plannerCoderJudge: Readonly<{
+      advisorAdvisorySeverities: readonly string[]
+      advisorGuardRefs: readonly string[]
+      architectPlanDecisions: readonly string[]
+      judgeVerdictKinds: readonly string[]
+      liveSmokeModes: readonly string[]
+      modelRoleRegistryRoles: readonly string[]
+      roleEconomicsRoleRefs: readonly string[]
+    }>
     rpcGroups: readonly string[]
     rpcMethodsByGroup: Readonly<Record<string, readonly string[]>>
     selectors: readonly string[]
@@ -103,6 +114,7 @@ const threadId = "thread-fixture"
 const forkThreadId = "thread-fork-fixture"
 const turnId = "turn-fixture"
 const runRef = "fleet-run-fixture"
+const architectPlanRef = "architect-plan-fixture"
 
 type FixtureFleetRunState = "draft" | "running" | "paused" | "draining" | "completed" | "stopped"
 type FixtureAppServerState = "errored" | "running" | "starting" | "stopped"
@@ -1084,6 +1096,13 @@ export const KHALA_CODE_QA_SEED_APPROVAL_DECISION_KINDS = KHALA_CODE_CODEX_APPRO
 export const KHALA_CODE_QA_SEED_SELECTORS = [] as const
 export const KHALA_CODE_QA_SEED_SLASH_COMMANDS = KHALA_CODE_DESKTOP_SLASH_COMMANDS.map((command) => command.command)
 export const KHALA_CODE_QA_SEED_CROSS_MODE_SURFACES = KHALA_CODE_QA_CROSS_MODE_SURFACES
+export const KHALA_CODE_QA_PLANNER_CODER_JUDGE_MODEL_ROLE_REGISTRY_ROLES = ["advisor", "architect", "coder", "judge"] as const
+export const KHALA_CODE_QA_PLANNER_CODER_JUDGE_ARCHITECT_PLAN_DECISIONS = ["approve", "reject"] as const
+export const KHALA_CODE_QA_PLANNER_CODER_JUDGE_VERDICT_KINDS = ["accept", "request_changes", "replan"] as const
+export const KHALA_CODE_QA_PLANNER_CODER_JUDGE_ADVISORY_SEVERITIES = ["blocker", "concern", "nit"] as const
+export const KHALA_CODE_QA_PLANNER_CODER_JUDGE_ADVISOR_GUARD_REFS = ["dedupe_guard", "interrupt_budget"] as const
+export const KHALA_CODE_QA_PLANNER_CODER_JUDGE_ROLE_ECONOMICS_REFS = ["advisor", "architect", "coder", "judge"] as const
+export const KHALA_CODE_QA_PLANNER_CODER_JUDGE_LIVE_SMOKE_MODES = ["skip_safe_default"] as const
 
 export const KHALA_CODE_QA_SEED_SLASH_COMMAND_AVAILABILITY_STATES =
   Object.fromEntries(KHALA_CODE_DESKTOP_SLASH_COMMANDS.map((command) => [
@@ -1389,6 +1408,164 @@ const groupedCrossModeScenarios: readonly GroupedScenario[] = [
   ),
 ]
 
+const groupedPlannerCoderJudgeScenarios: readonly GroupedScenario[] = [
+  groupedFixtureScenario(
+    "planner_coder_judge",
+    "scenario.khala_code.seed.planner_coder_judge_role_registry.v1",
+    [{
+      name: "read-and-write-role-registry",
+      act: [
+        { kind: "rpc_call", method: "modelRoleRegistryRead" },
+        {
+          kind: "rpc_call",
+          method: "modelRoleRegistryWrite",
+          args: [{
+            registry: {
+              schema: "openagents.khala_code.model_roles.v1",
+              roles: {
+                advisor: { role: "advisor", harness: "claude", effort: "high", model: "claude-fixture-advisor" },
+                architect: { role: "architect", harness: "claude", effort: "xhigh", model: "claude-fixture-architect" },
+                coder: { role: "coder", harness: "codex", effort: "xhigh", model: "gpt-5.1-codex-fixture" },
+                judge: { role: "judge", harness: "claude", effort: "xhigh", model: "claude-fixture-judge" },
+              },
+            },
+          }],
+        },
+        {
+          kind: "rpc_call",
+          method: "codexModelRolePresetApply",
+          args: [{ cwd: "/workspace", preset: "architect-coder-judge" }],
+        },
+      ],
+      expect: [
+        schema("modelRoleRegistryRead"),
+        schema("modelRoleRegistryWrite"),
+        schema("codexModelRolePresetApply"),
+        crash(),
+      ],
+    }],
+    [
+      commitment("seed.pcj.role_registry.schema", "model-role registry RPC group decodes", "schema"),
+      runPass("seed.pcj.role_registry.pass", "Planner/Coder/Judge role registry scenario passes"),
+    ],
+  ),
+  groupedFixtureScenario(
+    "planner_coder_judge",
+    "scenario.khala_code.seed.planner_coder_judge_plan_card_decisions.v1",
+    [
+      {
+        name: "run-architect-plan",
+        act: [{
+          kind: "rpc_call",
+          method: "architectPlanRun",
+          args: [{
+            baseCommit: "1422b4a8440fd16bf1505cd052583f9bc4bed28e",
+            branch: "main",
+            objective: "fixture plan then code then judge",
+            repo: "OpenAgentsInc/openagents",
+            sessionId: desktopSessionId,
+            threadId,
+            verify: "bun run check:deploy",
+          }],
+        }],
+        expect: [schema("architectPlanRun"), crash()],
+      },
+      {
+        name: "approve-plan-card",
+        act: [{
+          kind: "rpc_call",
+          method: "architectPlanDecision",
+          args: [{ decision: "approve", planRef: architectPlanRef, sessionId: desktopSessionId, threadId }],
+        }],
+        expect: [schema("architectPlanDecision"), crash()],
+      },
+      {
+        name: "reject-plan-card",
+        act: [{
+          kind: "rpc_call",
+          method: "architectPlanDecision",
+          args: [{ decision: "reject", planRef: architectPlanRef, sessionId: desktopSessionId, threadId }],
+        }],
+        expect: [schema("architectPlanDecision"), crash()],
+      },
+    ],
+    [
+      commitment("seed.pcj.plan_card.schema", "plan card run and decisions decode", "schema"),
+      runPass("seed.pcj.plan_card.pass", "Planner/Coder/Judge plan-card scenario passes"),
+    ],
+  ),
+  groupedFixtureScenario(
+    "planner_coder_judge",
+    "scenario.khala_code.seed.planner_coder_judge_judge_verdict_cards.v1",
+    KHALA_CODE_QA_PLANNER_CODER_JUDGE_VERDICT_KINDS.map((verdict) => ({
+      name: `judge-verdict-${verdict}`,
+      act: [{ kind: "rpc_call" as const, method: "codexThreadRead", args: [{ threadId: `pcj-judge-${verdict}`, includeTurns: true }] }],
+      expect: [
+        schema("codexThreadRead"),
+        { id: "judge-verdict-card", match: verdict, oracle: "invariant" as const },
+        crash(),
+      ],
+    })),
+    [
+      commitment("seed.pcj.judge_verdict_cards.schema", "judge verdict cards decode through the thread fixture", "schema"),
+      runPass("seed.pcj.judge_verdict_cards.pass", "Planner/Coder/Judge verdict-card scenario passes"),
+    ],
+  ),
+  groupedFixtureScenario(
+    "planner_coder_judge",
+    "scenario.khala_code.seed.planner_coder_judge_advisor_guards.v1",
+    [{
+      name: "advisor-advisory-severities-and-guards",
+      act: [{ kind: "rpc_call", method: "codexThreadRead", args: [{ threadId: "pcj-advisor-guards", includeTurns: true }] }],
+      expect: [
+        schema("codexThreadRead"),
+        { id: "advisor-advisory-severity", match: "blocker", oracle: "invariant" as const },
+        { id: "advisor-advisory-severity", match: "concern", oracle: "invariant" as const },
+        { id: "advisor-advisory-severity", match: "nit", oracle: "invariant" as const },
+        { id: "advisor-dedupe-guard", match: "dedupe_guard", oracle: "invariant" as const },
+        { id: "advisor-interrupt-budget", match: "interrupt_budget", oracle: "invariant" as const },
+        crash(),
+      ],
+    }],
+    [
+      commitment("seed.pcj.advisor.schema", "advisor advisory fixture decodes through the thread fixture", "schema"),
+      runPass("seed.pcj.advisor.pass", "Planner/Coder/Judge advisor guard scenario passes"),
+    ],
+  ),
+  groupedFixtureScenario(
+    "planner_coder_judge",
+    "scenario.khala_code.seed.planner_coder_judge_role_economics_and_live_smoke.v1",
+    [{
+      name: "role-economics-and-live-smoke-skip",
+      act: [
+        { kind: "rpc_call", method: "threadTokenSummary", args: [{ threadId }] },
+        {
+          kind: "rpc_call",
+          method: "qaMetricSample",
+          args: [{
+            ...qaMetricSample("startup.interactive_ms", 0),
+            context: {
+              mode: "skip_safe_default",
+              schema: "openagents.khala_code.architect_coder_judge_live_smoke.v1",
+              surface: "architect-coder-judge-live-smoke",
+            },
+          }],
+        },
+      ],
+      expect: [
+        schema("threadTokenSummary"),
+        schema("qaMetricSample"),
+        { id: "role-economics-exact-rows", match: "roleEconomics", oracle: "invariant" as const },
+        crash(),
+      ],
+    }],
+    [
+      commitment("seed.pcj.role_economics.schema", "per-role token summary rows decode from exact-row projections", "schema"),
+      runPass("seed.pcj.role_economics.pass", "Planner/Coder/Judge role-economics and skip-safe live-smoke scenario passes"),
+    ],
+  ),
+]
+
 const firstDistilledExploreSession: KhalaCodeQaExploreSession = {
   actionLog: [
     {
@@ -1443,6 +1620,7 @@ const groupedSeedScenarios: readonly GroupedScenario[] = [
   ...groupedQ41RpcScenarios,
   ...groupedHotbarScenarios,
   ...groupedCrossModeScenarios,
+  ...groupedPlannerCoderJudgeScenarios,
   ...groupedThreadItemScenarios,
   ...groupedErrorStateScenarios,
   ...groupedSlashCommandScenarios,
@@ -1462,6 +1640,15 @@ export const KHALA_CODE_QA_SEED_CORPUS_MANIFEST: KhalaCodeQaSeedCorpusManifest =
     fleetRunControlVerbs: KHALA_CODE_QA_SEED_FLEET_RUN_CONTROL_VERBS,
     hotbarPanels: KHALA_CODE_QA_SEED_HOTBAR_PANELS,
     inboxRoutingFlagKinds: KHALA_CODE_QA_SEED_INBOX_ROUTING_FLAG_KINDS,
+    plannerCoderJudge: {
+      advisorAdvisorySeverities: KHALA_CODE_QA_PLANNER_CODER_JUDGE_ADVISORY_SEVERITIES,
+      advisorGuardRefs: KHALA_CODE_QA_PLANNER_CODER_JUDGE_ADVISOR_GUARD_REFS,
+      architectPlanDecisions: KHALA_CODE_QA_PLANNER_CODER_JUDGE_ARCHITECT_PLAN_DECISIONS,
+      judgeVerdictKinds: KHALA_CODE_QA_PLANNER_CODER_JUDGE_VERDICT_KINDS,
+      liveSmokeModes: KHALA_CODE_QA_PLANNER_CODER_JUDGE_LIVE_SMOKE_MODES,
+      modelRoleRegistryRoles: KHALA_CODE_QA_PLANNER_CODER_JUDGE_MODEL_ROLE_REGISTRY_ROLES,
+      roleEconomicsRoleRefs: KHALA_CODE_QA_PLANNER_CODER_JUDGE_ROLE_ECONOMICS_REFS,
+    },
     rpcGroups: Object.keys(KHALA_CODE_QA_ROADMAP_RPC_METHOD_GROUPS),
     rpcMethodsByGroup: KHALA_CODE_QA_ROADMAP_RPC_METHOD_GROUPS,
     selectors: KHALA_CODE_QA_SEED_SELECTORS,
@@ -1936,6 +2123,28 @@ const fixtureRpcPayload = (
       const request = args[0] as { readonly keyPath?: string } | undefined
       return { ok: true, keyPath: request?.keyPath ?? "model", response: { applied: true }, settings: settingsProjection() }
     }
+    case "modelRoleRegistryRead":
+      return modelRoleRegistryResult(defaultKhalaCodeModelRoleRegistry())
+    case "modelRoleRegistryWrite": {
+      const request = args[0] as { readonly registry?: unknown; readonly entry?: { readonly role?: string } } | undefined
+      const registry = request?.registry ?? {
+        ...defaultKhalaCodeModelRoleRegistry(),
+        ...(request?.entry?.role === undefined ? {} : {
+          roles: {
+            ...defaultKhalaCodeModelRoleRegistry().roles,
+            [request.entry.role]: request.entry,
+          },
+        }),
+      }
+      return { ...modelRoleRegistryResult(registry), saved: true }
+    }
+    case "codexModelRolePresetApply":
+      return {
+        keyPath: "openagents.model_roles",
+        ok: true,
+        preset: "architect-coder-judge",
+        settings: settingsProjection({ architectCoderJudgeSelected: true }),
+      }
     case "harnessSettingRead":
       return harnessSetting("codex_harness", undefined, state.activeErrorStateCase === "all_boot_rpcs_failing" ? state.activeErrorStateCase : null)
     case "harnessSettingWrite": {
@@ -1992,6 +2201,19 @@ const fixtureRpcPayload = (
       return actionResult("skills/extraRoots/set", { extraRoots: ["/workspace/.khala/skills"] })
     case "threadTokenSummary":
       return threadTokenSummary(args[0])
+    case "architectPlanRun":
+      return { ok: true, artifact: architectPlanArtifact("pending_approval") }
+    case "architectPlanDecision": {
+      const request = args[0] as { readonly decision?: "approve" | "reject" } | undefined
+      const status = request?.decision === "reject" ? "rejected" : "dispatched"
+      return {
+        artifact: architectPlanArtifact(status),
+        message: request?.decision === "reject"
+          ? `Rejected plan ${architectPlanRef}.`
+          : `Approved plan ${architectPlanRef}; dispatched an in-thread Codex turn.`,
+        ok: true,
+      }
+    }
     case "sessionCatalog":
       return sessionCatalog(
         state.activeErrorStateCase === "corrupt_session_state_recovery" ||
@@ -2259,6 +2481,76 @@ const threadMessage = (
     }),
 })
 
+const judgeVerdict = (verdict: typeof KHALA_CODE_QA_PLANNER_CODER_JUDGE_VERDICT_KINDS[number]) => ({
+  confidence: verdict === "accept" ? 0.91 : verdict === "request_changes" ? 0.84 : 0.72,
+  diffRef: `diff.fixture.${verdict}`,
+  findings: verdict === "accept"
+    ? []
+    : [{
+      body: verdict === "replan"
+        ? "The approved plan no longer matches the implemented direction."
+        : "The retry guard was removed from the changed path.",
+      confidence: verdict === "replan" ? 0.76 : 0.82,
+      filePath: "packages/khala-qa-harness/src/seed-corpus.ts",
+      findingRef: `judge.finding.${verdict}.1`,
+      lineStart: 1,
+      priority: verdict === "replan" ? "P1" : "P2",
+      title: verdict === "replan" ? "Plan drift requires replanning" : "Retry guard removed",
+    }],
+  schema: "openagents.khala_code.judge_diff_verdict.v1",
+  summary: `${verdict} fixture verdict`,
+  verdict,
+  verifyAuthority: "verify_command_required",
+})
+
+const advisorAdvisory = (
+  severity: typeof KHALA_CODE_QA_PLANNER_CODER_JUDGE_ADVISORY_SEVERITIES[number],
+) => ({
+  advisoryRef: `advisor.${severity}.fixture`,
+  generatedAt: observedAt,
+  guidance: severity === "nit"
+    ? "Mention the verifier in the closeout."
+    : severity === "concern"
+      ? "Check that the migration preserves existing rows."
+      : "Do not weaken the verify command authority.",
+  role: "advisor",
+  schema: "openagents.khala_code.advisor_advisory.v1",
+  severity,
+  summary: `${severity} fixture advisory`,
+})
+
+const plannerCoderJudgeThreadBody = (
+  id: string,
+): string | null => {
+  const judgePrefix = "pcj-judge-"
+  if (id.startsWith(judgePrefix)) {
+    const verdict = id.slice(judgePrefix.length)
+    if ((KHALA_CODE_QA_PLANNER_CODER_JUDGE_VERDICT_KINDS as readonly string[]).includes(verdict)) {
+      const fixture = judgeVerdict(verdict as typeof KHALA_CODE_QA_PLANNER_CODER_JUDGE_VERDICT_KINDS[number])
+      return [
+        `judge_verdict:${fixture.verdict}`,
+        `judge_schema:${fixture.schema}`,
+        `verify_authority:${fixture.verifyAuthority}`,
+        `judge_summary:${fixture.summary}`,
+      ].join("\n")
+    }
+  }
+  if (id === "pcj-advisor-guards") {
+    return [
+      ...KHALA_CODE_QA_PLANNER_CODER_JUDGE_ADVISORY_SEVERITIES.map((severity) => {
+        const advisory = advisorAdvisory(severity)
+        return `advisor_advisory:${advisory.severity}:${advisory.advisoryRef}`
+      }),
+      "advisor_guard:dedupe_guard",
+      "advisor_guard:interrupt_budget",
+      "advisor_dropped:duplicate",
+      "advisor_dropped:content_free",
+      "advisor_steered:advisor.blocker.fixture",
+    ].join("\n")
+  }
+  return null
+}
+
 const threadResult = (id: string, state: FixtureThreadState = {
   archived: false,
   deleted: false,
@@ -2266,14 +2558,15 @@ const threadResult = (id: string, state: FixtureThreadState = {
   title: "Fixture thread",
 }, errorCase: KhalaCodeQaErrorStateCaseId | null = null) => {
   const fixture = threadItemFixtureForThreadId(id)
+  const plannerCoderJudgeBody = plannerCoderJudgeThreadBody(id)
   return {
     cwd: "/workspace",
     desktopSessionId,
     messages: [threadMessage(
       `message-${id}`,
-      fixture === undefined
+      plannerCoderJudgeBody ?? (fixture === undefined
         ? "fixture message"
-        : `Pinned ThreadItem fixture replay: ${fixture.variant}`,
+        : `Pinned ThreadItem fixture replay: ${fixture.variant}`),
       fixture,
     )],
     model: "gpt-5.1-codex",
@@ -2593,7 +2886,95 @@ const fleetRun = (
   },
 })
 
-const settingsProjection = () => {
+const modelRoleRegistryResult = (registry: unknown) => ({
+  ok: true,
+  path: "/fixture/khala-code-model-roles.json",
+  registry,
+})
+
+const architectPlanDag = () => ({
+  baseCommit: "1422b4a8440fd16bf1505cd052583f9bc4bed28e",
+  branch: "main",
+  evidenceRefs: ["fixture.architect.plan.public_safe"],
+  generatedAt: observedAt,
+  nodes: [{
+    baseCommit: "1422b4a8440fd16bf1505cd052583f9bc4bed28e",
+    branch: "main",
+    evidenceRefs: ["fixture.architect.node.public_safe"],
+    nodeRef: "architect-node-fixture",
+    objective: "Run the fixture coder turn and preserve verify authority.",
+    repo: "OpenAgentsInc/openagents",
+    title: "Fixture coder turn",
+    verify: "bun run check:deploy",
+  }],
+  objective: "fixture plan then code then judge",
+  planRef: architectPlanRef,
+  repo: "OpenAgentsInc/openagents",
+  schema: "openagents.khala_code.claude_plan_fanout_dag.v1",
+  source: "claude_plan_mode",
+  verify: "bun run check:deploy",
+})
+
+const architectPlanArtifact = (
+  status: "approved" | "dispatched" | "pending_approval" | "rejected",
+) => ({
+  architectRole: {
+    harness: "claude",
+    mode: "plan",
+    readOnly: true,
+    role: "architect",
+  },
+  coderTurnId: status === "dispatched" ? "architect-coder-fixture" : null,
+  createdAt: observedAt,
+  dag: architectPlanDag(),
+  dispatchMode: "in_thread",
+  fleetRunRef: null,
+  planRef: architectPlanRef,
+  schema: "openagents.khala_code.architect_plan_artifact.v1",
+  sessionId: desktopSessionId,
+  status,
+  updatedAt: observedAt,
+})
+
+const modelRolePresetProjection = (selected: boolean) => ({
+  activePreset: selected ? "architect-coder-judge" : null,
+  keyPath: "openagents.model_roles",
+  presets: [{
+    configKeyPath: "openagents.model_roles",
+    copyGate: "copy_gated_until_end_to_end_verifiable",
+    description: "Claude plans and judges through user auth; Codex codes through the existing login.",
+    id: "architect-coder-judge",
+    noProxyRails: true,
+    noResale: true,
+    promiseRef: "khala_code.architect_coder_judge.v1",
+    registry: {
+      activePreset: "architect-coder-judge",
+      copyGate: "copy_gated_until_end_to_end_verifiable",
+      noProxyRails: true,
+      noResale: true,
+      promiseRef: "khala_code.architect_coder_judge.v1",
+      roles: [
+        { role: "architect", harness: "claude", authRail: "user_anthropic_auth", authority: "advisory", enabled: true, effort: "xhigh", optional: false },
+        { role: "coder", harness: "codex", authRail: "user_codex_login", authority: "executor", enabled: true, effort: "xhigh", optional: false },
+        { role: "judge", harness: "claude", authRail: "user_anthropic_auth", authority: "advisory", enabled: true, effort: "xhigh", optional: false },
+        { role: "advisor", harness: "claude", authRail: "user_anthropic_auth", authority: "advisory", enabled: false, effort: "high", optional: true },
+      ],
+      schema: "openagents.khala_code.model_roles.v1",
+    },
+    roleSummary: [
+      "Architect: Claude, user Anthropic auth, advisory",
+      "Coder: Codex, existing local login, executor",
+      "Judge: Claude, user Anthropic auth, advisory",
+      "Advisor: Claude, optional and off by default",
+    ],
+    selected,
+    title: "Architect / Coder / Judge",
+  }],
+})
+
+const settingsProjection = (
+  options: { readonly architectCoderJudgeSelected?: boolean } = {},
+) => {
   const model = {
     defaultReasoningEffort: "medium",
     defaultServiceTier: "auto",
@@ -2658,6 +3039,7 @@ const settingsProjection = () => {
     },
     observedAt,
     ok: true,
+    modelRolePresets: modelRolePresetProjection(options.architectCoderJudgeSelected === true),
     permissions: {
       blockedProfileIds: [],
       profiles: [{ allowed: true, description: "Fixture", id: "workspace-write", selected: true }],
@@ -2763,10 +3145,16 @@ const threadTokenSummary = (request: unknown) => ({
   pendingSyncTokens: 0,
   remoteConfigured: false,
   remoteDisabled: true,
+  roleEconomics: [
+    { costAmount: 0.02, costCurrency: "USD", pricingState: "measured", roleRef: "architect", tokenRows: 1, tokens: 10 },
+    { costAmount: null, costCurrency: null, pricingState: "subscription_covered", roleRef: "coder", tokenRows: 1, tokens: 100 },
+    { costAmount: 0.01, costCurrency: "USD", pricingState: "measured", roleRef: "judge", tokenRows: 1, tokens: 8 },
+    { costAmount: 0.01, costCurrency: "USD", pricingState: "measured", roleRef: "advisor", tokenRows: 1, tokens: 6 },
+  ],
   threadId: (request as { readonly threadId?: string | null } | undefined)?.threadId ?? threadId,
-  totalTokens: 2,
+  totalTokens: 124,
   updatedAt: observedAt,
-  usageEventRows: 1,
+  usageEventRows: 4,
 })
 
 const sessionCatalog = (


### PR DESCRIPTION
## Summary

Closes #8059.

Adds Planner/Coder/Judge proof coverage to the Khala QA harness:

- fixture seed scenarios for model-role registry, architect plan approve/reject, judge verdict card markers for every verdict kind, advisor advisory severities/guards, role economics, and skip-safe live-smoke evidence
- coverage-ledger/frontier buckets for the Q9.7 surfaces so nightly/frontier reporting can see gaps explicitly
- default-skip `smoke:architect-coder-judge-live` entry point with armed-mode archived evidence validation
- real-bridge exclusion for the two transcript-fixture-only Q9.7 scenarios while keeping RPC-backed Q9.7 scenarios in the real bridge subset

## Verification

- `bun test packages/khala-qa-harness/src/seed-corpus.test.ts packages/khala-qa-harness/src/coverage-ledger.test.ts` ✅ 8 pass
- `bun run --cwd packages/khala-qa-harness typecheck` ✅
- `bun run --cwd packages/khala-qa-harness test` ✅ 81 pass
- `bun run --cwd packages/khala-qa-harness smoke:architect-coder-judge-live` ✅ skip-safe default evidence emitted
- `bun run check:deploy` ✅

## Public-safety / token accounting

No live model/provider turn was run in this PR. The new armed live-smoke path refuses to green without archived public-safe evidence containing architect/coder/judge roles and exact per-role token rows.