### PR TITLE
BF-2.3 recurring billing contract

### DIFF
--- a/apps/openagents.com/workers/api/src/site-payment-catalog.test.ts
+++ b/apps/openagents.com/workers/api/src/site-payment-catalog.test.ts
@@ -192,6 +192,71 @@ describe('OpenAgents Site payment catalog', () => {
     ])
   })
 
+  test('carries BF-2.3 recurring billing into catalog projections and entitlement refs', () => {
+    const catalog = sitePaymentCatalogFromManifest({
+      ...catalogInput,
+      manifest: {
+        payments: {
+          ...sitePaymentManifest.payments,
+          paidActions: [],
+          products: [
+            {
+              ...sitePaymentManifest.payments.products[0]!,
+              checkoutPath: '/checkout/monthly-retainer',
+              displayRef: 'display.monthly_retainer',
+              id: 'monthly_retainer',
+              metadataRefs: ['metadata.product.monthly_retainer'],
+              recurringBilling: {
+                billingKind: 'retainer',
+                entitlementRenewalMode: 'renew_on_payment_receipt',
+                interval: 'month',
+                renewalReceiptScopeRefs: [
+                  'receipt_scope.business.retainer.renewal',
+                ],
+              },
+            },
+          ],
+        },
+      },
+    })
+    const publicProjection = projectOpenAgentsSitePaymentCatalog(
+      catalog,
+      'public',
+    )
+    const endpointProduct = openAgentsPaidEndpointProductFromSitePaymentCatalogItem(
+      catalog.items[0]!,
+    )
+
+    expect(catalog.items[0]).toMatchObject({
+      itemKind: 'product',
+      productId: 'monthly_retainer',
+      recurringBilling: {
+        billingKind: 'retainer',
+        entitlementRenewalMode: 'renew_on_payment_receipt',
+        interval: 'month',
+        renewalReceiptScopeRefs: [
+          'receipt_scope.business.retainer.renewal',
+        ],
+      },
+    })
+    expect(publicProjection.items[0]).toMatchObject({
+      itemKind: 'product',
+      recurringBilling: {
+        billingKind: 'retainer',
+        interval: 'month',
+      },
+    })
+    expect(endpointProduct.entitlement).toMatchObject({
+      durationSeconds: 2_678_400,
+      kind: 'resource',
+    })
+    expect(endpointProduct.entitlement.scopeRefs).toEqual([
+      'entitlement.site_payment.site_otec.version_otec_v2.product.monthly_retainer',
+      'entitlement_renewal.site_payment.site_otec.version_otec_v2.retainer.monthly_retainer',
+      'receipt_scope.business.retainer.renewal',
+    ])
+  })
+
   test('integrates with paid endpoint product records and hosted checkout plans', () => {
     const catalog = sitePaymentCatalogFromManifest(catalogInput)
     const productRecord = openAgentsPaidEndpointProductFromSitePaymentCatalogItem(
@@ -287,6 +352,21 @@ describe('OpenAgents Site payment catalog', () => {
           {
             ...catalog.items[1]!,
             path: 'https://example.com/api/actions/download-report',
+          },
+        ],
+      }),
+    ).toThrow(OpenAgentsSitePaymentCatalogUnsafe)
+    expect(() =>
+      decodeOpenAgentsSitePaymentCatalog({
+        items: [
+          {
+            ...catalog.items[0]!,
+            recurringBilling: {
+              billingKind: 'subscription',
+              entitlementRenewalMode: 'renew_on_payment_receipt',
+              interval: 'month',
+              renewalReceiptScopeRefs: ['raw_invoice.lnbc2500n1unsafe'],
+            },
           },
         ],
       }),

--- a/apps/openagents.com/workers/api/src/site-payment-catalog.ts
+++ b/apps/openagents.com/workers/api/src/site-payment-catalog.ts
@@ -11,6 +11,7 @@ import { OpenAgentsPaymentPolicyAudience } from './payment-limit-policy'
 import { openAgentsRunnerGatewayPayloadHasPrivateMaterial } from './runner-gateway'
 import {
   OpenAgentsSitePaymentCustomerDataRequirement,
+  OpenAgentsSitePaymentRecurringBilling,
   OpenAgentsSitePaymentEntitlementScope,
   OpenAgentsSitePaymentManifest,
   OpenAgentsSitePaymentPaidAction,
@@ -66,6 +67,7 @@ const OpenAgentsSitePaymentCatalogCommonRecord = S.Struct({
   orderRef: S.NullOr(S.String),
   price: OpenAgentsPaidEndpointProductRecord.fields.price,
   publicProjectionState: OpenAgentsSitePaymentPublicProjectionState,
+  recurringBilling: S.NullOr(OpenAgentsSitePaymentRecurringBilling),
   sandbox: S.Boolean,
   settlementMode: OpenAgentsSitePaymentSettlementMode,
   siteId: S.String,
@@ -139,6 +141,7 @@ export const OpenAgentsSitePaymentCatalogItemProjection = S.Struct({
   operatorRefs: S.Array(S.String),
   price: OpenAgentsPaidEndpointProductRecord.fields.price,
   publicProjectionState: OpenAgentsSitePaymentPublicProjectionState,
+  recurringBilling: S.NullOr(OpenAgentsSitePaymentRecurringBilling),
   sandbox: S.Boolean,
   settlementMode: OpenAgentsSitePaymentSettlementMode,
   siteId: S.String,
@@ -258,6 +261,16 @@ const priceIsSupported = (
     (price.asset === 'credits' && price.denomination === 'credit')
   )
 
+const recurringBillingIsSafe = (
+  recurringBilling: OpenAgentsSitePaymentRecurringBilling | null,
+): boolean =>
+  recurringBilling === null ||
+  (
+    recurringBilling.entitlementRenewalMode === 'renew_on_payment_receipt' &&
+    recurringBilling.renewalReceiptScopeRefs.length > 0 &&
+    recurringBilling.renewalReceiptScopeRefs.every(stableRefIsSafe)
+  )
+
 const catalogIdSegment = (value: string, fallback: string): string => {
   const normalized = value
     .toLowerCase()
@@ -300,6 +313,10 @@ const commonRecord = (
   itemKind: OpenAgentsSitePaymentCatalogItemKind,
 ): typeof OpenAgentsSitePaymentCatalogCommonRecord.Type => {
   const linkage = linkageFromInput(input)
+  const recurringBilling =
+    itemKind === 'product' && 'recurringBilling' in item
+      ? item.recurringBilling ?? null
+      : null
 
   return {
     agentReadable: item.agentReadable,
@@ -320,6 +337,7 @@ const commonRecord = (
     orderRef: input.orderRef,
     price: item.price,
     publicProjectionState: item.publicProjectionState,
+    recurringBilling,
     sandbox: item.sandbox || input.manifest.payments.sandboxDefault,
     settlementMode: item.settlementMode,
     siteId: input.siteId,
@@ -420,6 +438,7 @@ const commonProjection = (
   operatorRefs: operatorRefsForItem(item, audience),
   price: item.price,
   publicProjectionState: item.publicProjectionState,
+  recurringBilling: item.recurringBilling,
   sandbox: item.sandbox,
   settlementMode: item.settlementMode,
   siteId: safeRefOrFallback(item.siteId, 'site.redacted'),
@@ -468,7 +487,11 @@ const paidEndpointStatusForItem = (
 const entitlementForItem = (
   item: OpenAgentsSitePaymentCatalogRecord,
 ): OpenAgentsPaidEndpointEntitlement => ({
-  durationSeconds: null,
+  durationSeconds: item.recurringBilling?.interval === 'month'
+    ? 2_678_400
+    : item.recurringBilling?.interval === 'year'
+      ? 31_536_000
+      : null,
   kind: 'resource',
   quotaUnits: null,
   scopeRefs: [
@@ -483,6 +506,12 @@ const entitlementForItem = (
         item.itemKind,
       ),
     ].join('.'),
+    ...(item.recurringBilling === null
+      ? []
+      : [
+          `entitlement_renewal.site_payment.${catalogIdSegment(item.siteId, 'site')}.${catalogIdSegment(item.siteVersionId, 'version')}.${item.recurringBilling.billingKind}.${catalogIdSegment(item.itemKind === 'product' ? item.productId : item.actionId, item.itemKind)}`,
+          ...item.recurringBilling.renewalReceiptScopeRefs,
+        ]),
   ],
 })
 
@@ -540,6 +569,7 @@ export const decodeOpenAgentsSitePaymentCatalog = (
     !optionalRefIsSafe(item.sourceManifestDigest) ||
     !optionalRefIsSafe(item.workroomRef) ||
     !priceIsSupported(item.price) ||
+    !recurringBillingIsSafe(item.recurringBilling) ||
     item.metadataRefs.some(ref => !stableRefIsSafe(ref)) ||
     item.customerDataRequirements.some(
       requirement =>

--- a/apps/openagents.com/workers/api/src/site-payment-manifest.test.ts
+++ b/apps/openagents.com/workers/api/src/site-payment-manifest.test.ts
@@ -146,6 +146,73 @@ describe('OpenAgents Site payment manifest', () => {
     ).toThrow()
   })
 
+  test('projects subscription and retainer products with receipt-renewed recurrence', () => {
+    const manifest = decodeOpenAgentsSitePaymentManifest({
+      payments: {
+        ...validManifest.payments,
+        products: [
+          {
+            ...validManifest.payments.products[0],
+            displayRef: 'display.monthly_retainer',
+            id: 'monthly_retainer',
+            metadataRefs: ['metadata.product.monthly_retainer'],
+            recurringBilling: {
+              billingKind: 'retainer',
+              entitlementRenewalMode: 'renew_on_payment_receipt',
+              interval: 'month',
+              renewalReceiptScopeRefs: [
+                'receipt_scope.business.retainer.renewal',
+              ],
+            },
+          },
+          {
+            ...validManifest.payments.products[0],
+            displayRef: 'display.membership_subscription',
+            id: 'membership_subscription',
+            metadataRefs: ['metadata.product.membership_subscription'],
+            recurringBilling: {
+              billingKind: 'subscription',
+              entitlementRenewalMode: 'renew_on_payment_receipt',
+              interval: 'year',
+              renewalReceiptScopeRefs: [
+                'receipt_scope.business.membership.renewal',
+              ],
+            },
+          },
+        ],
+      },
+    })
+    const publicProjection = projectOpenAgentsSitePaymentManifest(
+      manifest,
+      'public',
+    )
+
+    expect(publicProjection.products.map(product => product.recurringBilling))
+      .toEqual([
+        {
+          billingKind: 'retainer',
+          entitlementRenewalMode: 'renew_on_payment_receipt',
+          interval: 'month',
+          renewalReceiptScopeRefs: [
+            'receipt_scope.business.retainer.renewal',
+          ],
+        },
+        {
+          billingKind: 'subscription',
+          entitlementRenewalMode: 'renew_on_payment_receipt',
+          interval: 'year',
+          renewalReceiptScopeRefs: [
+            'receipt_scope.business.membership.renewal',
+          ],
+        },
+      ])
+    expect(
+      S.decodeUnknownSync(OpenAgentsSitePaymentManifestProjection)(
+        publicProjection,
+      ),
+    ).toEqual(publicProjection)
+  })
+
   test('rejects raw payment material and unsafe checkout paths', () => {
     expect(() =>
       decodeOpenAgentsSitePaymentManifest({
@@ -176,6 +243,24 @@ describe('OpenAgents Site payment manifest', () => {
             {
               ...validManifest.payments.paidActions[0],
               path: 'https://evil.test/api/actions/download-report',
+            },
+          ],
+        },
+      }),
+    ).toThrow(OpenAgentsSitePaymentManifestUnsafe)
+    expect(() =>
+      decodeOpenAgentsSitePaymentManifest({
+        payments: {
+          ...validManifest.payments,
+          products: [
+            {
+              ...validManifest.payments.products[0],
+              recurringBilling: {
+                billingKind: 'subscription',
+                entitlementRenewalMode: 'renew_on_payment_receipt',
+                interval: 'month',
+                renewalReceiptScopeRefs: ['customer_email.ben@example.com'],
+              },
             },
           ],
         },

--- a/apps/openagents.com/workers/api/src/site-payment-manifest.ts
+++ b/apps/openagents.com/workers/api/src/site-payment-manifest.ts
@@ -52,6 +52,29 @@ export const OpenAgentsSitePaymentCustomerDataRequirement = S.Struct({
 export type OpenAgentsSitePaymentCustomerDataRequirement =
   typeof OpenAgentsSitePaymentCustomerDataRequirement.Type
 
+export const OpenAgentsSitePaymentRecurringBillingKind = S.Literals([
+  'retainer',
+  'subscription',
+])
+export type OpenAgentsSitePaymentRecurringBillingKind =
+  typeof OpenAgentsSitePaymentRecurringBillingKind.Type
+
+export const OpenAgentsSitePaymentRecurringBillingInterval = S.Literals([
+  'month',
+  'year',
+])
+export type OpenAgentsSitePaymentRecurringBillingInterval =
+  typeof OpenAgentsSitePaymentRecurringBillingInterval.Type
+
+export const OpenAgentsSitePaymentRecurringBilling = S.Struct({
+  billingKind: OpenAgentsSitePaymentRecurringBillingKind,
+  entitlementRenewalMode: S.Literal('renew_on_payment_receipt'),
+  interval: OpenAgentsSitePaymentRecurringBillingInterval,
+  renewalReceiptScopeRefs: S.Array(S.String),
+})
+export type OpenAgentsSitePaymentRecurringBilling =
+  typeof OpenAgentsSitePaymentRecurringBilling.Type
+
 export const OpenAgentsSitePaymentProduct = S.Struct({
   agentReadable: S.Boolean,
   checkoutPath: S.String,
@@ -64,6 +87,7 @@ export const OpenAgentsSitePaymentProduct = S.Struct({
   metadataRefs: S.Array(S.String),
   price: OpenAgentsPaidEndpointPrice,
   publicProjectionState: OpenAgentsSitePaymentPublicProjectionState,
+  recurringBilling: S.optionalKey(S.NullOr(OpenAgentsSitePaymentRecurringBilling)),
   sandbox: S.Boolean,
   settlementMode: OpenAgentsSitePaymentSettlementMode,
 })
@@ -116,6 +140,7 @@ export const OpenAgentsSitePaymentProductProjection = S.Struct({
   id: S.String,
   price: OpenAgentsPaidEndpointPrice,
   publicProjectionState: OpenAgentsSitePaymentPublicProjectionState,
+  recurringBilling: S.NullOr(OpenAgentsSitePaymentRecurringBilling),
   sandbox: S.Boolean,
   settlementMode: OpenAgentsSitePaymentSettlementMode,
 })
@@ -205,13 +230,25 @@ const dataRequirementIsSafe = (
 ): boolean =>
   stableIdIsSafe(requirement.key) && stableRefIsSafe(requirement.labelRef)
 
+const recurringBillingIsSafe = (
+  recurringBilling: OpenAgentsSitePaymentRecurringBilling | null | undefined,
+): boolean =>
+  recurringBilling === null ||
+  recurringBilling === undefined ||
+  (
+    recurringBilling.entitlementRenewalMode === 'renew_on_payment_receipt' &&
+    recurringBilling.renewalReceiptScopeRefs.length > 0 &&
+    recurringBilling.renewalReceiptScopeRefs.every(stableRefIsSafe)
+  )
+
 const productIsSafe = (product: OpenAgentsSitePaymentProduct): boolean =>
   stableIdIsSafe(product.id) &&
   stableRefIsSafe(product.displayRef) &&
   checkoutPathIsSafe(product.checkoutPath) &&
   priceIsSupported(product.price) &&
   product.metadataRefs.every(stableRefIsSafe) &&
-  product.customerDataRequirements.every(dataRequirementIsSafe)
+  product.customerDataRequirements.every(dataRequirementIsSafe) &&
+  recurringBillingIsSafe(product.recurringBilling)
 
 const paidActionIsSafe = (action: OpenAgentsSitePaymentPaidAction): boolean =>
   stableIdIsSafe(action.id) &&
@@ -299,6 +336,7 @@ export const projectOpenAgentsSitePaymentManifest = (
       id: product.id,
       price: product.price,
       publicProjectionState: product.publicProjectionState,
+      recurringBilling: product.recurringBilling ?? null,
       sandbox: product.sandbox,
       settlementMode: product.settlementMode,
     })),


### PR DESCRIPTION
## Summary

Closes #8081.

Adds a receipt-backed recurring billing contract to Site payment manifests/catalogs so BF-2.3 subscription and retainer products can advertise:

- subscription vs retainer billing kind
- month/year renewal interval
- `renew_on_payment_receipt` entitlement renewal mode
- public-safe renewal receipt scope refs

The manifest, durable catalog projection, and paid-endpoint conversion now carry the recurrence metadata without adding settlement authority or raw payment material.

## Verification

- `bun run --cwd apps/openagents.com/workers/api test -- src/site-payment-manifest.test.ts src/site-payment-catalog.test.ts` green: 2 files, 11 tests passed.
- `bun run --cwd apps/openagents.com/workers/api typecheck` green.
- `bun run check:deploy` green, exit code 0.

Note: `check:deploy` includes the contract-drift fixture test, which intentionally prints fixture "FAILED" examples while the test file itself passes.
