### PR TITLE
BF-2.4: surface volume prepay credit tiers

### DIFF
--- a/apps/openagents.com/apps/web/src/domain/session.ts
+++ b/apps/openagents.com/apps/web/src/domain/session.ts
@@ -227,8 +227,13 @@ export type BillingAutoTopUpState = typeof BillingAutoTopUpState.Type
 export const BillingCreditPackage = S.Struct({
   id: S.String,
   label: S.String,
+  paidAmountCents: S.Number,
+  paidAmountFormatted: S.String,
+  bonusCents: S.Number,
+  bonusFormatted: S.String,
   amountCents: S.Number,
   amountFormatted: S.String,
+  creditsExpire: S.Literal(false),
   currency: S.Literal('USD'),
 })
 export type BillingCreditPackage = typeof BillingCreditPackage.Type

--- a/apps/openagents.com/apps/web/src/page/loggedIn/page/billing.ts
+++ b/apps/openagents.com/apps/web/src/page/loggedIn/page/billing.ts
@@ -86,7 +86,10 @@ export const view = (model: Model): Html => {
       id: pack.id,
       label: pack.label,
       amount: pack.amountFormatted,
-      detail: `Adds ${pack.amountFormatted} of credit to your balance.`,
+      detail:
+        pack.bonusCents > 0
+          ? `Pay ${pack.paidAmountFormatted}; adds ${pack.amountFormatted} credit including ${pack.bonusFormatted} bonus.`
+          : `Adds ${pack.amountFormatted} of credit to your balance.`,
       attrs: [
         h.Type('button'),
         ...(busy ? [h.Disabled(true)] : []),

--- a/apps/openagents.com/workers/api/src/billing-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/billing-routes.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'vitest'
 
+import { applyStripeCheckoutCredit } from './billing'
 import { makeBillingApiHandlers } from './billing-routes'
 
 type TestSession = Readonly<{ user: Readonly<{ userId: string }> }>
@@ -211,6 +212,7 @@ describe('billing API handlers', () => {
           },
           {
             amountCents: 5000,
+            bonusCents: 500,
             id: 'credits_50',
             label: '$50 credits',
             priceId: 'price_50',
@@ -226,9 +228,14 @@ describe('billing API handlers', () => {
         packages: ReadonlyArray<{
           amountCents: number
           amountFormatted: string
+          bonusCents: number
+          bonusFormatted: string
+          creditsExpire: false
           currency: string
           id: string
           label: string
+          paidAmountCents: number
+          paidAmountFormatted: string
         }>
       }
     }
@@ -238,16 +245,26 @@ describe('billing API handlers', () => {
       {
         amountCents: 1000,
         amountFormatted: '$10.00',
+        bonusCents: 0,
+        bonusFormatted: '$0.00',
+        creditsExpire: false,
         currency: 'USD',
         id: 'credits_10',
         label: '$10 credits',
+        paidAmountCents: 1000,
+        paidAmountFormatted: '$10.00',
       },
       {
-        amountCents: 5000,
-        amountFormatted: '$50.00',
+        amountCents: 5500,
+        amountFormatted: '$55.00',
+        bonusCents: 500,
+        bonusFormatted: '$5.00',
+        creditsExpire: false,
         currency: 'USD',
         id: 'credits_50',
         label: '$50 credits',
+        paidAmountCents: 5000,
+        paidAmountFormatted: '$50.00',
       },
     ])
   })
@@ -265,6 +282,45 @@ describe('billing API handlers', () => {
       billing: { packages: ReadonlyArray<unknown> }
     }
     expect(body.billing.packages).toEqual([])
+  })
+
+  test('Stripe volume prepay grants paid and bonus credits atomically', async () => {
+    const { bindings, db } = makeBillingD1()
+
+    await applyStripeCheckoutCredit(
+      db,
+      {
+        amountCents: 50_000,
+        bonusCents: 5_000,
+        packageId: 'prepay_500',
+        sessionId: 'cs_test_volume',
+        userId: 'github:1',
+      },
+      {
+        nowIso: () => '2026-07-02T00:00:00.000Z',
+        randomId: prefix => `${prefix}_fixed`,
+      },
+    )
+
+    const stripeCreditInsert = bindings.find(
+      binding =>
+        binding.query.includes("'stripe_checkout'") &&
+        binding.query.includes('billing_ledger_entries'),
+    )
+
+    expect(stripeCreditInsert?.values[2]).toBe(
+      'Stripe volume prepay credit purchase',
+    )
+    expect(stripeCreditInsert?.values[3]).toBe(55_000)
+    expect(stripeCreditInsert?.values[5]).toBe(55_000)
+    expect(JSON.parse(String(stripeCreditInsert?.values[7]))).toEqual({
+      bonusCents: 5_000,
+      creditsExpire: false,
+      packageId: 'prepay_500',
+      paidAmountCents: 50_000,
+      sessionId: 'cs_test_volume',
+      totalCreditCents: 55_000,
+    })
   })
 
   test('checkout rejects a missing packageId instead of defaulting', async () => {

--- a/apps/openagents.com/workers/api/src/billing.ts
+++ b/apps/openagents.com/workers/api/src/billing.ts
@@ -92,8 +92,13 @@ export type BillingAutoTopUpState = Readonly<{
 export type BillingCreditPackageDisplay = Readonly<{
   id: string
   label: string
+  paidAmountCents: number
+  paidAmountFormatted: string
+  bonusCents: number
+  bonusFormatted: string
   amountCents: number
   amountFormatted: string
+  creditsExpire: false
   currency: 'USD'
 }>
 
@@ -762,6 +767,7 @@ export const applyStripeCheckoutCredit = async (
   db: D1Database,
   input: Readonly<{
     amountCents: number
+    bonusCents?: number | undefined
     packageId: string
     sessionId: string
     userId: string
@@ -771,6 +777,8 @@ export const applyStripeCheckoutCredit = async (
   await ensureBillingAccount(db, input.userId, runtime)
 
   const amountCents = Math.max(1, Math.trunc(input.amountCents))
+  const bonusCents = Math.max(0, Math.trunc(input.bonusCents ?? 0))
+  const creditCents = amountCents + bonusCents
   const now = runtime.nowIso()
 
   await db.batch([
@@ -785,14 +793,18 @@ export const applyStripeCheckoutCredit = async (
       .bind(
         runtime.randomId('bill'),
         input.userId,
-        'Stripe credit purchase',
-        amountCents,
+        bonusCents > 0 ? 'Stripe volume prepay credit purchase' : 'Stripe credit purchase',
+        creditCents,
         BILLING_CURRENCY,
-        amountCents,
+        creditCents,
         'credit_cents',
         metadataJson({
+          bonusCents,
+          creditsExpire: false,
           packageId: input.packageId,
+          paidAmountCents: amountCents,
           sessionId: input.sessionId,
+          totalCreditCents: creditCents,
         }),
         `billing:stripe-checkout:${input.sessionId}`,
         now,

--- a/apps/openagents.com/workers/api/src/stripe-billing.ts
+++ b/apps/openagents.com/workers/api/src/stripe-billing.ts
@@ -47,7 +47,10 @@ export type BillingCreditPackageId = typeof BillingCreditPackageId.Type
 
 export type StripeCreditPackage = Readonly<{
   amountCents: number
+  bonusCents: number
+  totalCreditCents: number
   currency: 'USD'
+  creditsExpire: false
   id: BillingCreditPackageId
   label: string
   priceId: StripePriceId
@@ -347,6 +350,7 @@ export class BillingCreditService extends Context.Service<
   Readonly<{
     applyStripeCheckoutCredit: (input: {
       amountCents: number
+      bonusCents?: number | undefined
       db: D1Database
       packageId: string
       sessionId: string
@@ -445,6 +449,7 @@ const readPackages = (
           S.Array(
             S.Struct({
               amountCents: S.Number,
+              bonusCents: S.optionalKey(S.Number),
               id: S.String,
               label: S.String,
               priceId: S.String,
@@ -457,19 +462,27 @@ const readPackages = (
       const id = item.id.trim()
       const priceId = item.priceId.trim()
       const amountCents = Math.trunc(item.amountCents)
+      const bonusCents = Math.trunc(item.bonusCents ?? 0)
       const label = item.label.trim()
 
-      return id === '' || priceId === '' || label === '' || amountCents <= 0
+      return id === '' ||
+        priceId === '' ||
+        label === '' ||
+        amountCents <= 0 ||
+        bonusCents < 0
         ? Effect.fail(
             new StripeConfigError({
               field: 'STRIPE_CREDIT_PACKAGES_JSON',
               reason:
-                'Expected package id, label, positive amountCents, and priceId.',
+                'Expected package id, label, positive amountCents, non-negative bonusCents, and priceId.',
             }),
           )
         : Effect.succeed({
             amountCents,
+            bonusCents,
+            totalCreditCents: amountCents + bonusCents,
             currency: 'USD' as const,
+            creditsExpire: false as const,
             id: BillingCreditPackageId.make(id),
             label,
             priceId: StripePriceId.make(priceId),
@@ -504,8 +517,13 @@ export const readBillingCreditPackages = (
           (pack): BillingCreditPackageDisplay => ({
             id: pack.id,
             label: pack.label,
-            amountCents: pack.amountCents,
-            amountFormatted: formatUsdCents(pack.amountCents),
+            paidAmountCents: pack.amountCents,
+            paidAmountFormatted: formatUsdCents(pack.amountCents),
+            bonusCents: pack.bonusCents,
+            bonusFormatted: formatUsdCents(pack.bonusCents),
+            amountCents: pack.totalCreditCents,
+            amountFormatted: formatUsdCents(pack.totalCreditCents),
+            creditsExpire: false,
             currency: pack.currency,
           }),
         ),
@@ -635,9 +653,12 @@ const createCreditCheckout = async (
       line_items: [{ price: pack.priceId, quantity: 1 }],
       metadata: {
         amount_cents: String(pack.amountCents),
+        bonus_cents: String(pack.bonusCents),
         currency: pack.currency,
+        credits_expire: 'false',
         omega_user_id: input.userId,
         package_id: pack.id,
+        total_credit_cents: String(pack.totalCreditCents),
       },
       mode: 'payment',
       success_url: config.successUrl,
@@ -762,6 +783,7 @@ const fulfillCheckoutSession = async (
 
   const summary = await applyStripeCheckoutCredit(input.db, {
     amountCents: pack.amountCents,
+    bonusCents: pack.bonusCents,
     packageId: pack.id,
     sessionId: input.sessionId,
     userId,


### PR DESCRIPTION
## Summary

- Extends the Stripe credit package catalog with optional `bonusCents`, projected as one total credit balance with `creditsExpire: false`.
- Grants paid + bonus credits atomically in the existing `stripe_checkout` billing ledger row, preserving the paid/bonus split in metadata without a separate bonus bucket.
- Updates the billing page contract and compact package copy to show total credit and included bonus.

Closes #8082

## Verification

- `bun run --cwd apps/openagents.com/workers/api test -- src/billing-routes.test.ts` passed: 1 file, 13 tests.
- `bun run --cwd apps/openagents.com/apps/web typecheck` passed.
- `bun run check:deploy` passed.
