### PR TITLE
Add business funnel dashboard instrumentation

### DIFF
--- a/apps/openagents.com/INVARIANTS.md
+++ b/apps/openagents.com/INVARIANTS.md
@@ -2677,6 +2677,17 @@ check:architecture` inside `check:deploy`) discovers `/api/public/...`
     `accrueCrossCategoryReferral`, never on signups). The public response echoes
     only a `referralAttributed` boolean — never the code or the internal
     attribution id. A referral resolution failure never fails the intake.
+  - `GET /api/public/business/funnel-dashboard` — live at read over
+    `business_funnel_events`, the exact aggregate business-funnel stage ledger
+    for BF-1.4 — compliant (`generatedAt`, `live_at_read` contract). It reports
+    the fixed visit → signup → intake-spec → payment → provisioned →
+    first-outcome → retained stage order, per-stage counts, total event count,
+    and coarse source-kind breakdowns (`content`, `outbound`, `ai_search`,
+    `referral`, `direct`, `unknown`) only. It excludes contact details, user
+    ids, business names, payment payloads, raw provider payloads, client
+    identifiers, and per-user journey state. The dashboard grants no payment,
+    workspace, fulfillment, retention, payout, settlement, or public-claim
+    authority. `staleness_declared`.
   - `POST /api/public/business-intake-chat` — live-at-read conversational
     intake turn over one bounded, non-streaming Khala completion (or the
     deterministic opening constant for an empty transcript) — compliant

--- a/apps/openagents.com/scripts/check-zero-debt-architecture.mjs
+++ b/apps/openagents.com/scripts/check-zero-debt-architecture.mjs
@@ -1090,6 +1090,11 @@ const publicProjectionSurfaces = [
     status: 'staleness_declared',
   },
   {
+    module: 'workers/api/src/business-funnel-dashboard-routes.ts',
+    route: '/api/public/business/funnel-dashboard',
+    status: 'staleness_declared',
+  },
+  {
     module: 'workers/api/src/business-intake-chat-routes.ts',
     route: '/api/public/business-intake-chat',
     status: 'staleness_declared',

--- a/apps/openagents.com/workers/api/migrations/0270_business_funnel_events.sql
+++ b/apps/openagents.com/workers/api/migrations/0270_business_funnel_events.sql
@@ -1,0 +1,42 @@
+-- Business funnel stage receipt ledger (BF-1.4 / issue #8077).
+--
+-- This table records aggregate-countable stage receipts for the /business
+-- engine. Rows intentionally carry opaque refs and coarse source attribution
+-- only; they do not store contact details, user ids, payment payloads, raw
+-- provider data, or per-user journey state.
+
+CREATE TABLE IF NOT EXISTS business_funnel_events (
+  id TEXT PRIMARY KEY NOT NULL,
+  event_ref TEXT NOT NULL UNIQUE,
+  stage TEXT NOT NULL CHECK (
+    stage IN (
+      'visit',
+      'signup',
+      'intake_spec',
+      'payment',
+      'provisioned',
+      'first_outcome',
+      'retained'
+    )
+  ),
+  source_kind TEXT NOT NULL CHECK (
+    source_kind IN (
+      'content',
+      'outbound',
+      'ai_search',
+      'referral',
+      'direct',
+      'unknown'
+    )
+  ),
+  source_ref TEXT,
+  occurred_at TEXT NOT NULL,
+  observed_at TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS business_funnel_events_stage_time_idx
+  ON business_funnel_events(stage, occurred_at DESC);
+
+CREATE INDEX IF NOT EXISTS business_funnel_events_source_time_idx
+  ON business_funnel_events(source_kind, occurred_at DESC);
+

--- a/apps/openagents.com/workers/api/src/business-funnel-dashboard-routes.ts
+++ b/apps/openagents.com/workers/api/src/business-funnel-dashboard-routes.ts
@@ -1,0 +1,35 @@
+import { Effect } from 'effect'
+
+import {
+  handleBusinessFunnelDashboardApi,
+  type BusinessFunnelRuntime,
+  systemBusinessFunnelRuntime,
+} from './business-funnel-dashboard'
+import { methodNotAllowed, noStoreJsonResponse } from './http/responses'
+
+// Payload staleness is declared in business-funnel-dashboard.ts via the shared
+// public-projection-staleness contract.
+export const handlePublicBusinessFunnelDashboardApi = (
+  request: Request,
+  db: D1Database,
+  runtime: BusinessFunnelRuntime = systemBusinessFunnelRuntime,
+) => {
+  if (request.method !== 'GET') {
+    return Effect.succeed(methodNotAllowed(['GET']))
+  }
+
+  return Effect.tryPromise({
+    try: () => handleBusinessFunnelDashboardApi(db, runtime),
+    catch: () => new Error('business_funnel_dashboard_read_failed'),
+  }).pipe(
+    Effect.map(payload => noStoreJsonResponse(payload)),
+    Effect.catch(() =>
+      Effect.succeed(
+        noStoreJsonResponse(
+          { error: 'business_funnel_dashboard_read_failed' },
+          { status: 500 },
+        ),
+      ),
+    ),
+  )
+}

--- a/apps/openagents.com/workers/api/src/business-funnel-dashboard.test.ts
+++ b/apps/openagents.com/workers/api/src/business-funnel-dashboard.test.ts
@@ -1,0 +1,143 @@
+import { Effect } from 'effect'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { DatabaseSync } from 'node:sqlite'
+import { describe, expect, test } from 'vitest'
+
+import {
+  recordBusinessFunnelEvent,
+  type BusinessFunnelRuntime,
+} from './business-funnel-dashboard'
+import { handlePublicBusinessFunnelDashboardApi } from './business-funnel-dashboard-routes'
+
+type Row = Record<string, unknown>
+
+class SqliteD1Statement {
+  private bound: ReadonlyArray<unknown> = []
+
+  constructor(
+    private readonly db: DatabaseSync,
+    private readonly sql: string,
+  ) {}
+
+  bind(...values: ReadonlyArray<unknown>): SqliteD1Statement {
+    this.bound = values.map(value => (value === undefined ? null : value))
+    return this
+  }
+
+  async first<T = Row>(): Promise<T | null> {
+    const row = this.db.prepare(this.sql).get(...(this.bound as never[]))
+    return (row ?? null) as T | null
+  }
+
+  async all<T = Row>(): Promise<{ results: Array<T> }> {
+    return {
+      results: this.db.prepare(this.sql).all(...(this.bound as never[])) as Array<T>,
+    }
+  }
+
+  async run(): Promise<{ success: true }> {
+    this.db.prepare(this.sql).run(...(this.bound as never[]))
+    return { success: true }
+  }
+}
+
+class SqliteD1 {
+  constructor(private readonly db: DatabaseSync) {}
+
+  prepare(sql: string): SqliteD1Statement {
+    return new SqliteD1Statement(this.db, sql)
+  }
+}
+
+const migration = (name: string): string =>
+  readFileSync(join(__dirname, '..', 'migrations', name), 'utf8')
+
+const makeDb = (): D1Database => {
+  const db = new DatabaseSync(':memory:')
+  db.exec(migration('0270_business_funnel_events.sql'))
+  return new SqliteD1(db) as unknown as D1Database
+}
+
+let counter = 0
+
+const runtime: BusinessFunnelRuntime = {
+  makeId: (prefix: string) => `${prefix}_${(counter += 1)}`,
+  nowIso: () => '2026-07-02T17:00:00.000Z',
+}
+
+describe('business funnel dashboard', () => {
+  test('aggregates exact stage rows by coarse source without private fields', async () => {
+    const db = makeDb()
+
+    await recordBusinessFunnelEvent(
+      db,
+      {
+        eventRef: 'visit:content:2026-07-02',
+        stage: 'visit',
+        sourceKind: 'content',
+        sourceRef: 'source.public.business.content',
+        occurredAt: '2026-07-02T16:00:00.000Z',
+      },
+      runtime,
+    )
+    await recordBusinessFunnelEvent(
+      db,
+      {
+        eventRef: 'signup:business_signup_1',
+        stage: 'signup',
+        sourceKind: 'ai_search',
+        sourceRef: 'source.public.ai_search',
+        occurredAt: '2026-07-02T16:05:00.000Z',
+      },
+      runtime,
+    )
+    await recordBusinessFunnelEvent(
+      db,
+      {
+        eventRef: 'signup:business_signup_1',
+        stage: 'signup',
+        sourceKind: 'ai_search',
+        sourceRef: 'source.public.ai_search',
+        occurredAt: '2026-07-02T16:05:00.000Z',
+      },
+      runtime,
+    )
+
+    const response = await Effect.runPromise(
+      handlePublicBusinessFunnelDashboardApi(
+        new Request('https://openagents.com/api/public/business/funnel-dashboard'),
+        db,
+        runtime,
+      ),
+    )
+    const body = await response.json() as {
+      totals: { eventCount: number }
+      stages: ReadonlyArray<{
+        stage: string
+        count: number
+        sourceBreakdown: ReadonlyArray<{ sourceKind: string; count: number }>
+      }>
+      privacyBoundary: { aggregateOnly: boolean; excludes: ReadonlyArray<string> }
+      staleness: { composition: string; rebuildsOn: ReadonlyArray<string> }
+    }
+    const json = JSON.stringify(body)
+
+    expect(response.status).toBe(200)
+    expect(body.totals.eventCount).toBe(2)
+    expect(body.staleness).toMatchObject({
+      composition: 'live_at_read',
+      rebuildsOn: ['business_funnel_events.insert'],
+    })
+    expect(body.privacyBoundary.aggregateOnly).toBe(true)
+    expect(body.privacyBoundary.excludes).toContain('contact_email')
+    expect(json).not.toContain('lead@example.com')
+    expect(json).not.toContain('555')
+
+    const signup = body.stages.find(stage => stage.stage === 'signup')
+    expect(signup).toMatchObject({ count: 1 })
+    expect(
+      signup?.sourceBreakdown.find(source => source.sourceKind === 'ai_search'),
+    ).toEqual({ sourceKind: 'ai_search', count: 1 })
+  })
+})

--- a/apps/openagents.com/workers/api/src/business-funnel-dashboard.ts
+++ b/apps/openagents.com/workers/api/src/business-funnel-dashboard.ts
@@ -1,0 +1,332 @@
+import { Schema as S } from 'effect'
+
+import {
+  type PublicProjectionStalenessContract,
+  liveAtReadStaleness,
+} from './public-projection-staleness'
+import { compactRandomId, currentIsoTimestamp } from './runtime-primitives'
+
+export const BusinessFunnelDashboardEndpoint =
+  '/api/public/business/funnel-dashboard' as const
+
+export const BusinessFunnelStage = S.Literals([
+  'visit',
+  'signup',
+  'intake_spec',
+  'payment',
+  'provisioned',
+  'first_outcome',
+  'retained',
+])
+export type BusinessFunnelStage = typeof BusinessFunnelStage.Type
+
+export const BusinessFunnelSourceKind = S.Literals([
+  'content',
+  'outbound',
+  'ai_search',
+  'referral',
+  'direct',
+  'unknown',
+])
+export type BusinessFunnelSourceKind =
+  typeof BusinessFunnelSourceKind.Type
+
+export const BUSINESS_FUNNEL_STAGE_ORDER: ReadonlyArray<BusinessFunnelStage> = [
+  'visit',
+  'signup',
+  'intake_spec',
+  'payment',
+  'provisioned',
+  'first_outcome',
+  'retained',
+]
+
+export const BUSINESS_FUNNEL_SOURCE_KINDS: ReadonlyArray<BusinessFunnelSourceKind> =
+  ['content', 'outbound', 'ai_search', 'referral', 'direct', 'unknown']
+
+export type BusinessFunnelEventInput = Readonly<{
+  eventRef: string
+  stage: BusinessFunnelStage
+  sourceKind: BusinessFunnelSourceKind
+  sourceRef: string | null
+  occurredAt: string
+}>
+
+export type BusinessFunnelEventRecord = BusinessFunnelEventInput &
+  Readonly<{
+    id: string
+    observedAt: string
+  }>
+
+export type BusinessFunnelRuntime = Readonly<{
+  makeId: (prefix: string) => string
+  nowIso: () => string
+}>
+
+export const systemBusinessFunnelRuntime: BusinessFunnelRuntime = {
+  makeId: compactRandomId,
+  nowIso: currentIsoTimestamp,
+}
+
+type BusinessFunnelAggregateRow = Readonly<{
+  stage: BusinessFunnelStage
+  source_kind: BusinessFunnelSourceKind
+  count: number
+  last_occurred_at: string | null
+}>
+
+type BusinessFunnelTotalRow = Readonly<{
+  count: number
+}>
+
+export type BusinessFunnelStageSummary = Readonly<{
+  stage: BusinessFunnelStage
+  count: number
+  sourceBreakdown: ReadonlyArray<
+    Readonly<{
+      sourceKind: BusinessFunnelSourceKind
+      count: number
+    }>
+  >
+  lastOccurredAt: string | null
+}>
+
+export type PublicBusinessFunnelDashboardResponse = Readonly<{
+  schemaVersion: 'openagents.business_funnel_dashboard.v1'
+  generatedAt: string
+  staleness: PublicProjectionStalenessContract
+  stageOrder: ReadonlyArray<BusinessFunnelStage>
+  totals: Readonly<{
+    eventCount: number
+  }>
+  stages: ReadonlyArray<BusinessFunnelStageSummary>
+  sourceKinds: ReadonlyArray<BusinessFunnelSourceKind>
+  privacyBoundary: Readonly<{
+    aggregateOnly: true
+    excludes: ReadonlyArray<string>
+  }>
+  evidenceRefs: ReadonlyArray<string>
+}>
+
+const normalizeEventRef = (value: string): string => value.trim().slice(0, 240)
+
+const normalizeSourceRef = (value: string | null): string | null => {
+  if (value === null) {
+    return null
+  }
+  const trimmed = value.trim().slice(0, 240)
+  return trimmed === '' ? null : trimmed
+}
+
+export const businessFunnelSourceKindFromAttribution = (
+  sourceAttribution: string | null,
+): BusinessFunnelSourceKind => {
+  if (sourceAttribution === null) {
+    return 'direct'
+  }
+
+  const normalized = sourceAttribution.trim().toLowerCase()
+
+  if (normalized === 'content') {
+    return 'content'
+  }
+  if (normalized === 'outbound') {
+    return 'outbound'
+  }
+  if (
+    normalized === 'ai-search' ||
+    normalized === 'ai_search' ||
+    normalized === 'aisearch'
+  ) {
+    return 'ai_search'
+  }
+  if (normalized === 'referral') {
+    return 'referral'
+  }
+  if (normalized === 'direct') {
+    return 'direct'
+  }
+
+  return 'unknown'
+}
+
+export const businessFunnelSourceKindForSignup = (
+  input: Readonly<{
+    sourceAttribution: string | null
+    referralCode: string | null
+  }>,
+): BusinessFunnelSourceKind => {
+  const attributed = businessFunnelSourceKindFromAttribution(
+    input.sourceAttribution,
+  )
+
+  if (attributed !== 'direct' || input.referralCode === null) {
+    return attributed
+  }
+
+  return 'referral'
+}
+
+export const recordBusinessFunnelEvent = async (
+  db: D1Database,
+  input: BusinessFunnelEventInput,
+  runtime: BusinessFunnelRuntime = systemBusinessFunnelRuntime,
+): Promise<BusinessFunnelEventRecord> => {
+  const record: BusinessFunnelEventRecord = {
+    id: runtime.makeId('business_funnel_event'),
+    eventRef: normalizeEventRef(input.eventRef),
+    stage: input.stage,
+    sourceKind: input.sourceKind,
+    sourceRef: normalizeSourceRef(input.sourceRef),
+    occurredAt: input.occurredAt,
+    observedAt: runtime.nowIso(),
+  }
+
+  await db
+    .prepare(
+      `INSERT OR IGNORE INTO business_funnel_events (
+        id,
+        event_ref,
+        stage,
+        source_kind,
+        source_ref,
+        occurred_at,
+        observed_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    )
+    .bind(
+      record.id,
+      record.eventRef,
+      record.stage,
+      record.sourceKind,
+      record.sourceRef,
+      record.occurredAt,
+      record.observedAt,
+    )
+    .run()
+
+  return record
+}
+
+const emptySourceCounts = (): Record<BusinessFunnelSourceKind, number> => ({
+  content: 0,
+  outbound: 0,
+  ai_search: 0,
+  referral: 0,
+  direct: 0,
+  unknown: 0,
+})
+
+const buildEmptyStageMap = (): Record<
+  BusinessFunnelStage,
+  {
+    count: number
+    sourceCounts: Record<BusinessFunnelSourceKind, number>
+    lastOccurredAt: string | null
+  }
+> => ({
+  visit: { count: 0, sourceCounts: emptySourceCounts(), lastOccurredAt: null },
+  signup: { count: 0, sourceCounts: emptySourceCounts(), lastOccurredAt: null },
+  intake_spec: {
+    count: 0,
+    sourceCounts: emptySourceCounts(),
+    lastOccurredAt: null,
+  },
+  payment: { count: 0, sourceCounts: emptySourceCounts(), lastOccurredAt: null },
+  provisioned: {
+    count: 0,
+    sourceCounts: emptySourceCounts(),
+    lastOccurredAt: null,
+  },
+  first_outcome: {
+    count: 0,
+    sourceCounts: emptySourceCounts(),
+    lastOccurredAt: null,
+  },
+  retained: {
+    count: 0,
+    sourceCounts: emptySourceCounts(),
+    lastOccurredAt: null,
+  },
+})
+
+const latestIso = (a: string | null, b: string | null): string | null => {
+  if (a === null) {
+    return b
+  }
+  if (b === null) {
+    return a
+  }
+  return a >= b ? a : b
+}
+
+export const readBusinessFunnelDashboard = async (
+  db: D1Database,
+  nowIso: string,
+): Promise<PublicBusinessFunnelDashboardResponse> => {
+  const rows = await db
+    .prepare(
+      `SELECT
+          stage,
+          source_kind,
+          COUNT(*) AS count,
+          MAX(occurred_at) AS last_occurred_at
+        FROM business_funnel_events
+       GROUP BY stage, source_kind`,
+    )
+    .all<BusinessFunnelAggregateRow>()
+  const total = await db
+    .prepare(`SELECT COUNT(*) AS count FROM business_funnel_events`)
+    .first<BusinessFunnelTotalRow>()
+
+  const stageMap = buildEmptyStageMap()
+
+  for (const row of rows.results ?? []) {
+    const stage = stageMap[row.stage]
+    stage.count += Number(row.count)
+    stage.sourceCounts[row.source_kind] += Number(row.count)
+    stage.lastOccurredAt = latestIso(stage.lastOccurredAt, row.last_occurred_at)
+  }
+
+  return {
+    schemaVersion: 'openagents.business_funnel_dashboard.v1',
+    generatedAt: nowIso,
+    staleness: liveAtReadStaleness(['business_funnel_events.insert']),
+    stageOrder: BUSINESS_FUNNEL_STAGE_ORDER,
+    totals: {
+      eventCount: Number(total?.count ?? 0),
+    },
+    stages: BUSINESS_FUNNEL_STAGE_ORDER.map(stage => ({
+      stage,
+      count: stageMap[stage].count,
+      sourceBreakdown: BUSINESS_FUNNEL_SOURCE_KINDS.map(sourceKind => ({
+        sourceKind,
+        count: stageMap[stage].sourceCounts[sourceKind],
+      })),
+      lastOccurredAt: stageMap[stage].lastOccurredAt,
+    })),
+    sourceKinds: BUSINESS_FUNNEL_SOURCE_KINDS,
+    privacyBoundary: {
+      aggregateOnly: true,
+      excludes: [
+        'contact_email',
+        'phone',
+        'business_name',
+        'user_id',
+        'payment_payload',
+        'raw_provider_payload',
+      ],
+    },
+    evidenceRefs: [
+      'table:business_funnel_events',
+      'issue:8077',
+      'roadmap:BF-1.4',
+    ],
+  }
+}
+
+export const handleBusinessFunnelDashboardApi = (
+  db: D1Database,
+  runtime: BusinessFunnelRuntime = systemBusinessFunnelRuntime,
+): Promise<PublicBusinessFunnelDashboardResponse> =>
+  readBusinessFunnelDashboard(db, runtime.nowIso())

--- a/apps/openagents.com/workers/api/src/business-signup-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/business-signup-routes.test.ts
@@ -54,6 +54,7 @@ const migration = (name: string): string =>
 const SCHEMA = [
   '0191_business_signup_requests.sql',
   '0216_business_signup_referral_attribution.sql',
+  '0270_business_funnel_events.sql',
 ].map(migration)
 
 const makeDb = (): D1Database => {
@@ -154,6 +155,50 @@ describe('business signup routes', () => {
         slackConnectStatus: 'manual_invite_pending',
         nextAction: 'operator_manual_slack_connect_invite',
       },
+    })
+  })
+
+  test('records a signup-stage funnel event with coarse source attribution', async () => {
+    const db = makeDb()
+    const response = await run(
+      new Request('https://openagents.com/api/public/business-signup', {
+        method: 'POST',
+        headers: {
+          accept: 'application/json',
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({
+          businessName: 'Acme Co.',
+          contactEmail: 'lead@example.com',
+          phone: '+1 555 000 0000',
+          requestSlackChannel: false,
+          sourceAttribution: 'AI-search',
+        }),
+      }),
+      db,
+    )
+
+    expect(response.status).toBe(201)
+
+    const row = await db
+      .prepare(
+        `SELECT event_ref, stage, source_kind, source_ref
+           FROM business_funnel_events
+          WHERE event_ref = ?`,
+      )
+      .bind('business_signup:business_signup_1')
+      .first<{
+        event_ref: string
+        stage: string
+        source_kind: string
+        source_ref: string
+      }>()
+
+    expect(row).toEqual({
+      event_ref: 'business_signup:business_signup_1',
+      stage: 'signup',
+      source_kind: 'ai_search',
+      source_ref: '/business',
     })
   })
 

--- a/apps/openagents.com/workers/api/src/business-signup-routes.ts
+++ b/apps/openagents.com/workers/api/src/business-signup-routes.ts
@@ -1,6 +1,10 @@
 import { Effect, Schema as S } from 'effect'
 
 import { parseCookies } from './auth-cookies'
+import {
+  businessFunnelSourceKindForSignup,
+  recordBusinessFunnelEvent,
+} from './business-funnel-dashboard'
 import { methodNotAllowed, noStoreJsonResponse } from './http/responses'
 import {
   isRecord,
@@ -65,6 +69,9 @@ export type BusinessSignupInput = Readonly<{
   // from the /business ?ref= query param or a `referralCode` form field; null
   // when no code was present.
   referralCode: string | null
+  // Coarse acquisition bucket for aggregate funnel counters. It is deliberately
+  // a stage/source label only, not a user identity or per-contact trail.
+  sourceAttribution: string | null
 }>
 
 export type BusinessSignupRecord = BusinessSignupInput &
@@ -92,6 +99,7 @@ type BusinessSignupRow = Readonly<{
   source_route: string
   referral_code: string | null
   referral_attribution_id: string | null
+  source_attribution?: string | null
   created_at: string
   updated_at: string
 }>
@@ -273,6 +281,8 @@ const decodeSignupInput = (
       helpWith: normalizeMultiline(fields.helpWith, 2_000) ?? null,
       requestSlackChannel: booleanFromUnknown(fields.requestSlackChannel),
       referralCode: normalizeReferralCode(fields.referralCode ?? fields.ref),
+      sourceAttribution:
+        normalizeText(fields.sourceAttribution ?? fields.source, 80) ?? null,
     },
   }
 }
@@ -321,6 +331,7 @@ const rowToRecord = (row: BusinessSignupRow): BusinessSignupRecord => ({
   sourceRoute: '/business',
   referralCode: row.referral_code,
   referralAttributionId: row.referral_attribution_id,
+  sourceAttribution: row.source_attribution ?? null,
   createdAt: row.created_at,
   updatedAt: row.updated_at,
 })
@@ -390,6 +401,22 @@ const updateBusinessSignupReferralAttribution = async (
     )
     .bind(input.referralAttributionId, input.updatedAt, input.id)
     .run()
+}
+
+const recordBusinessSignupFunnelEvent = async (
+  db: D1Database,
+  record: BusinessSignupRecord,
+): Promise<void> => {
+  await recordBusinessFunnelEvent(db, {
+    eventRef: `business_signup:${record.id}`,
+    stage: 'signup',
+    sourceKind: businessFunnelSourceKindForSignup({
+      sourceAttribution: record.sourceAttribution,
+      referralCode: record.referralCode,
+    }),
+    sourceRef: record.referralCode ?? record.sourceRoute,
+    occurredAt: record.createdAt,
+  })
 }
 
 export const readBusinessSignupRequest = async (
@@ -561,6 +588,11 @@ export const handleBusinessSignupApi = (
       try: () => insertBusinessSignupRequest(db, input, runtime),
       catch: cause => new BusinessSignupIntakeFailure({ cause }),
     })
+
+    yield* Effect.tryPromise({
+      try: () => recordBusinessSignupFunnelEvent(db, record),
+      catch: cause => new BusinessSignupIntakeFailure({ cause }),
+    }).pipe(Effect.catch(() => Effect.succeed(undefined)))
 
     // Bind the referral after the signup is durably stored. A referral failure
     // must not fail the intake, so it is caught and dropped to null.

--- a/apps/openagents.com/workers/api/src/index.ts
+++ b/apps/openagents.com/workers/api/src/index.ts
@@ -238,6 +238,7 @@ import {
   listBlueprintProgramRuns,
   recordBlueprintProgramRun,
 } from './blueprint/repositories/program-runs'
+import { handlePublicBusinessFunnelDashboardApi } from './business-funnel-dashboard-routes'
 import { handleBusinessIntakeChatApi } from './business-intake-chat-routes'
 import { handleBusinessSignupApi } from './business-signup-routes'
 import { makeD1BuyModeDispatcherStore } from './buy-mode-dispatcher'
@@ -10606,6 +10607,11 @@ const exactRouteRegistry = makeExactRouteRegistry<Env>([
     path: '/api/public/business-signup',
     handler: (request, env) =>
       handleBusinessSignupApi(request, openAgentsDatabase(env)),
+  },
+  {
+    path: '/api/public/business/funnel-dashboard',
+    handler: (request, env) =>
+      handlePublicBusinessFunnelDashboardApi(request, openAgentsDatabase(env)),
   },
   {
     // OpenAgents Business conversational intake (Khala-run interview from

--- a/apps/openagents.com/workers/api/src/openagents-openapi.ts
+++ b/apps/openagents.com/workers/api/src/openagents-openapi.ts
@@ -2048,6 +2048,9 @@ const schemaComponents = (): JsonSchema => ({
   CodingQuickWinReceiptResponse: objectSummary(
     'Public-safe coding quick-win receipt or paid-delivery-claims projection. Carries assessedAt/generatedAt timestamps plus a live_at_read staleness contract for claim projections where available. Receipt reads expose lifecycle labels without customer-private refs and grant no auto-merge, deploy, payout, settlement, or green-claim authority.',
   ),
+  PublicBusinessFunnelDashboardResponse: objectSummary(
+    'Public-safe business funnel dashboard projection: schemaVersion, generatedAt, live_at_read staleness contract, stage order, total event count, per-stage counts, and coarse source-kind breakdowns for content/outbound/AI-search/referral/direct/unknown. Aggregate counts only; excludes contact details, user ids, payment payloads, raw provider payloads, and client-identifying material. Read-only dashboard; grants no payment, workspace, fulfillment, retention, payout, settlement, or public-claim authority.',
+  ),
   MarketingAgencyReceiptResponse: objectSummary(
     'Public-safe marketing-agency white-label receipt or paid-delivery-claims projection. Carries assessedAt/generatedAt timestamps plus a live_at_read staleness contract for claim projections where available. Fixture and stored receipts expose bounded delivery refs only and grant no new delivery, attribution, payout, settlement, or green-claim authority.',
   ),
@@ -6315,6 +6318,23 @@ const paths = (): JsonSchema => ({
         '200': okJson(
           'Coding quick-win receipt projection.',
           '#/components/schemas/CodingQuickWinReceiptResponse',
+        ),
+        ...errorResponses(),
+      },
+    }),
+  },
+  '/api/public/business/funnel-dashboard': {
+    get: operation({
+      operationId: 'readPublicBusinessFunnelDashboard',
+      summary: 'Read aggregate business funnel dashboard',
+      description:
+        'Returns public-safe aggregate counts for visit, signup, intake-spec, payment, provisioned, first-outcome, and retained business funnel stages with coarse source attribution. The projection is live-at-read over exact event rows and exposes counts only, never per-user surveillance, contact details, payment payloads, or client-identifying material.',
+      tags: ['Business', 'Public Proof'],
+      security: publicRead,
+      responses: {
+        '200': okJson(
+          'Aggregate business funnel dashboard.',
+          '#/components/schemas/PublicBusinessFunnelDashboardResponse',
         ),
         ...errorResponses(),
       },

--- a/apps/openagents.com/workers/api/src/worker-exact-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/worker-exact-routes.test.ts
@@ -12,6 +12,7 @@ const approvedExactRoutePaths = [
   '/api/operator/rlm/traces',
   '/api/operator/khala/unsupported-requests',
   '/api/public/business-signup',
+  '/api/public/business/funnel-dashboard',
   '/api/public/business-intake-chat',
   '/api/public/tassadar-run-summary',
   '/api/public/training/public-distributed-run-scale',


### PR DESCRIPTION
## Summary

- Adds `business_funnel_events`, an exact aggregate ledger for BF-1.4 funnel stage receipts with coarse source attribution only.
- Adds `GET /api/public/business/funnel-dashboard` as a live-at-read public-safe dashboard over visit -> signup -> intake_spec -> payment -> provisioned -> first_outcome -> retained stages.
- Emits signup-stage funnel events from `/api/public/business-signup` fail-soft, and registers the new projection in OpenAPI, exact-route tests, architecture guard inventory, and `INVARIANTS.md`.

## Privacy / Authority

- Counts only; no contact details, user ids, business names, payment payloads, raw provider payloads, or per-user journey state in the dashboard.
- The dashboard is read-only and grants no payment, workspace, fulfillment, retention, payout, settlement, or public-claim authority.

## Verification

- `bun run --cwd apps/openagents.com/workers/api test -- src/business-funnel-dashboard.test.ts src/business-signup-routes.test.ts src/worker-exact-routes.test.ts` passed: 3 files, 8 tests.
- `bun run --cwd apps/openagents.com/workers/api typecheck` passed.
- `bun scripts/check-zero-debt-architecture.mjs` passed from `apps/openagents.com`.
- `bun run check:deploy` passed.

Closes #8077.
