### PR TITLE
Wire business checkout kickoff fulfillment

### DIFF
--- a/apps/openagents.com/workers/api/migrations/0272_business_checkout_kickoffs.sql
+++ b/apps/openagents.com/workers/api/migrations/0272_business_checkout_kickoffs.sql
@@ -1,0 +1,23 @@
+CREATE TABLE IF NOT EXISTS business_checkout_kickoffs (
+  checkout_session_id TEXT PRIMARY KEY NOT NULL
+    REFERENCES stripe_checkout_sessions(session_id) ON DELETE CASCADE,
+  business_signup_request_id TEXT NOT NULL
+    REFERENCES business_signup_requests(id) ON DELETE CASCADE,
+  user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  total_amount_cents INTEGER NOT NULL CHECK (total_amount_cents >= 0),
+  setup_fee_cents INTEGER NOT NULL CHECK (setup_fee_cents >= 0),
+  credit_grant_cents INTEGER NOT NULL CHECK (credit_grant_cents >= 0),
+  workspace_id TEXT NOT NULL REFERENCES prefilled_workspaces(id) ON DELETE CASCADE,
+  service_promise_contract_id TEXT NOT NULL
+    REFERENCES omni_accepted_outcome_contracts(id) ON DELETE CASCADE,
+  public_receipt_ref TEXT NOT NULL,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  CHECK (setup_fee_cents + credit_grant_cents = total_amount_cents)
+);
+
+CREATE INDEX IF NOT EXISTS business_checkout_kickoffs_signup_idx
+  ON business_checkout_kickoffs(business_signup_request_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS business_checkout_kickoffs_user_idx
+  ON business_checkout_kickoffs(user_id, created_at DESC);

--- a/apps/openagents.com/workers/api/src/billing-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/billing-routes.test.ts
@@ -378,6 +378,38 @@ describe('billing API handlers', () => {
     })
   })
 
+  test('passes business signup id into checkout creation when provided', async () => {
+    const { db } = makeBillingD1()
+    const calls: Array<Parameters<TestStripe['createCreditCheckout']>[0]> = []
+    const response = await makeHandlers({
+      user: { userId: 'github:1' },
+    }, {
+      ...defaultStripe,
+      createCreditCheckout: input => {
+        calls.push(input)
+
+        return Promise.resolve({
+          checkoutUrl: 'https://checkout.stripe.test/session',
+        })
+      },
+    }).handleBillingCheckoutApi(
+      new Request('https://openagents.com/api/billing/checkout', {
+        body: JSON.stringify({
+          businessSignupId: 'business_signup_001',
+          packageId: 'pro',
+        }),
+        method: 'POST',
+      }),
+      { OPENAGENTS_DB: db },
+      executionContext(),
+    )
+
+    expect(response.status).toBe(200)
+    expect(calls[0]?.businessKickoff).toEqual({
+      signupId: 'business_signup_001',
+    })
+  })
+
   test('creates Stripe SetupIntent payload for card-on-file setup', async () => {
     const { db } = makeBillingD1()
     const response = await makeHandlers().handleBillingStripeSetupIntentApi(

--- a/apps/openagents.com/workers/api/src/billing-routes.ts
+++ b/apps/openagents.com/workers/api/src/billing-routes.ts
@@ -161,6 +161,7 @@ type BillingApiDependencies<
   ) => Promise<Session | undefined>
   stripe?: Readonly<{
     createCreditCheckout: (input: {
+      businessKickoff?: Readonly<{ signupId: string }> | undefined
       db: D1Database
       email?: string | undefined
       packageId: string
@@ -346,7 +347,11 @@ export const makeBillingApiHandlers = <
     try {
       const stripe =
         dependencies.stripe ?? makeStripeCheckoutServiceForRoutes(environment)
+      const businessSignupId = firstText(body.businessSignupId)
       const checkout = await stripe.createCreditCheckout({
+        ...(businessSignupId === undefined
+          ? {}
+          : { businessKickoff: { signupId: businessSignupId } }),
         db: openAgentsDatabase(environment),
         email: session.user.email,
         packageId,

--- a/apps/openagents.com/workers/api/src/business-checkout-kickoff.test.ts
+++ b/apps/openagents.com/workers/api/src/business-checkout-kickoff.test.ts
@@ -1,0 +1,186 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { DatabaseSync } from 'node:sqlite'
+import { describe, expect, test } from 'vitest'
+
+import { insertBusinessSignupRequest } from './business-signup-routes'
+import { provisionBusinessCheckoutKickoff } from './business-checkout-kickoff'
+
+type Row = Record<string, unknown>
+
+class SqliteD1Statement {
+  private bound: ReadonlyArray<unknown> = []
+
+  constructor(
+    private readonly db: DatabaseSync,
+    private readonly sql: string,
+  ) {}
+
+  bind(...values: ReadonlyArray<unknown>): SqliteD1Statement {
+    this.bound = values.map(value => (value === undefined ? null : value))
+    return this
+  }
+
+  async first<T = Row>(): Promise<T | null> {
+    const row = this.db.prepare(this.sql).get(...(this.bound as never[]))
+    return (row ?? null) as T | null
+  }
+
+  async all<T = Row>(): Promise<D1Result<T>> {
+    const results = this.db
+      .prepare(this.sql)
+      .all(...(this.bound as never[])) as Array<T>
+
+    return { results, success: true } as D1Result<T>
+  }
+
+  async run(): Promise<D1Result> {
+    this.db.prepare(this.sql).run(...(this.bound as never[]))
+    return { success: true } as D1Result
+  }
+}
+
+class SqliteD1 {
+  constructor(private readonly db: DatabaseSync) {}
+
+  batch<T = unknown>(
+    statements: ReadonlyArray<D1PreparedStatement>,
+  ): Promise<Array<D1Result<T>>> {
+    return Promise.all(statements.map(statement => statement.run<T>()))
+  }
+
+  dump(): Promise<ArrayBuffer> {
+    return Promise.resolve(new ArrayBuffer(0))
+  }
+
+  exec(sql: string): Promise<D1ExecResult> {
+    this.db.exec(sql)
+    return Promise.resolve({ count: 0, duration: 0 })
+  }
+
+  prepare(sql: string): SqliteD1Statement {
+    return new SqliteD1Statement(this.db, sql)
+  }
+}
+
+const migration = (name: string): string =>
+  readFileSync(join(__dirname, '..', 'migrations', name), 'utf8')
+
+const makeDb = (): D1Database => {
+  const db = new DatabaseSync(':memory:')
+  db.exec(`
+    CREATE TABLE users (id TEXT PRIMARY KEY);
+    CREATE TABLE teams (
+      id TEXT PRIMARY KEY,
+      status TEXT NOT NULL DEFAULT 'active',
+      archived_at TEXT
+    );
+    CREATE TABLE team_memberships (
+      team_id TEXT NOT NULL,
+      user_id TEXT NOT NULL,
+      status TEXT NOT NULL DEFAULT 'active'
+    );
+    CREATE TABLE team_projects (
+      id TEXT PRIMARY KEY,
+      team_id TEXT NOT NULL,
+      status TEXT NOT NULL DEFAULT 'active',
+      archived_at TEXT
+    );
+    CREATE TABLE stripe_checkout_sessions (session_id TEXT PRIMARY KEY);
+  `)
+  for (const name of [
+    '0091_omni_accepted_outcome_contracts.sql',
+    '0190_prefilled_workspaces.sql',
+    '0191_business_signup_requests.sql',
+    '0192_prefilled_workspace_invite_engagement.sql',
+    '0195_private_prefilled_workspace_access.sql',
+    '0216_business_signup_referral_attribution.sql',
+    '0271_business_signup_fulfillment.sql',
+    '0272_business_checkout_kickoffs.sql',
+  ]) {
+    db.exec(migration(name))
+  }
+
+  return new SqliteD1(db) as unknown as D1Database
+}
+
+describe('business checkout kickoff', () => {
+  test('settled checkout provisions workspace and service promise idempotently', async () => {
+    const db = makeDb()
+    await db
+      .prepare("INSERT INTO users (id) VALUES ('github:buyer_1')")
+      .run()
+    await db
+      .prepare(
+        "INSERT INTO stripe_checkout_sessions (session_id) VALUES ('cs_test_business_001')",
+      )
+      .run()
+    const signup = await insertBusinessSignupRequest(
+      db,
+      {
+        businessName: 'Vertical prospect',
+        contactEmail: 'buyer@example.com',
+        helpWith: 'Need a first deliverable.',
+        phone: '+1 555 0100',
+        referralCode: null,
+        requestSlackChannel: false,
+        sourceAttribution: null,
+        website: 'https://example.com',
+      },
+      {
+        expiresAtFromNow: () => '2026-08-02T00:00:00.000Z',
+        makeId: prefix => `${prefix}_001`,
+        nowIso: () => '2026-07-02T00:00:00.000Z',
+      },
+    )
+
+    const first = await provisionBusinessCheckoutKickoff(db, {
+      checkoutSessionId: 'cs_test_business_001',
+      creditGrantCents: 8000,
+      setupFeeCents: 2000,
+      signupId: signup.id,
+      totalAmountCents: 10000,
+      userId: 'github:buyer_1',
+    })
+    const second = await provisionBusinessCheckoutKickoff(db, {
+      checkoutSessionId: 'cs_test_business_001',
+      creditGrantCents: 8000,
+      setupFeeCents: 2000,
+      signupId: signup.id,
+      totalAmountCents: 10000,
+      userId: 'github:buyer_1',
+    })
+
+    expect(second).toEqual(first)
+
+    const workspaceCount = await db
+      .prepare('SELECT COUNT(*) AS count FROM prefilled_workspaces')
+      .first<{ count: number }>()
+    const contractCount = await db
+      .prepare('SELECT COUNT(*) AS count FROM omni_accepted_outcome_contracts')
+      .first<{ count: number }>()
+    const kickoff = await db
+      .prepare(
+        `SELECT credit_grant_cents,
+                setup_fee_cents,
+                public_receipt_ref
+           FROM business_checkout_kickoffs
+          WHERE checkout_session_id = ?`,
+      )
+      .bind('cs_test_business_001')
+      .first<{
+        credit_grant_cents: number
+        public_receipt_ref: string
+        setup_fee_cents: number
+      }>()
+
+    expect(workspaceCount?.count).toBe(1)
+    expect(contractCount?.count).toBe(1)
+    expect(kickoff).toMatchObject({
+      credit_grant_cents: 8000,
+      public_receipt_ref:
+        'receipt.business.checkout_kickoff.cs_test_business_001',
+      setup_fee_cents: 2000,
+    })
+  })
+})

--- a/apps/openagents.com/workers/api/src/business-checkout-kickoff.ts
+++ b/apps/openagents.com/workers/api/src/business-checkout-kickoff.ts
@@ -1,0 +1,348 @@
+import { Schema as S } from 'effect'
+
+import {
+  makePrefilledWorkspaceService,
+  type PrefilledWorkspaceRecord,
+} from './prefilled-workspace'
+import { readBusinessSignupRequest } from './business-signup-routes'
+import { compactRandomId, currentIsoTimestamp } from './runtime-primitives'
+
+export type BusinessCheckoutKickoffInput = Readonly<{
+  checkoutSessionId: string
+  creditGrantCents: number
+  setupFeeCents: number
+  signupId: string
+  totalAmountCents: number
+  userId: string
+}>
+
+export type BusinessCheckoutKickoffRecord = Readonly<{
+  checkoutSessionId: string
+  creditGrantCents: number
+  publicReceiptRef: string
+  servicePromiseContractId: string
+  setupFeeCents: number
+  signupId: string
+  totalAmountCents: number
+  userId: string
+  workspaceId: string
+}>
+
+type KickoffRow = Readonly<{
+  checkout_session_id: string
+  business_signup_request_id: string
+  user_id: string
+  total_amount_cents: number
+  setup_fee_cents: number
+  credit_grant_cents: number
+  workspace_id: string
+  service_promise_contract_id: string
+  public_receipt_ref: string
+}>
+
+export class BusinessCheckoutKickoffError extends S.TaggedErrorClass<BusinessCheckoutKickoffError>()(
+  'BusinessCheckoutKickoffError',
+  { reason: S.String },
+) {}
+
+const SAFE_REF_PATTERN = /^[A-Za-z0-9][A-Za-z0-9_.:/-]{0,220}$/
+
+const safeRef = (field: string, value: string): string => {
+  const ref = value.trim()
+
+  if (!SAFE_REF_PATTERN.test(ref)) {
+    throw new BusinessCheckoutKickoffError({
+      reason: `${field} must be an opaque public-safe ref.`,
+    })
+  }
+
+  return ref
+}
+
+const nonNegativeInt = (field: string, value: number): number => {
+  const next = Math.trunc(value)
+
+  if (!Number.isFinite(next) || next < 0) {
+    throw new BusinessCheckoutKickoffError({
+      reason: `${field} must be a non-negative integer.`,
+    })
+  }
+
+  return next
+}
+
+const rowToRecord = (row: KickoffRow): BusinessCheckoutKickoffRecord => ({
+  checkoutSessionId: row.checkout_session_id,
+  creditGrantCents: row.credit_grant_cents,
+  publicReceiptRef: row.public_receipt_ref,
+  servicePromiseContractId: row.service_promise_contract_id,
+  setupFeeCents: row.setup_fee_cents,
+  signupId: row.business_signup_request_id,
+  totalAmountCents: row.total_amount_cents,
+  userId: row.user_id,
+  workspaceId: row.workspace_id,
+})
+
+const readKickoff = async (
+  db: D1Database,
+  checkoutSessionId: string,
+): Promise<BusinessCheckoutKickoffRecord | null> => {
+  const row = await db
+    .prepare(
+      `SELECT checkout_session_id,
+              business_signup_request_id,
+              user_id,
+              total_amount_cents,
+              setup_fee_cents,
+              credit_grant_cents,
+              workspace_id,
+              service_promise_contract_id,
+              public_receipt_ref
+         FROM business_checkout_kickoffs
+        WHERE checkout_session_id = ?
+        LIMIT 1`,
+    )
+    .bind(checkoutSessionId)
+    .first<KickoffRow>()
+
+  return row === null ? null : rowToRecord(row)
+}
+
+const createWorkspace = async (
+  db: D1Database,
+  input: BusinessCheckoutKickoffInput,
+): Promise<PrefilledWorkspaceRecord> => {
+  const signup = await readBusinessSignupRequest(db, input.signupId)
+
+  if (signup === undefined) {
+    throw new BusinessCheckoutKickoffError({
+      reason: 'business signup request not found.',
+    })
+  }
+
+  return makePrefilledWorkspaceService(db, {
+    makeId: prefix => `${prefix}_${compactRandomId('business')}`,
+    nowIso: currentIsoTimestamp,
+  }).createWorkspace({
+    holderRef: `business_signup:${input.signupId}`,
+    holderUserId: input.userId,
+    introReceipt: {
+      summary: 'Business workspace provisioned from a settled checkout.',
+      publicSourceRefs: [
+        `business_signup:${input.signupId}`,
+        `receipt.billing.stripe_checkout.${input.checkoutSessionId}`,
+      ],
+    },
+    projectName: 'Business service workspace',
+    seededMemory: [
+      {
+        label: 'Signup receipt',
+        publicSourceRef: `business_signup:${input.signupId}`,
+        value: 'Business intake receipt recorded.',
+      },
+      {
+        label: 'Checkout receipt',
+        publicSourceRef: `receipt.billing.stripe_checkout.${input.checkoutSessionId}`,
+        value: 'Settled checkout recorded.',
+      },
+    ],
+    starterWorkflows: [
+      {
+        description: 'Prepare the first operator-reviewed business deliverable.',
+        outcomeKind: 'business_deliverable',
+        status: 'queued',
+        title: 'First deliverable',
+      },
+    ],
+    status: 'active',
+  })
+}
+
+const createServicePromise = (
+  db: D1Database,
+  input: BusinessCheckoutKickoffInput,
+  workspace: PrefilledWorkspaceRecord,
+): Promise<{ id: string }> =>
+  Promise.resolve().then(async () => {
+    const idempotencyKey = `business_checkout:${input.checkoutSessionId}`
+    const existing = await db
+      .prepare(
+        `SELECT id
+           FROM omni_accepted_outcome_contracts
+          WHERE idempotency_key = ?
+            AND archived_at IS NULL
+          LIMIT 1`,
+      )
+      .bind(idempotencyKey)
+      .first<{ id: string }>()
+
+    if (existing !== null) {
+      return existing
+    }
+
+    const now = currentIsoTimestamp()
+    const id = compactRandomId('omni_accepted_outcome_contract')
+    const receiptRef = `receipt.billing.stripe_checkout.${input.checkoutSessionId}`
+    const workspaceRef = `workspace:${workspace.id}`
+
+    await db
+      .prepare(
+        `INSERT OR IGNORE INTO omni_accepted_outcome_contracts
+           (id,
+            idempotency_key,
+            work_kind,
+            subject_ref,
+            customer_ref,
+            expected_artifacts_json,
+            review_policy,
+            acceptance_state,
+            proof_policy,
+            economic_state,
+            closeout_requirements_json,
+            legal_sensitive,
+            public_receipt_ref,
+            metadata_json,
+            created_at,
+            updated_at,
+            archived_at)
+         VALUES (?, ?, 'business', ?, ?, ?, 'operator_review', 'draft',
+                 'customer_safe_summary', 'credits_required', ?, 0, ?, ?, ?, ?, NULL)`,
+      )
+      .bind(
+        id,
+        idempotencyKey,
+        workspaceRef,
+        `business_signup:${input.signupId}`,
+        JSON.stringify([
+          {
+            artifactKind: 'operator_receipt',
+            publicSafe: false,
+            required: true,
+            sourceRef: receiptRef,
+          },
+        ]),
+        JSON.stringify([
+          {
+            required: true,
+            requirementKind: 'operator_review',
+            sourceRef: 'gate.business.service_promise.operator_review.v1',
+          },
+          {
+            required: true,
+            requirementKind: 'proof_bundle_ready',
+            sourceRef: receiptRef,
+          },
+        ]),
+        `omni_accepted_outcome:business:${idempotencyKey}`,
+        JSON.stringify({
+          creditGrantCents: input.creditGrantCents,
+          setupFeeCents: input.setupFeeCents,
+          signupRef: `business_signup:${input.signupId}`,
+          stripeCheckoutRef: input.checkoutSessionId,
+          workspaceRef,
+        }),
+        now,
+        now,
+      )
+      .run()
+
+    const inserted = await db
+      .prepare(
+        `SELECT id
+           FROM omni_accepted_outcome_contracts
+          WHERE idempotency_key = ?
+            AND archived_at IS NULL
+          LIMIT 1`,
+      )
+      .bind(idempotencyKey)
+      .first<{ id: string }>()
+
+    if (inserted === null) {
+      throw new BusinessCheckoutKickoffError({
+        reason: 'service promise contract was not persisted.',
+      })
+    }
+
+    return inserted
+  })
+
+export const provisionBusinessCheckoutKickoff = async (
+  db: D1Database,
+  rawInput: BusinessCheckoutKickoffInput,
+): Promise<BusinessCheckoutKickoffRecord> => {
+  const input: BusinessCheckoutKickoffInput = {
+    checkoutSessionId: safeRef(
+      'checkoutSessionId',
+      rawInput.checkoutSessionId,
+    ),
+    creditGrantCents: nonNegativeInt(
+      'creditGrantCents',
+      rawInput.creditGrantCents,
+    ),
+    setupFeeCents: nonNegativeInt('setupFeeCents', rawInput.setupFeeCents),
+    signupId: safeRef('signupId', rawInput.signupId),
+    totalAmountCents: nonNegativeInt(
+      'totalAmountCents',
+      rawInput.totalAmountCents,
+    ),
+    userId: safeRef('userId', rawInput.userId),
+  }
+
+  if (input.setupFeeCents + input.creditGrantCents !== input.totalAmountCents) {
+    throw new BusinessCheckoutKickoffError({
+      reason: 'setup fee plus credit grant must equal the checkout total.',
+    })
+  }
+
+  const existing = await readKickoff(db, input.checkoutSessionId)
+
+  if (existing !== null) {
+    return existing
+  }
+
+  const workspace = await createWorkspace(db, input)
+  const contract = await createServicePromise(db, input, workspace)
+  const now = currentIsoTimestamp()
+  const publicReceiptRef = `receipt.business.checkout_kickoff.${input.checkoutSessionId}`
+
+  await db
+    .prepare(
+      `INSERT OR IGNORE INTO business_checkout_kickoffs
+        (checkout_session_id,
+         business_signup_request_id,
+         user_id,
+         total_amount_cents,
+         setup_fee_cents,
+         credit_grant_cents,
+         workspace_id,
+         service_promise_contract_id,
+         public_receipt_ref,
+         created_at,
+         updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    )
+    .bind(
+      input.checkoutSessionId,
+      input.signupId,
+      input.userId,
+      input.totalAmountCents,
+      input.setupFeeCents,
+      input.creditGrantCents,
+      workspace.id,
+      contract.id,
+      publicReceiptRef,
+      now,
+      now,
+    )
+    .run()
+
+  const inserted = await readKickoff(db, input.checkoutSessionId)
+
+  if (inserted === null) {
+    throw new BusinessCheckoutKickoffError({
+      reason: 'business checkout kickoff was not persisted.',
+    })
+  }
+
+  return inserted
+}

--- a/apps/openagents.com/workers/api/src/stripe-billing.ts
+++ b/apps/openagents.com/workers/api/src/stripe-billing.ts
@@ -19,6 +19,7 @@ import { WorkerSecret, redactedValue } from './config'
 import { parseJsonWithSchema } from './json-boundary'
 import { type PartnerQualifyingPaidEvent } from './partner-attribution-eligibility'
 import { recordPartnerPayoutForPaidEvent } from './partner-payout-feed'
+import { provisionBusinessCheckoutKickoff } from './business-checkout-kickoff'
 import { recordReferralPayoutForPaidEvent } from './site-referral-payout-feed'
 
 export const STRIPE_API_VERSION = '2026-05-27.dahlia'
@@ -65,6 +66,10 @@ export type StripeCheckoutSnapshot = Readonly<{
   paymentStatus: string
   sessionId: StripeCheckoutSessionId
   userId: string
+}>
+
+export type StripeBusinessCheckoutKickoffInput = Readonly<{
+  signupId: string
 }>
 
 export type StripeWebhookResult = Readonly<{
@@ -232,6 +237,7 @@ export const StripeCustomerServiceLive = Layer.effect(
 
 export type StripeCheckoutServiceShape = Readonly<{
   createCreditCheckout: (input: {
+    businessKickoff?: StripeBusinessCheckoutKickoffInput | undefined
     db: D1Database
     email?: string | undefined
     packageId: string
@@ -632,6 +638,7 @@ const createCreditCheckout = async (
   config: StripeConfigShape,
   stripeClient: StripeClientShape,
   input: Readonly<{
+    businessKickoff?: StripeBusinessCheckoutKickoffInput | undefined
     db: D1Database
     email?: string | undefined
     packageId: string
@@ -654,6 +661,13 @@ const createCreditCheckout = async (
       metadata: {
         amount_cents: String(pack.amountCents),
         bonus_cents: String(pack.bonusCents),
+        business_credit_grant_cents: String(pack.amountCents),
+        ...(input.businessKickoff === undefined
+          ? {}
+          : {
+              business_setup_fee_cents: '0',
+              business_signup_id: input.businessKickoff.signupId,
+            }),
         currency: pack.currency,
         credits_expire: 'false',
         omega_user_id: input.userId,
@@ -743,6 +757,50 @@ export const buildStripeCheckoutPartnerPayoutEvent = (
   qualifyingEventRef: `evidence.stripe_checkout_paid.${input.sessionId}`,
 })
 
+const metadataInt = (
+  metadata: Stripe.Metadata | null,
+  key: string,
+): number | undefined => {
+  const raw = metadata?.[key]
+
+  if (raw === undefined) {
+    return undefined
+  }
+
+  const parsed = Number.parseInt(raw, 10)
+
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : undefined
+}
+
+const checkoutCreditGrantCents = (
+  session: Stripe.Checkout.Session,
+  fallbackAmountCents: number,
+): number => {
+  const grant = metadataInt(session.metadata, 'business_credit_grant_cents')
+
+  return grant === undefined ? fallbackAmountCents : Math.trunc(grant)
+}
+
+const checkoutSetupFeeCents = (
+  session: Stripe.Checkout.Session,
+  totalAmountCents: number,
+  creditGrantCents: number,
+): number => {
+  const fee = metadataInt(session.metadata, 'business_setup_fee_cents')
+
+  return fee === undefined
+    ? Math.max(0, totalAmountCents - creditGrantCents)
+    : Math.trunc(fee)
+}
+
+const businessSignupIdFromSession = (
+  session: Stripe.Checkout.Session,
+): string | undefined => {
+  const raw = session.metadata?.business_signup_id?.trim()
+
+  return raw === undefined || raw === '' ? undefined : raw
+}
+
 const fulfillCheckoutSession = async (
   config: StripeConfigShape,
   stripeClient: StripeClientShape,
@@ -781,13 +839,40 @@ const fulfillCheckoutSession = async (
     return readBillingSummary(input.db, userId)
   }
 
+  const creditGrantCents = checkoutCreditGrantCents(session, pack.amountCents)
+  const setupFeeCents = checkoutSetupFeeCents(
+    session,
+    pack.amountCents,
+    creditGrantCents,
+  )
+
+  if (setupFeeCents + creditGrantCents !== pack.amountCents) {
+    throw new StripeCheckoutError({
+      reason:
+        'Checkout setup-fee and credit-grant metadata do not match the package total.',
+    })
+  }
+
   const summary = await applyStripeCheckoutCredit(input.db, {
-    amountCents: pack.amountCents,
+    amountCents: creditGrantCents,
     bonusCents: pack.bonusCents,
     packageId: pack.id,
     sessionId: input.sessionId,
     userId,
   })
+
+  const businessSignupId = businessSignupIdFromSession(session)
+
+  if (businessSignupId !== undefined) {
+    await provisionBusinessCheckoutKickoff(input.db, {
+      checkoutSessionId: input.sessionId,
+      creditGrantCents,
+      setupFeeCents,
+      signupId: businessSignupId,
+      totalAmountCents: pack.amountCents,
+      userId,
+    })
+  }
 
   // RL-1 (openagents #5458): FEED the referral payout ledger from this real
   // paid event. A Stripe credit purchase is USD/credit revenue, so per the
@@ -1285,6 +1370,7 @@ export const makeStripeCheckoutServiceForRoutes = (env: StripeBillingEnv) => {
   }
   return {
     createCreditCheckout: (input: {
+      businessKickoff?: StripeBusinessCheckoutKickoffInput | undefined
       db: D1Database
       email?: string | undefined
       packageId: string


### PR DESCRIPTION
## Summary

- Adds a durable `business_checkout_kickoffs` receipt table for checkout-driven workspace/service-promise provisioning.
- Wires Stripe credit checkout metadata so a business signup id flows into checkout creation, with self-serve checkouts defaulting to 100% credit grant.
- On signed, paid Stripe checkout fulfillment, grants only the configured credit-grant split, provisions a prefilled workspace, creates the per-customer accepted-outcome service promise, and records the kickoff row idempotently.

Closes #8080.

## Verification

- `bun run --cwd apps/openagents.com/workers/api test -- src/business-checkout-kickoff.test.ts src/billing-routes.test.ts` passed: 2 files, 14 tests.
- `bun run --cwd apps/openagents.com/workers/api typecheck` passed.
- `bun run check:deploy` passed, including:
  - architecture/contract/public-projection guards
  - `packages/autopilot-control-protocol` typecheck
  - `apps/pylon` typecheck and `tests/security-adversarial-harness.test.ts` (11 tests)
  - web typecheck and selected web suite (22 files, 567 tests)
  - worker selected suite (13 files, 239 tests)