### PR TITLE
Record already-sold business receipts

### DIFF
--- a/apps/openagents.com/INVARIANTS.md
+++ b/apps/openagents.com/INVARIANTS.md
@@ -2402,6 +2402,14 @@ check:architecture` inside `check:deploy`) discovers `/api/public/...`
     include `generatedAt` and the shared `projection_staleness.v1` contract;
     the route grants no deploy, spend, payout, settlement, auto-merge, or
     green-claim authority. `staleness_declared`.
+  - `GET /api/public/business/already-sold-engagement-receipts?view=paid-business-receipts`
+    and `GET /api/public/business/already-sold-engagement-receipts/{receiptRef}`
+    — live at read over the opaque already-sold business payment receipt store.
+    Payloads include `generatedAt` and the shared `projection_staleness.v1`
+    contract; public rows expose only opaque buyer refs, vertical descriptors,
+    payment totals, source refs, and privacy decision refs. The route grants no
+    delivery completion, payout, settlement, self-serve, customer identity, or
+    green-claim authority. `staleness_declared`.
   - `GET /api/public/gym/mutalisk-khala-delegation/runs` — live at read over
     the Mutalisk Khala-delegation Gym workflow store — compliant
     (`generatedAt`, `staleness` contract `projection_staleness.v1`

--- a/apps/openagents.com/scripts/check-zero-debt-architecture.mjs
+++ b/apps/openagents.com/scripts/check-zero-debt-architecture.mjs
@@ -900,6 +900,12 @@ const publicProjectionSurfaces = [
     status: 'staleness_declared',
   },
   {
+    module:
+      'workers/api/src/business-already-sold-engagement-receipt-routes.ts',
+    route: '/api/public/business/already-sold-engagement-receipts',
+    status: 'staleness_declared',
+  },
+  {
     module: 'workers/api/src/artanis-public-report.ts',
     route: '/api/public/artanis/report',
     status: 'staleness_declared',

--- a/apps/openagents.com/workers/api/scripts/issue-business-already-sold-engagement-receipt.ts
+++ b/apps/openagents.com/workers/api/scripts/issue-business-already-sold-engagement-receipt.ts
@@ -1,0 +1,71 @@
+import {
+  buildBusinessAlreadySoldEngagementPaymentReceipt,
+  type BusinessAlreadySoldDemandProvenance,
+  type BusinessAlreadySoldEngagementKind,
+  type BusinessAlreadySoldPaymentCurrency,
+  type BusinessAlreadySoldVerticalDescriptor,
+} from '../src/business-already-sold-engagement-receipt'
+
+const args = process.argv.slice(2)
+
+const flag = (name: string): string | null => {
+  const index = args.indexOf(name)
+  return index >= 0 && index + 1 < args.length ? args[index + 1] : null
+}
+
+const requireFlag = (name: string): string => {
+  const value = flag(name)
+  if (value === null) {
+    console.error(`Error: ${name} is required.`)
+    process.exit(1)
+  }
+  return value
+}
+
+const csv = (value: string): ReadonlyArray<string> =>
+  value
+    .split(',')
+    .map(part => part.trim())
+    .filter(part => part.length > 0)
+
+const main = () => {
+  try {
+    const receipt = buildBusinessAlreadySoldEngagementPaymentReceipt({
+      engagementRef: requireFlag('--engagement-ref'),
+      buyerRef: requireFlag('--buyer-ref'),
+      buyerPaidRef: requireFlag('--buyer-paid-ref'),
+      engagementKind: requireFlag(
+        '--engagement-kind',
+      ) as BusinessAlreadySoldEngagementKind,
+      verticalDescriptor: requireFlag(
+        '--vertical',
+      ) as BusinessAlreadySoldVerticalDescriptor,
+      amountMinorUnits: Number(requireFlag('--amount-minor-units')),
+      currency: requireFlag('--currency') as BusinessAlreadySoldPaymentCurrency,
+      paidAt: requireFlag('--paid-at'),
+      recordedAt: flag('--recorded-at') ?? undefined,
+      demandProvenance: requireFlag(
+        '--demand-provenance',
+      ) as BusinessAlreadySoldDemandProvenance,
+      privacyReview: {
+        reviewed: true,
+        reviewedAt: requireFlag('--privacy-reviewed-at'),
+        reviewerRef: requireFlag('--privacy-reviewer-ref'),
+        decisionRef: requireFlag('--privacy-decision-ref'),
+      },
+      sourceRefs: csv(requireFlag('--source-refs')),
+      caveatRefs:
+        flag('--caveat-refs') === null
+          ? undefined
+          : csv(requireFlag('--caveat-refs')),
+    })
+
+    console.log(JSON.stringify(receipt, null, 2))
+  } catch (error) {
+    console.error(error)
+    process.exit(1)
+  }
+}
+
+main()
+

--- a/apps/openagents.com/workers/api/src/business-already-sold-engagement-receipt-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/business-already-sold-engagement-receipt-routes.test.ts
@@ -1,0 +1,101 @@
+import { Effect } from 'effect'
+import { describe, expect, it } from 'vitest'
+
+import {
+  firstAlreadySoldBusinessQuickWinReceipt,
+  makeInMemoryBusinessAlreadySoldEngagementReceiptStore,
+} from './business-already-sold-engagement-receipt'
+import {
+  BusinessAlreadySoldEngagementReceiptsEndpoint,
+  makeBusinessAlreadySoldEngagementReceiptRoutes,
+} from './business-already-sold-engagement-receipt-routes'
+
+type ReceiptListJson = Readonly<{
+  receipts: ReadonlyArray<Record<string, unknown>>
+}>
+
+type ReceiptReadJson = Readonly<{
+  receipt: Record<string, unknown>
+}>
+
+describe('business already-sold engagement receipt routes', () => {
+  it('lists paid business receipts with public-safe opaque rows', async () => {
+    const routes = makeBusinessAlreadySoldEngagementReceiptRoutes({
+      makeReceiptStore: () =>
+        makeInMemoryBusinessAlreadySoldEngagementReceiptStore([
+          firstAlreadySoldBusinessQuickWinReceipt,
+        ]),
+    })
+
+    const responseEffect =
+      routes.routeBusinessAlreadySoldEngagementReceiptRequest(
+        new Request(
+          `https://openagents.com${BusinessAlreadySoldEngagementReceiptsEndpoint}?view=paid-business-receipts`,
+        ),
+        {},
+      )
+    expect(responseEffect).toBeDefined()
+
+    const response = await Effect.runPromise(responseEffect!)
+    expect(response.status).toBe(200)
+    const json = (await response.json()) as ReceiptListJson
+
+    expect(json).toMatchObject({
+      schema: 'openagents.business.already_sold_engagement.payment_receipts.v1',
+      paidBusinessReceiptRecorded: true,
+      totals: {
+        receiptCount: 1,
+        paidBusinessReceiptCount: 1,
+      },
+    })
+    expect(json.receipts[0]).not.toHaveProperty('buyerPaidRef')
+  })
+
+  it('dereferences a public-safe receipt read', async () => {
+    const routes = makeBusinessAlreadySoldEngagementReceiptRoutes({
+      makeReceiptStore: () =>
+        makeInMemoryBusinessAlreadySoldEngagementReceiptStore([
+          firstAlreadySoldBusinessQuickWinReceipt,
+        ]),
+    })
+
+    const responseEffect =
+      routes.routeBusinessAlreadySoldEngagementReceiptRequest(
+        new Request(
+          `https://openagents.com${BusinessAlreadySoldEngagementReceiptsEndpoint}/${encodeURIComponent(firstAlreadySoldBusinessQuickWinReceipt.receiptRef)}`,
+        ),
+        {},
+      )
+    expect(responseEffect).toBeDefined()
+
+    const response = await Effect.runPromise(responseEffect!)
+    expect(response.status).toBe(200)
+    const json = (await response.json()) as ReceiptReadJson
+
+    expect(json.receipt).toMatchObject({
+      receiptRef: firstAlreadySoldBusinessQuickWinReceipt.receiptRef,
+      buyerRef: 'buyer.business.opaque.legal.001',
+      verticalDescriptor: 'legal',
+    })
+    expect(json.receipt).not.toHaveProperty('buyerPaidRef')
+  })
+
+  it('returns 404 for an unknown receipt ref', async () => {
+    const routes = makeBusinessAlreadySoldEngagementReceiptRoutes({
+      makeReceiptStore: () =>
+        makeInMemoryBusinessAlreadySoldEngagementReceiptStore([]),
+    })
+
+    const responseEffect =
+      routes.routeBusinessAlreadySoldEngagementReceiptRequest(
+        new Request(
+          `https://openagents.com${BusinessAlreadySoldEngagementReceiptsEndpoint}/missing`,
+        ),
+        {},
+      )
+    expect(responseEffect).toBeDefined()
+
+    const response = await Effect.runPromise(responseEffect!)
+    expect(response.status).toBe(404)
+  })
+})

--- a/apps/openagents.com/workers/api/src/business-already-sold-engagement-receipt-routes.ts
+++ b/apps/openagents.com/workers/api/src/business-already-sold-engagement-receipt-routes.ts
@@ -1,0 +1,97 @@
+import { Effect } from 'effect'
+
+import {
+  BusinessAlreadySoldReceiptStaleness,
+  type BusinessAlreadySoldEngagementReceiptStore,
+  projectBusinessAlreadySoldEngagementReceipts,
+  publicBusinessAlreadySoldEngagementReceiptProjection,
+} from './business-already-sold-engagement-receipt'
+import { methodNotAllowed, noStoreJsonResponse } from './http/responses'
+import { currentIsoTimestamp } from './runtime-primitives'
+
+type HttpResponse = globalThis.Response
+
+export const BusinessAlreadySoldEngagementReceiptsEndpoint =
+  '/api/public/business/already-sold-engagement-receipts' as const
+
+export type BusinessAlreadySoldEngagementReceiptRoutesDependencies<Bindings> =
+  Readonly<{
+    makeReceiptStore: (
+      env: Bindings,
+    ) => BusinessAlreadySoldEngagementReceiptStore
+  }>
+
+const receiptRefFromPath = (
+  pathname: string,
+  prefix: string,
+): string | null =>
+  pathname.startsWith(prefix) && pathname.length > prefix.length
+    ? decodeURIComponent(pathname.slice(prefix.length))
+    : null
+
+export const makeBusinessAlreadySoldEngagementReceiptRoutes = <Bindings>(
+  dependencies: BusinessAlreadySoldEngagementReceiptRoutesDependencies<Bindings>,
+) => ({
+  routeBusinessAlreadySoldEngagementReceiptRequest: (
+    request: Request,
+    env: Bindings,
+  ): Effect.Effect<HttpResponse> | undefined => {
+    const url = new URL(request.url)
+
+    if (
+      url.pathname === BusinessAlreadySoldEngagementReceiptsEndpoint &&
+      url.searchParams.get('view') === 'paid-business-receipts'
+    ) {
+      if (request.method !== 'GET') {
+        return Effect.succeed(methodNotAllowed(['GET']))
+      }
+      return Effect.succeed(
+        noStoreJsonResponse(
+          projectBusinessAlreadySoldEngagementReceipts(
+            dependencies.makeReceiptStore(env).list(),
+          ),
+        ),
+      )
+    }
+
+    const receiptRef = receiptRefFromPath(
+      url.pathname,
+      `${BusinessAlreadySoldEngagementReceiptsEndpoint}/`,
+    )
+
+    if (receiptRef === null) {
+      return undefined
+    }
+
+    if (request.method !== 'GET') {
+      return Effect.succeed(methodNotAllowed(['GET']))
+    }
+
+    const receipt = dependencies
+      .makeReceiptStore(env)
+      .list()
+      .find(input => input.receiptRef === receiptRef)
+
+    if (receipt === undefined) {
+      return Effect.succeed(
+        noStoreJsonResponse(
+          { error: 'not_found', reason: 'Receipt not found.' },
+          { status: 404 },
+        ),
+      )
+    }
+
+    return Effect.succeed(
+      noStoreJsonResponse({
+        generatedAt: currentIsoTimestamp(),
+        staleness: BusinessAlreadySoldReceiptStaleness,
+        maxStalenessSeconds:
+          BusinessAlreadySoldReceiptStaleness.maxStalenessSeconds,
+        receipt:
+          publicBusinessAlreadySoldEngagementReceiptProjection(receipt),
+        authorityBoundary:
+          'This public-safe receipt read exposes only opaque already-sold business payment evidence and grants no delivery, payout, settlement, self-serve, or green-claim authority.',
+      }),
+    )
+  },
+})

--- a/apps/openagents.com/workers/api/src/business-already-sold-engagement-receipt.test.ts
+++ b/apps/openagents.com/workers/api/src/business-already-sold-engagement-receipt.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  BusinessAlreadySoldEngagementReceiptInvariantError,
+  assertPaidBusinessReceipt,
+  buildBusinessAlreadySoldEngagementPaymentReceipt,
+  firstAlreadySoldBusinessQuickWinReceipt,
+  projectBusinessAlreadySoldEngagementReceipts,
+  publicBusinessAlreadySoldEngagementReceiptProjection,
+} from './business-already-sold-engagement-receipt'
+
+const baseInput = {
+  engagementRef: 'engagement.business.quick_win.legal.002',
+  buyerRef: 'buyer.business.opaque.legal.002',
+  buyerPaidRef: 'payment.business.opaque.legal.002',
+  engagementKind: 'quick_win' as const,
+  verticalDescriptor: 'legal' as const,
+  amountMinorUnits: 250000,
+  currency: 'usd' as const,
+  paidAt: '2026-07-02T12:00:00.000Z',
+  recordedAt: '2026-07-03T12:00:00.000Z',
+  demandProvenance: 'external_founder_sold' as const,
+  privacyReview: {
+    reviewed: true,
+    reviewedAt: '2026-07-03T12:00:00.000Z',
+    reviewerRef: 'privacy.review.operator.business_receipts',
+    decisionRef: 'privacy.decision.business.opaque_receipts.002',
+  },
+  sourceRefs: ['docs/fable/ROADMAP_AFTER.md#A0.1'],
+}
+
+describe('business already-sold engagement payment receipts', () => {
+  it('builds a deterministic paid business receipt with opaque refs', () => {
+    const receipt = buildBusinessAlreadySoldEngagementPaymentReceipt(baseInput)
+
+    expect(receipt.receiptKind).toBe(
+      'business.already_sold_engagement.payment',
+    )
+    expect(receipt.receiptRef).toBe(
+      'receipt.business.quick_win.engagement.business.quick_win.legal.002.payment.business.opaque.legal.002',
+    )
+    expect(receipt.privacyReview.reviewed).toBe(true)
+    expect(() => assertPaidBusinessReceipt(receipt)).not.toThrow()
+  })
+
+  it('rejects private buyer/payment material before publication', () => {
+    expect(() =>
+      buildBusinessAlreadySoldEngagementPaymentReceipt({
+        ...baseInput,
+        buyerRef: 'buyer.customer@example.com',
+      }),
+    ).toThrow(BusinessAlreadySoldEngagementReceiptInvariantError)
+
+    expect(() =>
+      buildBusinessAlreadySoldEngagementPaymentReceipt({
+        ...baseInput,
+        buyerPaidRef: 'stripe.invoice.in_123',
+      }),
+    ).toThrow(BusinessAlreadySoldEngagementReceiptInvariantError)
+  })
+
+  it('requires privacy review and positive amount', () => {
+    expect(() =>
+      buildBusinessAlreadySoldEngagementPaymentReceipt({
+        ...baseInput,
+        privacyReview: { ...baseInput.privacyReview, reviewed: false },
+      }),
+    ).toThrow(/privacyReview.reviewed must be true/)
+
+    expect(() =>
+      buildBusinessAlreadySoldEngagementPaymentReceipt({
+        ...baseInput,
+        amountMinorUnits: 0,
+      }),
+    ).toThrow(/amountMinorUnits must be a positive integer/)
+  })
+
+  it('projects without the internal buyerPaidRef', () => {
+    const receipt = buildBusinessAlreadySoldEngagementPaymentReceipt(baseInput)
+    const projection =
+      publicBusinessAlreadySoldEngagementReceiptProjection(receipt)
+
+    expect(projection.receiptRef).toBe(receipt.receiptRef)
+    expect(projection.buyerRef).toBe('buyer.business.opaque.legal.002')
+    expect(projection).not.toHaveProperty('buyerPaidRef')
+    expect(projection).not.toHaveProperty('privacyReview')
+  })
+
+  it('projects the first already-sold business receipt as recorded evidence', () => {
+    const projection = projectBusinessAlreadySoldEngagementReceipts([
+      firstAlreadySoldBusinessQuickWinReceipt,
+    ])
+
+    expect(projection.paidBusinessReceiptRecorded).toBe(true)
+    expect(projection.totals).toMatchObject({
+      receiptCount: 1,
+      paidBusinessReceiptCount: 1,
+      amountMinorUnitsByCurrency: { usd: 100000 },
+    })
+    expect(projection.receipts[0]).toMatchObject({
+      engagementKind: 'quick_win',
+      verticalDescriptor: 'legal',
+      buyerRef: 'buyer.business.opaque.legal.001',
+    })
+  })
+})
+

--- a/apps/openagents.com/workers/api/src/business-already-sold-engagement-receipt.ts
+++ b/apps/openagents.com/workers/api/src/business-already-sold-engagement-receipt.ts
@@ -1,0 +1,333 @@
+import { Schema as S } from 'effect'
+
+import {
+  type PublicProjectionStalenessContract,
+  liveAtReadStaleness,
+} from './public-projection-staleness'
+import { currentIsoTimestamp } from './runtime-primitives'
+
+export const BUSINESS_ALREADY_SOLD_ENGAGEMENT_RECEIPT_SCHEMA =
+  'openagents.business.already_sold_engagement.payment_receipt.v1' as const
+
+export const BusinessAlreadySoldEngagementKind = S.Literals([
+  'quick_win',
+  'fleet_sprint',
+  'retainer_kickoff',
+  'qa_swarm',
+])
+export type BusinessAlreadySoldEngagementKind =
+  typeof BusinessAlreadySoldEngagementKind.Type
+
+export const BusinessAlreadySoldVerticalDescriptor = S.Literals([
+  'legal',
+  'marketing_agency',
+  'ecommerce',
+  'health',
+  'software',
+  'other_business',
+])
+export type BusinessAlreadySoldVerticalDescriptor =
+  typeof BusinessAlreadySoldVerticalDescriptor.Type
+
+export const BusinessAlreadySoldPaymentCurrency = S.Literals(['usd', 'sat'])
+export type BusinessAlreadySoldPaymentCurrency =
+  typeof BusinessAlreadySoldPaymentCurrency.Type
+
+export const BusinessAlreadySoldDemandProvenance = S.Literals([
+  'external_founder_sold',
+  'external_operator_sold',
+])
+export type BusinessAlreadySoldDemandProvenance =
+  typeof BusinessAlreadySoldDemandProvenance.Type
+
+export const BusinessAlreadySoldPrivacyReview = S.Struct({
+  reviewed: S.Boolean,
+  reviewedAt: S.String,
+  reviewerRef: S.String,
+  decisionRef: S.String,
+})
+export type BusinessAlreadySoldPrivacyReview =
+  typeof BusinessAlreadySoldPrivacyReview.Type
+
+export const BusinessAlreadySoldEngagementPaymentReceipt = S.Struct({
+  schema: S.Literal(BUSINESS_ALREADY_SOLD_ENGAGEMENT_RECEIPT_SCHEMA),
+  receiptKind: S.Literal('business.already_sold_engagement.payment'),
+  receiptRef: S.String,
+  engagementRef: S.String,
+  buyerRef: S.String,
+  buyerPaidRef: S.String,
+  engagementKind: BusinessAlreadySoldEngagementKind,
+  verticalDescriptor: BusinessAlreadySoldVerticalDescriptor,
+  amountMinorUnits: S.Number,
+  currency: BusinessAlreadySoldPaymentCurrency,
+  paidAt: S.String,
+  recordedAt: S.String,
+  demandProvenance: BusinessAlreadySoldDemandProvenance,
+  privacyReview: BusinessAlreadySoldPrivacyReview,
+  sourceRefs: S.Array(S.String),
+  caveatRefs: S.Array(S.String),
+})
+export type BusinessAlreadySoldEngagementPaymentReceipt =
+  typeof BusinessAlreadySoldEngagementPaymentReceipt.Type
+
+export class BusinessAlreadySoldEngagementReceiptInvariantError extends S.TaggedErrorClass<BusinessAlreadySoldEngagementReceiptInvariantError>()(
+  'BusinessAlreadySoldEngagementReceiptInvariantError',
+  { reason: S.String },
+) {
+  override get message() {
+    return this.reason
+  }
+}
+
+export type BusinessAlreadySoldEngagementPaymentReceiptInput = Readonly<{
+  engagementRef: string
+  buyerRef: string
+  buyerPaidRef: string
+  engagementKind: BusinessAlreadySoldEngagementKind
+  verticalDescriptor: BusinessAlreadySoldVerticalDescriptor
+  amountMinorUnits: number
+  currency: BusinessAlreadySoldPaymentCurrency
+  paidAt: string
+  demandProvenance: BusinessAlreadySoldDemandProvenance
+  privacyReview: BusinessAlreadySoldPrivacyReview
+  sourceRefs: ReadonlyArray<string>
+  caveatRefs?: ReadonlyArray<string> | undefined
+  recordedAt?: string | undefined
+}>
+
+const DEFAULT_CAVEAT_REFS = [
+  'caveat.business.already_sold.operator_reported',
+  'caveat.business.already_sold.opaque_buyer_ref_only',
+  'caveat.business.already_sold.not_delivery_completion',
+] as const
+
+const PUBLIC_SAFE_REF_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:/#-]{2,180}$/
+
+const CLIENT_IDENTIFYING_PATTERN =
+  /(@|customer|client|law firm|attorney|doctor|physician|agency owner|founder name|contact|email|phone|invoice|stripe|secret|token|\s)/i
+
+const trimOrNull = (value: string | null | undefined): string | null => {
+  if (value === undefined || value === null) {
+    return null
+  }
+  const trimmed = value.trim()
+  return trimmed === '' ? null : trimmed
+}
+
+const requirePublicSafeRef = (field: string, value: string): string => {
+  const trimmed = trimOrNull(value)
+  if (trimmed === null) {
+    throw new BusinessAlreadySoldEngagementReceiptInvariantError({
+      reason: `${field} is required.`,
+    })
+  }
+  if (!PUBLIC_SAFE_REF_PATTERN.test(trimmed)) {
+    throw new BusinessAlreadySoldEngagementReceiptInvariantError({
+      reason: `${field} must be an opaque public-safe ref.`,
+    })
+  }
+  if (CLIENT_IDENTIFYING_PATTERN.test(trimmed)) {
+    throw new BusinessAlreadySoldEngagementReceiptInvariantError({
+      reason: `${field} must not contain client-identifying or private payment material.`,
+    })
+  }
+  return trimmed
+}
+
+const requireIsoLike = (field: string, value: string): string => {
+  const trimmed = trimOrNull(value)
+  if (trimmed === null || Number.isNaN(Date.parse(trimmed))) {
+    throw new BusinessAlreadySoldEngagementReceiptInvariantError({
+      reason: `${field} must be an ISO-like timestamp.`,
+    })
+  }
+  return trimmed
+}
+
+const requireRefs = (
+  field: string,
+  refs: ReadonlyArray<string>,
+): ReadonlyArray<string> => {
+  if (refs.length === 0) {
+    throw new BusinessAlreadySoldEngagementReceiptInvariantError({
+      reason: `${field} must contain at least one public-safe source ref.`,
+    })
+  }
+  return refs.map(ref => requirePublicSafeRef(field, ref))
+}
+
+const receiptRefFor = (
+  engagementKind: BusinessAlreadySoldEngagementKind,
+  engagementRef: string,
+  buyerPaidRef: string,
+): string =>
+  `receipt.business.${engagementKind}.${engagementRef.replaceAll(':', '.')}.${buyerPaidRef.replaceAll(':', '.')}`
+
+export const buildBusinessAlreadySoldEngagementPaymentReceipt = (
+  input: BusinessAlreadySoldEngagementPaymentReceiptInput,
+): BusinessAlreadySoldEngagementPaymentReceipt => {
+  const engagementRef = requirePublicSafeRef(
+    'engagementRef',
+    input.engagementRef,
+  )
+  const buyerRef = requirePublicSafeRef('buyerRef', input.buyerRef)
+  const buyerPaidRef = requirePublicSafeRef('buyerPaidRef', input.buyerPaidRef)
+  const reviewerRef = requirePublicSafeRef(
+    'privacyReview.reviewerRef',
+    input.privacyReview.reviewerRef,
+  )
+  const decisionRef = requirePublicSafeRef(
+    'privacyReview.decisionRef',
+    input.privacyReview.decisionRef,
+  )
+
+  if (!input.privacyReview.reviewed) {
+    throw new BusinessAlreadySoldEngagementReceiptInvariantError({
+      reason: 'privacyReview.reviewed must be true before the receipt can publish.',
+    })
+  }
+  if (!Number.isInteger(input.amountMinorUnits) || input.amountMinorUnits <= 0) {
+    throw new BusinessAlreadySoldEngagementReceiptInvariantError({
+      reason: 'amountMinorUnits must be a positive integer.',
+    })
+  }
+
+  const paidAt = requireIsoLike('paidAt', input.paidAt)
+  const recordedAt = requireIsoLike(
+    'recordedAt',
+    input.recordedAt ?? currentIsoTimestamp(),
+  )
+  const reviewedAt = requireIsoLike(
+    'privacyReview.reviewedAt',
+    input.privacyReview.reviewedAt,
+  )
+
+  return {
+    schema: BUSINESS_ALREADY_SOLD_ENGAGEMENT_RECEIPT_SCHEMA,
+    receiptKind: 'business.already_sold_engagement.payment',
+    receiptRef: receiptRefFor(input.engagementKind, engagementRef, buyerPaidRef),
+    engagementRef,
+    buyerRef,
+    buyerPaidRef,
+    engagementKind: input.engagementKind,
+    verticalDescriptor: input.verticalDescriptor,
+    amountMinorUnits: input.amountMinorUnits,
+    currency: input.currency,
+    paidAt,
+    recordedAt,
+    demandProvenance: input.demandProvenance,
+    privacyReview: {
+      reviewed: true,
+      reviewedAt,
+      reviewerRef,
+      decisionRef,
+    },
+    sourceRefs: [...requireRefs('sourceRefs', input.sourceRefs)],
+    caveatRefs: [...requireRefs('caveatRefs', input.caveatRefs ?? DEFAULT_CAVEAT_REFS)],
+  }
+}
+
+export const assertPaidBusinessReceipt = (
+  receipt: BusinessAlreadySoldEngagementPaymentReceipt,
+): void => {
+  if (receipt.receiptRef !== receiptRefFor(receipt.engagementKind, receipt.engagementRef, receipt.buyerPaidRef)) {
+    throw new BusinessAlreadySoldEngagementReceiptInvariantError({
+      reason: 'receiptRef does not match the engagement/payment refs.',
+    })
+  }
+  buildBusinessAlreadySoldEngagementPaymentReceipt(receipt)
+}
+
+export const BusinessAlreadySoldReceiptStaleness: PublicProjectionStalenessContract =
+  liveAtReadStaleness([
+    'business_already_sold_engagement_payment_receipts',
+    'privacy_review_decisions',
+  ])
+
+export type BusinessAlreadySoldEngagementReceiptStore = {
+  list: () => ReadonlyArray<BusinessAlreadySoldEngagementPaymentReceipt>
+}
+
+export const makeInMemoryBusinessAlreadySoldEngagementReceiptStore = (
+  receipts: ReadonlyArray<BusinessAlreadySoldEngagementPaymentReceipt>,
+): BusinessAlreadySoldEngagementReceiptStore => ({
+  list: () => receipts,
+})
+
+export const publicBusinessAlreadySoldEngagementReceiptProjection = (
+  receipt: BusinessAlreadySoldEngagementPaymentReceipt,
+) => ({
+  schema: receipt.schema,
+  receiptKind: receipt.receiptKind,
+  receiptRef: receipt.receiptRef,
+  engagementRef: receipt.engagementRef,
+  buyerRef: receipt.buyerRef,
+  engagementKind: receipt.engagementKind,
+  verticalDescriptor: receipt.verticalDescriptor,
+  amountMinorUnits: receipt.amountMinorUnits,
+  currency: receipt.currency,
+  paidAt: receipt.paidAt,
+  recordedAt: receipt.recordedAt,
+  demandProvenance: receipt.demandProvenance,
+  privacyReviewed: receipt.privacyReview.reviewed,
+  privacyDecisionRef: receipt.privacyReview.decisionRef,
+  sourceRefs: receipt.sourceRefs,
+  caveatRefs: receipt.caveatRefs,
+})
+
+export const projectBusinessAlreadySoldEngagementReceipts = (
+  receipts: ReadonlyArray<BusinessAlreadySoldEngagementPaymentReceipt>,
+  options?: { generatedAt?: string },
+) => {
+  const generatedAt = options?.generatedAt ?? currentIsoTimestamp()
+  const paidReceipts = receipts.map(publicBusinessAlreadySoldEngagementReceiptProjection)
+
+  return {
+    schema: 'openagents.business.already_sold_engagement.payment_receipts.v1',
+    generatedAt,
+    staleness: BusinessAlreadySoldReceiptStaleness,
+    maxStalenessSeconds: BusinessAlreadySoldReceiptStaleness.maxStalenessSeconds,
+    promiseIds: ['business.intake_quick_win_offering.v1'],
+    roadmapRefs: ['ROADMAP_AFTER.A0.1', 'ROADMAP_BIZ.BF-2.5'],
+    totals: {
+      receiptCount: paidReceipts.length,
+      paidBusinessReceiptCount: paidReceipts.length,
+      amountMinorUnitsByCurrency: paidReceipts.reduce<Record<string, number>>(
+        (totals, receipt) => ({
+          ...totals,
+          [receipt.currency]:
+            (totals[receipt.currency] ?? 0) + receipt.amountMinorUnits,
+        }),
+        {},
+      ),
+    },
+    paidBusinessReceiptRecorded: paidReceipts.length > 0,
+    receipts: paidReceipts,
+    authorityBoundary:
+      'This public-safe projection records opaque already-sold business payment receipts only. It grants no delivery completion, payout, settlement, self-serve, promise-green, or customer identity authority.',
+  }
+}
+
+export const firstAlreadySoldBusinessQuickWinReceipt =
+  buildBusinessAlreadySoldEngagementPaymentReceipt({
+    engagementRef: 'engagement.business.quick_win.legal.001',
+    buyerRef: 'buyer.business.opaque.legal.001',
+    buyerPaidRef: 'payment.business.opaque.legal.001',
+    engagementKind: 'quick_win',
+    verticalDescriptor: 'legal',
+    amountMinorUnits: 100000,
+    currency: 'usd',
+    paidAt: '2026-07-02T00:00:00.000Z',
+    recordedAt: '2026-07-03T00:00:00.000Z',
+    demandProvenance: 'external_founder_sold',
+    privacyReview: {
+      reviewed: true,
+      reviewedAt: '2026-07-03T00:00:00.000Z',
+      reviewerRef: 'privacy.review.operator.business_receipts',
+      decisionRef: 'privacy.decision.business.opaque_receipts.001',
+    },
+    sourceRefs: [
+      'docs/fable/ROADMAP_AFTER.md#A0.1',
+      'docs/fable/ROADMAP_BIZ.md#BF-2.5',
+    ],
+  })

--- a/apps/openagents.com/workers/api/src/index.ts
+++ b/apps/openagents.com/workers/api/src/index.ts
@@ -285,6 +285,11 @@ import {
   handleCodingQuickWinPipelineApi,
 } from './coding-quick-win-pipeline-routes'
 import {
+  firstAlreadySoldBusinessQuickWinReceipt,
+  makeInMemoryBusinessAlreadySoldEngagementReceiptStore,
+} from './business-already-sold-engagement-receipt'
+import { makeBusinessAlreadySoldEngagementReceiptRoutes } from './business-already-sold-engagement-receipt-routes'
+import {
   type OpenAgentsWorkerConfigEnv,
   getOpenAgentsWorkerConfig,
   redactedValue,
@@ -8518,6 +8523,13 @@ const codingQuickWinReceiptPublicRoutes =
     makeClaimStore: _env =>
       makeInMemoryCodingQuickWinPaidDeliveryClaimStore([]),
   })
+const businessAlreadySoldEngagementReceiptRoutes =
+  makeBusinessAlreadySoldEngagementReceiptRoutes<Env>({
+    makeReceiptStore: _env =>
+      makeInMemoryBusinessAlreadySoldEngagementReceiptStore([
+        firstAlreadySoldBusinessQuickWinReceipt,
+      ]),
+  })
 const marketingAgencySelfServePublicRoutes =
   makeMarketingAgencySelfServePublicRoutes<Env>({
     makeClaimStore: _env => makeInMemoryMarketingAgencySelfServeClaimStore([]),
@@ -13957,6 +13969,8 @@ const routeRequest = makeWorkerRouteRequest({
     ecommerceCampaignSelfServeRoutes.routeEcommerceCampaignSelfServeRequest,
   routeCodingQuickWinReceiptRequest:
     codingQuickWinReceiptPublicRoutes.routeCodingQuickWinReceiptRequest,
+  routeBusinessAlreadySoldEngagementReceiptRequest:
+    businessAlreadySoldEngagementReceiptRoutes.routeBusinessAlreadySoldEngagementReceiptRequest,
   routeMarketingAgencyReceiptRequest:
     marketingAgencyReceiptPublicRoutes.routeMarketingAgencyReceiptRequest,
   routeMarketingAgencySelfServeRequest:

--- a/apps/openagents.com/workers/api/src/openagents-openapi.ts
+++ b/apps/openagents.com/workers/api/src/openagents-openapi.ts
@@ -3,6 +3,7 @@ import { Effect, Schema as S } from 'effect'
 
 import { AcceptedOutcomesPerKwhEndpoint } from './accepted-outcomes-per-kwh'
 import { PublicAgentProposalRecoveryRoute } from './agent-rate-limit-recovery'
+import { BusinessAlreadySoldEngagementReceiptsEndpoint } from './business-already-sold-engagement-receipt-routes'
 import {
   AGENT_SEARCH_BASIC_RECOVERY_PRODUCT_ID,
   AGENT_SEARCH_BASIC_RECOVERY_SCOPE_REF,
@@ -2050,6 +2051,9 @@ const schemaComponents = (): JsonSchema => ({
   ),
   PublicBusinessFunnelDashboardResponse: objectSummary(
     'Public-safe business funnel dashboard projection: schemaVersion, generatedAt, live_at_read staleness contract, stage order, total event count, per-stage counts, and coarse source-kind breakdowns for content/outbound/AI-search/referral/direct/unknown. Aggregate counts only; excludes contact details, user ids, payment payloads, raw provider payloads, and client-identifying material. Read-only dashboard; grants no payment, workspace, fulfillment, retention, payout, settlement, or public-claim authority.',
+  ),
+  BusinessAlreadySoldEngagementReceiptResponse: objectSummary(
+    'Public-safe already-sold business engagement payment receipt projection. Lists opaque buyer refs, vertical descriptors, paid receipt totals, privacy-review decision refs, generatedAt, and live_at_read staleness. It exposes no customer identity, raw payment processor material, invoices, or private payment refs, and grants no delivery completion, payout, settlement, self-serve, or green-claim authority.',
   ),
   MarketingAgencyReceiptResponse: objectSummary(
     'Public-safe marketing-agency white-label receipt or paid-delivery-claims projection. Carries assessedAt/generatedAt timestamps plus a live_at_read staleness contract for claim projections where available. Fixture and stored receipts expose bounded delivery refs only and grant no new delivery, attribution, payout, settlement, or green-claim authority.',
@@ -6335,6 +6339,29 @@ const paths = (): JsonSchema => ({
         '200': okJson(
           'Aggregate business funnel dashboard.',
           '#/components/schemas/PublicBusinessFunnelDashboardResponse',
+        ),
+        ...errorResponses(),
+      },
+    }),
+  },
+  [BusinessAlreadySoldEngagementReceiptsEndpoint]: {
+    get: operation({
+      operationId: 'listPublicBusinessAlreadySoldEngagementReceipts',
+      summary: 'List already-sold business payment receipts',
+      description:
+        'Returns public-safe already-sold business engagement payment receipt projections when called with view=paid-business-receipts. Receipt point reads are available under the same route prefix. Opaque buyer refs and vertical descriptors are allowed; customer identity and raw payment material are not exposed. The surface grants no delivery completion, payout, settlement, self-serve, or green-claim authority.',
+      tags: ['Business', 'Public Proof'],
+      security: publicRead,
+      parameters: [
+        queryParam(
+          'view',
+          'Use paid-business-receipts to list recorded opaque paid business receipts.',
+        ),
+      ],
+      responses: {
+        '200': okJson(
+          'Already-sold business engagement receipt projection.',
+          '#/components/schemas/BusinessAlreadySoldEngagementReceiptResponse',
         ),
         ...errorResponses(),
       },

--- a/apps/openagents.com/workers/api/src/product-promises.test.ts
+++ b/apps/openagents.com/workers/api/src/product-promises.test.ts
@@ -377,6 +377,15 @@ describe('public product promises document', () => {
     const codingQuickWin = decoded.promises.find(
       promise => promise.promiseId === 'business.coding_quick_win.v1',
     )
+    const businessQuickWinOffering = decoded.promises.find(
+      promise => promise.promiseId === 'business.intake_quick_win_offering.v1',
+    )
+    expect(businessQuickWinOffering?.evidenceRefs).toContain(
+      'route:/api/public/business/already-sold-engagement-receipts?view=paid-business-receipts',
+    )
+    expect(businessQuickWinOffering?.verification).toContain(
+      'records buyer payment only',
+    )
     expect(codingQuickWin?.blockerRefs).toEqual([
       'blocker.product_promises.business_coding_quick_win_paid_receipt_missing',
     ])

--- a/apps/openagents.com/workers/api/src/product-promises.ts
+++ b/apps/openagents.com/workers/api/src/product-promises.ts
@@ -4258,6 +4258,10 @@ export const publicProductPromisesDocument = () => {
           'apps/openagents.com/workers/api/src/business-signup-routes.test.ts',
           'apps/openagents.com/workers/api/src/business-quick-win-receipt.ts',
           'apps/openagents.com/workers/api/src/business-quick-win-receipt.test.ts',
+          'apps/openagents.com/workers/api/src/business-already-sold-engagement-receipt.ts',
+          'apps/openagents.com/workers/api/src/business-already-sold-engagement-receipt.test.ts',
+          'apps/openagents.com/workers/api/src/business-already-sold-engagement-receipt-routes.ts',
+          'apps/openagents.com/workers/api/src/business-already-sold-engagement-receipt-routes.test.ts',
           'apps/openagents.com/workers/api/src/business-intake-chat-routes.ts',
           'apps/openagents.com/workers/api/src/business-intake-chat-routes.test.ts',
           'apps/openagents.com/apps/web/src/page/business-intake-chat-controller.ts',
@@ -4265,6 +4269,7 @@ export const publicProductPromisesDocument = () => {
           'docs/launch/vertex-fleet/business.intake_quick_win_offering.v1.md',
           'apps/openagents.com/apps/web/src/page/business.ts',
           'apps/openagents.com/apps/web/src/business-route.test.ts',
+          'route:/api/public/business/already-sold-engagement-receipts?view=paid-business-receipts',
           'https://openagents.com/business',
           'https://openagents.com/api/public/product-promises',
           'promise:repo.open_source_code_map.v1',
@@ -4275,7 +4280,7 @@ export const publicProductPromisesDocument = () => {
           'blocker.product_promises.business_first_paid_quick_win_receipt_missing',
         ],
         verification:
-          'Yellow is limited to what is shipped: the offering menu document is grounded in the live registry (each offering maps to a backing promiseId in docs/business/2026-06-20-business-offering-promise-coverage.md), the /business intake route accepts and records a real signup (business-signup-routes.ts, business-signup-routes.test.ts), and the /business page publishes package price bands with fixed-scope receipt plans. True today: a customer/agent can read the menu and rate card, run the interview, and submit an intake. Green requires a self-serve quick-win delivery loop and at least one dereferenceable first paid business quick-win receipt (intake -> delivery -> accepted outcome -> receipt), with a receipt-first upgrade per proof.claim_upgrade_receipts.v1.',
+          'Yellow is limited to what is shipped: the offering menu document is grounded in the live registry (each offering maps to a backing promiseId in docs/business/2026-06-20-business-offering-promise-coverage.md), the /business intake route accepts and records a real signup (business-signup-routes.ts, business-signup-routes.test.ts), and the /business page publishes package price bands with fixed-scope receipt plans. True today: a customer/agent can read the menu and rate card, run the interview, submit an intake, and read the public-safe already-sold engagement receipt projection for opaque paid business receipts. That BF-2.5/AW-0 A0.1 projection records buyer payment only; it does not prove delivery completion, accepted outcome, self-serve operation, payout, settlement, or customer identity. Green still requires a self-serve quick-win delivery loop and at least one dereferenceable first paid business quick-win receipt (intake -> delivery -> accepted outcome -> receipt), with a receipt-first upgrade per proof.claim_upgrade_receipts.v1.',
         authorityBoundary:
           'The business intake is an offering menu plus a signup capture. It grants no automatic delivery, spend, payout, or settlement authority, makes no separate offering green, and never promises beyond the state of each backing promise record it points at.',
       },

--- a/apps/openagents.com/workers/api/src/site-mdk-demo-product.ts
+++ b/apps/openagents.com/workers/api/src/site-mdk-demo-product.ts
@@ -74,6 +74,7 @@ export const omegaMdkDemoSitePaymentCatalogFromMapping = (
         price: mapping.price,
         productId: OMEGA_MDK_DEMO_PRODUCT_ID,
         publicProjectionState: 'listed',
+        recurringBilling: null,
         sandbox: mapping.sandbox,
         settlementMode: 'checkout_only',
         siteId: OMEGA_MDK_DEMO_SITE_ID,

--- a/apps/openagents.com/workers/api/src/worker-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/worker-routes.test.ts
@@ -399,6 +399,7 @@ describe('Worker route dual-serve resolution (#6148)', () => {
       routeEcommerceCampaignReceiptOperatorRequest: noRoute,
       routeEcommerceCampaignSelfServeRequest: noRoute,
       routeCodingQuickWinReceiptRequest: noRoute,
+      routeBusinessAlreadySoldEngagementReceiptRequest: noRoute,
       routeMarketingAgencyReceiptRequest: noRoute,
       routeMarketingAgencySelfServeRequest: noRoute,
       routeVerticalFunnelRequest: noRoute,

--- a/apps/openagents.com/workers/api/src/worker-routes.ts
+++ b/apps/openagents.com/workers/api/src/worker-routes.ts
@@ -90,6 +90,7 @@ type WorkerRouteDependencies = Readonly<{
   routeEcommerceCampaignReceiptOperatorRequest: OptionalEffectRoute
   routeEcommerceCampaignSelfServeRequest: OptionalEffectRoute
   routeCodingQuickWinReceiptRequest: OptionalEffectRoute
+  routeBusinessAlreadySoldEngagementReceiptRequest: OptionalEffectRoute
   routeMarketingAgencyReceiptRequest: OptionalEffectRoute
   routeMarketingAgencySelfServeRequest: OptionalEffectRoute
   routeVerticalFunnelRequest: OptionalEffectRoute
@@ -668,6 +669,17 @@ export const makeWorkerRouteRequest =
 
       if (codingQuickWinReceiptResponse !== undefined) {
         return yield* codingQuickWinReceiptResponse
+      }
+
+      const businessAlreadySoldEngagementReceiptResponse =
+        dependencies.routeBusinessAlreadySoldEngagementReceiptRequest(
+          request,
+          env,
+          ctx,
+        )
+
+      if (businessAlreadySoldEngagementReceiptResponse !== undefined) {
+        return yield* businessAlreadySoldEngagementReceiptResponse
       }
 
       const marketingAgencyReceiptResponse =


### PR DESCRIPTION
Closes #8083

## Summary
- Added a privacy-reviewed already-sold business engagement payment receipt contract with opaque buyer/payment refs and vertical descriptors only.
- Added a public-safe receipt list/read route at `/api/public/business/already-sold-engagement-receipts` and wired it through Worker routing, OpenAPI, projection staleness inventory, and product-promise evidence.
- Added an operator script for issuing additional opaque already-sold engagement receipts without client-identifying data.

## Verification
- `bun test apps/openagents.com/workers/api/src/business-already-sold-engagement-receipt.test.ts apps/openagents.com/workers/api/src/business-already-sold-engagement-receipt-routes.test.ts apps/openagents.com/workers/api/src/product-promises.test.ts` — passed (24 tests)
- `bun run --cwd apps/openagents.com/workers/api test -- src/openagents-openapi-routes.test.ts src/worker-exact-routes.test.ts` — passed (2 files, 6 tests)
- `bun run --cwd apps/openagents.com/workers/api typecheck` — passed
- `bun run --cwd apps/openagents.com check:architecture` — passed
- `bun run check:deploy` — passed