### PR TITLE
Close /business signup fulfillment loop

### DIFF
--- a/apps/openagents.com/workers/api/migrations/0271_business_signup_fulfillment.sql
+++ b/apps/openagents.com/workers/api/migrations/0271_business_signup_fulfillment.sql
@@ -1,0 +1,57 @@
+-- Business signup fulfillment ledger (BF-1.1 / issue #8074).
+--
+-- A /business signup must not silently stop at the intake row. This migration
+-- adds a small state projection on the signup row plus a receipt table for the
+-- follow-up chain: enrichment hook, private project/workspace seed, invite, and
+-- email ledger send. Parked is explicit and operator-visible.
+
+ALTER TABLE business_signup_requests
+  ADD COLUMN fulfillment_status TEXT NOT NULL DEFAULT 'pending'
+    CHECK (fulfillment_status IN ('pending', 'invited', 'operator_parked'));
+
+ALTER TABLE business_signup_requests
+  ADD COLUMN fulfillment_ref TEXT;
+
+ALTER TABLE business_signup_requests
+  ADD COLUMN fulfillment_reason TEXT;
+
+CREATE INDEX IF NOT EXISTS business_signup_requests_fulfillment_status_idx
+  ON business_signup_requests(fulfillment_status, updated_at DESC);
+
+CREATE TABLE IF NOT EXISTS business_signup_fulfillments (
+  id TEXT PRIMARY KEY NOT NULL,
+  business_signup_request_id TEXT NOT NULL UNIQUE
+    REFERENCES business_signup_requests(id) ON DELETE CASCADE,
+  status TEXT NOT NULL CHECK (status IN ('invited', 'operator_parked')),
+  reason TEXT,
+  enrichment_ref TEXT NOT NULL,
+  team_id TEXT,
+  project_id TEXT,
+  workspace_id TEXT,
+  invite_id TEXT,
+  email_message_id TEXT,
+  email_delivery_status TEXT NOT NULL CHECK (
+    email_delivery_status IN (
+      'accepted',
+      'disabled',
+      'failed',
+      'missing_config',
+      'not_attempted'
+    )
+  ),
+  metadata_json TEXT NOT NULL DEFAULT '{}',
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  FOREIGN KEY (team_id) REFERENCES teams(id) ON DELETE SET NULL,
+  FOREIGN KEY (project_id) REFERENCES team_projects(id) ON DELETE SET NULL,
+  FOREIGN KEY (workspace_id) REFERENCES prefilled_workspaces(id) ON DELETE SET NULL,
+  FOREIGN KEY (invite_id) REFERENCES team_workspace_invites(id) ON DELETE SET NULL,
+  FOREIGN KEY (email_message_id) REFERENCES email_messages(id) ON DELETE SET NULL
+);
+
+CREATE INDEX IF NOT EXISTS business_signup_fulfillments_status_idx
+  ON business_signup_fulfillments(status, updated_at DESC);
+
+CREATE INDEX IF NOT EXISTS business_signup_fulfillments_workspace_idx
+  ON business_signup_fulfillments(workspace_id)
+  WHERE workspace_id IS NOT NULL;

--- a/apps/openagents.com/workers/api/src/business-funnel-dashboard-routes.ts
+++ b/apps/openagents.com/workers/api/src/business-funnel-dashboard-routes.ts
@@ -1,4 +1,4 @@
-import { Effect } from 'effect'
+import { Effect, Schema as S } from 'effect'
 
 import {
   handleBusinessFunnelDashboardApi,
@@ -6,6 +6,13 @@ import {
   systemBusinessFunnelRuntime,
 } from './business-funnel-dashboard'
 import { methodNotAllowed, noStoreJsonResponse } from './http/responses'
+
+class BusinessFunnelDashboardReadFailure extends S.TaggedErrorClass<BusinessFunnelDashboardReadFailure>()(
+  'BusinessFunnelDashboardReadFailure',
+  {
+    cause: S.Unknown,
+  },
+) {}
 
 // Payload staleness is declared in business-funnel-dashboard.ts via the shared
 // public-projection-staleness contract.
@@ -20,7 +27,7 @@ export const handlePublicBusinessFunnelDashboardApi = (
 
   return Effect.tryPromise({
     try: () => handleBusinessFunnelDashboardApi(db, runtime),
-    catch: () => new Error('business_funnel_dashboard_read_failed'),
+    catch: cause => new BusinessFunnelDashboardReadFailure({ cause }),
   }).pipe(
     Effect.map(payload => noStoreJsonResponse(payload)),
     Effect.catch(() =>

--- a/apps/openagents.com/workers/api/src/business-signup-fulfillment.ts
+++ b/apps/openagents.com/workers/api/src/business-signup-fulfillment.ts
@@ -1,0 +1,576 @@
+import { Effect, Schema as S } from 'effect'
+
+import type { ResendEmailConfig } from './config'
+import { PrivateWorkspaceInviteEmailInput } from './email'
+import type { EmailLedgerSendResult, EmailServiceError } from './email'
+import { makeD1PrivateProjectWorkspaceStore } from './private-project-workspace-routes'
+import {
+  makeEcommerceDesignPartnerWorkspaceInput,
+  makeLegalDesignPartnerWorkspaceInput,
+  makeMarketingAgencyDesignPartnerWorkspaceInput,
+} from './prefilled-workspace-vertical-templates'
+import {
+  type BusinessSignupRecord,
+  type BusinessSignupRuntime,
+} from './business-signup-routes'
+import type {
+  CreatePrefilledWorkspaceInput,
+  PrefilledWorkspaceRecord,
+  PrefilledWorkspaceServiceShape,
+  SeededMemoryEntry,
+  StarterWorkflow,
+} from './prefilled-workspace'
+import { makePrefilledWorkspaceService } from './prefilled-workspace'
+import {
+  type TeamWorkspaceInviteCreateResult,
+  type TeamWorkspaceInviteStore,
+  makeD1TeamWorkspaceInviteStore,
+} from './team-workspace-invites'
+
+export type BusinessSignupFulfillmentStatus =
+  | 'invited'
+  | 'operator_parked'
+
+type EmailDeliveryStatus =
+  | 'accepted'
+  | 'disabled'
+  | 'failed'
+  | 'missing_config'
+  | 'not_attempted'
+
+export type BusinessSignupFulfillmentRecord = Readonly<{
+  emailDeliveryStatus: EmailDeliveryStatus
+  emailMessageId: string | null
+  enrichmentRef: string
+  id: string
+  inviteId: string | null
+  projectId: string | null
+  reason: string | null
+  signupId: string
+  status: BusinessSignupFulfillmentStatus
+  teamId: string | null
+  updatedAt: string
+  workspaceId: string | null
+}>
+
+type BusinessSignupFulfillmentDependencies = Readonly<{
+  appOrigin: string
+  getResendEmailConfig?: () => ResendEmailConfig | undefined
+  inviteStore: TeamWorkspaceInviteStore
+  privateProjectStore: ReturnType<typeof makeD1PrivateProjectWorkspaceStore>
+  runtime: BusinessSignupRuntime
+  sendInviteEmailWithLedger?: (
+    config: ResendEmailConfig,
+    input: PrivateWorkspaceInviteEmailInput,
+  ) => Effect.Effect<EmailLedgerSendResult, EmailServiceError>
+  workspaceStore: PrefilledWorkspaceServiceShape
+}>
+
+export type BusinessSignupFulfillmentOptions = Readonly<{
+  appOrigin?: string | undefined
+  getResendEmailConfig?: (() => ResendEmailConfig | undefined) | undefined
+  inviteStore?: TeamWorkspaceInviteStore | undefined
+  privateProjectStore?: ReturnType<typeof makeD1PrivateProjectWorkspaceStore>
+  sendInviteEmailWithLedger?:
+    | ((
+        config: ResendEmailConfig,
+        input: PrivateWorkspaceInviteEmailInput,
+      ) => Effect.Effect<EmailLedgerSendResult, EmailServiceError>)
+    | undefined
+  workspaceStore?: PrefilledWorkspaceServiceShape | undefined
+}>
+
+type FulfillmentRow = Readonly<{
+  email_delivery_status: EmailDeliveryStatus
+  email_message_id: string | null
+  enrichment_ref: string
+  id: string
+  invite_id: string | null
+  project_id: string | null
+  reason: string | null
+  status: BusinessSignupFulfillmentStatus
+  team_id: string | null
+  updated_at: string
+  workspace_id: string | null
+}>
+
+class BusinessSignupFulfillmentFailure extends S.TaggedErrorClass<BusinessSignupFulfillmentFailure>()(
+  'BusinessSignupFulfillmentFailure',
+  {
+    cause: S.Unknown,
+  },
+) {}
+
+const promiseEffect = <A>(
+  tryPromise: () => Promise<A>,
+): Effect.Effect<A, BusinessSignupFulfillmentFailure> =>
+  Effect.tryPromise({
+    catch: cause => new BusinessSignupFulfillmentFailure({ cause }),
+    try: tryPromise,
+  })
+
+const compactText = (value: string, maxLength: number): string =>
+  value.trim().replace(/\s+/g, ' ').slice(0, maxLength)
+
+const slugFromText = (value: string): string => {
+  const slug = compactText(value, 80)
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 70)
+
+  return slug === '' ? 'business-signup' : slug
+}
+
+const fulfillmentRef = (signupId: string): string =>
+  `business_signup_fulfillment:${signupId}`
+
+const enrichmentRef = (signupId: string): string =>
+  `business_signup_enrichment:${signupId}:v1`
+
+const sourceRef = (signupId: string): string =>
+  `business_signup_request:${signupId}`
+
+const readFulfillment = async (
+  db: D1Database,
+  signupId: string,
+): Promise<BusinessSignupFulfillmentRecord | undefined> => {
+  const row = await db
+    .prepare(
+      `SELECT id, business_signup_request_id, status, reason, enrichment_ref,
+              team_id, project_id, workspace_id, invite_id, email_message_id,
+              email_delivery_status, updated_at
+         FROM business_signup_fulfillments
+        WHERE business_signup_request_id = ?
+        LIMIT 1`,
+    )
+    .bind(signupId)
+    .first<FulfillmentRow & Readonly<{ business_signup_request_id: string }>>()
+
+  return row === null
+    ? undefined
+    : {
+        emailDeliveryStatus: row.email_delivery_status,
+        emailMessageId: row.email_message_id,
+        enrichmentRef: row.enrichment_ref,
+        id: row.id,
+        inviteId: row.invite_id,
+        projectId: row.project_id,
+        reason: row.reason,
+        signupId: row.business_signup_request_id,
+        status: row.status,
+        teamId: row.team_id,
+        updatedAt: row.updated_at,
+        workspaceId: row.workspace_id,
+      }
+}
+
+const writeFulfillment = async (
+  db: D1Database,
+  input: BusinessSignupFulfillmentRecord,
+  metadata: Readonly<Record<string, unknown>>,
+): Promise<BusinessSignupFulfillmentRecord> => {
+  await db
+    .prepare(
+      `INSERT INTO business_signup_fulfillments
+        (id, business_signup_request_id, status, reason, enrichment_ref,
+         team_id, project_id, workspace_id, invite_id, email_message_id,
+         email_delivery_status, metadata_json, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+       ON CONFLICT(business_signup_request_id) DO UPDATE SET
+         status = excluded.status,
+         reason = excluded.reason,
+         enrichment_ref = excluded.enrichment_ref,
+         team_id = excluded.team_id,
+         project_id = excluded.project_id,
+         workspace_id = excluded.workspace_id,
+         invite_id = excluded.invite_id,
+         email_message_id = excluded.email_message_id,
+         email_delivery_status = excluded.email_delivery_status,
+         metadata_json = excluded.metadata_json,
+         updated_at = excluded.updated_at`,
+    )
+    .bind(
+      input.id,
+      input.signupId,
+      input.status,
+      input.reason,
+      input.enrichmentRef,
+      input.teamId,
+      input.projectId,
+      input.workspaceId,
+      input.inviteId,
+      input.emailMessageId,
+      input.emailDeliveryStatus,
+      JSON.stringify(metadata),
+      input.updatedAt,
+      input.updatedAt,
+    )
+    .run()
+
+  await db
+    .prepare(
+      `UPDATE business_signup_requests
+          SET fulfillment_status = ?,
+              fulfillment_ref = ?,
+              fulfillment_reason = ?,
+              updated_at = ?
+        WHERE id = ?`,
+    )
+    .bind(input.status, input.id, input.reason, input.updatedAt, input.signupId)
+    .run()
+
+  return input
+}
+
+const fulfillmentDependencies = (
+  db: D1Database,
+  runtime: BusinessSignupRuntime,
+  options: BusinessSignupFulfillmentOptions,
+): BusinessSignupFulfillmentDependencies => {
+  const dependencies: BusinessSignupFulfillmentDependencies = {
+    appOrigin: options.appOrigin ?? 'https://openagents.com',
+    inviteStore: options.inviteStore ?? makeD1TeamWorkspaceInviteStore(db),
+    privateProjectStore:
+      options.privateProjectStore ?? makeD1PrivateProjectWorkspaceStore(db),
+    runtime,
+    workspaceStore: options.workspaceStore ?? makePrefilledWorkspaceService(db),
+  }
+
+  return {
+    ...dependencies,
+    ...(options.getResendEmailConfig === undefined
+      ? {}
+      : { getResendEmailConfig: options.getResendEmailConfig }),
+    ...(options.sendInviteEmailWithLedger === undefined
+      ? {}
+      : { sendInviteEmailWithLedger: options.sendInviteEmailWithLedger }),
+  }
+}
+
+const verticalTemplateForSignup = (
+  signup: BusinessSignupRecord,
+): CreatePrefilledWorkspaceInput => {
+  const text =
+    `${signup.businessName} ${signup.website ?? ''} ${signup.helpWith ?? ''}`.toLowerCase()
+
+  if (/legal|law|attorney|contract|nda|intake/.test(text)) {
+    return makeLegalDesignPartnerWorkspaceInput()
+  }
+
+  if (/agency|marketing|landing|email|white.?label|funnel/.test(text)) {
+    return makeMarketingAgencyDesignPartnerWorkspaceInput()
+  }
+
+  return makeEcommerceDesignPartnerWorkspaceInput()
+}
+
+const appendSignupMemory = (
+  template: CreatePrefilledWorkspaceInput,
+  signup: BusinessSignupRecord,
+): ReadonlyArray<SeededMemoryEntry> => [
+  ...(template.seededMemory ?? []),
+  {
+    label: 'Intake source',
+    publicSourceRef: sourceRef(signup.id),
+    value:
+      'Created from a /business signup. Contact details stay in the private invite ledger; workspace seed material stays public-safe until the customer signs in.',
+  },
+  {
+    label: 'Requested help',
+    publicSourceRef: sourceRef(signup.id),
+    value: compactText(signup.helpWith ?? 'General business automation intake.', 600),
+  },
+]
+
+const appendSignupWorkflows = (
+  template: CreatePrefilledWorkspaceInput,
+): ReadonlyArray<StarterWorkflow> => [
+  ...(template.starterWorkflows ?? []).slice(0, 2),
+  {
+    description:
+      'Confirm the requested outcome, missing access, approval gates, and first receipt plan before any external send, publish, or spend.',
+    outcomeKind: 'business_intake_scope_confirmation',
+    status: 'queued',
+    title: 'Confirm first scope',
+  },
+]
+
+const workspaceInputForSignup = (
+  signup: BusinessSignupRecord,
+  teamId: string,
+  projectId: string,
+): CreatePrefilledWorkspaceInput => {
+  const template = verticalTemplateForSignup(signup)
+
+  return {
+    ...template,
+    accessMode: 'private_team',
+    holderRef: `business_signup.${signup.id}`,
+    introReceipt: {
+      publicSourceRefs: [
+        ...(template.introReceipt.publicSourceRefs ?? []),
+        sourceRef(signup.id),
+      ],
+      summary:
+        'Provisioned from the /business intake path with public-safe template seed material, an explicit scope-confirmation starter, and no external authority until review receipts exist.',
+    },
+    privateProjectId: projectId,
+    privateTeamId: teamId,
+    projectName: `${compactText(signup.businessName, 80)} Workspace`,
+    seededMemory: appendSignupMemory(template, signup),
+    starterWorkflows: appendSignupWorkflows(template),
+    status: 'invited',
+  }
+}
+
+const acceptUrl = (appOrigin: string, token: string): string =>
+  `${appOrigin}/api/team-workspace-invites/accept?token=${encodeURIComponent(token)}`
+
+const inviteEmailInput = (
+  signup: BusinessSignupRecord,
+  invite: Extract<
+    TeamWorkspaceInviteCreateResult,
+    { _tag: 'Created' | 'Refreshed' }
+  >['invite'],
+  token: string,
+  appOrigin: string,
+): PrivateWorkspaceInviteEmailInput =>
+  new PrivateWorkspaceInviteEmailInput({
+    acceptUrl: acceptUrl(appOrigin, token),
+    displayName: 'there',
+    expiresAt: invite.expiresAt,
+    idempotencyKey: `business_signup_invite:${signup.id}:${invite.sendCount + 1}`,
+    inviteId: invite.id,
+    projectId: invite.projectId,
+    teamId: invite.teamId,
+    to: invite.inviteeEmail,
+    workspaceLabel: `${compactText(signup.businessName, 80)} OpenAgents workspace`,
+  })
+
+const parked = (
+  db: D1Database,
+  dependencies: BusinessSignupFulfillmentDependencies,
+  signup: BusinessSignupRecord,
+  reason: string,
+  partial: Partial<BusinessSignupFulfillmentRecord> = {},
+): Promise<BusinessSignupFulfillmentRecord> => {
+  const now = dependencies.runtime.nowIso()
+
+  return writeFulfillment(
+    db,
+    {
+      emailDeliveryStatus: partial.emailDeliveryStatus ?? 'not_attempted',
+      emailMessageId: partial.emailMessageId ?? null,
+      enrichmentRef: enrichmentRef(signup.id),
+      id: fulfillmentRef(signup.id),
+      inviteId: partial.inviteId ?? null,
+      projectId: partial.projectId ?? null,
+      reason,
+      signupId: signup.id,
+      status: 'operator_parked',
+      teamId: partial.teamId ?? null,
+      updatedAt: now,
+      workspaceId: partial.workspaceId ?? null,
+    },
+    { reason, sourceIssue: 8074 },
+  )
+}
+
+const sendInvite = (
+  dependencies: BusinessSignupFulfillmentDependencies,
+  signup: BusinessSignupRecord,
+  invite: Extract<
+    TeamWorkspaceInviteCreateResult,
+    { _tag: 'Created' | 'Refreshed' }
+  >['invite'],
+  token: string,
+): Effect.Effect<
+  Readonly<{
+    emailDeliveryStatus: EmailDeliveryStatus
+    emailMessageId: string | null
+    reason: string | null
+  }>
+> => {
+  const config = dependencies.getResendEmailConfig?.()
+
+  if (
+    config === undefined ||
+    dependencies.sendInviteEmailWithLedger === undefined
+  ) {
+    return Effect.succeed({
+      emailDeliveryStatus: 'missing_config',
+      emailMessageId: null,
+      reason: 'business_signup_invite_email_config_missing',
+    })
+  }
+
+  return dependencies
+    .sendInviteEmailWithLedger(
+      config,
+      inviteEmailInput(signup, invite, token, dependencies.appOrigin),
+    )
+    .pipe(
+      Effect.flatMap(result =>
+        Effect.gen(function* () {
+          if (result.emailMessageId !== null) {
+            yield* Effect.tryPromise({
+              catch: () => undefined,
+              try: () =>
+                dependencies.inviteStore.recordEmailAttempt({
+                  attemptedAt: dependencies.runtime.nowIso(),
+                  emailMessageId: result.emailMessageId,
+                  inviteId: invite.id,
+                }),
+            }).pipe(Effect.catch(() => Effect.void))
+          }
+
+          return result.ok
+            ? {
+                emailDeliveryStatus: 'accepted' as const,
+                emailMessageId: result.emailMessageId,
+                reason: null,
+              }
+            : {
+                emailDeliveryStatus: 'failed' as const,
+                emailMessageId: result.emailMessageId,
+                reason: result.errorName ?? 'business_signup_invite_email_failed',
+              }
+        }),
+      ),
+      Effect.catch(() =>
+        Effect.succeed({
+          emailDeliveryStatus: 'failed' as const,
+          emailMessageId: null,
+          reason: 'business_signup_invite_email_failed',
+        }),
+      ),
+    )
+}
+
+export const fulfillBusinessSignup = (
+  db: D1Database,
+  signup: BusinessSignupRecord,
+  runtime: BusinessSignupRuntime,
+  options: BusinessSignupFulfillmentOptions = {},
+): Effect.Effect<BusinessSignupFulfillmentRecord> => {
+  const dependencies = fulfillmentDependencies(db, runtime, options)
+  const parkForException = () =>
+    Effect.promise(() =>
+      parked(
+        db,
+        dependencies,
+        signup,
+        'business_signup_fulfillment_exception',
+      ),
+    )
+
+  return Effect.gen(function* () {
+    const existing = yield* promiseEffect(() => readFulfillment(db, signup.id))
+
+    if (existing !== undefined) {
+      return existing
+    }
+
+    const slugSuffix = `${slugFromText(signup.businessName)}-${signup.id
+      .replace(/[^A-Za-z0-9]+/g, '-')
+      .toLowerCase()
+      .slice(-16)}`
+    const privateProject = yield* promiseEffect(() =>
+      dependencies.privateProjectStore.createOrUpdateProject({
+        description: 'Business signup private workspace.',
+        projectName: `${compactText(signup.businessName, 100)} Intake`,
+        projectSlug: slugSuffix,
+        teamName: `${compactText(signup.businessName, 100)} Team`,
+        teamSlug: `${slugSuffix}-team`,
+      }),
+    )
+    const existingWorkspace = yield* promiseEffect(() =>
+      dependencies.workspaceStore.readPrivateWorkspaceByTarget(
+        privateProject.team.id,
+        privateProject.project.id,
+      ),
+    )
+    const workspace: PrefilledWorkspaceRecord =
+      existingWorkspace ??
+      (yield* promiseEffect(() =>
+        dependencies.workspaceStore.createWorkspace(
+          workspaceInputForSignup(
+            signup,
+            privateProject.team.id,
+            privateProject.project.id,
+          ),
+        ),
+      ))
+    const inviteResult = yield* promiseEffect(() =>
+      dependencies.inviteStore.createOrRefreshInvite({
+        email: signup.contactEmail,
+        invitedByActorRef: 'system:business_signup_fulfillment',
+        metadataJson: JSON.stringify({
+          businessSignupRequestId: signup.id,
+          source: 'business_signup_fulfillment',
+          sourceIssue: 8074,
+          workspaceId: workspace.id,
+        }),
+        projectId: privateProject.project.id,
+        role: 'member',
+        teamId: privateProject.team.id,
+      }),
+    )
+
+    if (inviteResult._tag !== 'Created' && inviteResult._tag !== 'Refreshed') {
+      return yield* promiseEffect(() =>
+        parked(
+          db,
+          dependencies,
+          signup,
+          `business_signup_invite_${inviteResult._tag.toLowerCase()}`,
+          {
+            projectId: privateProject.project.id,
+            teamId: privateProject.team.id,
+            workspaceId: workspace.id,
+          },
+        ),
+      )
+    }
+
+    const delivery = yield* sendInvite(
+      dependencies,
+      signup,
+      inviteResult.invite,
+      inviteResult.token,
+    )
+    const status =
+      delivery.emailDeliveryStatus === 'accepted'
+        ? 'invited'
+        : 'operator_parked'
+    const reason =
+      status === 'invited'
+        ? null
+        : (delivery.reason ?? 'business_signup_invite_not_sent')
+
+    return yield* promiseEffect(() =>
+      writeFulfillment(
+        db,
+        {
+          emailDeliveryStatus: delivery.emailDeliveryStatus,
+          emailMessageId: delivery.emailMessageId,
+          enrichmentRef: enrichmentRef(signup.id),
+          id: fulfillmentRef(signup.id),
+          inviteId: inviteResult.invite.id,
+          projectId: privateProject.project.id,
+          reason,
+          signupId: signup.id,
+          status,
+          teamId: privateProject.team.id,
+          updatedAt: dependencies.runtime.nowIso(),
+          workspaceId: workspace.id,
+        },
+        {
+          sourceIssue: 8074,
+          workspaceStatus: workspace.status,
+        },
+      ),
+    )
+  }).pipe(Effect.catch(() => parkForException()))
+}

--- a/apps/openagents.com/workers/api/src/business-signup-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/business-signup-routes.test.ts
@@ -1,9 +1,10 @@
-import { Effect } from 'effect'
+import { Effect, Redacted } from 'effect'
 import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { DatabaseSync } from 'node:sqlite'
 import { beforeEach, describe, expect, test } from 'vitest'
 
+import { ResendEmailSender, WorkerSecret } from './config'
 import {
   type BusinessSignupRuntime,
   handleBusinessSignupApi,
@@ -30,6 +31,13 @@ class SqliteD1Statement {
     return (row ?? null) as T | null
   }
 
+  async all<T = Row>(): Promise<{ results: Array<T> }> {
+    const results = this.db
+      .prepare(this.sql)
+      .all(...(this.bound as never[])) as Array<T>
+    return { results }
+  }
+
   async run(): Promise<{ success: true }> {
     this.db.prepare(this.sql).run(...(this.bound as never[]))
     return { success: true }
@@ -41,6 +49,12 @@ class SqliteD1 {
 
   prepare(sql: string): SqliteD1Statement {
     return new SqliteD1Statement(this.db, sql)
+  }
+
+  async batch(
+    statements: ReadonlyArray<SqliteD1Statement>,
+  ): Promise<ReadonlyArray<{ success: true }>> {
+    return Promise.all(statements.map(statement => statement.run()))
   }
 }
 
@@ -55,10 +69,80 @@ const SCHEMA = [
   '0191_business_signup_requests.sql',
   '0216_business_signup_referral_attribution.sql',
   '0270_business_funnel_events.sql',
+  '0190_prefilled_workspaces.sql',
+  '0192_prefilled_workspace_invite_engagement.sql',
+  '0195_private_prefilled_workspace_access.sql',
+  '0194_team_workspace_invites.sql',
+  '0271_business_signup_fulfillment.sql',
 ].map(migration)
+
+const SUPPORT_SCHEMA = `
+CREATE TABLE users (
+  id TEXT PRIMARY KEY,
+  email TEXT,
+  name TEXT,
+  kind TEXT NOT NULL DEFAULT 'human',
+  status TEXT NOT NULL DEFAULT 'active',
+  created_at TEXT,
+  updated_at TEXT,
+  deleted_at TEXT
+);
+
+CREATE TABLE teams (
+  id TEXT PRIMARY KEY,
+  name TEXT NOT NULL,
+  slug TEXT UNIQUE,
+  kind TEXT NOT NULL DEFAULT 'organization',
+  plan TEXT,
+  logo_url TEXT,
+  credits INTEGER,
+  owner_user_id TEXT,
+  status TEXT NOT NULL,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  archived_at TEXT
+);
+
+CREATE TABLE team_projects (
+  id TEXT PRIMARY KEY,
+  team_id TEXT NOT NULL,
+  slug TEXT NOT NULL,
+  name TEXT NOT NULL,
+  description TEXT NOT NULL DEFAULT '',
+  status TEXT NOT NULL DEFAULT 'active',
+  metadata_json TEXT NOT NULL DEFAULT '{}',
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  archived_at TEXT,
+  UNIQUE (team_id, slug)
+);
+
+CREATE TABLE email_messages (
+  id TEXT PRIMARY KEY,
+  idempotency_key TEXT NOT NULL UNIQUE,
+  kind TEXT NOT NULL,
+  status TEXT NOT NULL,
+  provider TEXT,
+  provider_message_id TEXT,
+  subject TEXT,
+  to_email TEXT,
+  from_email TEXT,
+  reply_to_email TEXT,
+  template_slug TEXT,
+  template_context_json TEXT,
+  metadata_json TEXT,
+  rendered_html TEXT,
+  rendered_text TEXT,
+  error_name TEXT,
+  error_message TEXT,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+);
+`
 
 const makeDb = (): D1Database => {
   const db = new DatabaseSync(':memory:')
+  db.exec(SUPPORT_SCHEMA)
   for (const sql of SCHEMA) {
     db.exec(sql)
   }
@@ -81,6 +165,149 @@ beforeEach(() => {
 })
 
 describe('business signup routes', () => {
+  test('creates workspace, invite, fulfillment receipt, and accepted email evidence', async () => {
+    const db = makeDb()
+    const response = await Effect.runPromise(
+      handleBusinessSignupApi(
+        new Request('https://openagents.com/api/public/business-signup', {
+          method: 'POST',
+          headers: {
+            accept: 'application/json',
+            'content-type': 'application/json',
+          },
+          body: JSON.stringify({
+            businessName: 'Acme Agency',
+            contactEmail: 'lead@example.com',
+            helpWith: 'Need a landing page and email launch workflow.',
+            phone: '+1 555 000 0000',
+          }),
+        }),
+        db,
+        runtime,
+        {
+          getResendEmailConfig: () => ({
+            apiKey: Redacted.make(WorkerSecret.make('resend_test_key')),
+            fromEmail: ResendEmailSender.make(
+              'OpenAgents <hello@example.com>',
+            ),
+          }),
+          sendInviteEmailWithLedger: (_config, input) =>
+            Effect.tryPromise({
+              try: async () => {
+                const emailMessageId = `email_msg_${input.inviteId}`
+                await db
+                  .prepare(
+                    `INSERT INTO email_messages
+                      (id, idempotency_key, kind, status, created_at,
+                       updated_at)
+                     VALUES (?, ?, 'operator_notification', 'accepted', ?, ?)`,
+                  )
+                  .bind(
+                    emailMessageId,
+                    input.idempotencyKey,
+                    runtime.nowIso(),
+                    runtime.nowIso(),
+                  )
+                  .run()
+
+                return {
+                  emailMessageId,
+                  ok: true as const,
+                  providerMessageId: 'resend_message_1',
+                }
+              },
+              catch: error => error as never,
+            }),
+        },
+      ),
+    )
+    const body = await response.json<{
+      request: Readonly<{
+        fulfillmentRef: string
+        fulfillmentStatus: string
+        nextAction: string
+      }>
+    }>()
+
+    const fulfillment = await db
+      .prepare(
+        `SELECT status, workspace_id, invite_id, email_message_id,
+                email_delivery_status, reason
+           FROM business_signup_fulfillments
+          WHERE business_signup_request_id = ?`,
+      )
+      .bind('business_signup_1')
+      .first<Row>()
+
+    expect(response.status).toBe(201)
+    expect(body.request).toMatchObject({
+      fulfillmentRef: 'business_signup_fulfillment:business_signup_1',
+      fulfillmentStatus: 'invited',
+      nextAction: 'workspace_invite_sent',
+    })
+
+    expect(fulfillment).toMatchObject({
+      email_delivery_status: 'accepted',
+      status: 'invited',
+    })
+    expect(String(fulfillment?.email_message_id)).toContain(
+      'email_msg_team_workspace_invite_',
+    )
+    expect(String(fulfillment?.workspace_id)).toContain('workspace_')
+    expect(String(fulfillment?.invite_id)).toContain('team_workspace_invite_')
+
+    const signup = await readBusinessSignupRequest(db, 'business_signup_1')
+    expect(signup).toMatchObject({
+      fulfillmentRef: 'business_signup_fulfillment:business_signup_1',
+      fulfillmentStatus: 'invited',
+    })
+  })
+
+  test('parks signup explicitly when invite email config is absent', async () => {
+    const db = makeDb()
+    const response = await run(
+      new Request('https://openagents.com/api/public/business-signup', {
+        method: 'POST',
+        headers: {
+          accept: 'application/json',
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({
+          businessName: 'Acme Co.',
+          contactEmail: 'lead@example.com',
+          phone: '+1 555 000 0000',
+        }),
+      }),
+      db,
+    )
+    const body = await response.json<{
+      request: Readonly<{ fulfillmentStatus: string; nextAction: string }>
+    }>()
+
+    expect(response.status).toBe(201)
+    expect(body.request).toMatchObject({
+      fulfillmentStatus: 'operator_parked',
+      nextAction: 'operator_workspace_intake',
+    })
+
+    const fulfillment = await db
+      .prepare(
+        `SELECT status, reason, workspace_id, invite_id, email_delivery_status
+           FROM business_signup_fulfillments
+          WHERE business_signup_request_id = ?`,
+      )
+      .bind('business_signup_1')
+      .first<Row>()
+
+    expect(fulfillment).toMatchObject({
+      email_delivery_status: 'missing_config',
+      reason: 'business_signup_invite_email_config_missing',
+      status: 'operator_parked',
+    })
+    expect(String(fulfillment?.workspace_id)).toContain('workspace_')
+    expect(String(fulfillment?.invite_id)).toContain('team_workspace_invite_')
+  })
+
   test('stores Slack opt-in form posts as manual invite pending', async () => {
     const db = makeDb()
     const body = new URLSearchParams({

--- a/apps/openagents.com/workers/api/src/business-signup-routes.ts
+++ b/apps/openagents.com/workers/api/src/business-signup-routes.ts
@@ -5,6 +5,13 @@ import {
   businessFunnelSourceKindForSignup,
   recordBusinessFunnelEvent,
 } from './business-funnel-dashboard'
+import type { ResendEmailConfig } from './config'
+import type { PrivateWorkspaceInviteEmailInput } from './email'
+import type { EmailLedgerSendResult, EmailServiceError } from './email'
+import {
+  type BusinessSignupFulfillmentOptions,
+  fulfillBusinessSignup,
+} from './business-signup-fulfillment'
 import { methodNotAllowed, noStoreJsonResponse } from './http/responses'
 import {
   isRecord,
@@ -84,6 +91,9 @@ export type BusinessSignupRecord = BusinessSignupInput &
     // active referral source was resolved (consume-once via the spine); null
     // when there was no captured/resolvable attribution.
     referralAttributionId: string | null
+    fulfillmentStatus: 'pending' | 'invited' | 'operator_parked'
+    fulfillmentRef: string | null
+    fulfillmentReason: string | null
     createdAt: string
     updatedAt: string
   }>
@@ -101,9 +111,24 @@ type BusinessSignupRow = Readonly<{
   referral_code: string | null
   referral_attribution_id: string | null
   source_attribution?: string | null
+  fulfillment_status: 'pending' | 'invited' | 'operator_parked'
+  fulfillment_ref: string | null
+  fulfillment_reason: string | null
   created_at: string
   updated_at: string
 }>
+
+export type BusinessSignupApiOptions = BusinessSignupFulfillmentOptions &
+  Readonly<{
+    appOrigin?: string | undefined
+    getResendEmailConfig?: (() => ResendEmailConfig | undefined) | undefined
+    sendInviteEmailWithLedger?:
+      | ((
+          config: ResendEmailConfig,
+          input: PrivateWorkspaceInviteEmailInput,
+        ) => Effect.Effect<EmailLedgerSendResult, EmailServiceError>)
+      | undefined
+  }>
 
 const wantsJsonResponse = (request: Request): boolean => {
   const accept = request.headers.get('accept') ?? ''
@@ -315,6 +340,9 @@ export const makeBusinessSignupRecord = (
       : 'not_requested',
     sourceRoute: input.sourceRoute ?? '/business',
     referralAttributionId: null,
+    fulfillmentStatus: 'pending',
+    fulfillmentRef: null,
+    fulfillmentReason: null,
     createdAt: now,
     updatedAt: now,
   }
@@ -333,6 +361,9 @@ const rowToRecord = (row: BusinessSignupRow): BusinessSignupRecord => ({
   referralCode: row.referral_code,
   referralAttributionId: row.referral_attribution_id,
   sourceAttribution: row.source_attribution ?? null,
+  fulfillmentStatus: row.fulfillment_status,
+  fulfillmentRef: row.fulfillment_ref,
+  fulfillmentReason: row.fulfillment_reason,
   createdAt: row.created_at,
   updatedAt: row.updated_at,
 })
@@ -438,6 +469,9 @@ export const readBusinessSignupRequest = async (
         source_route,
         referral_code,
         referral_attribution_id,
+        fulfillment_status,
+        fulfillment_ref,
+        fulfillment_reason,
         created_at,
         updated_at
       FROM business_signup_requests
@@ -526,18 +560,26 @@ const publicResponseBody = (record: BusinessSignupRecord) => ({
     // Public-safe: a boolean only; never echoes the referral code or the
     // internal attribution id.
     referralAttributed: record.referralAttributionId !== null,
+    fulfillmentStatus: record.fulfillmentStatus,
+    fulfillmentRef: record.fulfillmentRef,
     nextAction: record.requestSlackChannel
       ? 'operator_manual_slack_connect_invite'
-      : 'operator_workspace_intake',
+      : record.fulfillmentStatus === 'invited'
+        ? 'workspace_invite_sent'
+        : 'operator_workspace_intake',
     authorityBoundary:
       'Intake receipt only; grants no Slack, workspace, spend, payout, or agent authority.',
   },
 })
 
 const successHtml = (record: BusinessSignupRecord): string => {
+  const workspaceCopy =
+    record.fulfillmentStatus === 'invited'
+      ? 'We sent the workspace invite and queued the first scope confirmation.'
+      : 'We queued the workspace intake handoff.'
   const slackCopy = record.requestSlackChannel
     ? 'We queued the Slack Connect invite handoff. Slack Connect still requires your workspace to accept the invite.'
-    : 'We queued the workspace intake handoff.'
+    : workspaceCopy
 
   return `<!doctype html><html><head><meta charset="utf-8"><title>Request received</title></head><body><main><h1>Request received</h1><p>${slackCopy}</p><p>Reference: ${record.id}</p><p><a href="/business">Return to the business page</a></p></main></body></html>`
 }
@@ -546,6 +588,7 @@ export const handleBusinessSignupApi = (
   request: Request,
   db: D1Database,
   runtime: BusinessSignupRuntime = systemBusinessSignupRuntime,
+  options: BusinessSignupApiOptions = {},
 ) =>
   Effect.gen(function* () {
     if (request.method !== 'POST') {
@@ -593,7 +636,7 @@ export const handleBusinessSignupApi = (
     yield* Effect.tryPromise({
       try: () => recordBusinessSignupFunnelEvent(db, record),
       catch: cause => new BusinessSignupIntakeFailure({ cause }),
-    }).pipe(Effect.catch(() => Effect.succeed(undefined)))
+    }).pipe(Effect.catch(() => Effect.void))
 
     // Bind the referral after the signup is durably stored. A referral failure
     // must not fail the intake, so it is caught and dropped to null.
@@ -606,10 +649,24 @@ export const handleBusinessSignupApi = (
       catch: cause => new BusinessSignupIntakeFailure({ cause }),
     }).pipe(Effect.catch(() => Effect.succeed(null)))
 
-    const storedRecord: BusinessSignupRecord =
+    const referredRecord: BusinessSignupRecord =
       referralAttributionId === null
         ? record
         : { ...record, referralAttributionId }
+    const fulfillment = yield* fulfillBusinessSignup(
+      db,
+      referredRecord,
+      runtime,
+      options,
+    )
+    const storedRecord: BusinessSignupRecord =
+      {
+        ...referredRecord,
+        fulfillmentRef: fulfillment.id,
+        fulfillmentReason: fulfillment.reason,
+        fulfillmentStatus: fulfillment.status,
+        updatedAt: fulfillment.updatedAt,
+      }
 
     return wantsJsonResponse(request)
       ? noStoreJsonResponse(publicResponseBody(storedRecord), { status: 201 })

--- a/apps/openagents.com/workers/api/src/index.ts
+++ b/apps/openagents.com/workers/api/src/index.ts
@@ -10607,7 +10607,16 @@ const exactRouteRegistry = makeExactRouteRegistry<Env>([
   {
     path: '/api/public/business-signup',
     handler: (request, env) =>
-      handleBusinessSignupApi(request, openAgentsDatabase(env)),
+      handleBusinessSignupApi(request, openAgentsDatabase(env), undefined, {
+        appOrigin: getAppOrigin(env),
+        getResendEmailConfig: () => getResendEmailConfig(env),
+        sendInviteEmailWithLedger: (config, input) =>
+          sendPrivateWorkspaceInviteEmailWithLedger(
+            openAgentsDatabase(env),
+            config,
+            input,
+          ),
+      }),
   },
   {
     path: '/api/public/business/funnel-dashboard',

--- a/apps/openagents.com/workers/api/src/vertical-funnel-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/vertical-funnel-routes.test.ts
@@ -54,6 +54,7 @@ const migration = (name: string): string =>
 const SCHEMA = [
   '0191_business_signup_requests.sql',
   '0216_business_signup_referral_attribution.sql',
+  '0271_business_signup_fulfillment.sql',
 ].map(migration)
 
 const makeDb = (): D1Database => {

--- a/apps/openagents.com/workers/api/src/vertical-funnel-routes.ts
+++ b/apps/openagents.com/workers/api/src/vertical-funnel-routes.ts
@@ -323,6 +323,7 @@ const handleApplyPost = (
           phone,
           referralCode: null,
           requestSlackChannel: false,
+          sourceAttribution: `vertical:${template.slug}`,
           sourceRoute: template.applyRoute,
           website,
         },


### PR DESCRIPTION
Closes #8074.

## Summary
- Adds a `business_signup_fulfillments` ledger and signup fulfillment projection columns so each `/business` signup reaches `invited` or an explicit `operator_parked` state.
- Wires public signup intake into the existing private project/workspace, team invite, and private workspace invite email ledger primitives.
- Seeds a private prefilled workspace from existing vertical templates and records explicit parked reasons when invite email config or provisioning fails.

## Verification
- `bun run --cwd apps/openagents.com/workers/api test -- src/business-signup-routes.test.ts` passed (6 tests).
- `bun run --cwd apps/openagents.com/workers/api typecheck` passed.
- `bun run check:deploy` passed on the final tree.