### PR TITLE
Add accepted outcome service promise contract

### DIFF
--- a/apps/openagents.com/workers/api/migrations/0273_accepted_outcome_service_promises.sql
+++ b/apps/openagents.com/workers/api/migrations/0273_accepted_outcome_service_promises.sql
@@ -1,0 +1,22 @@
+ALTER TABLE omni_accepted_outcome_contracts
+  ADD COLUMN committed_deliverables_json TEXT NOT NULL DEFAULT '[]';
+
+ALTER TABLE omni_accepted_outcome_contracts
+  ADD COLUMN service_promise_state TEXT NOT NULL DEFAULT 'not_promised'
+  CHECK (
+    service_promise_state IN (
+      'not_promised',
+      'proposed',
+      'active',
+      'fulfilled',
+      'paused',
+      'breached',
+      'cancelled'
+    )
+  );
+
+ALTER TABLE omni_accepted_outcome_contracts
+  ADD COLUMN sla_terms_json TEXT NOT NULL DEFAULT '[]';
+
+ALTER TABLE omni_accepted_outcome_contracts
+  ADD COLUMN fulfillment_receipts_json TEXT NOT NULL DEFAULT '[]';

--- a/apps/openagents.com/workers/api/src/omni-accepted-outcome-contracts.test.ts
+++ b/apps/openagents.com/workers/api/src/omni-accepted-outcome-contracts.test.ts
@@ -19,6 +19,7 @@ type ContractRow = Readonly<{
     | 'unavailable'
   archived_at: string | null
   closeout_requirements_json: string
+  committed_deliverables_json: string
   created_at: string
   customer_ref: string | null
   economic_state:
@@ -28,6 +29,7 @@ type ContractRow = Readonly<{
     | 'sats_required'
     | 'internal_only'
   expected_artifacts_json: string
+  fulfillment_receipts_json: string
   id: string
   idempotency_key: string
   legal_sensitive: number
@@ -44,6 +46,15 @@ type ContractRow = Readonly<{
     | 'dual_review'
     | 'owner_review'
     | 'no_review'
+  service_promise_state:
+    | 'not_promised'
+    | 'proposed'
+    | 'active'
+    | 'fulfilled'
+    | 'paused'
+    | 'breached'
+    | 'cancelled'
+  sla_terms_json: string
   subject_ref: string
   updated_at: string
   work_kind:
@@ -111,19 +122,24 @@ class AcceptedOutcomeContractStatement implements D1PreparedStatement {
           acceptance_state: this.values[7] as ContractRow['acceptance_state'],
           archived_at: null,
           closeout_requirements_json: String(this.values[10]),
-          created_at: String(this.values[14]),
+          committed_deliverables_json: String(this.values[11]),
+          created_at: String(this.values[18]),
           customer_ref: this.values[4] as string | null,
           economic_state: this.values[9] as ContractRow['economic_state'],
           expected_artifacts_json: String(this.values[5]),
+          fulfillment_receipts_json: String(this.values[14]),
           id: String(this.values[0]),
           idempotency_key: idempotencyKey,
-          legal_sensitive: Number(this.values[11]),
-          metadata_json: String(this.values[13]),
+          legal_sensitive: Number(this.values[15]),
+          metadata_json: String(this.values[17]),
           proof_policy: this.values[8] as ContractRow['proof_policy'],
-          public_receipt_ref: String(this.values[12]),
+          public_receipt_ref: String(this.values[16]),
           review_policy: this.values[6] as ContractRow['review_policy'],
+          service_promise_state:
+            this.values[12] as ContractRow['service_promise_state'],
+          sla_terms_json: String(this.values[13]),
           subject_ref: String(this.values[3]),
-          updated_at: String(this.values[15]),
+          updated_at: String(this.values[19]),
           work_kind: this.values[2] as ContractRow['work_kind'],
         })
       }
@@ -235,10 +251,19 @@ describe('Omni accepted outcome contracts', () => {
     expect(projection).toEqual({
       acceptanceState: 'draft',
       closeoutRequirementCount: 2,
+      committedDeliverableCount: 0,
       economicState: 'free_beta',
       expectedArtifactCount: 2,
+      fulfillmentReceiptSummary: {
+        blocked: 0,
+        failed: 0,
+        fulfilled: 0,
+        partial: 0,
+        total: 0,
+      },
       legalSensitive: false,
       proofPolicy: 'customer_safe_summary',
+      publicCommittedDeliverables: [],
       publicExpectedArtifacts: [
         {
           artifactKind: 'site_url',
@@ -249,6 +274,8 @@ describe('Omni accepted outcome contracts', () => {
       publicReceiptRef:
         'omni_accepted_outcome:site:accepted-outcome-contract:site:1',
       reviewPolicy: 'dual_review',
+      servicePromiseState: 'not_promised',
+      slaTermCount: 0,
       subjectRef: 'software_order_otec',
       workKind: 'site',
     })
@@ -296,6 +323,139 @@ describe('Omni accepted outcome contracts', () => {
       subjectRef: 'github_repo_issue_ref',
       workKind: 'coding',
     })
+  })
+
+  test('records per-customer service promises with SLA terms and verifier receipts', async () => {
+    const store = new AcceptedOutcomeContractStore()
+    const contract = await createContract(store, {
+      committedDeliverables: [
+        {
+          backingCapabilityRef: 'promise.autopilot.agentic_labor_products.v1',
+          backingCapabilityState: 'yellow',
+          deliverableRef: 'deliverable.customer_safe_site_launch',
+          expectedArtifactKind: 'site_url',
+          required: true,
+          sourceRef: 'scope.customer_safe_site_launch',
+        },
+      ],
+      fulfillmentReceipts: [
+        {
+          blockerRefs: [],
+          deliverableRef: 'deliverable.customer_safe_site_launch',
+          evaluatedAt: '2026-07-02T12:00:00.000Z',
+          evidenceRef: 'evidence.site_launch_verifier_passed',
+          receiptRef: 'fulfillment_receipt.site_launch.1',
+          state: 'fulfilled',
+          verifierRef: 'verifier.promise_fulfillment.site_launch.v1',
+        },
+      ],
+      idempotencyKey: 'accepted-outcome-contract:service-promise:1',
+      servicePromiseState: 'active',
+      slaTerms: [
+        {
+          dueAt: '2026-07-09T00:00:00.000Z',
+          metricRef: 'metric.first_delivery',
+          sourceRef: 'sla.quick_win.first_delivery',
+          target: 5,
+          termRef: 'sla.first_delivery.business_days',
+          unit: 'business_days',
+        },
+      ],
+    })
+    const projection = publicOmniAcceptedOutcomeContractProjection(contract)
+
+    expect(contract.servicePromiseState).toBe('active')
+    expect(contract.committedDeliverables).toHaveLength(1)
+    expect(contract.slaTerms).toHaveLength(1)
+    expect(contract.fulfillmentReceipts).toHaveLength(1)
+    expect(projection).toMatchObject({
+      committedDeliverableCount: 1,
+      fulfillmentReceiptSummary: {
+        blocked: 0,
+        failed: 0,
+        fulfilled: 1,
+        partial: 0,
+        total: 1,
+      },
+      publicCommittedDeliverables: [
+        {
+          backingCapabilityRef: 'promise.autopilot.agentic_labor_products.v1',
+          backingCapabilityState: 'yellow',
+          deliverableRef: 'deliverable.customer_safe_site_launch',
+          expectedArtifactKind: 'site_url',
+          required: true,
+        },
+      ],
+      servicePromiseState: 'active',
+      slaTermCount: 1,
+    })
+  })
+
+  test('fulfillment receipts evidence promises without flipping service promise state', async () => {
+    const contract = await createContract(new AcceptedOutcomeContractStore(), {
+      committedDeliverables: [
+        {
+          backingCapabilityRef: 'promise.autopilot.agentic_labor_products.v1',
+          backingCapabilityState: 'green',
+          deliverableRef: 'deliverable.reviewed_campaign_receipt',
+          expectedArtifactKind: 'operator_receipt',
+          required: true,
+          sourceRef: 'scope.reviewed_campaign_receipt',
+        },
+      ],
+      fulfillmentReceipts: [
+        {
+          blockerRefs: [],
+          deliverableRef: 'deliverable.reviewed_campaign_receipt',
+          evaluatedAt: '2026-07-02T13:00:00.000Z',
+          evidenceRef: 'evidence.campaign_receipt_verified',
+          receiptRef: 'fulfillment_receipt.campaign.1',
+          state: 'fulfilled',
+          verifierRef: 'verifier.promise_fulfillment.campaign.v1',
+        },
+      ],
+      idempotencyKey: 'accepted-outcome-contract:service-promise:decoupled',
+      servicePromiseState: 'breached',
+    })
+
+    expect(contract.fulfillmentReceipts[0]?.state).toBe('fulfilled')
+    expect(contract.servicePromiseState).toBe('breached')
+  })
+
+  test('rejects committed deliverables backed by red or planned capabilities', async () => {
+    await expect(
+      createContract(new AcceptedOutcomeContractStore(), {
+        committedDeliverables: [
+          {
+            backingCapabilityRef: 'promise.autopilot.superapp_desktop_business.v1',
+            backingCapabilityState: 'red',
+            deliverableRef: 'deliverable.unsupported_business_suite',
+            expectedArtifactKind: 'operator_receipt',
+            required: true,
+            sourceRef: 'scope.unsupported_business_suite',
+          },
+        ],
+        idempotencyKey: 'accepted-outcome-contract:service-promise:red',
+        servicePromiseState: 'active',
+      }),
+    ).rejects.toBeInstanceOf(OmniAcceptedOutcomeContractValidationError)
+
+    await expect(
+      createContract(new AcceptedOutcomeContractStore(), {
+        committedDeliverables: [
+          {
+            backingCapabilityRef: 'promise.future.private_compute_tier.v1',
+            backingCapabilityState: 'planned',
+            deliverableRef: 'deliverable.future_private_compute',
+            expectedArtifactKind: 'operator_receipt',
+            required: true,
+            sourceRef: 'scope.future_private_compute',
+          },
+        ],
+        idempotencyKey: 'accepted-outcome-contract:service-promise:planned',
+        servicePromiseState: 'active',
+      }),
+    ).rejects.toBeInstanceOf(OmniAcceptedOutcomeContractValidationError)
   })
 
   test('enforces legal-sensitive private proof policy', async () => {

--- a/apps/openagents.com/workers/api/src/omni-accepted-outcome-contracts.ts
+++ b/apps/openagents.com/workers/api/src/omni-accepted-outcome-contracts.ts
@@ -74,6 +74,38 @@ export const OmniAcceptedOutcomeEconomicState = S.Literals([
 export type OmniAcceptedOutcomeEconomicState =
   typeof OmniAcceptedOutcomeEconomicState.Type
 
+export const OmniAcceptedOutcomeServicePromiseState = S.Literals([
+  'not_promised',
+  'proposed',
+  'active',
+  'fulfilled',
+  'paused',
+  'breached',
+  'cancelled',
+])
+export type OmniAcceptedOutcomeServicePromiseState =
+  typeof OmniAcceptedOutcomeServicePromiseState.Type
+
+export const OmniAcceptedOutcomeBackingCapabilityState = S.Literals([
+  'green',
+  'yellow',
+  'degraded',
+  'manual_gate',
+  'red',
+  'planned',
+])
+export type OmniAcceptedOutcomeBackingCapabilityState =
+  typeof OmniAcceptedOutcomeBackingCapabilityState.Type
+
+export const OmniAcceptedOutcomeFulfillmentReceiptState = S.Literals([
+  'fulfilled',
+  'partial',
+  'failed',
+  'blocked',
+])
+export type OmniAcceptedOutcomeFulfillmentReceiptState =
+  typeof OmniAcceptedOutcomeFulfillmentReceiptState.Type
+
 export const OmniAcceptedOutcomeCloseoutRequirementKind = S.Literals([
   'customer_review',
   'operator_review',
@@ -106,19 +138,61 @@ export const OmniAcceptedOutcomeCloseoutRequirement = S.Struct({
 export type OmniAcceptedOutcomeCloseoutRequirement =
   typeof OmniAcceptedOutcomeCloseoutRequirement.Type
 
+export const OmniAcceptedOutcomeCommittedDeliverable = S.Struct({
+  backingCapabilityRef: S.String,
+  backingCapabilityState: OmniAcceptedOutcomeBackingCapabilityState,
+  deliverableRef: S.String,
+  expectedArtifactKind: OmniAcceptedOutcomeArtifactKind,
+  required: S.Boolean,
+  sourceRef: S.String,
+})
+export type OmniAcceptedOutcomeCommittedDeliverable =
+  typeof OmniAcceptedOutcomeCommittedDeliverable.Type
+
+export const OmniAcceptedOutcomeSlaTerm = S.Struct({
+  dueAt: S.NullOr(S.String),
+  metricRef: S.String,
+  sourceRef: S.String,
+  target: S.Number,
+  termRef: S.String,
+  unit: S.Literals(['hours', 'days', 'business_days', 'receipts', 'percent']),
+})
+export type OmniAcceptedOutcomeSlaTerm = typeof OmniAcceptedOutcomeSlaTerm.Type
+
+export const OmniAcceptedOutcomeFulfillmentReceipt = S.Struct({
+  blockerRefs: S.Array(S.String),
+  deliverableRef: S.String,
+  evaluatedAt: S.String,
+  evidenceRef: S.String,
+  receiptRef: S.String,
+  state: OmniAcceptedOutcomeFulfillmentReceiptState,
+  verifierRef: S.String,
+})
+export type OmniAcceptedOutcomeFulfillmentReceipt =
+  typeof OmniAcceptedOutcomeFulfillmentReceipt.Type
+
 const ExpectedArtifactArray = S.Array(OmniAcceptedOutcomeExpectedArtifact)
 const CloseoutRequirementArray = S.Array(
   OmniAcceptedOutcomeCloseoutRequirement,
+)
+const CommittedDeliverableArray = S.Array(
+  OmniAcceptedOutcomeCommittedDeliverable,
+)
+const SlaTermArray = S.Array(OmniAcceptedOutcomeSlaTerm)
+const FulfillmentReceiptArray = S.Array(
+  OmniAcceptedOutcomeFulfillmentReceipt,
 )
 
 export const OmniAcceptedOutcomeContractRecord = S.Struct({
   acceptanceState: OmniAcceptedOutcomeAcceptanceState,
   archivedAt: S.NullOr(S.String),
   closeoutRequirements: S.Array(OmniAcceptedOutcomeCloseoutRequirement),
+  committedDeliverables: S.Array(OmniAcceptedOutcomeCommittedDeliverable),
   createdAt: S.String,
   customerRef: S.NullOr(S.String),
   economicState: OmniAcceptedOutcomeEconomicState,
   expectedArtifacts: S.Array(OmniAcceptedOutcomeExpectedArtifact),
+  fulfillmentReceipts: S.Array(OmniAcceptedOutcomeFulfillmentReceipt),
   id: S.String,
   idempotencyKey: S.String,
   legalSensitive: S.Boolean,
@@ -126,6 +200,8 @@ export const OmniAcceptedOutcomeContractRecord = S.Struct({
   proofPolicy: OmniAcceptedOutcomeProofPolicy,
   publicReceiptRef: S.String,
   reviewPolicy: OmniAcceptedOutcomeReviewPolicy,
+  servicePromiseState: OmniAcceptedOutcomeServicePromiseState,
+  slaTerms: S.Array(OmniAcceptedOutcomeSlaTerm),
   subjectRef: S.String,
   updatedAt: S.String,
   workKind: OmniAcceptedOutcomeWorkKind,
@@ -147,9 +223,15 @@ export const systemOmniAcceptedOutcomeContractsRuntime: OmniAcceptedOutcomeContr
 export type CreateOmniAcceptedOutcomeContractInput = Readonly<{
   acceptanceState?: OmniAcceptedOutcomeAcceptanceState | undefined
   closeoutRequirements: ReadonlyArray<OmniAcceptedOutcomeCloseoutRequirement>
+  committedDeliverables?:
+    | ReadonlyArray<OmniAcceptedOutcomeCommittedDeliverable>
+    | undefined
   customerRef?: string | undefined
   economicState: OmniAcceptedOutcomeEconomicState
   expectedArtifacts: ReadonlyArray<OmniAcceptedOutcomeExpectedArtifact>
+  fulfillmentReceipts?:
+    | ReadonlyArray<OmniAcceptedOutcomeFulfillmentReceipt>
+    | undefined
   id?: string | undefined
   idempotencyKey: string
   legalSensitive?: boolean | undefined
@@ -157,6 +239,8 @@ export type CreateOmniAcceptedOutcomeContractInput = Readonly<{
   proofPolicy: OmniAcceptedOutcomeProofPolicy
   publicReceiptRef?: string | undefined
   reviewPolicy: OmniAcceptedOutcomeReviewPolicy
+  servicePromiseState?: OmniAcceptedOutcomeServicePromiseState | undefined
+  slaTerms?: ReadonlyArray<OmniAcceptedOutcomeSlaTerm> | undefined
   subjectRef: string
   workKind: OmniAcceptedOutcomeWorkKind
 }>
@@ -165,10 +249,12 @@ type ContractRow = Readonly<{
   acceptance_state: OmniAcceptedOutcomeAcceptanceState
   archived_at: string | null
   closeout_requirements_json: string
+  committed_deliverables_json: string
   created_at: string
   customer_ref: string | null
   economic_state: OmniAcceptedOutcomeEconomicState
   expected_artifacts_json: string
+  fulfillment_receipts_json: string
   id: string
   idempotency_key: string
   legal_sensitive: number
@@ -176,6 +262,8 @@ type ContractRow = Readonly<{
   proof_policy: OmniAcceptedOutcomeProofPolicy
   public_receipt_ref: string
   review_policy: OmniAcceptedOutcomeReviewPolicy
+  service_promise_state: OmniAcceptedOutcomeServicePromiseState
+  sla_terms_json: string
   subject_ref: string
   updated_at: string
   work_kind: OmniAcceptedOutcomeWorkKind
@@ -265,6 +353,103 @@ const assertCloseoutRequirements = (
   })
 }
 
+const assertCommittedDeliverables = (
+  deliverables:
+    | ReadonlyArray<OmniAcceptedOutcomeCommittedDeliverable>
+    | undefined,
+): void => {
+  if (deliverables === undefined) {
+    return
+  }
+
+  deliverables.forEach(deliverable => {
+    assertSafeRef('committedDeliverables.deliverableRef', deliverable.deliverableRef)
+    assertSafeRef(
+      'committedDeliverables.backingCapabilityRef',
+      deliverable.backingCapabilityRef,
+    )
+    assertSafeRef('committedDeliverables.sourceRef', deliverable.sourceRef)
+
+    if (
+      deliverable.backingCapabilityState === 'red' ||
+      deliverable.backingCapabilityState === 'planned'
+    ) {
+      throw new OmniAcceptedOutcomeContractValidationError({
+        reason:
+          'committedDeliverables cannot include a deliverable backed by a red or planned capability record.',
+      })
+    }
+  })
+}
+
+const assertSlaTerms = (
+  terms: ReadonlyArray<OmniAcceptedOutcomeSlaTerm> | undefined,
+): void => {
+  if (terms === undefined) {
+    return
+  }
+
+  terms.forEach(term => {
+    assertSafeRef('slaTerms.termRef', term.termRef)
+    assertSafeRef('slaTerms.metricRef', term.metricRef)
+    assertSafeRef('slaTerms.sourceRef', term.sourceRef)
+
+    if (term.target < 0) {
+      throw new OmniAcceptedOutcomeContractValidationError({
+        reason: 'slaTerms.target must be non-negative.',
+      })
+    }
+  })
+}
+
+const assertFulfillmentReceipts = (
+  receipts:
+    | ReadonlyArray<OmniAcceptedOutcomeFulfillmentReceipt>
+    | undefined,
+  committedDeliverables:
+    | ReadonlyArray<OmniAcceptedOutcomeCommittedDeliverable>
+    | undefined,
+): void => {
+  if (receipts === undefined) {
+    return
+  }
+
+  const deliverableRefs = new Set(
+    (committedDeliverables ?? []).map(deliverable => deliverable.deliverableRef),
+  )
+
+  receipts.forEach(receipt => {
+    assertSafeRef('fulfillmentReceipts.receiptRef', receipt.receiptRef)
+    assertSafeRef('fulfillmentReceipts.deliverableRef', receipt.deliverableRef)
+    assertSafeRef('fulfillmentReceipts.verifierRef', receipt.verifierRef)
+    assertSafeRef('fulfillmentReceipts.evidenceRef', receipt.evidenceRef)
+    receipt.blockerRefs.forEach(ref =>
+      assertSafeRef('fulfillmentReceipts.blockerRefs', ref),
+    )
+
+    if (!deliverableRefs.has(receipt.deliverableRef)) {
+      throw new OmniAcceptedOutcomeContractValidationError({
+        reason:
+          'fulfillmentReceipts must reference a committed deliverable; receipts evidence fulfillment and do not create promises.',
+      })
+    }
+  })
+}
+
+const assertServicePromiseState = (
+  input: CreateOmniAcceptedOutcomeContractInput,
+): void => {
+  if (
+    input.servicePromiseState === 'not_promised' &&
+    (input.committedDeliverables?.length ?? 0) > 0
+  ) {
+    throw new OmniAcceptedOutcomeContractValidationError({
+      reason:
+        'not_promised contracts cannot carry committedDeliverables; choose an explicit service promise state.',
+    })
+  }
+}
+
 const assertPolicyCompatibility = (
   input: CreateOmniAcceptedOutcomeContractInput,
 ): void => {
@@ -298,6 +483,10 @@ const assertValidInput = (
   assertSafeMetadata(input.metadata)
   assertExpectedArtifacts(input.expectedArtifacts)
   assertCloseoutRequirements(input.closeoutRequirements)
+  assertCommittedDeliverables(input.committedDeliverables)
+  assertSlaTerms(input.slaTerms)
+  assertFulfillmentReceipts(input.fulfillmentReceipts, input.committedDeliverables)
+  assertServicePromiseState(input)
   assertPolicyCompatibility(input)
 }
 
@@ -328,12 +517,20 @@ const contractFromRow = (
     CloseoutRequirementArray,
     row.closeout_requirements_json,
   ),
+  committedDeliverables: parseJsonWithSchema(
+    CommittedDeliverableArray,
+    row.committed_deliverables_json,
+  ),
   createdAt: row.created_at,
   customerRef: row.customer_ref,
   economicState: row.economic_state,
   expectedArtifacts: parseJsonWithSchema(
     ExpectedArtifactArray,
     row.expected_artifacts_json,
+  ),
+  fulfillmentReceipts: parseJsonWithSchema(
+    FulfillmentReceiptArray,
+    row.fulfillment_receipts_json,
   ),
   id: row.id,
   idempotencyKey: row.idempotency_key,
@@ -342,6 +539,8 @@ const contractFromRow = (
   proofPolicy: row.proof_policy,
   publicReceiptRef: row.public_receipt_ref,
   reviewPolicy: row.review_policy,
+  servicePromiseState: row.service_promise_state,
+  slaTerms: parseJsonWithSchema(SlaTermArray, row.sla_terms_json),
   subjectRef: row.subject_ref,
   updatedAt: row.updated_at,
   workKind: row.work_kind,
@@ -394,14 +593,20 @@ export const createOmniAcceptedOutcomeContract = (
     }
 
     const now = runtime.nowIso()
+    const committedDeliverables = input.committedDeliverables ?? []
+    const servicePromiseState =
+      input.servicePromiseState ??
+      (committedDeliverables.length === 0 ? 'not_promised' : 'active')
     const record: OmniAcceptedOutcomeContractRecord = {
       acceptanceState: input.acceptanceState ?? 'draft',
       archivedAt: null,
       closeoutRequirements: [...input.closeoutRequirements],
+      committedDeliverables: [...committedDeliverables],
       createdAt: now,
       customerRef: input.customerRef ?? null,
       economicState: input.economicState,
       expectedArtifacts: [...input.expectedArtifacts],
+      fulfillmentReceipts: [...(input.fulfillmentReceipts ?? [])],
       id: input.id ?? runtime.makeContractId(),
       idempotencyKey: input.idempotencyKey,
       legalSensitive:
@@ -412,6 +617,8 @@ export const createOmniAcceptedOutcomeContract = (
         input.publicReceiptRef ??
         publicReceiptRef(input.workKind, input.idempotencyKey),
       reviewPolicy: input.reviewPolicy,
+      servicePromiseState,
+      slaTerms: [...(input.slaTerms ?? [])],
       subjectRef: input.subjectRef,
       updatedAt: now,
       workKind: input.workKind,
@@ -432,13 +639,17 @@ export const createOmniAcceptedOutcomeContract = (
               proof_policy,
               economic_state,
               closeout_requirements_json,
+              committed_deliverables_json,
+              service_promise_state,
+              sla_terms_json,
+              fulfillment_receipts_json,
               legal_sensitive,
               public_receipt_ref,
               metadata_json,
               created_at,
               updated_at,
               archived_at)
-           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL)`,
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL)`,
         )
         .bind(
           record.id,
@@ -452,6 +663,10 @@ export const createOmniAcceptedOutcomeContract = (
           record.proofPolicy,
           record.economicState,
           JSON.stringify(record.closeoutRequirements),
+          JSON.stringify(record.committedDeliverables),
+          record.servicePromiseState,
+          JSON.stringify(record.slaTerms),
+          JSON.stringify(record.fulfillmentReceipts),
           record.legalSensitive ? 1 : 0,
           record.publicReceiptRef,
           JSON.stringify(record.metadata),
@@ -473,10 +688,35 @@ export const publicOmniAcceptedOutcomeContractProjection = (
 ) => ({
   acceptanceState: contract.acceptanceState,
   closeoutRequirementCount: contract.closeoutRequirements.length,
+  committedDeliverableCount: contract.committedDeliverables.length,
   economicState: contract.economicState,
   expectedArtifactCount: contract.expectedArtifacts.length,
+  fulfillmentReceiptSummary: {
+    blocked: contract.fulfillmentReceipts.filter(
+      receipt => receipt.state === 'blocked',
+    ).length,
+    failed: contract.fulfillmentReceipts.filter(
+      receipt => receipt.state === 'failed',
+    ).length,
+    fulfilled: contract.fulfillmentReceipts.filter(
+      receipt => receipt.state === 'fulfilled',
+    ).length,
+    partial: contract.fulfillmentReceipts.filter(
+      receipt => receipt.state === 'partial',
+    ).length,
+    total: contract.fulfillmentReceipts.length,
+  },
   legalSensitive: contract.legalSensitive,
   proofPolicy: contract.proofPolicy,
+  publicCommittedDeliverables: contract.committedDeliverables.map(
+    deliverable => ({
+      backingCapabilityRef: deliverable.backingCapabilityRef,
+      backingCapabilityState: deliverable.backingCapabilityState,
+      deliverableRef: deliverable.deliverableRef,
+      expectedArtifactKind: deliverable.expectedArtifactKind,
+      required: deliverable.required,
+    }),
+  ),
   publicExpectedArtifacts: contract.expectedArtifacts
     .filter(artifact => artifact.publicSafe)
     .map(artifact => ({
@@ -486,6 +726,8 @@ export const publicOmniAcceptedOutcomeContractProjection = (
     })),
   publicReceiptRef: contract.publicReceiptRef,
   reviewPolicy: contract.reviewPolicy,
+  servicePromiseState: contract.servicePromiseState,
+  slaTermCount: contract.slaTerms.length,
   subjectRef: contract.subjectRef,
   workKind: contract.workKind,
 })


### PR DESCRIPTION
Closes #8089.

## Summary
- Extends accepted-outcome contracts with service-promise state, committed deliverables, SLA terms, and verifier-evaluated fulfillment receipts.
- Keeps fulfillment receipts decoupled from promise state: receipts evidence fulfillment but do not flip `servicePromiseState`.
- Rejects committed deliverables whose backing capability record is `red` or `planned`, and persists the new fields through D1 JSON/default columns.

## Verification
- `bun run --cwd apps/openagents.com/workers/api test -- src/omni-accepted-outcome-contracts.test.ts` — 1 file passed, 8 tests passed.
- `bun run --cwd apps/openagents.com/workers/api typecheck` — passed.
- `bun run check:deploy` — passed. The drift-guard failure text in output is expected fixture text inside `scripts/check-contract-drift.test.ts`; the guard test passed and the command exited 0.
