### PR TITLE
BF-4.3 approval ladder gate

### DIFF
--- a/apps/openagents.com/workers/api/src/omni-workroom-approval-gates.test.ts
+++ b/apps/openagents.com/workers/api/src/omni-workroom-approval-gates.test.ts
@@ -1,0 +1,190 @@
+import { Schema as S } from 'effect'
+import { describe, expect, test } from 'vitest'
+
+import {
+  OmniWorkroomApprovalGatePolicy,
+  OmniWorkroomApprovalGateUnsafe,
+  OmniWorkroomOutboundDeliverableReviewDecision,
+  OmniWorkroomOutboundDeliverableReviewInput,
+  decideOmniWorkroomOutboundDeliverableReview,
+} from './omni-workroom-approval-gates'
+
+const policy = (
+  overrides: Partial<OmniWorkroomApprovalGatePolicy> = {},
+): OmniWorkroomApprovalGatePolicy =>
+  new OmniWorkroomApprovalGatePolicy({
+    approvalLevel: 'execute_with_approval',
+    professionalReviewRequired: false,
+    professionalReviewerRole: null,
+    sourceRefs: ['policy.business_fulfillment.approval_ladder.v1'],
+    workspaceRef: 'workspace.business.fulfillment.demo',
+    ...overrides,
+  })
+
+const input = (
+  overrides: Partial<OmniWorkroomOutboundDeliverableReviewInput> = {},
+): OmniWorkroomOutboundDeliverableReviewInput =>
+  new OmniWorkroomOutboundDeliverableReviewInput({
+    approvalDecisionReceiptRefs: ['receipt.review.operator_approved.001'],
+    deliverableRef: 'deliverable.business_site_revision.001',
+    evidenceRefs: ['evidence.workroom.preview.001'],
+    outboundActionKind: 'publish',
+    policy: policy(),
+    professionalReviewReceiptRefs: [],
+    reviewerRoleRefs: [],
+    sourceRefs: ['issue.8090'],
+    workKind: 'site',
+    workroomRef: 'workroom.business.fulfillment.001',
+    ...overrides,
+  })
+
+describe('Omni workroom approval gates', () => {
+  test('allows an execute-with-approval outbound deliverable only when a decision receipt is recorded', () => {
+    const decision = decideOmniWorkroomOutboundDeliverableReview(input())
+
+    expect(
+      S.decodeUnknownSync(OmniWorkroomOutboundDeliverableReviewDecision)(
+        decision,
+      ),
+    ).toEqual(decision)
+    expect(decision).toMatchObject({
+      approvalDecisionRecorded: true,
+      approvalLevel: 'execute_with_approval',
+      blockedExternalAction: false,
+      blockerRefs: [],
+      externalActionAllowed: true,
+      outboundActionKind: 'publish',
+      professionalReviewRecorded: true,
+      professionalReviewRequired: false,
+      receiptRefs: ['receipt.review.operator_approved.001'],
+    })
+    expect(decision.sourceRefs).toEqual([
+      'issue.8090',
+      'policy.business_fulfillment.approval_ladder.v1',
+    ])
+  })
+
+  test('blocks draft and suggest ladder levels from external send, publish, file, or spend actions', () => {
+    for (const approvalLevel of ['draft', 'suggest'] as const) {
+      const decision = decideOmniWorkroomOutboundDeliverableReview(
+        input({
+          outboundActionKind: 'send',
+          policy: policy({ approvalLevel }),
+        }),
+      )
+
+      expect(decision.externalActionAllowed).toBe(false)
+      expect(decision.blockerRefs).toContain(
+        `blocker.workroom_approval_ladder.${approvalLevel}.external_action_not_allowed`,
+      )
+    }
+  })
+
+  test('blocks outbound deliverables at executable levels without a per-deliverable review decision receipt', () => {
+    for (const approvalLevel of ['execute_with_approval', 'trusted'] as const) {
+      const decision = decideOmniWorkroomOutboundDeliverableReview(
+        input({
+          approvalDecisionReceiptRefs: [],
+          outboundActionKind: 'spend',
+          policy: policy({ approvalLevel }),
+        }),
+      )
+
+      expect(decision.externalActionAllowed).toBe(false)
+      expect(decision.approvalDecisionRecorded).toBe(false)
+      expect(decision.blockerRefs).toContain(
+        'blocker.workroom_approval_ladder.decision_receipt_missing',
+      )
+    }
+  })
+
+  test('requires licensed-practitioner professional review receipts for legal-sensitive deliverables', () => {
+    const blocked = decideOmniWorkroomOutboundDeliverableReview(
+      input({
+        outboundActionKind: 'file',
+        policy: policy({
+          professionalReviewRequired: true,
+          professionalReviewerRole: 'licensed_practitioner',
+        }),
+        workKind: 'legal_sensitive',
+      }),
+    )
+
+    expect(blocked.externalActionAllowed).toBe(false)
+    expect(blocked.professionalReviewRequired).toBe(true)
+    expect(blocked.professionalReviewerRole).toBe('licensed_practitioner')
+    expect(blocked.blockerRefs).toEqual([
+      'blocker.workroom_approval_ladder.professional_review_receipt_missing',
+      'blocker.workroom_approval_ladder.professional_reviewer_role_missing',
+    ])
+
+    const allowed = decideOmniWorkroomOutboundDeliverableReview(
+      input({
+        outboundActionKind: 'file',
+        policy: policy({
+          professionalReviewRequired: true,
+          professionalReviewerRole: 'licensed_practitioner',
+        }),
+        professionalReviewReceiptRefs: [
+          'receipt.professional_review.licensed_practitioner.001',
+        ],
+        reviewerRoleRefs: ['role.licensed_practitioner.verified.001'],
+        workKind: 'legal_sensitive',
+      }),
+    )
+
+    expect(allowed.externalActionAllowed).toBe(true)
+    expect(allowed.professionalReviewRecorded).toBe(true)
+    expect(allowed.receiptRefs).toEqual([
+      'receipt.professional_review.licensed_practitioner.001',
+      'receipt.review.operator_approved.001',
+    ])
+  })
+
+  test('defaults legal-sensitive work to licensed-practitioner review even when policy omits the role', () => {
+    const decision = decideOmniWorkroomOutboundDeliverableReview(
+      input({
+        policy: policy({
+          professionalReviewRequired: false,
+          professionalReviewerRole: null,
+        }),
+        professionalReviewReceiptRefs: [
+          'receipt.professional_review.licensed_practitioner.002',
+        ],
+        reviewerRoleRefs: ['role.licensed_practitioner.verified.002'],
+        workKind: 'legal_sensitive',
+      }),
+    )
+
+    expect(decision.professionalReviewRequired).toBe(true)
+    expect(decision.professionalReviewerRole).toBe('licensed_practitioner')
+    expect(decision.externalActionAllowed).toBe(true)
+  })
+
+  test('rejects private refs, raw email, provider, payment, settlement, and wallet material', () => {
+    for (const badInput of [
+      () =>
+        decideOmniWorkroomOutboundDeliverableReview(
+          input({ deliverableRef: 'deliverable.customer_email.raw' }),
+        ),
+      () =>
+        decideOmniWorkroomOutboundDeliverableReview(
+          input({ evidenceRefs: ['evidence.provider_payload.raw'] }),
+        ),
+      () =>
+        decideOmniWorkroomOutboundDeliverableReview(
+          input({ approvalDecisionReceiptRefs: ['receipt.payment_settled.001'] }),
+        ),
+      () =>
+        decideOmniWorkroomOutboundDeliverableReview(
+          input({
+            policy: policy({
+              sourceRefs: ['policy.wallet_secret.operator_notes'],
+            }),
+          }),
+        ),
+    ]) {
+      expect(badInput).toThrow(OmniWorkroomApprovalGateUnsafe)
+    }
+  })
+})

--- a/apps/openagents.com/workers/api/src/omni-workroom-approval-gates.ts
+++ b/apps/openagents.com/workers/api/src/omni-workroom-approval-gates.ts
@@ -1,0 +1,223 @@
+import { containsProviderSecretMaterial } from '@openagentsinc/provider-account-schema'
+import { Schema as S } from 'effect'
+
+import { OmniAcceptedOutcomeWorkKind as OmniAcceptedOutcomeWorkKindSchema } from './omni-accepted-outcome-contracts'
+
+export const OmniWorkroomApprovalLadderLevel = S.Literals([
+  'draft',
+  'suggest',
+  'execute_with_approval',
+  'trusted',
+])
+export type OmniWorkroomApprovalLadderLevel =
+  typeof OmniWorkroomApprovalLadderLevel.Type
+
+export const OmniWorkroomOutboundActionKind = S.Literals([
+  'send',
+  'publish',
+  'file',
+  'spend',
+])
+export type OmniWorkroomOutboundActionKind =
+  typeof OmniWorkroomOutboundActionKind.Type
+
+export const OmniWorkroomProfessionalReviewerRole = S.Literals([
+  'licensed_practitioner',
+  'professional_reviewer',
+])
+export type OmniWorkroomProfessionalReviewerRole =
+  typeof OmniWorkroomProfessionalReviewerRole.Type
+
+export class OmniWorkroomApprovalGatePolicy extends S.Class<OmniWorkroomApprovalGatePolicy>(
+  'OmniWorkroomApprovalGatePolicy',
+)({
+  approvalLevel: OmniWorkroomApprovalLadderLevel,
+  professionalReviewRequired: S.Boolean,
+  professionalReviewerRole: S.NullOr(OmniWorkroomProfessionalReviewerRole),
+  sourceRefs: S.Array(S.String),
+  workspaceRef: S.String,
+}) {}
+
+export class OmniWorkroomOutboundDeliverableReviewInput extends S.Class<OmniWorkroomOutboundDeliverableReviewInput>(
+  'OmniWorkroomOutboundDeliverableReviewInput',
+)({
+  approvalDecisionReceiptRefs: S.Array(S.String),
+  deliverableRef: S.String,
+  evidenceRefs: S.Array(S.String),
+  outboundActionKind: OmniWorkroomOutboundActionKind,
+  policy: OmniWorkroomApprovalGatePolicy,
+  professionalReviewReceiptRefs: S.Array(S.String),
+  reviewerRoleRefs: S.Array(S.String),
+  sourceRefs: S.Array(S.String),
+  workKind: OmniAcceptedOutcomeWorkKindSchema,
+  workroomRef: S.String,
+}) {}
+
+export class OmniWorkroomOutboundDeliverableReviewDecision extends S.Class<OmniWorkroomOutboundDeliverableReviewDecision>(
+  'OmniWorkroomOutboundDeliverableReviewDecision',
+)({
+  approvalDecisionRecorded: S.Boolean,
+  approvalLevel: OmniWorkroomApprovalLadderLevel,
+  blockedExternalAction: S.Boolean,
+  blockerRefs: S.Array(S.String),
+  deliverableRef: S.String,
+  evidenceRefs: S.Array(S.String),
+  externalActionAllowed: S.Boolean,
+  outboundActionKind: OmniWorkroomOutboundActionKind,
+  professionalReviewRecorded: S.Boolean,
+  professionalReviewRequired: S.Boolean,
+  professionalReviewerRole: S.NullOr(OmniWorkroomProfessionalReviewerRole),
+  receiptRefs: S.Array(S.String),
+  reviewerRoleRefs: S.Array(S.String),
+  sourceRefs: S.Array(S.String),
+  workKind: OmniAcceptedOutcomeWorkKindSchema,
+  workroomRef: S.String,
+  workspaceRef: S.String,
+}) {}
+
+export class OmniWorkroomApprovalGateUnsafe extends S.TaggedErrorClass<OmniWorkroomApprovalGateUnsafe>()(
+  'OmniWorkroomApprovalGateUnsafe',
+  { reason: S.String },
+) {}
+
+const SAFE_REF_PATTERN = /^[A-Za-z0-9][A-Za-z0-9_.:/-]{0,260}$/
+const PROHIBITED_TEXT_PATTERN =
+  /\b(provider[_ -]?payload|provider[_ -]?account|raw[_ -]?email|email[_ -]?body|contact[_ -]?email|customer[_ -]?email|customer[_ -]?name|run[_ -]?log|auth[_ -]?grant|access_token|refresh_token|device_auth_id|code_verifier|token_hash|private_key|wallet_secret|mdk_access_token|payment_preimage|payment_secret|webhook_secret|settlement|payout|paid[_ -]?out|payment[_ -]?settled|eligible[_ -]?for[_ -]?payout|gho_[a-z0-9_]+|lnbc[0-9a-z]*|lntb[0-9a-z]*|lnbcrt[0-9a-z]*|lno1[0-9a-z]*|xprv|mnemonic)\b|@/i
+
+const levelAllowsExternalAction: Readonly<
+  Record<OmniWorkroomApprovalLadderLevel, boolean>
+> = {
+  draft: false,
+  execute_with_approval: true,
+  suggest: false,
+  trusted: true,
+}
+
+const textIsSafe = (value: string): boolean =>
+  !containsProviderSecretMaterial(value) && !PROHIBITED_TEXT_PATTERN.test(value)
+
+const assertSafeRef = (field: string, value: string): void => {
+  if (!SAFE_REF_PATTERN.test(value) || !textIsSafe(value)) {
+    throw new OmniWorkroomApprovalGateUnsafe({
+      reason: `${field} must be a public-safe ref without raw provider, run log, email, payment, settlement, payout, wallet, or private customer material.`,
+    })
+  }
+}
+
+const assertSafeRefs = (
+  field: string,
+  refs: ReadonlyArray<string>,
+): void => {
+  refs.forEach(ref => {
+    assertSafeRef(field, ref)
+  })
+}
+
+const uniqueSorted = (refs: ReadonlyArray<string>): ReadonlyArray<string> =>
+  [...new Set(refs)].sort()
+
+const professionalReviewRequiredFor = (
+  input: OmniWorkroomOutboundDeliverableReviewInput,
+): boolean =>
+  input.policy.professionalReviewRequired || input.workKind === 'legal_sensitive'
+
+const requiredProfessionalReviewerRoleFor = (
+  input: OmniWorkroomOutboundDeliverableReviewInput,
+): OmniWorkroomProfessionalReviewerRole | null =>
+  professionalReviewRequiredFor(input)
+    ? input.policy.professionalReviewerRole ?? 'licensed_practitioner'
+    : null
+
+const validateInputRefs = (
+  input: OmniWorkroomOutboundDeliverableReviewInput,
+): void => {
+  assertSafeRef('deliverableRef', input.deliverableRef)
+  assertSafeRef('workroomRef', input.workroomRef)
+  assertSafeRef('workspaceRef', input.policy.workspaceRef)
+  assertSafeRefs(
+    'approvalDecisionReceiptRefs',
+    input.approvalDecisionReceiptRefs,
+  )
+  assertSafeRefs('evidenceRefs', input.evidenceRefs)
+  assertSafeRefs(
+    'professionalReviewReceiptRefs',
+    input.professionalReviewReceiptRefs,
+  )
+  assertSafeRefs('reviewerRoleRefs', input.reviewerRoleRefs)
+  assertSafeRefs('sourceRefs', input.sourceRefs)
+  assertSafeRefs('policy.sourceRefs', input.policy.sourceRefs)
+}
+
+const blockerRefsFor = (
+  input: OmniWorkroomOutboundDeliverableReviewInput,
+): ReadonlyArray<string> => {
+  const approvalLevelAllowsExternalAction =
+    levelAllowsExternalAction[input.policy.approvalLevel]
+  const approvalDecisionRecorded = input.approvalDecisionReceiptRefs.length > 0
+  const professionalReviewRequired = professionalReviewRequiredFor(input)
+  const professionalReviewRecorded =
+    !professionalReviewRequired ||
+    input.professionalReviewReceiptRefs.length > 0
+  const requiredProfessionalReviewerRole =
+    requiredProfessionalReviewerRoleFor(input)
+  const requiredReviewerRoleRecorded =
+    requiredProfessionalReviewerRole === null ||
+    input.reviewerRoleRefs.some(ref =>
+      ref.includes(requiredProfessionalReviewerRole),
+    )
+
+  return [
+    ...(!approvalLevelAllowsExternalAction
+      ? [
+          `blocker.workroom_approval_ladder.${input.policy.approvalLevel}.external_action_not_allowed`,
+        ]
+      : []),
+    ...(!approvalDecisionRecorded
+      ? ['blocker.workroom_approval_ladder.decision_receipt_missing']
+      : []),
+    ...(!professionalReviewRecorded
+      ? ['blocker.workroom_approval_ladder.professional_review_receipt_missing']
+      : []),
+    ...(!requiredReviewerRoleRecorded
+      ? ['blocker.workroom_approval_ladder.professional_reviewer_role_missing']
+      : []),
+  ].sort()
+}
+
+export const decideOmniWorkroomOutboundDeliverableReview = (
+  input: OmniWorkroomOutboundDeliverableReviewInput,
+): OmniWorkroomOutboundDeliverableReviewDecision => {
+  validateInputRefs(input)
+
+  const blockerRefs = blockerRefsFor(input)
+  const professionalReviewRequired = professionalReviewRequiredFor(input)
+  const professionalReviewerRole = requiredProfessionalReviewerRoleFor(input)
+  const professionalReviewRecorded =
+    !professionalReviewRequired ||
+    input.professionalReviewReceiptRefs.length > 0
+  const approvalDecisionRecorded = input.approvalDecisionReceiptRefs.length > 0
+  const externalActionAllowed = blockerRefs.length === 0
+
+  return new OmniWorkroomOutboundDeliverableReviewDecision({
+    approvalDecisionRecorded,
+    approvalLevel: input.policy.approvalLevel,
+    blockedExternalAction: !externalActionAllowed,
+    blockerRefs,
+    deliverableRef: input.deliverableRef,
+    evidenceRefs: uniqueSorted(input.evidenceRefs),
+    externalActionAllowed,
+    outboundActionKind: input.outboundActionKind,
+    professionalReviewRecorded,
+    professionalReviewRequired,
+    professionalReviewerRole,
+    receiptRefs: uniqueSorted([
+      ...input.approvalDecisionReceiptRefs,
+      ...input.professionalReviewReceiptRefs,
+    ]),
+    reviewerRoleRefs: uniqueSorted(input.reviewerRoleRefs),
+    sourceRefs: uniqueSorted([...input.sourceRefs, ...input.policy.sourceRefs]),
+    workKind: input.workKind,
+    workroomRef: input.workroomRef,
+    workspaceRef: input.policy.workspaceRef,
+  })
+}


### PR DESCRIPTION
## Summary

Closes #8090.

Adds a schema-backed workroom outbound deliverable approval gate for BF-4.3:

- models the workspace approval ladder: `draft`, `suggest`, `execute_with_approval`, `trusted`
- blocks external `send`, `publish`, `file`, and `spend` actions at non-executable levels
- requires a per-deliverable review decision receipt before any external action is allowed
- requires professional-review receipts and licensed-practitioner role evidence for legal-sensitive deliverables
- rejects private/customer/provider/payment/settlement/wallet material in refs

## Verification

- `bun run --cwd apps/openagents.com/workers/api test -- src/omni-workroom-approval-gates.test.ts` passed: 1 file, 6 tests
- `bun run --cwd apps/openagents.com/workers/api typecheck` passed
- `bun run check:deploy` passed
