### PR TITLE
Close site form sequence enrollment loop

### DIFF
--- a/apps/openagents.com/workers/api/src/index.ts
+++ b/apps/openagents.com/workers/api/src/index.ts
@@ -953,6 +953,7 @@ import {
   isSiteFormCaptureEnabled,
   makeSitePageFormCaptureRoutes,
 } from './site-page-form-capture-routes'
+import { enrollListSubscriberInSequence } from './list-sequence-enrollment'
 import {
   type ReferralConsumptionResult,
   consumePendingReferralForUser,
@@ -8028,8 +8029,42 @@ const sitePageFormCaptureRoutes = makeSitePageFormCaptureRoutes<WorkerBindings>(
           .SITE_FORM_CAPTURE_ENABLED,
       ),
     makeSink: env => ({
-      addSubscriber: makeNativeListsService(openAgentsDatabase(env))
-        .addSubscriber,
+      addSubscriber: async input => {
+        const db = openAgentsDatabase(env)
+        const lists = makeNativeListsService(db)
+        const result = await lists.addSubscriber(input)
+
+        if (
+          input.sequenceSlug === undefined ||
+          input.sequenceSlug.trim() === ''
+        ) {
+          return result
+        }
+
+        const sequenceEnrollment = await enrollListSubscriberInSequence(
+          db,
+          {
+            email: result.subscriber.email,
+            listId: input.listId,
+            sequenceSlug: input.sequenceSlug,
+          },
+          'system:site-form-capture',
+        )
+
+        return {
+          ...result,
+          sequenceEnrollment:
+            sequenceEnrollment.status === 'enrolled'
+              ? {
+                  scheduledSendCount: sequenceEnrollment.scheduledSendCount,
+                  status: sequenceEnrollment.status,
+                }
+              : {
+                  reason: sequenceEnrollment.reason,
+                  status: sequenceEnrollment.status,
+                },
+        }
+      },
     }),
     readSiteFormMetadata: async (env, formId) => {
       const row = await openAgentsDatabase(env)

--- a/apps/openagents.com/workers/api/src/site-form-spec-registry.test.ts
+++ b/apps/openagents.com/workers/api/src/site-form-spec-registry.test.ts
@@ -8,6 +8,7 @@ import {
 const leadFormSpec = {
   id: 'lead.newsletter',
   listId: 'list.newsletter',
+  sequenceSlug: 'welcome-nurture',
   fields: [
     { name: 'email', kind: 'email' as const, required: true },
     { name: 'name', kind: 'text' as const },
@@ -30,6 +31,7 @@ describe('site form-spec registry', () => {
   test('resolves a typed form spec by id from a metadata object', () => {
     const spec = resolveSiteFormSpec(metadataObject, 'lead.newsletter')
     expect(spec).toEqual(leadFormSpec)
+    expect(spec?.sequenceSlug).toBe('welcome-nurture')
   })
 
   test('resolves a form spec when metadata is a JSON string', () => {

--- a/apps/openagents.com/workers/api/src/site-page-form-capture-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/site-page-form-capture-routes.test.ts
@@ -5,6 +5,9 @@ import { DatabaseSync } from 'node:sqlite'
 import { Effect } from 'effect'
 import { beforeEach, describe, expect, test } from 'vitest'
 
+import type { EmailCampaignRuntime } from './email-campaigns'
+import { createEmailSequence } from './email-sequence-authoring'
+import { enrollListSubscriberInSequence } from './list-sequence-enrollment'
 import {
   makeNativeListsService,
   type NativeListsRuntime,
@@ -65,13 +68,19 @@ const migrationSql = readFileSync(
   join(__dirname, '..', 'migrations', '0181_native_lists_subscribers.sql'),
   'utf8',
 )
+const campaignsMigrationSql = readFileSync(
+  join(__dirname, '..', 'migrations', '0063_email_campaign_records.sql'),
+  'utf8',
+)
 
 const makeDb = (): D1Database => {
   const db = new DatabaseSync(':memory:')
   db.exec('CREATE TABLE users (id TEXT PRIMARY KEY)')
   db.exec('CREATE TABLE teams (id TEXT PRIMARY KEY)')
+  db.exec('CREATE TABLE email_messages (id TEXT PRIMARY KEY)')
   db.exec('PRAGMA foreign_keys = ON')
   db.exec(migrationSql)
+  db.exec(campaignsMigrationSql)
   return new SqliteD1(db) as unknown as D1Database
 }
 
@@ -80,8 +89,13 @@ const runtime: NativeListsRuntime = {
   makeId: (prefix: string) => `${prefix}_${(counter += 1)}`,
   nowIso: () => '2026-06-14T12:00:00.000Z',
 }
+const campaignRuntime: EmailCampaignRuntime = {
+  makeId: (prefix: string) => `${prefix}_${(counter += 1)}`,
+  nowIso: () => '2026-06-14T12:00:00.000Z',
+}
 
 const FORM_ID = 'opt_in_hero'
+const SEQUENCE_SLUG = 'welcome-nurture'
 
 type TestBindings = Readonly<Record<string, unknown>>
 
@@ -99,12 +113,44 @@ const post = (formId: string, body: unknown): Request =>
 // the FormCaptureSpec from a published-site metadata_json blob via the registry
 // (the join that was previously missing). The list is created first so the
 // spec's listId points at a real subscriber_lists row.
-const makeHarness = async (enabled: boolean) => {
-  const service = makeNativeListsService(makeDb(), runtime)
+const makeHarness = async (
+  enabled: boolean,
+  options: { withSequence?: boolean } = {},
+) => {
+  const db = makeDb()
+  const service = makeNativeListsService(db, runtime)
   const list = await service.createList({
     name: 'Opt-in Waitlist',
     sourceAuthorityRef: 'site.form.v1',
   })
+
+  if (options.withSequence === true) {
+    await createEmailSequence(
+      db,
+      'system:site-form-capture',
+      {
+        audience: 'sales_qualified_leads',
+        name: 'Welcome nurture',
+        slug: SEQUENCE_SLUG,
+        status: 'active',
+        steps: [
+          {
+            delaySeconds: 0,
+            name: 'Day 0 intro',
+            stepKey: 'day_0',
+            templateSlug: 'sequence.welcome.day_0.v1',
+          },
+          {
+            delaySeconds: 86_400,
+            name: 'Day 1 value',
+            stepKey: 'day_1',
+            templateSlug: 'sequence.welcome.day_1.v1',
+          },
+        ],
+      },
+      campaignRuntime,
+    )
+  }
 
   // A realistic published-site metadata_json carrying a formSpecs map — exactly
   // what site_versions.metadata_json holds in production.
@@ -114,6 +160,9 @@ const makeHarness = async (enabled: boolean) => {
       [FORM_ID]: {
         id: FORM_ID,
         listId: list.id,
+        ...(options.withSequence === true
+          ? { sequenceSlug: SEQUENCE_SLUG }
+          : {}),
         fields: [
           { name: 'email', kind: 'email', required: true },
           { name: 'name', kind: 'text', required: true },
@@ -124,7 +173,44 @@ const makeHarness = async (enabled: boolean) => {
 
   const routes = makeSitePageFormCaptureRoutes<TestBindings>({
     isEnabled: () => enabled,
-    makeSink: () => ({ addSubscriber: service.addSubscriber }),
+    makeSink: () => ({
+      addSubscriber: async input => {
+        const result = await service.addSubscriber(input)
+
+        if (
+          input.sequenceSlug === undefined ||
+          input.sequenceSlug.trim() === ''
+        ) {
+          return result
+        }
+
+        const sequenceEnrollment = await enrollListSubscriberInSequence(
+          db,
+          {
+            email: result.subscriber.email,
+            listId: input.listId,
+            sequenceSlug: input.sequenceSlug,
+          },
+          'system:site-form-capture',
+          runtime,
+          campaignRuntime,
+        )
+
+        return {
+          ...result,
+          sequenceEnrollment:
+            sequenceEnrollment.status === 'enrolled'
+              ? {
+                  scheduledSendCount: sequenceEnrollment.scheduledSendCount,
+                  status: sequenceEnrollment.status,
+                }
+              : {
+                  reason: sequenceEnrollment.reason,
+                  status: sequenceEnrollment.status,
+                },
+        }
+      },
+    }),
     // Stand-in for the index.ts D1 read of the active site version's
     // metadata_json that owns this formId. Only the known form resolves.
     readSiteFormMetadata: async (_env, formId) =>
@@ -132,8 +218,17 @@ const makeHarness = async (enabled: boolean) => {
     nowIso: () => '2026-06-14T12:00:00.000Z',
   })
 
-  return { routes, service, listId: list.id }
+  return { db, routes, service, listId: list.id }
 }
+
+const countSends = (db: D1Database, email: string): Promise<number> =>
+  db
+    .prepare(
+      `SELECT COUNT(*) AS n FROM email_campaign_sends WHERE email = ?`,
+    )
+    .bind(email)
+    .first<{ n: number }>()
+    .then(row => row?.n ?? 0)
 
 const run = async (
   routes: Awaited<ReturnType<typeof makeHarness>>['routes'],
@@ -212,6 +307,36 @@ describe('site page form-capture wiring (flag ON → registry-resolved)', () => 
     const subscribers = await service.listSubscribers({ listId })
     expect(subscribers).toHaveLength(1)
     expect(subscribers[0]?.sourceRef).toBe(`site_form.${FORM_ID}`)
+  })
+
+  test('form spec with sequenceSlug captures and schedules sequence sends', async () => {
+    const { db, routes, service, listId } = await makeHarness(true, {
+      withSequence: true,
+    })
+
+    const response = await run(
+      routes,
+      post(FORM_ID, {
+        email: 'LEAD@example.com',
+        name: 'Ada Lovelace',
+      }),
+    )
+
+    expect(response.status).toBe(201)
+    const json = (await response.json()) as Record<string, unknown>
+    expect(json).toMatchObject({
+      email: 'lead@example.com',
+      idempotent: false,
+      listId,
+      sequenceEnrollment: {
+        scheduledSendCount: 2,
+        status: 'enrolled',
+      },
+    })
+
+    const subscribers = await service.listSubscribers({ listId })
+    expect(subscribers).toHaveLength(1)
+    expect(await countSends(db, 'lead@example.com')).toBe(2)
   })
 
   test('replayed submission is idempotent → 200', async () => {

--- a/apps/openagents.com/workers/api/src/site-page-form-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/site-page-form-routes.test.ts
@@ -180,6 +180,50 @@ describe('site page form-capture route', () => {
     expect(subscribers).toHaveLength(1)
   })
 
+  test('returns sequence enrollment when the form feeds a sequence', async () => {
+    const service = makeNativeListsService(makeDb(), runtime)
+    const list = await service.createList({
+      name: 'Opt-in Waitlist',
+      sourceAuthorityRef: 'site.form.v1',
+    })
+    const routes = makeSitePageFormRoutes<TestBindings>({
+      makeSink: () => ({
+        addSubscriber: async input => {
+          const result = await service.addSubscriber(input)
+
+          return {
+            ...result,
+            sequenceEnrollment:
+              input.sequenceSlug === 'welcome-nurture'
+                ? { scheduledSendCount: 2, status: 'enrolled' }
+                : undefined,
+          }
+        },
+      }),
+      lookupFormSpec: async (_env, formId) =>
+        formId === FORM_ID
+          ? { ...formSpecFor(list.id), sequenceSlug: 'welcome-nurture' }
+          : undefined,
+      nowIso: () => '2026-06-14T12:00:00.000Z',
+    })
+
+    const response = await run(
+      routes,
+      post('opt_in_hero', { email: 'lead@example.com', name: 'Ada' }),
+    )
+
+    expect(response.status).toBe(201)
+    await expect(response.json()).resolves.toMatchObject({
+      email: 'lead@example.com',
+      idempotent: false,
+      listId: list.id,
+      sequenceEnrollment: {
+        scheduledSendCount: 2,
+        status: 'enrolled',
+      },
+    })
+  })
+
   test('missing email fails validation → 400', async () => {
     const { routes, service, listId } = await makeHarness()
 

--- a/apps/openagents.com/workers/api/src/site-page-form-routes.ts
+++ b/apps/openagents.com/workers/api/src/site-page-form-routes.ts
@@ -48,6 +48,7 @@ import { Effect, Match as M } from 'effect'
 
 import {
   type FormCaptureSink,
+  type FormCaptureSequenceEnrollment,
   type FormCaptureSpec,
   captureFormSubmission,
 } from './site-page-kinds'
@@ -102,6 +103,13 @@ const notFound = (): HttpResponse =>
     },
     { status: 404 },
   )
+
+const sequenceEnrollmentPayload = (
+  sequenceEnrollment: FormCaptureSequenceEnrollment | undefined,
+):
+  | Readonly<{ sequenceEnrollment: FormCaptureSequenceEnrollment }>
+  | Record<string, never> =>
+  sequenceEnrollment === undefined ? {} : { sequenceEnrollment }
 
 // Read the request body as a plain JSON object. A malformed/non-object body
 // degrades to an empty object so the spec-driven validator (not a parser
@@ -158,6 +166,7 @@ const submitForm = <Bindings extends SitePageFormRouteEnv>(
             generatedAt: nowIso,
             idempotent: false,
             listId: captured.listId,
+            ...sequenceEnrollmentPayload(captured.sequenceEnrollment),
           },
           { status: 201 },
         ),
@@ -169,6 +178,7 @@ const submitForm = <Bindings extends SitePageFormRouteEnv>(
             generatedAt: nowIso,
             idempotent: true,
             listId: idempotent.listId,
+            ...sequenceEnrollmentPayload(idempotent.sequenceEnrollment),
           },
           { status: 200 },
         ),

--- a/apps/openagents.com/workers/api/src/site-page-kinds.ts
+++ b/apps/openagents.com/workers/api/src/site-page-kinds.ts
@@ -172,6 +172,7 @@ export type FormCaptureField = typeof FormCaptureField.Type
 export const FormCaptureSpec = S.Struct({
   id: S.String,
   listId: S.String,
+  sequenceSlug: S.optionalKey(S.String),
   fields: S.Array(FormCaptureField),
 })
 export type FormCaptureSpec = typeof FormCaptureSpec.Type
@@ -189,14 +190,46 @@ export type FormCaptureSink = Readonly<{
       email: string
       listId: string
       metadata?: Record<string, string | number | boolean | null> | undefined
+      sequenceSlug?: string | undefined
       sourceRef: string
     }>,
-  ) => Promise<Readonly<{ idempotent: boolean; subscriber: { email: string } }>>
+  ) => Promise<
+    Readonly<{
+      idempotent: boolean
+      sequenceEnrollment?: FormCaptureSequenceEnrollment | undefined
+      subscriber: { email: string }
+    }>
+  >
 }>
 
+export type FormCaptureSequenceEnrollment =
+  | Readonly<{
+      scheduledSendCount: number
+      status: 'enrolled'
+    }>
+  | Readonly<{
+      reason:
+        | 'drip_preference_disabled'
+        | 'drip_suppressed'
+        | 'sequence_not_found'
+        | 'subscriber_not_active'
+        | 'subscriber_not_on_list'
+      status: 'skipped'
+    }>
+
 export type FormCaptureOutcome =
-  | Readonly<{ _tag: 'captured'; email: string; listId: string }>
-  | Readonly<{ _tag: 'idempotent'; email: string; listId: string }>
+  | Readonly<{
+      _tag: 'captured'
+      email: string
+      listId: string
+      sequenceEnrollment?: FormCaptureSequenceEnrollment | undefined
+    }>
+  | Readonly<{
+      _tag: 'idempotent'
+      email: string
+      listId: string
+      sequenceEnrollment?: FormCaptureSequenceEnrollment | undefined
+    }>
   | Readonly<{ _tag: 'validation_error'; reason: string }>
 
 // Extract metadata from a submission constrained to the spec's declared
@@ -281,6 +314,7 @@ export const captureFormSubmission = async (
     email,
     listId: formSpec.listId,
     metadata: Object.keys(metadata).length === 0 ? undefined : metadata,
+    sequenceSlug: formSpec.sequenceSlug,
     sourceRef:
       input.sourceRef === undefined || input.sourceRef.trim() === ''
         ? `site_form.${formSpec.id}`
@@ -292,11 +326,17 @@ export const captureFormSubmission = async (
         _tag: 'idempotent',
         email: result.subscriber.email,
         listId: formSpec.listId,
+        ...(result.sequenceEnrollment === undefined
+          ? {}
+          : { sequenceEnrollment: result.sequenceEnrollment }),
       }
     : {
         _tag: 'captured',
         email: result.subscriber.email,
         listId: formSpec.listId,
+        ...(result.sequenceEnrollment === undefined
+          ? {}
+          : { sequenceEnrollment: result.sequenceEnrollment }),
       }
 }
 


### PR DESCRIPTION
Closes #8093

## Summary
- Adds optional `sequenceSlug` support to published site `FormCaptureSpec`s.
- Carries sequence enrollment status through the public site form capture response when a form feeds a sequence.
- Wires the production site form capture sink to add the native-list subscriber and then enroll the stored subscriber into the existing authored email sequence engine.
- Adds SQL-backed coverage proving a form submit writes the subscriber and schedules campaign sends.

## Verification
- `bun run --cwd apps/openagents.com/workers/api test -- src/site-page-kinds.test.ts src/site-form-spec-registry.test.ts src/site-page-form-routes.test.ts src/site-page-form-capture-routes.test.ts src/list-sequence-enrollment.test.ts` → 5 files / 51 tests passed
- `bun run --cwd apps/openagents.com/workers/api typecheck` → passed
- `bun run check:deploy` → passed