### PR TITLE
[codex] Add inventory-aware campaign workflow receipt

### DIFF
--- a/apps/openagents.com/workers/api/src/ecommerce-campaign-claim-upgrade.test.ts
+++ b/apps/openagents.com/workers/api/src/ecommerce-campaign-claim-upgrade.test.ts
@@ -12,6 +12,7 @@ import {
   ECOMMERCE_CAMPAIGN_DELIVERY_RECEIPT_DOC_VERSION,
   buildEcommerceCampaignDeliveryReceipt,
 } from './ecommerce-campaign-delivery-receipt'
+import { buildEcommerceCampaignWorkflowReceipt } from './ecommerce-campaign-workflow'
 
 const receiptFixture = (overrides = {}): EcommerceCampaignDeliveryReceiptDocument => ({
   docVersion: ECOMMERCE_CAMPAIGN_DELIVERY_RECEIPT_DOC_VERSION,
@@ -30,6 +31,28 @@ const receiptFixture = (overrides = {}): EcommerceCampaignDeliveryReceiptDocumen
     spendObservedCents: 1000,
     publishedArtifactRefs: ['artifact.fixture'],
     statsWindow: null,
+    campaignWorkflow: buildEcommerceCampaignWorkflowReceipt({
+      workflowRef: 'workflow.fixture',
+      inventorySnapshotRef: 'inventory.snapshot.fixture',
+      inventoryItems: [
+        {
+          skuRef: 'sku.fixture',
+          title: 'Fixture product',
+          stockState: 'in_stock',
+          availableQuantity: 3,
+          productImageRef: 'image.fixture',
+          productImageVerified: true,
+          productPageRef: 'product.fixture',
+        },
+      ],
+      selectedSkuRefs: ['sku.fixture'],
+      spendCapCents: 50000,
+      requestedSpendCents: 1000,
+      statsWindow: null,
+      conversationalEditRefs: ['conversation.fixture'],
+      merchantApprovalMode: 'approved_for_publish',
+      publishState: 'published_with_receipt',
+    }),
     attributionCaveat: 'fixture',
     stockoutFollowUp: 'fixture',
     paidSettlement: {

--- a/apps/openagents.com/workers/api/src/ecommerce-campaign-delivery-receipt-fixture.ts
+++ b/apps/openagents.com/workers/api/src/ecommerce-campaign-delivery-receipt-fixture.ts
@@ -3,6 +3,7 @@ import {
   toEcommerceCampaignDeliveryReceiptDocument,
   type EcommerceCampaignDeliveryReceiptDocument,
 } from './ecommerce-campaign-delivery-receipt'
+import { buildEcommerceCampaignWorkflowReceipt } from './ecommerce-campaign-workflow'
 
 /**
  * A dereferenceable first-paid delivery-receipt fixture for an e-commerce
@@ -29,6 +30,37 @@ export const firstPaidEcommerceCampaignDeliveryReceiptFixture: EcommerceCampaign
       attributionCaveat:
         'Engagement attribution is modeled, not deterministic; treat as directional.',
       stockoutFollowUp: 'Alert merchant if any advertised SKU stock drops below 5 units.',
+      campaignWorkflow: buildEcommerceCampaignWorkflowReceipt({
+        workflowRef: 'workflow.ecommerce.inventory_campaign.fixture',
+        inventorySnapshotRef: 'inventory.snapshot.ecommerce_campaign.fixture',
+        inventoryItems: [
+          {
+            skuRef: 'sku.fixture.in_stock',
+            title: 'Fixture in-stock product',
+            stockState: 'in_stock',
+            availableQuantity: 12,
+            productImageRef: 'image.fixture.in_stock',
+            productImageVerified: true,
+            productPageRef: 'product.fixture.in_stock',
+          },
+          {
+            skuRef: 'sku.fixture.out_of_stock',
+            title: 'Fixture out-of-stock product',
+            stockState: 'out_of_stock',
+            availableQuantity: 0,
+            productImageRef: 'image.fixture.out_of_stock',
+            productImageVerified: true,
+            productPageRef: 'product.fixture.out_of_stock',
+          },
+        ],
+        selectedSkuRefs: ['sku.fixture.in_stock'],
+        spendCapCents: 50000,
+        requestedSpendCents: 45000,
+        statsWindow: '2026-06-20/2026-06-27',
+        conversationalEditRefs: ['conversation.ecommerce_campaign.fixture_edit'],
+        merchantApprovalMode: 'approved_for_publish',
+        publishState: 'published_with_receipt',
+      }),
       paidSettlement: {
         amountCents: 15000,
         asset: 'usd',

--- a/apps/openagents.com/workers/api/src/ecommerce-campaign-delivery-receipt.test.ts
+++ b/apps/openagents.com/workers/api/src/ecommerce-campaign-delivery-receipt.test.ts
@@ -13,6 +13,10 @@ import {
   verifyDereferencedEcommerceCampaignReceipt,
   verifyEcommerceCampaignPaidDelivery,
 } from './ecommerce-campaign-delivery-receipt'
+import {
+  buildEcommerceCampaignWorkflowReceipt,
+  type EcommerceCampaignWorkflowInput,
+} from './ecommerce-campaign-workflow'
 
 const allBlockedGates: Record<EcommerceCampaignAuthorityGateId, boolean> = {
   merchant_approval: false,
@@ -44,6 +48,7 @@ const baseInput = (
   attributionCaveat:
     'Attribution is modeled, not deterministic; treat as directional.',
   stockoutFollowUp: 'Re-check SKU stock before any re-run.',
+  campaignWorkflow: undefined,
   paidSettlement: {
     amountCents: 0,
     asset: 'usd',
@@ -56,6 +61,45 @@ const baseInput = (
   ],
   ...overrides,
 })
+
+const workflowInput = (
+  overrides: Partial<EcommerceCampaignWorkflowInput> = {},
+): EcommerceCampaignWorkflowInput => ({
+  workflowRef: 'workflow.ecommerce.inventory_campaign.fixture',
+  inventorySnapshotRef: 'inventory.snapshot.fixture',
+  inventoryItems: [
+    {
+      skuRef: 'sku.fixture.in_stock',
+      title: 'Fixture in-stock product',
+      stockState: 'in_stock',
+      availableQuantity: 7,
+      productImageRef: 'image.fixture.in_stock',
+      productImageVerified: true,
+      productPageRef: 'product.fixture.in_stock',
+    },
+    {
+      skuRef: 'sku.fixture.out_of_stock',
+      title: 'Fixture out-of-stock product',
+      stockState: 'out_of_stock',
+      availableQuantity: 0,
+      productImageRef: 'image.fixture.out_of_stock',
+      productImageVerified: true,
+      productPageRef: 'product.fixture.out_of_stock',
+    },
+  ],
+  selectedSkuRefs: ['sku.fixture.in_stock'],
+  spendCapCents: 50_000,
+  requestedSpendCents: 42_000,
+  statsWindow: '2026-06-20/2026-06-27',
+  conversationalEditRefs: ['conversation.ecommerce.edit.fixture'],
+  merchantApprovalMode: 'approved_for_publish',
+  publishState: 'published_with_receipt',
+  ...overrides,
+})
+
+const workflowReceipt = (
+  overrides: Partial<EcommerceCampaignWorkflowInput> = {},
+) => buildEcommerceCampaignWorkflowReceipt(workflowInput(overrides))
 
 describe('e-commerce campaign delivery receipt', () => {
   test('a fresh draft with all gates blocked is blocked, not delivered', () => {
@@ -96,6 +140,7 @@ describe('e-commerce campaign delivery receipt', () => {
         publishedArtifactRefs: ['campaign.meta.set.123'],
         spendObservedCents: 42_000,
         statsWindow: '2026-06-20/2026-06-27',
+        campaignWorkflow: workflowReceipt(),
         paidSettlement: {
           amountCents: 25_000,
           asset: 'usd',
@@ -146,6 +191,7 @@ describe('e-commerce campaign delivery receipt', () => {
         humanReviewAccepted: true,
         receiptedGates: allReceiptedGates,
         publishedArtifactRefs: ['campaign.meta.set.123'],
+        campaignWorkflow: workflowReceipt(),
         paidSettlement: {
           amountCents: 25_000,
           asset: 'usd',
@@ -159,6 +205,43 @@ describe('e-commerce campaign delivery receipt', () => {
       'paid settlement recorded without a dereferenceable payment ref',
     )
   })
+
+  test('does not verify a paid delivery without inventory workflow evidence', () => {
+    const receipt = buildEcommerceCampaignDeliveryReceipt(
+      baseInput({
+        humanReviewAccepted: true,
+        receiptedGates: allReceiptedGates,
+        publishedArtifactRefs: ['campaign.meta.set.123'],
+        spendObservedCents: 42_000,
+        statsWindow: '2026-06-20/2026-06-27',
+        paidSettlement: {
+          amountCents: 25_000,
+          asset: 'usd',
+          evidenced: true,
+          publicPaymentRef: 'payment.public.ref.abc',
+        },
+      }),
+    )
+
+    expect(verifyEcommerceCampaignPaidDelivery(receipt)).toContain(
+      'inventory-aware campaign workflow receipt missing',
+    )
+  })
+
+  test('rejects delivery receipts whose spend cap diverges from workflow evidence', () => {
+    expect(() =>
+      buildEcommerceCampaignDeliveryReceipt(
+        baseInput({
+          receiptedGates: allReceiptedGates,
+          spendCapCents: 50_000,
+          campaignWorkflow: workflowReceipt({
+            spendCapCents: 40_000,
+            requestedSpendCents: 40_000,
+          }),
+        }),
+      ),
+    ).toThrow(EcommerceCampaignDeliveryReceiptInvariantError)
+  })
 })
 
 const paidReceipt = () =>
@@ -169,6 +252,7 @@ const paidReceipt = () =>
       publishedArtifactRefs: ['campaign.meta.set.123'],
       spendObservedCents: 42_000,
       statsWindow: '2026-06-20/2026-06-27',
+      campaignWorkflow: workflowReceipt(),
       paidSettlement: {
         amountCents: 25_000,
         asset: 'usd',

--- a/apps/openagents.com/workers/api/src/ecommerce-campaign-delivery-receipt.ts
+++ b/apps/openagents.com/workers/api/src/ecommerce-campaign-delivery-receipt.ts
@@ -2,6 +2,10 @@ import { Schema as S } from 'effect'
 
 import { parseJsonWithSchema } from './json-boundary'
 import { ECOMMERCE_DESIGN_PARTNER_TEMPLATE_REF } from './prefilled-workspace-vertical-templates'
+import {
+  EcommerceCampaignWorkflowReceipt,
+  verifyEcommerceCampaignWorkflowReceipt,
+} from './ecommerce-campaign-workflow'
 
 /**
  * First-paid delivery receipt for an e-commerce inventory-aware ad-campaign
@@ -130,6 +134,7 @@ export const EcommerceCampaignDeliveryReceipt = S.Struct({
   statsWindow: S.NullOr(S.String),
   attributionCaveat: S.String,
   stockoutFollowUp: S.String,
+  campaignWorkflow: S.optionalKey(EcommerceCampaignWorkflowReceipt),
   paidSettlement: EcommerceCampaignPaidSettlement,
   freshnessTimestamp: S.String,
   publicSourceRefs: S.Array(S.String),
@@ -163,6 +168,7 @@ export type EcommerceCampaignDeliveryInput = Readonly<{
   statsWindow: string | null
   attributionCaveat: string
   stockoutFollowUp: string
+  campaignWorkflow?: EcommerceCampaignWorkflowReceipt | undefined
   paidSettlement: EcommerceCampaignPaidSettlement
   freshnessTimestamp: string
   publicSourceRefs: ReadonlyArray<string>
@@ -222,6 +228,25 @@ export const buildEcommerceCampaignDeliveryReceipt = (
     })
   }
 
+  if (
+    input.campaignWorkflow !== undefined &&
+    input.campaignWorkflow.spendCapCents !== input.spendCapCents
+  ) {
+    throw new EcommerceCampaignDeliveryReceiptInvariantError({
+      reason: 'campaign workflow spend cap must match delivery receipt spend cap',
+    })
+  }
+
+  if (
+    spendObserved != null &&
+    input.campaignWorkflow !== undefined &&
+    spendObserved !== input.campaignWorkflow.requestedSpendCents
+  ) {
+    throw new EcommerceCampaignDeliveryReceiptInvariantError({
+      reason: 'observed spend must match campaign workflow requested spend',
+    })
+  }
+
   if (input.paidSettlement.amountCents < 0) {
     throw new EcommerceCampaignDeliveryReceiptInvariantError({
       reason: 'paid settlement amount must not be negative',
@@ -264,6 +289,9 @@ export const buildEcommerceCampaignDeliveryReceipt = (
     statsWindow: input.statsWindow,
     attributionCaveat: input.attributionCaveat,
     stockoutFollowUp: input.stockoutFollowUp,
+    ...(input.campaignWorkflow === undefined
+      ? {}
+      : { campaignWorkflow: input.campaignWorkflow }),
     paidSettlement: input.paidSettlement,
     freshnessTimestamp: input.freshnessTimestamp,
     publicSourceRefs: [...input.publicSourceRefs],
@@ -309,6 +337,26 @@ export const verifyEcommerceCampaignPaidDelivery = (
   }
   if (receipt.publishedArtifactRefs.length === 0) {
     reasons.push('no published artifact refs')
+  }
+  if (receipt.campaignWorkflow === undefined) {
+    reasons.push('inventory-aware campaign workflow receipt missing')
+  } else {
+    reasons.push(...verifyEcommerceCampaignWorkflowReceipt(receipt.campaignWorkflow))
+    if (receipt.campaignWorkflow.spendCapCents !== receipt.spendCapCents) {
+      reasons.push('workflow spend cap does not match delivery receipt spend cap')
+    }
+    if (
+      receipt.spendObservedCents != null &&
+      receipt.campaignWorkflow.requestedSpendCents !== receipt.spendObservedCents
+    ) {
+      reasons.push('workflow requested spend does not match observed spend')
+    }
+    if (
+      receipt.statsWindow !== null &&
+      receipt.campaignWorkflow.statsWindow !== receipt.statsWindow
+    ) {
+      reasons.push('workflow stats window does not match delivery receipt stats window')
+    }
   }
 
   return reasons

--- a/apps/openagents.com/workers/api/src/ecommerce-campaign-receipt-operator-routes.ts
+++ b/apps/openagents.com/workers/api/src/ecommerce-campaign-receipt-operator-routes.ts
@@ -13,6 +13,7 @@ import {
   buildEcommerceCampaignDeliveryReceipt,
   toEcommerceCampaignDeliveryReceiptDocument,
 } from './ecommerce-campaign-delivery-receipt'
+import { EcommerceCampaignWorkflowReceipt } from './ecommerce-campaign-workflow'
 
 export type EcommerceCampaignReceiptOperatorRoutesDependencies<Bindings> = Readonly<{
   makeStore: (env: Bindings) => EcommerceCampaignReceiptStore
@@ -33,6 +34,7 @@ const RecordReceiptRequest = S.Struct({
   statsWindow: S.NullOr(S.String),
   attributionCaveat: S.String,
   stockoutFollowUp: S.String,
+  campaignWorkflow: S.optionalKey(EcommerceCampaignWorkflowReceipt),
   paidSettlement: EcommerceCampaignPaidSettlement,
   freshnessTimestamp: S.String,
   publicSourceRefs: S.Array(S.String),
@@ -85,6 +87,7 @@ export const makeEcommerceCampaignReceiptOperatorRoutes = <Bindings>(
           statsWindow: parsed.statsWindow,
           attributionCaveat: parsed.attributionCaveat,
           stockoutFollowUp: parsed.stockoutFollowUp,
+          campaignWorkflow: parsed.campaignWorkflow,
           paidSettlement: parsed.paidSettlement,
           freshnessTimestamp: parsed.freshnessTimestamp,
           publicSourceRefs: parsed.publicSourceRefs,

--- a/apps/openagents.com/workers/api/src/ecommerce-campaign-workflow.test.ts
+++ b/apps/openagents.com/workers/api/src/ecommerce-campaign-workflow.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, test } from 'vitest'
+
+import {
+  type EcommerceCampaignWorkflowInput,
+  EcommerceCampaignWorkflowInvariantError,
+  buildEcommerceCampaignWorkflowReceipt,
+  verifyEcommerceCampaignWorkflowReceipt,
+} from './ecommerce-campaign-workflow'
+
+const workflowInput = (
+  overrides: Partial<EcommerceCampaignWorkflowInput> = {},
+): EcommerceCampaignWorkflowInput => ({
+  workflowRef: 'workflow.ecommerce.inventory_campaign.fixture',
+  inventorySnapshotRef: 'inventory.snapshot.fixture',
+  inventoryItems: [
+    {
+      skuRef: 'sku.in_stock',
+      title: 'In-stock product',
+      stockState: 'in_stock',
+      availableQuantity: 12,
+      productImageRef: 'image.in_stock',
+      productImageVerified: true,
+      productPageRef: 'product.in_stock',
+    },
+    {
+      skuRef: 'sku.out_of_stock',
+      title: 'Out-of-stock product',
+      stockState: 'out_of_stock',
+      availableQuantity: 0,
+      productImageRef: 'image.out_of_stock',
+      productImageVerified: true,
+      productPageRef: 'product.out_of_stock',
+    },
+  ],
+  selectedSkuRefs: ['sku.in_stock'],
+  spendCapCents: 50_000,
+  requestedSpendCents: 42_000,
+  statsWindow: '2026-06-20/2026-06-27',
+  conversationalEditRefs: ['conversation.edit.1'],
+  merchantApprovalMode: 'approved_for_publish',
+  publishState: 'published_with_receipt',
+  ...overrides,
+})
+
+describe('e-commerce inventory-aware campaign workflow', () => {
+  test('builds a clean receipt for in-stock products with verified imagery, edits, and spend cap', () => {
+    const receipt = buildEcommerceCampaignWorkflowReceipt(workflowInput())
+
+    expect(receipt.eligibleSkuRefs).toEqual(['sku.in_stock'])
+    expect(receipt.excludedSkuRefs).toEqual(['sku.out_of_stock'])
+    expect(receipt.productImageRefs).toEqual(['image.in_stock'])
+    expect(receipt.blockerRefs).toEqual([])
+    expect(verifyEcommerceCampaignWorkflowReceipt(receipt)).toEqual([])
+  })
+
+  test('rejects selected products that are not in stock', () => {
+    expect(() =>
+      buildEcommerceCampaignWorkflowReceipt(
+        workflowInput({ selectedSkuRefs: ['sku.out_of_stock'] }),
+      ),
+    ).toThrow(EcommerceCampaignWorkflowInvariantError)
+  })
+
+  test('rejects selected products without verified imagery', () => {
+    expect(() =>
+      buildEcommerceCampaignWorkflowReceipt(
+        workflowInput({
+          inventoryItems: [
+            {
+              skuRef: 'sku.in_stock',
+              title: 'In-stock product',
+              stockState: 'in_stock',
+              availableQuantity: 12,
+              productImageRef: null,
+              productImageVerified: false,
+              productPageRef: 'product.in_stock',
+            },
+          ],
+        }),
+      ),
+    ).toThrow(EcommerceCampaignWorkflowInvariantError)
+  })
+
+  test('rejects requested spend above the cap', () => {
+    expect(() =>
+      buildEcommerceCampaignWorkflowReceipt(
+        workflowInput({ requestedSpendCents: 50_001 }),
+      ),
+    ).toThrow(EcommerceCampaignWorkflowInvariantError)
+  })
+
+  test('keeps draft workflows blocked until conversational edits and publish approval exist', () => {
+    const receipt = buildEcommerceCampaignWorkflowReceipt(
+      workflowInput({
+        conversationalEditRefs: [],
+        merchantApprovalMode: 'approval_required',
+        publishState: 'not_published',
+      }),
+    )
+
+    expect(receipt.blockerRefs).toEqual([
+      'blocker.ecommerce_campaign.conversational_edit_thread_missing',
+      'blocker.ecommerce_campaign.merchant_publish_approval_missing',
+      'blocker.ecommerce_campaign.not_published_with_receipt',
+    ])
+    expect(verifyEcommerceCampaignWorkflowReceipt(receipt)).toContain(
+      'conversational edit thread missing',
+    )
+  })
+})

--- a/apps/openagents.com/workers/api/src/ecommerce-campaign-workflow.ts
+++ b/apps/openagents.com/workers/api/src/ecommerce-campaign-workflow.ts
@@ -1,0 +1,181 @@
+import { Schema as S } from 'effect'
+
+export const ECOMMERCE_CAMPAIGN_WORKFLOW_SCHEMA =
+  'openagents.ecommerce_campaign.inventory_workflow.v1' as const
+
+export const EcommerceCampaignInventoryItem = S.Struct({
+  skuRef: S.String,
+  title: S.String,
+  stockState: S.Literals(['in_stock', 'out_of_stock']),
+  availableQuantity: S.Number,
+  productImageRef: S.NullOr(S.String),
+  productImageVerified: S.Boolean,
+  productPageRef: S.String,
+})
+export type EcommerceCampaignInventoryItem =
+  typeof EcommerceCampaignInventoryItem.Type
+
+export const EcommerceCampaignWorkflowReceipt = S.Struct({
+  schema: S.Literal(ECOMMERCE_CAMPAIGN_WORKFLOW_SCHEMA),
+  workflowRef: S.String,
+  inventorySnapshotRef: S.String,
+  eligibleSkuRefs: S.Array(S.String),
+  excludedSkuRefs: S.Array(S.String),
+  productImageRefs: S.Array(S.String),
+  spendCapCents: S.Number,
+  requestedSpendCents: S.Number,
+  statsWindow: S.NullOr(S.String),
+  conversationalEditRefs: S.Array(S.String),
+  merchantApprovalMode: S.Literals([
+    'draft_only',
+    'approval_required',
+    'approved_for_publish',
+  ]),
+  publishState: S.Literals(['not_published', 'published_with_receipt']),
+  blockerRefs: S.Array(S.String),
+})
+export type EcommerceCampaignWorkflowReceipt =
+  typeof EcommerceCampaignWorkflowReceipt.Type
+
+export class EcommerceCampaignWorkflowInvariantError extends S.TaggedErrorClass<EcommerceCampaignWorkflowInvariantError>()(
+  'EcommerceCampaignWorkflowInvariantError',
+  { reason: S.String },
+) {}
+
+export type EcommerceCampaignWorkflowInput = Readonly<{
+  workflowRef: string
+  inventorySnapshotRef: string
+  inventoryItems: ReadonlyArray<EcommerceCampaignInventoryItem>
+  selectedSkuRefs: ReadonlyArray<string>
+  spendCapCents: number
+  requestedSpendCents: number
+  statsWindow: string | null
+  conversationalEditRefs: ReadonlyArray<string>
+  merchantApprovalMode: EcommerceCampaignWorkflowReceipt['merchantApprovalMode']
+  publishState: EcommerceCampaignWorkflowReceipt['publishState']
+}>
+
+const unique = (values: ReadonlyArray<string>): ReadonlyArray<string> => [
+  ...new Set(values),
+]
+
+export const buildEcommerceCampaignWorkflowReceipt = (
+  input: EcommerceCampaignWorkflowInput,
+): EcommerceCampaignWorkflowReceipt => {
+  if (input.spendCapCents < 0 || input.requestedSpendCents < 0) {
+    throw new EcommerceCampaignWorkflowInvariantError({
+      reason: 'spend cap and requested spend must not be negative',
+    })
+  }
+
+  if (input.requestedSpendCents > input.spendCapCents) {
+    throw new EcommerceCampaignWorkflowInvariantError({
+      reason: `requested spend ${input.requestedSpendCents} exceeds spend cap ${input.spendCapCents}`,
+    })
+  }
+
+  const itemsBySku = new Map(input.inventoryItems.map(item => [item.skuRef, item]))
+  const selectedSkuRefs = unique(input.selectedSkuRefs)
+  const missingSkuRefs = selectedSkuRefs.filter(skuRef => !itemsBySku.has(skuRef))
+
+  if (missingSkuRefs.length > 0) {
+    throw new EcommerceCampaignWorkflowInvariantError({
+      reason: 'selected SKU missing from inventory snapshot: ' + missingSkuRefs.join(', '),
+    })
+  }
+
+  const selectedItems = selectedSkuRefs.map(skuRef => itemsBySku.get(skuRef)!)
+  const invalidStockSkuRefs = selectedItems
+    .filter(item => item.stockState !== 'in_stock' || item.availableQuantity <= 0)
+    .map(item => item.skuRef)
+
+  if (invalidStockSkuRefs.length > 0) {
+    throw new EcommerceCampaignWorkflowInvariantError({
+      reason: 'selected SKU is not in stock: ' + invalidStockSkuRefs.join(', '),
+    })
+  }
+
+  const invalidImageSkuRefs = selectedItems
+    .filter(item => item.productImageRef === null || !item.productImageVerified)
+    .map(item => item.skuRef)
+
+  if (invalidImageSkuRefs.length > 0) {
+    throw new EcommerceCampaignWorkflowInvariantError({
+      reason: 'selected SKU lacks verified product imagery: ' + invalidImageSkuRefs.join(', '),
+    })
+  }
+
+  if (
+    input.publishState === 'published_with_receipt' &&
+    input.merchantApprovalMode !== 'approved_for_publish'
+  ) {
+    throw new EcommerceCampaignWorkflowInvariantError({
+      reason: 'published campaigns require merchant approval for publish',
+    })
+  }
+
+  const blockerRefs: Array<string> = []
+  if (selectedSkuRefs.length === 0) {
+    blockerRefs.push('blocker.ecommerce_campaign.no_in_stock_products_selected')
+  }
+  if (input.conversationalEditRefs.length === 0) {
+    blockerRefs.push('blocker.ecommerce_campaign.conversational_edit_thread_missing')
+  }
+  if (input.merchantApprovalMode !== 'approved_for_publish') {
+    blockerRefs.push('blocker.ecommerce_campaign.merchant_publish_approval_missing')
+  }
+  if (input.publishState !== 'published_with_receipt') {
+    blockerRefs.push('blocker.ecommerce_campaign.not_published_with_receipt')
+  }
+
+  return {
+    schema: ECOMMERCE_CAMPAIGN_WORKFLOW_SCHEMA,
+    workflowRef: input.workflowRef,
+    inventorySnapshotRef: input.inventorySnapshotRef,
+    eligibleSkuRefs: selectedSkuRefs,
+    excludedSkuRefs: input.inventoryItems
+      .filter(item => !selectedSkuRefs.includes(item.skuRef))
+      .map(item => item.skuRef),
+    productImageRefs: selectedItems.map(item => item.productImageRef!),
+    spendCapCents: input.spendCapCents,
+    requestedSpendCents: input.requestedSpendCents,
+    statsWindow: input.statsWindow,
+    conversationalEditRefs: [...input.conversationalEditRefs],
+    merchantApprovalMode: input.merchantApprovalMode,
+    publishState: input.publishState,
+    blockerRefs,
+  }
+}
+
+export const verifyEcommerceCampaignWorkflowReceipt = (
+  receipt: EcommerceCampaignWorkflowReceipt,
+): ReadonlyArray<string> => {
+  const reasons: Array<string> = []
+
+  if (receipt.inventorySnapshotRef.trim().length === 0) {
+    reasons.push('inventory snapshot ref missing')
+  }
+  if (receipt.eligibleSkuRefs.length === 0) {
+    reasons.push('no eligible in-stock SKU refs')
+  }
+  if (receipt.productImageRefs.length < receipt.eligibleSkuRefs.length) {
+    reasons.push('verified product image refs missing for eligible SKUs')
+  }
+  if (receipt.requestedSpendCents > receipt.spendCapCents) {
+    reasons.push('requested spend exceeds spend cap')
+  }
+  if (receipt.conversationalEditRefs.length === 0) {
+    reasons.push('conversational edit thread missing')
+  }
+  if (receipt.publishState !== 'published_with_receipt') {
+    reasons.push(`publish state is ${receipt.publishState}, not published_with_receipt`)
+  }
+  if (receipt.merchantApprovalMode !== 'approved_for_publish') {
+    reasons.push('merchant publish approval missing')
+  }
+  if (receipt.blockerRefs.length > 0) {
+    reasons.push('workflow blockers still present: ' + receipt.blockerRefs.join(', '))
+  }
+
+  return reasons
+}


### PR DESCRIPTION
Closes #8094

## What changed

- Added a typed `openagents.ecommerce_campaign.inventory_workflow.v1` receipt for inventory-aware campaign workflows.
- Enforced real-stock-only selected SKUs, verified product imagery, spend-cap bounds, conversational edit evidence, merchant publish approval, and published-with-receipt state.
- Extended e-commerce paid delivery receipts to optionally carry the workflow receipt and made paid-delivery verification require it before a receipt can substantiate the campaign claim.
- Wired the workflow receipt through the operator receipt recording schema and updated the public fixture/test coverage.

## Why

BF-4.7 requires the campaign deliverable to be grounded in live inventory, accurate product imagery, a bounded spend cap, conversational edits before posting, and stats returned with a receipt. The existing paid-delivery receipt could verify spend/artifact/payment, but did not prove those inventory and edit gates.

## Verification

- `bun run --cwd apps/openagents.com/workers/api test -- src/ecommerce-campaign-workflow.test.ts src/ecommerce-campaign-delivery-receipt.test.ts src/ecommerce-campaign-claim-upgrade.test.ts src/ecommerce-campaign-receipt-routes.test.ts src/ecommerce-campaign-self-serve-routes.test.ts`
  - 5 files passed, 29 tests passed.
- `bun run --cwd apps/openagents.com/workers/api typecheck`
  - passed.
- `bun run check:deploy`
  - passed. The contract-drift guard fixture prints expected failure examples while the guard test asserts them; the command continued through web/API suites and exited 0.