### PR TITLE
BF-5.1: add fulfillment loop daily motion receipts

### DIFF
--- a/apps/openagents.com/workers/api/migrations/0274_business_fulfillment_loop.sql
+++ b/apps/openagents.com/workers/api/migrations/0274_business_fulfillment_loop.sql
@@ -1,0 +1,46 @@
+CREATE TABLE IF NOT EXISTS business_service_promises (
+  id TEXT PRIMARY KEY NOT NULL,
+  promise_ref TEXT NOT NULL UNIQUE,
+  accepted_outcome_contract_id TEXT
+    REFERENCES omni_accepted_outcome_contracts(id) ON DELETE SET NULL,
+  workspace_ref TEXT NOT NULL,
+  crm_state_ref TEXT NOT NULL,
+  stakeholder_refs_json TEXT NOT NULL DEFAULT '[]',
+  state TEXT NOT NULL CHECK (
+    state IN ('active', 'paused', 'blocked', 'closed')
+  ),
+  cadence TEXT NOT NULL CHECK (cadence IN ('daily')),
+  next_motion_due_at TEXT,
+  last_motion_receipt_ref TEXT,
+  source_refs_json TEXT NOT NULL DEFAULT '[]',
+  metadata_json TEXT NOT NULL DEFAULT '{}',
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_business_service_promises_due
+  ON business_service_promises(state, next_motion_due_at, updated_at DESC);
+
+CREATE TABLE IF NOT EXISTS business_fulfillment_motion_receipts (
+  id TEXT PRIMARY KEY NOT NULL,
+  promise_id TEXT NOT NULL
+    REFERENCES business_service_promises(id) ON DELETE CASCADE,
+  promise_ref TEXT NOT NULL,
+  motion_date TEXT NOT NULL,
+  receipt_ref TEXT NOT NULL UNIQUE,
+  agent_definition_ref TEXT NOT NULL,
+  crm_state_ref TEXT NOT NULL,
+  stakeholder_refs_json TEXT NOT NULL DEFAULT '[]',
+  stakeholder_flag_refs_json TEXT NOT NULL DEFAULT '[]',
+  forward_motion_ref TEXT NOT NULL,
+  client_comms_draft_ref TEXT NOT NULL,
+  approval_gate_ref TEXT NOT NULL,
+  outbound_allowed INTEGER NOT NULL DEFAULT 0 CHECK (outbound_allowed IN (0, 1)),
+  blocker_refs_json TEXT NOT NULL DEFAULT '[]',
+  source_refs_json TEXT NOT NULL DEFAULT '[]',
+  created_at TEXT NOT NULL,
+  UNIQUE (promise_id, motion_date)
+);
+
+CREATE INDEX IF NOT EXISTS idx_business_fulfillment_motion_receipts_promise
+  ON business_fulfillment_motion_receipts(promise_id, created_at DESC);

--- a/apps/openagents.com/workers/api/src/business-fulfillment-loop.test.ts
+++ b/apps/openagents.com/workers/api/src/business-fulfillment-loop.test.ts
@@ -1,0 +1,332 @@
+import { Effect } from 'effect'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { DatabaseSync } from 'node:sqlite'
+import { describe, expect, test } from 'vitest'
+
+import {
+  type BusinessFulfillmentLoopStore,
+  type BusinessServicePromiseRecord,
+  BUSINESS_FULFILLMENT_LOOP_AGENT_DEFINITION_REF,
+  BusinessFulfillmentLoopValidationError,
+  buildBusinessFulfillmentMotionReceipt,
+  makeD1BusinessFulfillmentLoopStore,
+  runBusinessFulfillmentLoop,
+} from './business-fulfillment-loop'
+
+type Row = Record<string, unknown>
+
+const activePromise = (
+  overrides?: Partial<BusinessServicePromiseRecord>,
+): BusinessServicePromiseRecord => ({
+  acceptedOutcomeContractId: 'omni_accepted_outcome_contract.business_001',
+  cadence: 'daily',
+  createdAt: '2026-07-02T00:00:00.000Z',
+  crmStateRef: 'crm_state.business.promise_001.public_safe',
+  id: 'business_service_promise_001',
+  lastMotionReceiptRef: null,
+  nextMotionDueAt: '2026-07-03T00:00:00.000Z',
+  promiseRef: 'promise.business.fulfillment.001',
+  sourceRefs: ['github.public.issue.8096'],
+  stakeholderRefs: [
+    'stakeholder.business.operator',
+    'stakeholder.business.customer_success',
+  ],
+  state: 'active',
+  updatedAt: '2026-07-02T00:00:00.000Z',
+  workspaceRef: 'workspace.business.fulfillment.001',
+  ...overrides,
+})
+
+const runtime = {
+  makeId: (prefix: string) => `${prefix}_test`,
+  nowIso: () => '2026-07-03T12:00:00.000Z',
+}
+
+class SqliteD1Statement {
+  private bound: ReadonlyArray<unknown> = []
+
+  constructor(
+    private readonly db: DatabaseSync,
+    private readonly sql: string,
+  ) {}
+
+  bind(...values: ReadonlyArray<unknown>): SqliteD1Statement {
+    this.bound = values.map(value => (value === undefined ? null : value))
+    return this
+  }
+
+  async first<T = Row>(): Promise<T | null> {
+    const row = this.db.prepare(this.sql).get(...(this.bound as never[]))
+    return (row ?? null) as T | null
+  }
+
+  async all<T = Row>(): Promise<{ results: Array<T> }> {
+    return {
+      results: this.db.prepare(this.sql).all(...(this.bound as never[])) as Array<T>,
+    }
+  }
+
+  async run(): Promise<{ meta: { changes: number }; success: true }> {
+    const result = this.db.prepare(this.sql).run(...(this.bound as never[]))
+    return { meta: { changes: Number(result.changes) }, success: true }
+  }
+}
+
+class SqliteD1 {
+  constructor(private readonly db: DatabaseSync) {}
+
+  prepare(sql: string): SqliteD1Statement {
+    return new SqliteD1Statement(this.db, sql)
+  }
+}
+
+const migration = (name: string): string =>
+  readFileSync(join(__dirname, '..', 'migrations', name), 'utf8')
+
+const makeDb = (): D1Database => {
+  const db = new DatabaseSync(':memory:')
+  db.exec(migration('0091_omni_accepted_outcome_contracts.sql'))
+  db.exec(migration('0274_business_fulfillment_loop.sql'))
+  return new SqliteD1(db) as unknown as D1Database
+}
+
+class MemoryFulfillmentLoopStore implements BusinessFulfillmentLoopStore {
+  public readonly receipts = new Map<string, string>()
+  public readonly updates: Array<{
+    nextMotionDueAt: string
+    promiseId: string
+    receiptRef: string
+  }> = []
+
+  constructor(
+    private readonly promises: ReadonlyArray<BusinessServicePromiseRecord>,
+  ) {}
+
+  async claimDailyMotionReceipt(receipt: {
+    motionDate: string
+    promiseId: string
+    receiptRef: string
+  }): Promise<Readonly<{ claimed: boolean }>> {
+    const key = `${receipt.promiseId}:${receipt.motionDate}`
+    if (this.receipts.has(key)) {
+      return { claimed: false }
+    }
+    this.receipts.set(key, receipt.receiptRef)
+    return { claimed: true }
+  }
+
+  async listDuePromises(
+    nowIso: string,
+    limit: number,
+  ): Promise<ReadonlyArray<BusinessServicePromiseRecord>> {
+    return this.promises
+      .filter(
+        promise =>
+          promise.state === 'active' &&
+          (promise.nextMotionDueAt === null || promise.nextMotionDueAt <= nowIso),
+      )
+      .slice(0, limit)
+  }
+
+  async markPromiseMotionRecorded(
+    promiseId: string,
+    receiptRef: string,
+    nextMotionDueAt: string,
+  ): Promise<void> {
+    this.updates.push({ nextMotionDueAt, promiseId, receiptRef })
+  }
+}
+
+describe('business fulfillment loop', () => {
+  test('records a daily motion receipt with approval-gated client comms', async () => {
+    const promise = activePromise()
+    const receipt = buildBusinessFulfillmentMotionReceipt(promise, runtime)
+
+    expect(receipt).toMatchObject({
+      agentDefinitionRef: BUSINESS_FULFILLMENT_LOOP_AGENT_DEFINITION_REF,
+      approvalGateRef:
+        'approval_gate.business_fulfillment.client_comms.promise_business_fulfillment_001_2026_07_03',
+      clientCommsDraftRef:
+        'draft.business_fulfillment.client_comms.promise_business_fulfillment_001_2026_07_03',
+      crmStateRef: promise.crmStateRef,
+      forwardMotionRef:
+        'motion.business_fulfillment.daily.promise_business_fulfillment_001_2026_07_03',
+      motionDate: '2026-07-03',
+      outboundAllowed: false,
+      promiseRef: promise.promiseRef,
+      receiptRef:
+        'receipt.business_fulfillment.daily_motion.promise_business_fulfillment_001_2026_07_03',
+    })
+    expect(receipt.stakeholderFlagRefs).toEqual([
+      'stakeholder_flag.business_fulfillment.stakeholder_business_operator.20260703',
+      'stakeholder_flag.business_fulfillment.stakeholder_business_customer_success.20260703',
+    ])
+    expect(JSON.stringify(receipt)).not.toMatch(/@|customer_email|raw_crm/i)
+  })
+
+  test('cron tick claims each due active promise once per day', async () => {
+    const store = new MemoryFulfillmentLoopStore([activePromise()])
+    const result = await Effect.runPromise(
+      runBusinessFulfillmentLoop({ runtime, store }),
+    )
+
+    expect(result).toEqual({
+      duePromiseCount: 1,
+      motionReceiptRefs: [
+        'receipt.business_fulfillment.daily_motion.promise_business_fulfillment_001_2026_07_03',
+      ],
+      skippedDuplicateCount: 0,
+      state: 'completed',
+    })
+    expect(store.updates).toEqual([
+      {
+        nextMotionDueAt: '2026-07-04T12:00:00.000Z',
+        promiseId: 'business_service_promise_001',
+        receiptRef:
+          'receipt.business_fulfillment.daily_motion.promise_business_fulfillment_001_2026_07_03',
+      },
+    ])
+
+    const duplicate = await Effect.runPromise(
+      runBusinessFulfillmentLoop({ runtime, store }),
+    )
+    expect(duplicate).toMatchObject({
+      duePromiseCount: 1,
+      motionReceiptRefs: [],
+      skippedDuplicateCount: 1,
+      state: 'completed',
+    })
+  })
+
+  test('ignores paused promises and unsafe CRM refs', async () => {
+    const pausedStore = new MemoryFulfillmentLoopStore([
+      activePromise({ state: 'paused' }),
+    ])
+    await expect(
+      Effect.runPromise(runBusinessFulfillmentLoop({ runtime, store: pausedStore })),
+    ).resolves.toMatchObject({
+      duePromiseCount: 0,
+      motionReceiptRefs: [],
+      state: 'skipped',
+    })
+
+    let caught: unknown
+    try {
+      buildBusinessFulfillmentMotionReceipt(
+        activePromise({ crmStateRef: 'raw_crm.customer_email@example.com' }),
+        runtime,
+      )
+    } catch (error) {
+      caught = error
+    }
+    expect(caught).toBeInstanceOf(BusinessFulfillmentLoopValidationError)
+    expect((caught as BusinessFulfillmentLoopValidationError).reason).toContain(
+      'opaque public-safe ref',
+    )
+  })
+
+  test('D1 store claims one daily receipt per active service promise', async () => {
+    const db = makeDb()
+    await db
+      .prepare(
+        `INSERT INTO business_service_promises (
+          id,
+          promise_ref,
+          accepted_outcome_contract_id,
+          workspace_ref,
+          crm_state_ref,
+          stakeholder_refs_json,
+          state,
+          cadence,
+          next_motion_due_at,
+          last_motion_receipt_ref,
+          source_refs_json,
+          metadata_json,
+          created_at,
+          updated_at
+        ) VALUES (?, ?, NULL, ?, ?, ?, 'active', 'daily', ?, NULL, ?, '{}', ?, ?)`,
+      )
+      .bind(
+        'business_service_promise_d1',
+        'promise.business.fulfillment.d1',
+        'workspace.business.fulfillment.d1',
+        'crm_state.business.promise_d1.public_safe',
+        JSON.stringify(['stakeholder.business.operator']),
+        '2026-07-03T00:00:00.000Z',
+        JSON.stringify(['docs/fable/ROADMAP_BIZ.md#BF-5.1']),
+        '2026-07-02T00:00:00.000Z',
+        '2026-07-02T00:00:00.000Z',
+      )
+      .run()
+
+    const first = await Effect.runPromise(
+      runBusinessFulfillmentLoop({
+        runtime,
+        store: makeD1BusinessFulfillmentLoopStore(db),
+      }),
+    )
+    const second = await Effect.runPromise(
+      runBusinessFulfillmentLoop({
+        runtime,
+        store: makeD1BusinessFulfillmentLoopStore(db),
+      }),
+    )
+    const receiptRow = await db
+      .prepare(
+        `SELECT receipt_ref,
+                outbound_allowed,
+                approval_gate_ref,
+                client_comms_draft_ref
+           FROM business_fulfillment_motion_receipts
+          WHERE promise_id = ?`,
+      )
+      .bind('business_service_promise_d1')
+      .first<{
+        approval_gate_ref: string
+        client_comms_draft_ref: string
+        outbound_allowed: number
+        receipt_ref: string
+      }>()
+    const promiseRow = await db
+      .prepare(
+        `SELECT last_motion_receipt_ref, next_motion_due_at
+           FROM business_service_promises
+          WHERE id = ?`,
+      )
+      .bind('business_service_promise_d1')
+      .first<{
+        last_motion_receipt_ref: string
+        next_motion_due_at: string
+      }>()
+
+    expect(first).toEqual({
+      duePromiseCount: 1,
+      motionReceiptRefs: [
+        'receipt.business_fulfillment.daily_motion.promise_business_fulfillment_d1_2026_07_03',
+      ],
+      skippedDuplicateCount: 0,
+      state: 'completed',
+    })
+    expect(second).toMatchObject({
+      duePromiseCount: 0,
+      motionReceiptRefs: [],
+      skippedDuplicateCount: 0,
+      state: 'skipped',
+    })
+    expect(receiptRow).toMatchObject({
+      approval_gate_ref:
+        'approval_gate.business_fulfillment.client_comms.promise_business_fulfillment_d1_2026_07_03',
+      client_comms_draft_ref:
+        'draft.business_fulfillment.client_comms.promise_business_fulfillment_d1_2026_07_03',
+      outbound_allowed: 0,
+      receipt_ref:
+        'receipt.business_fulfillment.daily_motion.promise_business_fulfillment_d1_2026_07_03',
+    })
+    expect(promiseRow).toMatchObject({
+      last_motion_receipt_ref:
+        'receipt.business_fulfillment.daily_motion.promise_business_fulfillment_d1_2026_07_03',
+      next_motion_due_at: '2026-07-04T12:00:00.000Z',
+    })
+  })
+})

--- a/apps/openagents.com/workers/api/src/business-fulfillment-loop.ts
+++ b/apps/openagents.com/workers/api/src/business-fulfillment-loop.ts
@@ -1,0 +1,392 @@
+import { Effect, Schema as S } from 'effect'
+
+import { parseJsonStringArray } from './json-boundary'
+import {
+  compactRandomId,
+  epochMillisToIsoTimestamp,
+  isoTimestampAfterIso,
+} from './runtime-primitives'
+
+export const BUSINESS_FULFILLMENT_LOOP_AGENT_DEFINITION_REF =
+  'agent_definition.v1.business_fulfillment_loop'
+
+export const BUSINESS_FULFILLMENT_LOOP_DEFAULT_LIMIT = 10
+
+export const BusinessServicePromiseState = S.Literals([
+  'active',
+  'paused',
+  'blocked',
+  'closed',
+])
+export type BusinessServicePromiseState =
+  typeof BusinessServicePromiseState.Type
+
+export const BusinessServicePromiseRecord = S.Struct({
+  acceptedOutcomeContractId: S.NullOr(S.String),
+  cadence: S.Literal('daily'),
+  createdAt: S.String,
+  crmStateRef: S.String,
+  id: S.String,
+  lastMotionReceiptRef: S.NullOr(S.String),
+  nextMotionDueAt: S.NullOr(S.String),
+  promiseRef: S.String,
+  sourceRefs: S.Array(S.String),
+  stakeholderRefs: S.Array(S.String),
+  state: BusinessServicePromiseState,
+  updatedAt: S.String,
+  workspaceRef: S.String,
+})
+export type BusinessServicePromiseRecord =
+  typeof BusinessServicePromiseRecord.Type
+
+export const BusinessFulfillmentMotionReceipt = S.Struct({
+  agentDefinitionRef: S.String,
+  approvalGateRef: S.String,
+  blockerRefs: S.Array(S.String),
+  clientCommsDraftRef: S.String,
+  createdAt: S.String,
+  crmStateRef: S.String,
+  forwardMotionRef: S.String,
+  id: S.String,
+  motionDate: S.String,
+  outboundAllowed: S.Boolean,
+  promiseId: S.String,
+  promiseRef: S.String,
+  receiptRef: S.String,
+  sourceRefs: S.Array(S.String),
+  stakeholderFlagRefs: S.Array(S.String),
+  stakeholderRefs: S.Array(S.String),
+})
+export type BusinessFulfillmentMotionReceipt =
+  typeof BusinessFulfillmentMotionReceipt.Type
+
+export type BusinessFulfillmentLoopStore = Readonly<{
+  claimDailyMotionReceipt: (
+    receipt: BusinessFulfillmentMotionReceipt,
+  ) => Promise<Readonly<{ claimed: boolean }>>
+  listDuePromises: (
+    nowIso: string,
+    limit: number,
+  ) => Promise<ReadonlyArray<BusinessServicePromiseRecord>>
+  markPromiseMotionRecorded: (
+    promiseId: string,
+    receiptRef: string,
+    nextMotionDueAt: string,
+    nowIso: string,
+  ) => Promise<void>
+}>
+
+export type BusinessFulfillmentLoopRuntime = Readonly<{
+  makeId: (prefix: string) => string
+  nowIso: () => string
+}>
+
+export type BusinessFulfillmentLoopResult = Readonly<{
+  duePromiseCount: number
+  motionReceiptRefs: ReadonlyArray<string>
+  skippedDuplicateCount: number
+  state: 'completed' | 'skipped'
+}>
+
+export class BusinessFulfillmentLoopValidationError extends S.TaggedErrorClass<BusinessFulfillmentLoopValidationError>()(
+  'BusinessFulfillmentLoopValidationError',
+  { reason: S.String },
+) {}
+
+export class BusinessFulfillmentLoopStorageError extends S.TaggedErrorClass<BusinessFulfillmentLoopStorageError>()(
+  'BusinessFulfillmentLoopStorageError',
+  { reason: S.String },
+) {}
+
+export type BusinessFulfillmentLoopError =
+  | BusinessFulfillmentLoopStorageError
+  | BusinessFulfillmentLoopValidationError
+
+const businessFulfillmentLoopErrorFromUnknown = (
+  error: unknown,
+): BusinessFulfillmentLoopError =>
+  error instanceof BusinessFulfillmentLoopValidationError
+    ? error
+    : new BusinessFulfillmentLoopStorageError({
+        reason: error instanceof Error ? error.message : String(error),
+      })
+
+const tryLoopPromise = <A>(
+  promise: () => Promise<A>,
+): Effect.Effect<A, BusinessFulfillmentLoopError> =>
+  Effect.tryPromise({
+    catch: businessFulfillmentLoopErrorFromUnknown,
+    try: promise,
+  })
+
+const SAFE_REF_PATTERN = /^[A-Za-z0-9][A-Za-z0-9_.:/=#-]{0,220}$/
+const UNSAFE_TEXT_PATTERN =
+  /\b(raw[_ -]?crm|raw[_ -]?email|email[_ -]?body|client[_ -]?name|client[_ -]?email|customer[_ -]?name|customer[_ -]?email|contact[_ -]?email|provider[_ -]?payload|access_token|refresh_token|private_key|wallet_secret|payment_preimage|webhook_secret|xprv|mnemonic)\b|@/i
+
+const assertSafeRef = (field: string, value: string): void => {
+  if (!SAFE_REF_PATTERN.test(value) || UNSAFE_TEXT_PATTERN.test(value)) {
+    throw new BusinessFulfillmentLoopValidationError({
+      reason: `${field} must be an opaque public-safe ref`,
+    })
+  }
+}
+
+const assertSafeRefs = (
+  field: string,
+  values: ReadonlyArray<string>,
+): void => {
+  values.forEach(value => assertSafeRef(field, value))
+}
+
+const promiseFromRow = (
+  row: Readonly<Record<string, unknown>>,
+): BusinessServicePromiseRecord => ({
+  acceptedOutcomeContractId:
+    typeof row.accepted_outcome_contract_id === 'string'
+      ? row.accepted_outcome_contract_id
+      : null,
+  cadence: 'daily',
+  createdAt: String(row.created_at),
+  crmStateRef: String(row.crm_state_ref),
+  id: String(row.id),
+  lastMotionReceiptRef:
+    typeof row.last_motion_receipt_ref === 'string'
+      ? row.last_motion_receipt_ref
+      : null,
+  nextMotionDueAt:
+    typeof row.next_motion_due_at === 'string' ? row.next_motion_due_at : null,
+  promiseRef: String(row.promise_ref),
+  sourceRefs: parseJsonStringArray(String(row.source_refs_json ?? '[]')),
+  stakeholderRefs: parseJsonStringArray(
+    String(row.stakeholder_refs_json ?? '[]'),
+  ),
+  state: S.decodeUnknownSync(BusinessServicePromiseState)(row.state),
+  updatedAt: String(row.updated_at),
+  workspaceRef: String(row.workspace_ref),
+})
+
+export const makeD1BusinessFulfillmentLoopStore = (
+  db: D1Database,
+): BusinessFulfillmentLoopStore => ({
+  claimDailyMotionReceipt: async receipt => {
+    const result = await db
+      .prepare(
+        `INSERT OR IGNORE INTO business_fulfillment_motion_receipts (
+          id,
+          promise_id,
+          promise_ref,
+          motion_date,
+          receipt_ref,
+          agent_definition_ref,
+          crm_state_ref,
+          stakeholder_refs_json,
+          stakeholder_flag_refs_json,
+          forward_motion_ref,
+          client_comms_draft_ref,
+          approval_gate_ref,
+          outbound_allowed,
+          blocker_refs_json,
+          source_refs_json,
+          created_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .bind(
+        receipt.id,
+        receipt.promiseId,
+        receipt.promiseRef,
+        receipt.motionDate,
+        receipt.receiptRef,
+        receipt.agentDefinitionRef,
+        receipt.crmStateRef,
+        JSON.stringify(receipt.stakeholderRefs),
+        JSON.stringify(receipt.stakeholderFlagRefs),
+        receipt.forwardMotionRef,
+        receipt.clientCommsDraftRef,
+        receipt.approvalGateRef,
+        receipt.outboundAllowed ? 1 : 0,
+        JSON.stringify(receipt.blockerRefs),
+        JSON.stringify(receipt.sourceRefs),
+        receipt.createdAt,
+      )
+      .run()
+
+    return { claimed: (result.meta.changes ?? 0) > 0 }
+  },
+  listDuePromises: async (nowIso, limit) => {
+    const rows = await db
+      .prepare(
+        `SELECT *
+           FROM business_service_promises
+          WHERE state = 'active'
+            AND cadence = 'daily'
+            AND (next_motion_due_at IS NULL OR next_motion_due_at <= ?)
+          ORDER BY COALESCE(next_motion_due_at, created_at) ASC, updated_at ASC
+          LIMIT ?`,
+      )
+      .bind(nowIso, limit)
+      .all<Record<string, unknown>>()
+
+    return (rows.results ?? []).map(promiseFromRow)
+  },
+  markPromiseMotionRecorded: async (
+    promiseId,
+    receiptRef,
+    nextMotionDueAt,
+    nowIso,
+  ) => {
+    await db
+      .prepare(
+        `UPDATE business_service_promises
+            SET last_motion_receipt_ref = ?,
+                next_motion_due_at = ?,
+                updated_at = ?
+          WHERE id = ?`,
+      )
+      .bind(receiptRef, nextMotionDueAt, nowIso, promiseId)
+      .run()
+  },
+})
+
+const refSuffix = (value: string): string =>
+  value.toLowerCase().replace(/[^a-z0-9]+/g, '_').replace(/^_+|_+$/g, '')
+
+const nextDailyDueAt = (nowIso: string): string =>
+  isoTimestampAfterIso(nowIso, 24 * 60 * 60 * 1000)
+
+const validatePromise = (promise: BusinessServicePromiseRecord): void => {
+  assertSafeRef('promiseRef', promise.promiseRef)
+  assertSafeRef('crmStateRef', promise.crmStateRef)
+  assertSafeRef('workspaceRef', promise.workspaceRef)
+  if (promise.acceptedOutcomeContractId !== null) {
+    assertSafeRef('acceptedOutcomeContractId', promise.acceptedOutcomeContractId)
+  }
+  assertSafeRefs('stakeholderRefs', promise.stakeholderRefs)
+  assertSafeRefs('sourceRefs', promise.sourceRefs)
+}
+
+export const buildBusinessFulfillmentMotionReceipt = (
+  promise: BusinessServicePromiseRecord,
+  runtime: BusinessFulfillmentLoopRuntime,
+): BusinessFulfillmentMotionReceipt => {
+  validatePromise(promise)
+
+  const nowIso = runtime.nowIso()
+  const motionDate = nowIso.slice(0, 10)
+  const suffix = refSuffix(`${promise.promiseRef}.${motionDate}`)
+  const sourceRefs = [
+    ...promise.sourceRefs,
+    'docs/fable/ROADMAP_BIZ.md#BF-5.1',
+    'docs/fable/2026-07-02-business-fulfillment-engine-meditations.md#fulfillment-agents',
+  ]
+
+  return {
+    agentDefinitionRef: BUSINESS_FULFILLMENT_LOOP_AGENT_DEFINITION_REF,
+    approvalGateRef: `approval_gate.business_fulfillment.client_comms.${suffix}`,
+    blockerRefs: [],
+    clientCommsDraftRef: `draft.business_fulfillment.client_comms.${suffix}`,
+    createdAt: nowIso,
+    crmStateRef: promise.crmStateRef,
+    forwardMotionRef: `motion.business_fulfillment.daily.${suffix}`,
+    id: runtime.makeId('business_fulfillment_motion'),
+    motionDate,
+    outboundAllowed: false,
+    promiseId: promise.id,
+    promiseRef: promise.promiseRef,
+    receiptRef: `receipt.business_fulfillment.daily_motion.${suffix}`,
+    sourceRefs,
+    stakeholderFlagRefs: promise.stakeholderRefs.map(
+      stakeholderRef =>
+        `stakeholder_flag.business_fulfillment.${refSuffix(stakeholderRef)}.${motionDate.replaceAll('-', '')}`,
+    ),
+    stakeholderRefs: promise.stakeholderRefs,
+  }
+}
+
+export const runBusinessFulfillmentLoop = (
+  input: Readonly<{
+    limit?: number | undefined
+    runtime: BusinessFulfillmentLoopRuntime
+    store: BusinessFulfillmentLoopStore
+  }>,
+): Effect.Effect<BusinessFulfillmentLoopResult, BusinessFulfillmentLoopError> =>
+  Effect.gen(function* () {
+    const nowIso = input.runtime.nowIso()
+    const duePromises = yield* tryLoopPromise(() =>
+      input.store.listDuePromises(
+        nowIso,
+        input.limit ?? BUSINESS_FULFILLMENT_LOOP_DEFAULT_LIMIT,
+      ),
+    )
+    const outcomes = yield* Effect.forEach(
+      duePromises,
+      promise =>
+        Effect.gen(function* () {
+          const receipt = yield* Effect.try({
+            catch: businessFulfillmentLoopErrorFromUnknown,
+            try: () =>
+              buildBusinessFulfillmentMotionReceipt(promise, input.runtime),
+          })
+          const claim = yield* tryLoopPromise(() =>
+            input.store.claimDailyMotionReceipt(receipt),
+          )
+
+          if (!claim.claimed) {
+            return {
+              maybeReceiptRef: null,
+              skippedDuplicateCount: 1,
+            }
+          }
+
+          yield* tryLoopPromise(() =>
+            input.store.markPromiseMotionRecorded(
+              promise.id,
+              receipt.receiptRef,
+              nextDailyDueAt(nowIso),
+              nowIso,
+            ),
+          )
+
+          return {
+            maybeReceiptRef: receipt.receiptRef,
+            skippedDuplicateCount: 0,
+          }
+        }),
+      { concurrency: 1 },
+    )
+
+    const motionReceiptRefs = outcomes.flatMap(outcome =>
+      outcome.maybeReceiptRef === null ? [] : [outcome.maybeReceiptRef],
+    )
+    const skippedDuplicateCount = outcomes.reduce(
+      (sum, outcome) => sum + outcome.skippedDuplicateCount,
+      0,
+    )
+
+    return {
+      duePromiseCount: duePromises.length,
+      motionReceiptRefs,
+      skippedDuplicateCount,
+      state: duePromises.length === 0 ? 'skipped' : 'completed',
+    }
+  })
+
+export const runBusinessFulfillmentLoopScheduled = (
+  db: D1Database,
+  scheduledTimeMs: number,
+): Effect.Effect<BusinessFulfillmentLoopResult, never> =>
+  runBusinessFulfillmentLoop({
+    runtime: {
+      makeId: compactRandomId,
+      nowIso: () => epochMillisToIsoTimestamp(scheduledTimeMs),
+    },
+    store: makeD1BusinessFulfillmentLoopStore(db),
+  }).pipe(
+    Effect.catch(() =>
+      Effect.succeed({
+        duePromiseCount: 0,
+        motionReceiptRefs: [],
+        skippedDuplicateCount: 0,
+        state: 'skipped' as const,
+      }),
+    ),
+  )

--- a/apps/openagents.com/workers/api/src/index.ts
+++ b/apps/openagents.com/workers/api/src/index.ts
@@ -240,6 +240,7 @@ import {
 } from './blueprint/repositories/program-runs'
 import { handlePublicBusinessFunnelDashboardApi } from './business-funnel-dashboard-routes'
 import { handleBusinessIntakeChatApi } from './business-intake-chat-routes'
+import { runBusinessFulfillmentLoopScheduled } from './business-fulfillment-loop'
 import { handleBusinessSignupApi } from './business-signup-routes'
 import { makeD1BuyModeDispatcherStore } from './buy-mode-dispatcher'
 import { buyModePaymentBridgeForEnv } from './buy-mode-http-payment-bridge'
@@ -14562,6 +14563,13 @@ export default {
       observedEffect(
         'EmailCampaignDispatcher.dispatchDue',
         dispatchDueEmailCampaignSendsScheduled(env),
+      ),
+      observedEffect(
+        'BusinessFulfillmentLoop.dailyMotion',
+        runBusinessFulfillmentLoopScheduled(
+          openAgentsDatabase(env),
+          event.scheduledTime,
+        ).pipe(Effect.asVoid),
       ),
       observedEffect(
         'AutopilotScheduledLaunches.dispatchDue',


### PR DESCRIPTION
## Summary
- Add D1 tables for active business service promises and per-day fulfillment motion receipts.
- Add a cron-safe fulfillment loop that records daily motion, stakeholder flag refs, and approval-gated client comms draft refs without sending outbound comms.
- Wire the loop into the existing Worker minute cron and cover idempotency/public-safe ref behavior.
- Rebased onto current main, moved the migration to `0274_business_fulfillment_loop.sql`, and added D1-backed coverage for the real store/migration path.

Closes #8096

## Verification
- `bun run --cwd apps/openagents.com/workers/api test -- src/business-fulfillment-loop.test.ts`
  - 1 test file passed, 4 tests passed.
- `bun run --cwd apps/openagents.com/workers/api typecheck`
  - `tsc -p tsconfig.json --noEmit` passed.
- `bun run check:deploy`
  - Passed. Final suites included apps/web: 22 files / 567 tests passed, workers/api: 13 files / 239 tests passed.
