### PR TITLE
Add agent definition tool authority contract

### DIFF
--- a/INVARIANTS.md
+++ b/INVARIANTS.md
@@ -81,6 +81,31 @@ More specific invariant ledgers apply inside imported apps and packages.
   payloads, and private customer data must not be committed or written into
   docs, tests, fixtures, logs, or public projections.
 
+## Background Agent Definition Tool Authority
+
+- Harness-agnostic background agents are defined by
+  `openagents.agent_definition.v1` in
+  `packages/agent-runtime-schema`. The durable definition owns the standing
+  workflow contract: name, goal, harness hint, lane, triggers, budget,
+  escalation, source refs, and the explicit toolset.
+- The harness field is never authority. Codex, Claude Code, Khala, hosted,
+  custom, or fixture adapters may execute only after their local or cloud
+  tool boundary compiles and enforces the definition's toolset.
+- `decideAgentDefinitionToolAuthority` is the shared deny-by-default contract:
+  explicit deny rules beat ask and allow rules, ask rules create an operator
+  escalation record without authorizing execution, allow rules authorize only
+  the matched tool ref, and unmatched tools are denied.
+- Runtime runs may link back to `agentDefinitionId` as evidence that a run was
+  definition-backed, but that link alone grants no tool, spend, dispatch,
+  payout, settlement, public-claim, provider-account, or external-send
+  authority.
+- Any Worker, Pylon, desktop, or cloud-workroom executor that claims
+  definition-backed tool enforcement must use this contract or a formally
+  equivalent compiled policy at the execution boundary, with regression tests
+  for deny precedence, ask escalation, allow, and default-deny behavior.
+- Regression coverage starts in
+  `packages/agent-runtime-schema/src/index.test.ts`.
+
 ## Cloudflare Verse World Service
 
 - Live Verse world work belongs to `apps/openagents-world/`, a Cloudflare

--- a/packages/agent-runtime-schema/README.md
+++ b/packages/agent-runtime-schema/README.md
@@ -13,3 +13,16 @@ RK5 also adds a small shared surface presenter:
 `projectAgentRuntimeSurfaceStatus`. Workroom and TUI views use it to render the
 same public-safe run truth from kernel projections without reading raw adapter
 transcripts.
+
+`openagents.agent_definition.v1` is the harness-agnostic background-agent
+definition contract. It stores the durable workflow object separately from the
+runtime harness: name, goal, harness hint, lane, triggers, budget, escalation,
+and an enforced toolset with `allow`, `deny`, and `ask` lists. Runtime runs can
+link back to `agentDefinitionId`, so fulfillment loops can prove they were
+definition-backed without baking Codex, Claude Code, or any other harness into
+the durable record.
+
+The pure helper `decideAgentDefinitionToolAuthority` is the shared
+tool-authority boundary. It is deny-by-default, gives `deny` precedence over
+`ask` and `allow`, and converts `ask` matches into an operator escalation record
+instead of authorizing the tool invocation.

--- a/packages/agent-runtime-schema/src/fixtures.ts
+++ b/packages/agent-runtime-schema/src/fixtures.ts
@@ -1,4 +1,5 @@
 import type {
+  AgentDefinition,
   AgentRuntimeAdapterKind,
   AgentRuntimeEvent,
   AgentRuntimeEventLog,
@@ -15,6 +16,7 @@ function run(input: {
 }): AgentRuntimeRun {
   return {
     runId: input.runId,
+    agentDefinitionId: `agent_definition.public.${input.runId}`,
     assignmentId: `assignment.public.${input.runId}`,
     workspaceRef: `workspace.public.${input.runId}`,
     adapterKind: input.adapterKind,
@@ -58,6 +60,60 @@ function event(
     blockerRefs: [],
     ...input,
   }
+}
+
+export const fulfillmentLoopAgentDefinitionFixture: AgentDefinition = {
+  schema: "openagents.agent_definition.v1",
+  id: "agent_definition.public.fulfillment_loop.daily_motion",
+  ownerRef: "owner.public.fixture",
+  name: "Daily Fulfillment Motion",
+  slug: "daily-fulfillment-motion",
+  goal: "Review the service promise state and produce one public-safe daily motion receipt.",
+  harness: {
+    kind: "codex",
+    modelHint: "openagents/pylon-codex",
+    versionPin: "fixture",
+  },
+  toolset: {
+    allow: [
+      "tool.openagents.promise.read",
+      "tool.openagents.crm.read",
+      "tool.openagents.receipt.write",
+    ],
+    deny: [
+      "tool.openagents.payment.*",
+      "tool.openagents.email.send",
+    ],
+    ask: [
+      "tool.openagents.email.draft",
+      "tool.openagents.stakeholder.page",
+    ],
+    networkPolicy: "owner_scoped",
+    secretPolicy: "owner_scoped_refs_only",
+  },
+  triggers: [
+    {
+      kind: "cron",
+      triggerRef: "trigger.public.fulfillment_loop.daily",
+      cron: "0 14 * * *",
+    },
+  ],
+  lane: "own_pylon",
+  budget: {
+    maxRunSeconds: 900,
+    maxRunsPerDay: 1,
+    maxCreditsPerDay: 0,
+  },
+  escalation: {
+    channel: "operator",
+    askPolicy: {
+      policyRef: "policy.public.agent_definition.operator_required.v1",
+      mode: "operator_required",
+    },
+  },
+  sourceRefs: ["issue.public.github.OpenAgentsInc.openagents.8097"],
+  createdAt: at,
+  updatedAt: at,
 }
 
 export const fixtureLoopEventLog: AgentRuntimeEventLog = {

--- a/packages/agent-runtime-schema/src/index.test.ts
+++ b/packages/agent-runtime-schema/src/index.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test"
 import {
+  AgentDefinition,
   AgentRuntimeEvent,
   AgentRuntimeRun,
   PylonLifecycleWireEventFromJsonString,
@@ -15,12 +16,17 @@ import {
   assertAgentRuntimePublicEventSafe,
   assertAgentRuntimeRunStateTransition,
   agentRuntimeSurfaceStatusHasUnsafeMaterial,
+  decodeAgentDefinition,
   decodeAgentRuntimeEvent,
   decodeAgentRuntimeEventLog,
   decodeAgentRuntimeRun,
+  decideAgentDefinitionToolAuthority,
   projectAgentRuntimeSurfaceStatus,
 } from "./index.js"
-import { agentRuntimeFixtureEventLogs } from "./fixtures.js"
+import {
+  agentRuntimeFixtureEventLogs,
+  fulfillmentLoopAgentDefinitionFixture,
+} from "./fixtures.js"
 
 const baseRun = {
   runId: "run.public.schema_test",
@@ -77,6 +83,108 @@ describe("@openagentsinc/agent-runtime-schema", () => {
     }
   })
 
+  test("decodes agent_definition.v1 records and definition-backed runtime runs", () => {
+    const definition = decodeAgentDefinition(fulfillmentLoopAgentDefinitionFixture)
+    expect(definition).toMatchObject({
+      schema: "openagents.agent_definition.v1",
+      id: "agent_definition.public.fulfillment_loop.daily_motion",
+      harness: { kind: "codex" },
+      lane: "own_pylon",
+      escalation: {
+        channel: "operator",
+        askPolicy: { mode: "operator_required" },
+      },
+    })
+
+    expect(decodeAgentRuntimeRun({
+      ...baseRun,
+      agentDefinitionId: definition.id,
+      state: "running",
+    })).toMatchObject({
+      agentDefinitionId: definition.id,
+      state: "running",
+    })
+  })
+
+  test("enforces definition toolsets with deny, ask escalation, allow, and deny-by-default", () => {
+    const definition = decodeAgentDefinition(fulfillmentLoopAgentDefinitionFixture)
+
+    expect(decideAgentDefinitionToolAuthority({
+      definition,
+      toolRef: "tool.openagents.crm.read",
+    })).toMatchObject({
+      allowed: true,
+      status: "allowed",
+      reasonRef: "reason.agent_definition.tool_allowed",
+      blockerRefs: [],
+    })
+
+    expect(decideAgentDefinitionToolAuthority({
+      definition,
+      toolRef: "tool.openagents.payment.refund",
+    })).toMatchObject({
+      allowed: false,
+      status: "denied",
+      matchedPolicyRef: "tool.openagents.payment.*",
+      blockerRefs: ["blocker.agent_definition.tool_denied"],
+    })
+
+    const askDecision = decideAgentDefinitionToolAuthority({
+      definition,
+      toolRef: "tool.openagents.email.draft",
+      invocationRef: "invocation.public.fixture.email_draft",
+    })
+    expect(askDecision).toMatchObject({
+      allowed: false,
+      status: "operator_escalation_required",
+      blockerRefs: ["blocker.agent_definition.operator_escalation_required"],
+      escalation: {
+        definitionId: definition.id,
+        ownerRef: definition.ownerRef,
+        toolRef: "tool.openagents.email.draft",
+        channel: "operator",
+        askPolicyRef: "policy.public.agent_definition.operator_required.v1",
+        reasonRef: "reason.agent_definition.ask_policy_hit",
+      },
+    })
+    expect(askDecision.escalation?.escalationRef).toMatch(
+      /^escalation\.operator\.agent_definition\.[a-f0-9]{8}$/,
+    )
+
+    expect(decideAgentDefinitionToolAuthority({
+      definition,
+      toolRef: "tool.openagents.github.write",
+    })).toMatchObject({
+      allowed: false,
+      status: "denied",
+      reasonRef: "reason.agent_definition.tool_not_in_allowlist",
+      blockerRefs: ["blocker.agent_definition.tool_not_in_allowlist"],
+    })
+  })
+
+  test("gives deny policy precedence over overlapping ask and allow entries", () => {
+    const definition = decodeAgentDefinition({
+      ...fulfillmentLoopAgentDefinitionFixture,
+      toolset: {
+        ...fulfillmentLoopAgentDefinitionFixture.toolset,
+        allow: ["tool.openagents.email.draft"],
+        ask: ["tool.openagents.email.draft"],
+        deny: ["tool.openagents.email.*"],
+      },
+    })
+
+    expect(decideAgentDefinitionToolAuthority({
+      definition,
+      toolRef: "tool.openagents.email.draft",
+    })).toMatchObject({
+      allowed: false,
+      status: "denied",
+      matchedPolicyRef: "tool.openagents.email.*",
+      reasonRef: "reason.agent_definition.tool_denied",
+      blockerRefs: ["blocker.agent_definition.tool_denied"],
+    })
+  })
+
   test("decodes every RK1 event tag", () => {
     expect(agentRuntimeEventTags).toHaveLength(32)
     for (const tag of agentRuntimeEventTags) {
@@ -129,7 +237,7 @@ describe("@openagentsinc/agent-runtime-schema", () => {
   })
 
   test("has no provider SDK or Vercel AI SDK fields in the durable schema shape", () => {
-    const schemas = JSON.stringify([AgentRuntimeRun.ast, AgentRuntimeEvent.ast])
+    const schemas = JSON.stringify([AgentRuntimeRun.ast, AgentRuntimeEvent.ast, AgentDefinition.ast])
     expect(schemas).not.toContain("@anthropic-ai")
     expect(schemas).not.toContain("@openai/codex-sdk")
     expect(schemas).not.toContain("ai-sdk")

--- a/packages/agent-runtime-schema/src/index.ts
+++ b/packages/agent-runtime-schema/src/index.ts
@@ -3,6 +3,11 @@ import { Schema as S } from "effect"
 export const AgentRuntimeRunId = S.String
 export type AgentRuntimeRunId = typeof AgentRuntimeRunId.Type
 
+export const AgentDefinitionSchemaLiteral = "openagents.agent_definition.v1" as const
+
+export const AgentDefinitionId = S.String
+export type AgentDefinitionId = typeof AgentDefinitionId.Type
+
 export const AgentRuntimeEventId = S.String
 export type AgentRuntimeEventId = typeof AgentRuntimeEventId.Type
 
@@ -26,6 +31,31 @@ export const agentRuntimeAdapterKinds: ReadonlyArray<AgentRuntimeAdapterKind> = 
   "hermes",
   "hosted_container",
   "shc",
+  "test_fixture",
+]
+
+export const AgentDefinitionHarnessKind = S.Literals([
+  "codex",
+  "claude_code",
+  "khala",
+  "opencode",
+  "hermes",
+  "openagents_native",
+  "hosted_container",
+  "custom",
+  "test_fixture",
+])
+export type AgentDefinitionHarnessKind = typeof AgentDefinitionHarnessKind.Type
+
+export const agentDefinitionHarnessKinds: ReadonlyArray<AgentDefinitionHarnessKind> = [
+  "codex",
+  "claude_code",
+  "khala",
+  "opencode",
+  "hermes",
+  "openagents_native",
+  "hosted_container",
+  "custom",
   "test_fixture",
 ]
 
@@ -77,6 +107,145 @@ export const AgentRuntimeRedactionPolicy = S.Struct({
   secretMaterialAllowed: S.Boolean,
 })
 export type AgentRuntimeRedactionPolicy = typeof AgentRuntimeRedactionPolicy.Type
+
+export const AgentDefinitionNetworkPolicy = S.Literals([
+  "none",
+  "owner_scoped",
+  "public_internet",
+])
+export type AgentDefinitionNetworkPolicy = typeof AgentDefinitionNetworkPolicy.Type
+
+export const AgentDefinitionSecretPolicy = S.Literals([
+  "none",
+  "owner_scoped_refs_only",
+])
+export type AgentDefinitionSecretPolicy = typeof AgentDefinitionSecretPolicy.Type
+
+export const AgentDefinitionToolRef = S.String
+export type AgentDefinitionToolRef = typeof AgentDefinitionToolRef.Type
+
+export const AgentDefinitionToolset = S.Struct({
+  allow: S.Array(AgentDefinitionToolRef),
+  deny: S.Array(AgentDefinitionToolRef),
+  ask: S.Array(AgentDefinitionToolRef),
+  networkPolicy: AgentDefinitionNetworkPolicy,
+  secretPolicy: AgentDefinitionSecretPolicy,
+})
+export type AgentDefinitionToolset = typeof AgentDefinitionToolset.Type
+
+export const AgentDefinitionHarness = S.Struct({
+  kind: AgentDefinitionHarnessKind,
+  modelHint: S.optional(S.String),
+  versionPin: S.optional(S.String),
+})
+export type AgentDefinitionHarness = typeof AgentDefinitionHarness.Type
+
+export const AgentDefinitionTrigger = S.Union([
+  S.Struct({
+    kind: S.Literal("cron"),
+    triggerRef: S.String,
+    cron: S.String,
+  }),
+  S.Struct({
+    kind: S.Literal("webhook"),
+    triggerRef: S.String,
+    sourceRef: S.String,
+  }),
+  S.Struct({
+    kind: S.Literal("inbox_match"),
+    triggerRef: S.String,
+    classifierRef: S.String,
+  }),
+  S.Struct({
+    kind: S.Literal("manual"),
+    triggerRef: S.String,
+  }),
+])
+export type AgentDefinitionTrigger = typeof AgentDefinitionTrigger.Type
+
+export const AgentDefinitionLane = S.Literals([
+  "own_pylon",
+  "cloud_workroom",
+  "worker_only",
+  "test_fixture",
+])
+export type AgentDefinitionLane = typeof AgentDefinitionLane.Type
+
+export const AgentDefinitionBudget = S.Struct({
+  maxRunSeconds: S.Number,
+  maxRunsPerDay: S.Number,
+  maxCreditsPerDay: S.optional(S.Number),
+})
+export type AgentDefinitionBudget = typeof AgentDefinitionBudget.Type
+
+export const AgentDefinitionEscalationChannel = S.Literals([
+  "operator",
+  "forum",
+  "push",
+  "email",
+])
+export type AgentDefinitionEscalationChannel =
+  typeof AgentDefinitionEscalationChannel.Type
+
+export const AgentDefinitionAskPolicy = S.Struct({
+  policyRef: S.String,
+  mode: S.Literals(["operator_required", "deny_when_unavailable"]),
+})
+export type AgentDefinitionAskPolicy = typeof AgentDefinitionAskPolicy.Type
+
+export const AgentDefinitionEscalation = S.Struct({
+  channel: AgentDefinitionEscalationChannel,
+  askPolicy: AgentDefinitionAskPolicy,
+})
+export type AgentDefinitionEscalation = typeof AgentDefinitionEscalation.Type
+
+export const AgentDefinition = S.Struct({
+  schema: S.Literal(AgentDefinitionSchemaLiteral),
+  id: AgentDefinitionId,
+  ownerRef: S.String,
+  name: S.String,
+  slug: S.String,
+  goal: S.String,
+  harness: AgentDefinitionHarness,
+  toolset: AgentDefinitionToolset,
+  triggers: S.Array(AgentDefinitionTrigger),
+  lane: AgentDefinitionLane,
+  budget: AgentDefinitionBudget,
+  escalation: AgentDefinitionEscalation,
+  sourceRefs: S.Array(S.String),
+  createdAt: S.String,
+  updatedAt: S.String,
+})
+export type AgentDefinition = typeof AgentDefinition.Type
+
+export const AgentDefinitionToolAuthorityStatus = S.Literals([
+  "allowed",
+  "denied",
+  "operator_escalation_required",
+])
+export type AgentDefinitionToolAuthorityStatus =
+  typeof AgentDefinitionToolAuthorityStatus.Type
+
+export type AgentDefinitionOperatorEscalation = {
+  readonly escalationRef: string
+  readonly definitionId: AgentDefinitionId
+  readonly ownerRef: string
+  readonly toolRef: AgentDefinitionToolRef
+  readonly channel: AgentDefinitionEscalationChannel
+  readonly askPolicyRef: string
+  readonly reasonRef: string
+}
+
+export type AgentDefinitionToolAuthorityDecision = {
+  readonly status: AgentDefinitionToolAuthorityStatus
+  readonly allowed: boolean
+  readonly toolRef: AgentDefinitionToolRef
+  readonly definitionId: AgentDefinitionId
+  readonly reasonRef: string
+  readonly matchedPolicyRef?: string
+  readonly blockerRefs: ReadonlyArray<string>
+  readonly escalation?: AgentDefinitionOperatorEscalation
+}
 
 export const AgentRuntimeRunState = S.Literals([
   "pending",
@@ -245,6 +414,7 @@ export type AgentRuntimeEvent = typeof AgentRuntimeEvent.Type
 
 export const AgentRuntimeRun = S.Struct({
   runId: AgentRuntimeRunId,
+  agentDefinitionId: S.optional(AgentDefinitionId),
   assignmentId: S.optional(S.String),
   workOrderId: S.optional(S.String),
   workspaceRef: S.String,
@@ -307,6 +477,7 @@ export type AgentRuntimeSurfaceStatusRow = {
 export const decodeAgentRuntimeRun = S.decodeUnknownSync(AgentRuntimeRun)
 export const decodeAgentRuntimeEvent = S.decodeUnknownSync(AgentRuntimeEvent)
 export const decodeAgentRuntimeEventLog = S.decodeUnknownSync(AgentRuntimeEventLog)
+export const decodeAgentDefinition = S.decodeUnknownSync(AgentDefinition)
 
 export const PylonAssignmentRunLifecycleEventSchemaLiteral =
   "openagents.pylon.assignment_run_lifecycle_event.v0.1" as const
@@ -492,6 +663,103 @@ export function projectAgentRuntimeSurfaceStatus(
 
 export function agentRuntimeSurfaceStatusHasUnsafeMaterial(row: AgentRuntimeSurfaceStatusRow): boolean {
   return unsafePublicMaterialPattern.test(JSON.stringify(row))
+}
+
+export function decideAgentDefinitionToolAuthority(input: {
+  readonly definition: AgentDefinition
+  readonly toolRef: AgentDefinitionToolRef
+  readonly invocationRef?: string
+}): AgentDefinitionToolAuthorityDecision {
+  const toolRef = input.toolRef
+  const toolset = input.definition.toolset
+
+  const deniedBy = firstMatchingToolPolicy(toolset.deny, toolRef)
+  if (deniedBy !== undefined) {
+    return {
+      status: "denied",
+      allowed: false,
+      toolRef,
+      definitionId: input.definition.id,
+      matchedPolicyRef: deniedBy,
+      reasonRef: "reason.agent_definition.tool_denied",
+      blockerRefs: ["blocker.agent_definition.tool_denied"],
+    }
+  }
+
+  const askBy = firstMatchingToolPolicy(toolset.ask, toolRef)
+  if (askBy !== undefined) {
+    const escalationRef = stableAgentDefinitionRef("escalation.operator.agent_definition", [
+      input.definition.id,
+      input.invocationRef ?? toolRef,
+      askBy,
+    ])
+    return {
+      status: "operator_escalation_required",
+      allowed: false,
+      toolRef,
+      definitionId: input.definition.id,
+      matchedPolicyRef: askBy,
+      reasonRef: "reason.agent_definition.tool_requires_operator",
+      blockerRefs: ["blocker.agent_definition.operator_escalation_required"],
+      escalation: {
+        escalationRef,
+        definitionId: input.definition.id,
+        ownerRef: input.definition.ownerRef,
+        toolRef,
+        channel: input.definition.escalation.channel,
+        askPolicyRef: input.definition.escalation.askPolicy.policyRef,
+        reasonRef: "reason.agent_definition.ask_policy_hit",
+      },
+    }
+  }
+
+  const allowedBy = firstMatchingToolPolicy(toolset.allow, toolRef)
+  if (allowedBy !== undefined) {
+    return {
+      status: "allowed",
+      allowed: true,
+      toolRef,
+      definitionId: input.definition.id,
+      matchedPolicyRef: allowedBy,
+      reasonRef: "reason.agent_definition.tool_allowed",
+      blockerRefs: [],
+    }
+  }
+
+  return {
+    status: "denied",
+    allowed: false,
+    toolRef,
+    definitionId: input.definition.id,
+    reasonRef: "reason.agent_definition.tool_not_in_allowlist",
+    blockerRefs: ["blocker.agent_definition.tool_not_in_allowlist"],
+  }
+}
+
+function firstMatchingToolPolicy(
+  policyRefs: ReadonlyArray<AgentDefinitionToolRef>,
+  toolRef: AgentDefinitionToolRef,
+): AgentDefinitionToolRef | undefined {
+  return policyRefs.find((policyRef) => toolRefMatchesPolicyRef(policyRef, toolRef))
+}
+
+function toolRefMatchesPolicyRef(
+  policyRef: AgentDefinitionToolRef,
+  toolRef: AgentDefinitionToolRef,
+): boolean {
+  if (policyRef === toolRef) return true
+  if (!policyRef.endsWith(".*")) return false
+  const prefix = policyRef.slice(0, -1)
+  return toolRef.startsWith(prefix)
+}
+
+function stableAgentDefinitionRef(prefix: string, parts: ReadonlyArray<string>): string {
+  let hash = 2166136261
+  for (const char of parts.join("\u001f")) {
+    hash ^= char.charCodeAt(0)
+    hash = Math.imul(hash, 16777619)
+  }
+  return `${prefix}.${(hash >>> 0).toString(16).padStart(8, "0")}`
 }
 
 const terminalRunStates: ReadonlySet<AgentRuntimeRunState> = new Set([


### PR DESCRIPTION
## Summary

Closes #8097.

- Add `openagents.agent_definition.v1` to `@openagentsinc/agent-runtime-schema` with harness, toolset, triggers, lane, budget, and escalation fields.
- Link runtime runs back to `agentDefinitionId` so fulfillment loops can prove they are definition-backed while staying harness-agnostic.
- Add `decideAgentDefinitionToolAuthority`, a pure deny-by-default tool-authority helper where `deny` takes precedence, `ask` produces an operator escalation record without authorizing execution, and unmatched tools are denied.
- Add a fulfillment-loop fixture and tests for decode, definition-backed runs, allow/deny/ask/default decisions, deny precedence over overlapping ask/allow, and SDK-shape neutrality.
- Update `INVARIANTS.md` with the background agent definition tool-authority contract.

## Verification

- `bun run test:agent-runtime-schema` - 12 passed
- `bun run typecheck:agent-runtime-schema` - passed
- `bun run check:deploy` - passed
  - web suite: 22 files / 567 tests passed
  - worker API suite: 13 files / 239 tests passed
  - included architecture, contract drift, projection freshness, Pylon typecheck, and security adversarial harness stages
