### PR TITLE
BF-6.5 connector authority redaction gate

### DIFF
--- a/INVARIANTS.md
+++ b/INVARIANTS.md
@@ -115,6 +115,30 @@ More specific invariant ledgers apply inside imported apps and packages.
 - Regression coverage starts in
   `packages/agent-runtime-schema/src/index.test.ts`.
 
+## Connector Authority And Redaction
+
+- Connector sidecars never own workspace, payment, email, membership,
+  settlement, identity, or broad provider-account authority. The platform
+  remains authoritative for those state changes; connectors may only emit
+  source-verified, bounded events and execute explicitly modeled per-connector
+  tools.
+- Before any connector event reaches model context, session history, logs, or
+  outbound provider mutation, provider credentials, authorization headers, raw
+  webhook bodies, raw payloads, signatures, and webhook secrets must be
+  excluded or redacted. Public or model-visible connector envelopes may carry
+  only typed subjects, source refs, redacted refs, booleans, timestamps, and
+  blocker/caveat refs.
+- Outbound connector mutation must pass an app-owned idempotency gate before
+  dispatch. Provider retry keys alone are not enough; the OpenAgents connector
+  contract owns the dedupe key and the bounded receipt/projection.
+- Generic provider tools are forbidden. Tool authority must name the connector,
+  provider, subject kind, and operation, and it must stay bound to the verified
+  event subject, such as one issue or one pull request.
+- Regression coverage for the BF-6 connector gate lives in
+  `packages/connector-sidecar/src/index.test.ts`, including denial cases for
+  raw provider material in context/history/logs, missing app-owned idempotency,
+  generic provider tools, and platform-authority widening.
+
 ## Cloudflare Verse World Service
 
 - Live Verse world work belongs to `apps/openagents-world/`, a Cloudflare

--- a/packages/connector-sidecar/src/index.test.ts
+++ b/packages/connector-sidecar/src/index.test.ts
@@ -5,6 +5,7 @@ import {
   connectorEventHasRawProviderMaterial,
   createConnectorDeliveryDedupeKey,
   createGitHubWebhookSignature,
+  decideConnectorDispatchAuthority,
   decideConnectorWritebackToolAuthority,
   normalizeGitHubWebhookEvent,
   projectConnectorEventToWorkspaceLane,
@@ -28,6 +29,19 @@ const headersFor = (rawBody: string) => ({
   delivery: "delivery-public-8100",
   signature256: createGitHubWebhookSignature("fixture-secret", rawBody),
 })
+
+const normalizedIssueEvent = () => {
+  const result = normalizeGitHubWebhookEvent({
+    headers: headersFor(rawIssueBody),
+    rawBody: rawIssueBody,
+    webhookSecret: "fixture-secret",
+    receivedAt: "2026-07-02T00:00:00.000Z",
+  })
+  if (!result.ok) {
+    throw new Error(result.reasonRef)
+  }
+  return result.event
+}
 
 describe("@openagentsinc/connector-sidecar", () => {
   test("normalizes a signed GitHub issue webhook into a bounded source-verified event", () => {
@@ -106,19 +120,11 @@ describe("@openagentsinc/connector-sidecar", () => {
   })
 
   test("authorizes only same-issue bounded writeback tools", () => {
-    const result = normalizeGitHubWebhookEvent({
-      headers: headersFor(rawIssueBody),
-      rawBody: rawIssueBody,
-      webhookSecret: "fixture-secret",
-      receivedAt: "2026-07-02T00:00:00.000Z",
-    })
-    if (!result.ok) {
-      throw new Error(result.reasonRef)
-    }
+    const event = normalizedIssueEvent()
 
     expect(
       decideConnectorWritebackToolAuthority({
-        event: result.event,
+        event,
         request: {
           provider: "github",
           toolRef: "tool.connector.github.issue.comment.create",
@@ -136,7 +142,7 @@ describe("@openagentsinc/connector-sidecar", () => {
 
     expect(
       decideConnectorWritebackToolAuthority({
-        event: result.event,
+        event,
         request: {
           provider: "github",
           toolRef: "tool.connector.github.issue.comment.create",
@@ -153,7 +159,7 @@ describe("@openagentsinc/connector-sidecar", () => {
 
     expect(
       decideConnectorWritebackToolAuthority({
-        event: result.event,
+        event,
         request: {
           provider: "github",
           toolRef: "tool.connector.github.payment.refund",
@@ -162,6 +168,133 @@ describe("@openagentsinc/connector-sidecar", () => {
           subjectKind: "issue",
           number: 8100,
         },
+      }),
+    ).toMatchObject({
+      allowed: false,
+      reasonRef: "reason.connector.tool_forbidden_authority",
+    })
+  })
+
+  test("allows dispatch only after source verification, app idempotency, redacted context, and bounded tools", () => {
+    const event = normalizedIssueEvent()
+
+    expect(
+      decideConnectorDispatchAuthority({
+        event,
+        appOwnedIdempotencyKey: event.dedupeKey,
+        toolRefs: ["tool.connector.github.issue.comment.create"],
+        modelContextItems: [
+          {
+            action: event.action,
+            sourceRefs: event.sourceRefs,
+            subject: event.subject,
+          },
+        ],
+        requestedPlatformAuthorityRefs: ["authority.connector.github.issue.writeback"],
+      }),
+    ).toMatchObject({
+      allowed: true,
+      reasonRef: "reason.connector.dispatch.authority_bound",
+    })
+  })
+
+  test("blocks connector dispatch when app-owned idempotency is absent before provider mutation", () => {
+    const event = normalizedIssueEvent()
+
+    expect(
+      decideConnectorDispatchAuthority({
+        event,
+        appOwnedIdempotencyKey: null,
+        toolRefs: ["tool.connector.github.issue.comment.create"],
+      }),
+    ).toMatchObject({
+      allowed: false,
+      reasonRef: "reason.connector.app_idempotency_required",
+    })
+
+    expect(
+      decideConnectorDispatchAuthority({
+        event,
+        appOwnedIdempotencyKey: "github-provider-retry-key",
+        toolRefs: ["tool.connector.github.issue.comment.create"],
+      }),
+    ).toMatchObject({
+      allowed: false,
+      reasonRef: "reason.connector.app_idempotency_required",
+    })
+  })
+
+  test("blocks provider credentials, raw webhook bodies, and raw payloads from model context, history, and logs", () => {
+    const event = normalizedIssueEvent()
+
+    expect(
+      decideConnectorDispatchAuthority({
+        event,
+        appOwnedIdempotencyKey: event.dedupeKey,
+        toolRefs: ["tool.connector.github.issue.comment.create"],
+        modelContextItems: [{ rawWebhookBody: rawIssueBody }],
+      }),
+    ).toMatchObject({
+      allowed: false,
+      reasonRef: "reason.connector.model_context_contains_private_provider_material",
+    })
+
+    expect(
+      decideConnectorDispatchAuthority({
+        event,
+        appOwnedIdempotencyKey: event.dedupeKey,
+        toolRefs: ["tool.connector.github.issue.comment.create"],
+        sessionHistoryItems: [{ authorization: "Bearer gho_fixturetoken" }],
+      }),
+    ).toMatchObject({
+      allowed: false,
+      reasonRef: "reason.connector.model_context_contains_private_provider_material",
+    })
+
+    expect(
+      decideConnectorDispatchAuthority({
+        event,
+        appOwnedIdempotencyKey: event.dedupeKey,
+        toolRefs: ["tool.connector.github.issue.comment.create"],
+        logItems: [{ webhookSecret: "fixture-secret" }],
+      }),
+    ).toMatchObject({
+      allowed: false,
+      reasonRef: "reason.connector.model_context_contains_private_provider_material",
+    })
+  })
+
+  test("blocks generic provider tools and platform authority widening", () => {
+    const event = normalizedIssueEvent()
+
+    expect(
+      decideConnectorDispatchAuthority({
+        event,
+        appOwnedIdempotencyKey: event.dedupeKey,
+        toolRefs: ["tool.github.rest.request"],
+      }),
+    ).toMatchObject({
+      allowed: false,
+      reasonRef: "reason.connector.generic_provider_tool_forbidden",
+    })
+
+    expect(
+      decideConnectorDispatchAuthority({
+        event,
+        appOwnedIdempotencyKey: event.dedupeKey,
+        toolRefs: ["tool.connector.github.issue.comment.create"],
+        requestedPlatformAuthorityRefs: ["authority.connector.payment.capture"],
+      }),
+    ).toMatchObject({
+      allowed: false,
+      reasonRef: "reason.connector.platform_authority_forbidden",
+    })
+
+    expect(
+      decideConnectorDispatchAuthority({
+        event,
+        appOwnedIdempotencyKey: event.dedupeKey,
+        toolRefs: ["tool.connector.github.email.send"],
       }),
     ).toMatchObject({
       allowed: false,

--- a/packages/connector-sidecar/src/index.ts
+++ b/packages/connector-sidecar/src/index.ts
@@ -71,13 +71,20 @@ export type ConnectorAuthorityDecision =
   | {
       allowed: true
       status: "allowed"
-      reasonRef: "reason.connector.writeback.subject_bound"
+      reasonRef:
+        | "reason.connector.dispatch.authority_bound"
+        | "reason.connector.writeback.subject_bound"
       blockerRefs: []
     }
   | {
       allowed: false
       status: "denied"
       reasonRef:
+        | "reason.connector.app_idempotency_required"
+        | "reason.connector.generic_provider_tool_forbidden"
+        | "reason.connector.model_context_contains_private_provider_material"
+        | "reason.connector.platform_authority_forbidden"
+        | "reason.connector.source_verification_required"
         | "reason.connector.tool_not_allowed"
         | "reason.connector.tool_forbidden_authority"
         | "reason.connector.writeback_subject_mismatch"
@@ -112,6 +119,16 @@ export type NormalizeGitHubWebhookResult =
         | "reason.connector.github.invalid_json"
       blockerRefs: [string]
     }
+
+export type ConnectorDispatchAuthorityInput = {
+  event: ConnectorSourceVerifiedEvent
+  appOwnedIdempotencyKey: string | null | undefined
+  toolRefs: ReadonlyArray<string>
+  modelContextItems?: ReadonlyArray<unknown> | undefined
+  sessionHistoryItems?: ReadonlyArray<unknown> | undefined
+  logItems?: ReadonlyArray<unknown> | undefined
+  requestedPlatformAuthorityRefs?: ReadonlyArray<string> | undefined
+}
 
 const textEncoder = new TextEncoder()
 
@@ -308,6 +325,105 @@ export const projectConnectorEventToWorkspaceLane = (
 }
 
 const forbiddenAuthorityPattern = /\.(membership|payment|email|settlement|identity)\./
+const platformAuthorityPattern =
+  /(?:^|[._:-])(workspace|payment|email|membership|settlement|identity)(?:[._:-]|$)/i
+const genericProviderToolPattern =
+  /^(?:github|tool\.github|tool\.provider\.github|tool\.connector\.github\.(?:api|graphql|rest|generic|raw))(?:\.|$)/i
+const privateProviderMaterialPattern =
+  /(?:access[_-]?token|authorization|bearer|client[_-]?secret|cookie|gho_[A-Za-z0-9_]+|github[_-]?secret|hookshot|oauth|payload|private[_-]?key|provider[_-]?(credential|payload|secret)|raw[_-]?(body|headers|payload|webhook)|secret|signature256|token|webhook[_-]?(body|headers|payload|secret)|x-hub-signature)/i
+
+const hasPrivateProviderMaterial = (value: unknown): boolean =>
+  privateProviderMaterialPattern.test(JSON.stringify(value))
+
+export const decideConnectorDispatchAuthority = (
+  input: ConnectorDispatchAuthorityInput,
+): ConnectorAuthorityDecision => {
+  const { event } = input
+
+  if (event.sourceVerified !== true) {
+    return {
+      allowed: false,
+      status: "denied",
+      reasonRef: "reason.connector.source_verification_required",
+      blockerRefs: ["blocker.connector.source_verification_required"],
+    }
+  }
+
+  if (input.appOwnedIdempotencyKey !== event.dedupeKey) {
+    return {
+      allowed: false,
+      status: "denied",
+      reasonRef: "reason.connector.app_idempotency_required",
+      blockerRefs: ["blocker.connector.app_idempotency_required"],
+    }
+  }
+
+  const contextEnvelope = {
+    logs: input.logItems ?? [],
+    modelContext: input.modelContextItems ?? [],
+    sessionHistory: input.sessionHistoryItems ?? [],
+  }
+  if (hasPrivateProviderMaterial(contextEnvelope)) {
+    return {
+      allowed: false,
+      status: "denied",
+      reasonRef: "reason.connector.model_context_contains_private_provider_material",
+      blockerRefs: [
+        "blocker.connector.model_context_contains_private_provider_material",
+      ],
+    }
+  }
+
+  if (
+    (input.requestedPlatformAuthorityRefs ?? []).some((authorityRef) =>
+      platformAuthorityPattern.test(authorityRef),
+    )
+  ) {
+    return {
+      allowed: false,
+      status: "denied",
+      reasonRef: "reason.connector.platform_authority_forbidden",
+      blockerRefs: ["blocker.connector.platform_authority_forbidden"],
+    }
+  }
+
+  const projection = projectConnectorEventToWorkspaceLane(event)
+  for (const toolRef of input.toolRefs) {
+    if (
+      genericProviderToolPattern.test(toolRef) ||
+      forbiddenAuthorityPattern.test(toolRef)
+    ) {
+      return {
+        allowed: false,
+        status: "denied",
+        reasonRef: genericProviderToolPattern.test(toolRef)
+          ? "reason.connector.generic_provider_tool_forbidden"
+          : "reason.connector.tool_forbidden_authority",
+        blockerRefs: [
+          genericProviderToolPattern.test(toolRef)
+            ? "blocker.connector.generic_provider_tool_forbidden"
+            : "blocker.connector.tool_forbidden_authority",
+        ],
+      }
+    }
+
+    if (!projection.allowedWritebackToolRefs.includes(toolRef)) {
+      return {
+        allowed: false,
+        status: "denied",
+        reasonRef: "reason.connector.tool_not_allowed",
+        blockerRefs: ["blocker.connector.tool_not_allowed"],
+      }
+    }
+  }
+
+  return {
+    allowed: true,
+    status: "allowed",
+    reasonRef: "reason.connector.dispatch.authority_bound",
+    blockerRefs: [],
+  }
+}
 
 export const decideConnectorWritebackToolAuthority = (input: {
   event: ConnectorSourceVerifiedEvent
@@ -359,6 +475,5 @@ export const decideConnectorWritebackToolAuthority = (input: {
 export const connectorEventHasRawProviderMaterial = (
   value: ConnectorSourceVerifiedEvent,
 ): boolean => {
-  const serialized = JSON.stringify(value)
-  return /raw|payload|webhookSecret|secret|token|email|payment|member/i.test(serialized)
+  return hasPrivateProviderMaterial(value)
 }


### PR DESCRIPTION
Closes #8104

## Summary
- Adds the BF-6.5 connector authority/redaction invariant to `INVARIANTS.md`.
- Adds a connector dispatch authority gate for source verification, app-owned idempotency, redacted context/history/log material, bounded per-connector tools, and platform authority refusal.
- Extends connector-sidecar tests for raw provider material, missing idempotency, generic provider tools, and workspace/payment/email authority widening.

## Verification
- `bun run --cwd packages/connector-sidecar test` (9 pass)
- `bun run --cwd packages/connector-sidecar typecheck`
- `bun run check:deploy` (exit code 0; web targeted suite 22 files/567 tests passed, Worker targeted suite 13 files/239 tests passed)
