### PR TITLE
Add BF-6.3 gated social publishing connector

### DIFF
--- a/apps/openagents.com/workers/api/src/business-social-publishing-connector.test.ts
+++ b/apps/openagents.com/workers/api/src/business-social-publishing-connector.test.ts
@@ -1,0 +1,217 @@
+import { describe, expect, test } from 'vitest'
+
+import {
+  BusinessSocialPublishingConnectorInvariantError,
+  buildBusinessSocialPublishingConnectorReceipt,
+  publicBusinessSocialPublishingConnectorProjection,
+  publishApprovedBusinessSocialPost,
+  type BusinessSocialPlatformPublisher,
+} from './business-social-publishing-connector'
+import {
+  OmniWorkroomApprovalGatePolicy,
+  OmniWorkroomOutboundDeliverableReviewInput,
+  decideOmniWorkroomOutboundDeliverableReview,
+} from './omni-workroom-approval-gates'
+
+const approvalPolicy = (
+  approvalLevel: 'draft' | 'suggest' | 'execute_with_approval' | 'trusted' =
+    'execute_with_approval',
+) =>
+  new OmniWorkroomApprovalGatePolicy({
+    approvalLevel,
+    professionalReviewRequired: false,
+    professionalReviewerRole: null,
+    sourceRefs: ['policy.business_fulfillment.approval_ladder.v1'],
+    workspaceRef: 'workspace.business.fulfillment.001',
+  })
+
+const approvalDecision = (
+  overrides: Partial<OmniWorkroomOutboundDeliverableReviewInput> = {},
+) =>
+  decideOmniWorkroomOutboundDeliverableReview(
+    new OmniWorkroomOutboundDeliverableReviewInput({
+      approvalDecisionReceiptRefs: ['receipt.review.social_post_approved.001'],
+      deliverableRef: 'deliverable.social_post.campaign_001',
+      evidenceRefs: ['evidence.social_post.preview.001'],
+      outboundActionKind: 'publish',
+      policy: approvalPolicy(),
+      professionalReviewReceiptRefs: [],
+      reviewerRoleRefs: [],
+      sourceRefs: ['github.public.issue.8102'],
+      workKind: 'business',
+      workroomRef: 'workroom.business.fulfillment.001',
+      ...overrides,
+    }),
+  )
+
+const validInput = {
+  approvalDecision: approvalDecision(),
+  approvedPostRef: 'artifact.social_post.approved.001',
+  campaignRef: 'campaign.business.social.001',
+  connectorRef: 'connector.social.x.workspace_001',
+  createdAt: '2026-07-03T12:00:00.000Z',
+  engagementRef: 'engagement.business.opaque.001',
+  platform: 'x' as const,
+  publishRequestRef: 'request.social_publish.x.001',
+  sourceRefs: [
+    'github.public.issue.8102',
+    'docs/fable/2026-07-02-business-fulfillment-engine-meditations.md#connector-lane',
+  ],
+}
+
+describe('business social publishing connector', () => {
+  test('publishes an approved X post through an injected connector and returns a per-post receipt', async () => {
+    const calls: Array<unknown> = []
+    const publisher: BusinessSocialPlatformPublisher = async request => {
+      calls.push(request)
+      return {
+        platformPostRef: 'x.post.public.opaque_001',
+        platformReceiptRef: 'receipt.x.publish.opaque_001',
+      }
+    }
+
+    const receipt = await publishApprovedBusinessSocialPost(validInput, publisher)
+
+    expect(calls).toEqual([
+      {
+        approvedPostRef: 'artifact.social_post.approved.001',
+        campaignRef: 'campaign.business.social.001',
+        connectorRef: 'connector.social.x.workspace_001',
+        engagementRef: 'engagement.business.opaque.001',
+        platform: 'x',
+        publishRequestRef: 'request.social_publish.x.001',
+        toolRef: 'tool.business.social_publish.x.v1',
+        workspaceRef: 'workspace.business.fulfillment.001',
+      },
+    ])
+    expect(receipt).toMatchObject({
+      approvalDecisionReceiptRef: 'receipt.review.social_post_approved.001',
+      credentialMaterialInModelContext: false,
+      externalActionKind: 'publish',
+      platform: 'x',
+      publishAllowed: true,
+      rawProviderPayloadInModelContext: false,
+      receiptKind: 'business.social_publishing_connector.post_published',
+      receiptRef:
+        'receipt.business.social_publish.campaign_business_social_001.x_post_public_opaque_001',
+      schema: 'openagents.business.social_publishing_connector.receipt.v1',
+      toolRef: 'tool.business.social_publish.x.v1',
+    })
+    expect(receipt.sourceRefs).toContain('docs/fable/ROADMAP_BIZ.md#BF-6.3')
+    expect(receipt.caveatRefs).toContain(
+      'caveat.business.social_publishing.approval_gate_required',
+    )
+    expect(JSON.stringify(receipt)).not.toMatch(
+      /@|access_token|raw_post|provider_payload|customer_email|x\.com\//i,
+    )
+  })
+
+  test('blocks posting when the BF-4.3 approval gate has not authorized publish', async () => {
+    const blockedDecision = approvalDecision({
+      approvalDecisionReceiptRefs: [],
+    })
+    let called = false
+
+    await expect(
+      publishApprovedBusinessSocialPost(
+        { ...validInput, approvalDecision: blockedDecision },
+        async () => {
+          called = true
+          return {
+            platformPostRef: 'x.post.public.opaque_001',
+            platformReceiptRef: 'receipt.x.publish.opaque_001',
+          }
+        },
+      ),
+    ).rejects.toThrow(BusinessSocialPublishingConnectorInvariantError)
+    expect(called).toBe(false)
+  })
+
+  test('blocks non-publish approval decisions and draft/suggest ladder levels', () => {
+    expect(() =>
+      buildBusinessSocialPublishingConnectorReceipt({
+        ...validInput,
+        approvalDecision: approvalDecision({ outboundActionKind: 'send' }),
+        platformPostRef: 'x.post.public.opaque_001',
+        platformReceiptRef: 'receipt.x.publish.opaque_001',
+      }),
+    ).toThrow(/publish decisions/)
+
+    for (const approvalLevel of ['draft', 'suggest'] as const) {
+      expect(() =>
+        buildBusinessSocialPublishingConnectorReceipt({
+          ...validInput,
+          approvalDecision: approvalDecision({
+            policy: approvalPolicy(approvalLevel),
+          }),
+          platformPostRef: 'x.post.public.opaque_001',
+          platformReceiptRef: 'receipt.x.publish.opaque_001',
+        }),
+      ).toThrow(/approval gate/)
+    }
+  })
+
+  test('rejects unsafe refs so raw posts, provider payloads, credentials, and client identifiers stay out of receipts', () => {
+    expect(() =>
+      buildBusinessSocialPublishingConnectorReceipt({
+        ...validInput,
+        approvedPostRef: 'raw_post.hello_world',
+        platformPostRef: 'x.post.public.opaque_001',
+        platformReceiptRef: 'receipt.x.publish.opaque_001',
+      }),
+    ).toThrow(/public-safe ref/)
+
+    expect(() =>
+      buildBusinessSocialPublishingConnectorReceipt({
+        ...validInput,
+        connectorRef: 'connector.social.x.access_token.sk_test',
+        platformPostRef: 'x.post.public.opaque_001',
+        platformReceiptRef: 'receipt.x.publish.opaque_001',
+      }),
+    ).toThrow(/public-safe ref/)
+
+    expect(() =>
+      buildBusinessSocialPublishingConnectorReceipt({
+        ...validInput,
+        engagementRef: 'engagement.customer_email@example.com',
+        platformPostRef: 'x.post.public.opaque_001',
+        platformReceiptRef: 'receipt.x.publish.opaque_001',
+      }),
+    ).toThrow(/public-safe ref/)
+  })
+
+  test('public projection keeps receipt and approval evidence but omits connector internals', () => {
+    const receipt = buildBusinessSocialPublishingConnectorReceipt({
+      ...validInput,
+      platformPostRef: 'x.post.public.opaque_001',
+      platformReceiptRef: 'receipt.x.publish.opaque_001',
+    })
+
+    const projection = publicBusinessSocialPublishingConnectorProjection(receipt)
+
+    expect(projection).toEqual({
+      approvalDecisionReceiptRef: 'receipt.review.social_post_approved.001',
+      approvedPostRef: 'artifact.social_post.approved.001',
+      campaignRef: 'campaign.business.social.001',
+      caveatRefs: receipt.caveatRefs,
+      createdAt: '2026-07-03T12:00:00.000Z',
+      credentialMaterialInModelContext: false,
+      deliverableRef: 'deliverable.social_post.campaign_001',
+      engagementRef: 'engagement.business.opaque.001',
+      externalActionKind: 'publish',
+      platform: 'x',
+      platformPostRef: 'x.post.public.opaque_001',
+      platformReceiptRef: 'receipt.x.publish.opaque_001',
+      publishAllowed: true,
+      rawProviderPayloadInModelContext: false,
+      receiptKind: 'business.social_publishing_connector.post_published',
+      receiptRef: receipt.receiptRef,
+      schema: 'openagents.business.social_publishing_connector.receipt.v1',
+      sourceRefs: receipt.sourceRefs,
+      toolRef: 'tool.business.social_publish.x.v1',
+      workspaceRef: 'workspace.business.fulfillment.001',
+    })
+    expect(projection).not.toHaveProperty('connectorRef')
+    expect(projection).not.toHaveProperty('publishRequestRef')
+  })
+})

--- a/apps/openagents.com/workers/api/src/business-social-publishing-connector.ts
+++ b/apps/openagents.com/workers/api/src/business-social-publishing-connector.ts
@@ -1,0 +1,302 @@
+import { Schema as S } from 'effect'
+
+import {
+  type OmniWorkroomOutboundDeliverableReviewDecision,
+} from './omni-workroom-approval-gates'
+import { currentIsoTimestamp } from './runtime-primitives'
+
+export const BUSINESS_SOCIAL_PUBLISHING_CONNECTOR_RECEIPT_SCHEMA =
+  'openagents.business.social_publishing_connector.receipt.v1' as const
+
+export const BusinessSocialPublishingPlatform = S.Literals(['x'])
+export type BusinessSocialPublishingPlatform =
+  typeof BusinessSocialPublishingPlatform.Type
+
+export const BUSINESS_SOCIAL_PUBLISHING_TOOL_REF =
+  'tool.business.social_publish.x.v1' as const
+
+export const BusinessSocialPublishingConnectorReceipt = S.Struct({
+  schema: S.Literal(BUSINESS_SOCIAL_PUBLISHING_CONNECTOR_RECEIPT_SCHEMA),
+  receiptKind: S.Literal('business.social_publishing_connector.post_published'),
+  receiptRef: S.String,
+  engagementRef: S.String,
+  workspaceRef: S.String,
+  campaignRef: S.String,
+  deliverableRef: S.String,
+  platform: BusinessSocialPublishingPlatform,
+  connectorRef: S.String,
+  toolRef: S.Literal(BUSINESS_SOCIAL_PUBLISHING_TOOL_REF),
+  approvedPostRef: S.String,
+  approvalDecisionReceiptRef: S.String,
+  publishRequestRef: S.String,
+  platformPostRef: S.String,
+  platformReceiptRef: S.String,
+  externalActionKind: S.Literal('publish'),
+  publishAllowed: S.Literal(true),
+  credentialMaterialInModelContext: S.Literal(false),
+  rawProviderPayloadInModelContext: S.Literal(false),
+  createdAt: S.String,
+  sourceRefs: S.Array(S.String),
+  caveatRefs: S.Array(S.String),
+})
+export type BusinessSocialPublishingConnectorReceipt =
+  typeof BusinessSocialPublishingConnectorReceipt.Type
+
+export type BusinessSocialPublishingConnectorInput = Readonly<{
+  approvalDecision: OmniWorkroomOutboundDeliverableReviewDecision
+  approvedPostRef: string
+  campaignRef: string
+  caveatRefs?: ReadonlyArray<string> | undefined
+  connectorRef: string
+  createdAt?: string | undefined
+  engagementRef: string
+  platform: BusinessSocialPublishingPlatform
+  publishRequestRef: string
+  sourceRefs: ReadonlyArray<string>
+}>
+
+export type BusinessSocialPlatformPublishRequest = Readonly<{
+  approvedPostRef: string
+  campaignRef: string
+  connectorRef: string
+  engagementRef: string
+  platform: BusinessSocialPublishingPlatform
+  publishRequestRef: string
+  toolRef: typeof BUSINESS_SOCIAL_PUBLISHING_TOOL_REF
+  workspaceRef: string
+}>
+
+export type BusinessSocialPlatformPublishResult = Readonly<{
+  platformPostRef: string
+  platformReceiptRef: string
+}>
+
+export type BusinessSocialPlatformPublisher = (
+  request: BusinessSocialPlatformPublishRequest,
+) => Promise<BusinessSocialPlatformPublishResult>
+
+export class BusinessSocialPublishingConnectorInvariantError extends S.TaggedErrorClass<BusinessSocialPublishingConnectorInvariantError>()(
+  'BusinessSocialPublishingConnectorInvariantError',
+  { reason: S.String },
+) {
+  override get message() {
+    return this.reason
+  }
+}
+
+const SAFE_REF_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:/=#-]{2,220}$/
+const UNSAFE_REF_PATTERN =
+  /(@|access[_-]?token|\bauth\b|auth[_-]?(content|json|token)|bearer|client[_-]?(email|name|phone)|contact[_-]?(email|name|phone)|cookie|customer[_-]?(email|name|phone|record|value)|email|oauth|phone|private|provider[_-]?(credential|payload|secret|token)|raw[_-]?(body|connector|content|customer|message|payload|post|provider|text|webhook)|secret|token|twitter\.com\/|x\.com\/)/i
+
+const DEFAULT_CAVEAT_REFS = [
+  'caveat.business.social_publishing.x_first_only',
+  'caveat.business.social_publishing.approval_gate_required',
+  'caveat.business.social_publishing.receipt_per_post',
+  'caveat.business.social_publishing.sensitive_material_excluded_from_context',
+] as const
+
+const trimOrNull = (value: string | null | undefined): string | null => {
+  if (value === undefined || value === null) return null
+  const trimmed = value.trim()
+  return trimmed === '' ? null : trimmed
+}
+
+const requirePublicSafeRef = (field: string, value: string): string => {
+  const trimmed = trimOrNull(value)
+  if (trimmed === null) {
+    throw new BusinessSocialPublishingConnectorInvariantError({
+      reason: `${field} is required.`,
+    })
+  }
+  if (!SAFE_REF_PATTERN.test(trimmed) || UNSAFE_REF_PATTERN.test(trimmed)) {
+    throw new BusinessSocialPublishingConnectorInvariantError({
+      reason: `${field} must be an opaque public-safe ref.`,
+    })
+  }
+  return trimmed
+}
+
+const requirePublicSafeRefs = (
+  field: string,
+  values: ReadonlyArray<string>,
+): ReadonlyArray<string> => {
+  if (values.length === 0) {
+    throw new BusinessSocialPublishingConnectorInvariantError({
+      reason: `${field} must contain at least one public-safe ref.`,
+    })
+  }
+  return values.map(value => requirePublicSafeRef(field, value))
+}
+
+const requireIsoLike = (field: string, value: string): string => {
+  const trimmed = trimOrNull(value)
+  if (trimmed === null || Number.isNaN(Date.parse(trimmed))) {
+    throw new BusinessSocialPublishingConnectorInvariantError({
+      reason: `${field} must be an ISO-like timestamp.`,
+    })
+  }
+  return trimmed
+}
+
+const refSuffix = (value: string): string =>
+  value.toLowerCase().replace(/[^a-z0-9]+/g, '_').replace(/^_+|_+$/g, '')
+
+const receiptRefFor = (
+  campaignRef: string,
+  platformPostRef: string,
+): string =>
+  `receipt.business.social_publish.${refSuffix(campaignRef)}.${refSuffix(platformPostRef)}`
+
+const firstReceiptRef = (
+  refs: ReadonlyArray<string>,
+): string | undefined => refs[0]
+
+const assertApprovalDecisionAllowsPublish = (
+  decision: OmniWorkroomOutboundDeliverableReviewDecision,
+): string => {
+  if (decision.outboundActionKind !== 'publish') {
+    throw new BusinessSocialPublishingConnectorInvariantError({
+      reason: 'social publishing connector only accepts BF-4.3 publish decisions.',
+    })
+  }
+  if (decision.externalActionAllowed !== true) {
+    throw new BusinessSocialPublishingConnectorInvariantError({
+      reason:
+        'social publishing connector requires a recorded approval gate decision before posting.',
+    })
+  }
+  if (decision.deliverableRef !== decision.deliverableRef.trim()) {
+    throw new BusinessSocialPublishingConnectorInvariantError({
+      reason: 'approval decision deliverableRef must be normalized.',
+    })
+  }
+  const receiptRef = firstReceiptRef(decision.receiptRefs)
+  if (receiptRef === undefined) {
+    throw new BusinessSocialPublishingConnectorInvariantError({
+      reason: 'approval decision must carry a receipt ref.',
+    })
+  }
+  return requirePublicSafeRef('approvalDecisionReceiptRef', receiptRef)
+}
+
+export const buildBusinessSocialPublishingConnectorReceipt = (
+  input: BusinessSocialPublishingConnectorInput &
+    BusinessSocialPlatformPublishResult,
+): BusinessSocialPublishingConnectorReceipt => {
+  const approvalDecisionReceiptRef = assertApprovalDecisionAllowsPublish(
+    input.approvalDecision,
+  )
+  const campaignRef = requirePublicSafeRef('campaignRef', input.campaignRef)
+  const platformPostRef = requirePublicSafeRef(
+    'platformPostRef',
+    input.platformPostRef,
+  )
+
+  return {
+    schema: BUSINESS_SOCIAL_PUBLISHING_CONNECTOR_RECEIPT_SCHEMA,
+    receiptKind: 'business.social_publishing_connector.post_published',
+    receiptRef: receiptRefFor(campaignRef, platformPostRef),
+    engagementRef: requirePublicSafeRef('engagementRef', input.engagementRef),
+    workspaceRef: requirePublicSafeRef(
+      'workspaceRef',
+      input.approvalDecision.workspaceRef,
+    ),
+    campaignRef,
+    deliverableRef: requirePublicSafeRef(
+      'deliverableRef',
+      input.approvalDecision.deliverableRef,
+    ),
+    platform: input.platform,
+    connectorRef: requirePublicSafeRef('connectorRef', input.connectorRef),
+    toolRef: BUSINESS_SOCIAL_PUBLISHING_TOOL_REF,
+    approvedPostRef: requirePublicSafeRef(
+      'approvedPostRef',
+      input.approvedPostRef,
+    ),
+    approvalDecisionReceiptRef,
+    publishRequestRef: requirePublicSafeRef(
+      'publishRequestRef',
+      input.publishRequestRef,
+    ),
+    platformPostRef,
+    platformReceiptRef: requirePublicSafeRef(
+      'platformReceiptRef',
+      input.platformReceiptRef,
+    ),
+    externalActionKind: 'publish',
+    publishAllowed: true,
+    credentialMaterialInModelContext: false,
+    rawProviderPayloadInModelContext: false,
+    createdAt: requireIsoLike(
+      'createdAt',
+      input.createdAt ?? currentIsoTimestamp(),
+    ),
+    sourceRefs: [
+      ...requirePublicSafeRefs('sourceRefs', input.sourceRefs),
+      'docs/fable/ROADMAP_BIZ.md#BF-6.3',
+    ],
+    caveatRefs: [
+      ...requirePublicSafeRefs(
+        'caveatRefs',
+        input.caveatRefs ?? DEFAULT_CAVEAT_REFS,
+      ),
+    ],
+  }
+}
+
+export const publishApprovedBusinessSocialPost = async (
+  input: BusinessSocialPublishingConnectorInput,
+  publisher: BusinessSocialPlatformPublisher,
+): Promise<BusinessSocialPublishingConnectorReceipt> => {
+  assertApprovalDecisionAllowsPublish(input.approvalDecision)
+
+  const publishResult = await publisher({
+    approvedPostRef: requirePublicSafeRef(
+      'approvedPostRef',
+      input.approvedPostRef,
+    ),
+    campaignRef: requirePublicSafeRef('campaignRef', input.campaignRef),
+    connectorRef: requirePublicSafeRef('connectorRef', input.connectorRef),
+    engagementRef: requirePublicSafeRef('engagementRef', input.engagementRef),
+    platform: input.platform,
+    publishRequestRef: requirePublicSafeRef(
+      'publishRequestRef',
+      input.publishRequestRef,
+    ),
+    toolRef: BUSINESS_SOCIAL_PUBLISHING_TOOL_REF,
+    workspaceRef: requirePublicSafeRef(
+      'workspaceRef',
+      input.approvalDecision.workspaceRef,
+    ),
+  })
+
+  return buildBusinessSocialPublishingConnectorReceipt({
+    ...input,
+    ...publishResult,
+  })
+}
+
+export const publicBusinessSocialPublishingConnectorProjection = (
+  receipt: BusinessSocialPublishingConnectorReceipt,
+) => ({
+  schema: receipt.schema,
+  receiptKind: receipt.receiptKind,
+  receiptRef: receipt.receiptRef,
+  engagementRef: receipt.engagementRef,
+  workspaceRef: receipt.workspaceRef,
+  campaignRef: receipt.campaignRef,
+  deliverableRef: receipt.deliverableRef,
+  platform: receipt.platform,
+  toolRef: receipt.toolRef,
+  approvedPostRef: receipt.approvedPostRef,
+  approvalDecisionReceiptRef: receipt.approvalDecisionReceiptRef,
+  platformPostRef: receipt.platformPostRef,
+  platformReceiptRef: receipt.platformReceiptRef,
+  externalActionKind: receipt.externalActionKind,
+  publishAllowed: receipt.publishAllowed,
+  credentialMaterialInModelContext: receipt.credentialMaterialInModelContext,
+  rawProviderPayloadInModelContext: receipt.rawProviderPayloadInModelContext,
+  createdAt: receipt.createdAt,
+  sourceRefs: receipt.sourceRefs,
+  caveatRefs: receipt.caveatRefs,
+})


### PR DESCRIPTION
Closes #8102.

## Summary
- Adds the BF-6.3 X-first social publishing connector contract with an injected publisher boundary.
- Requires a BF-4.3 workroom approval decision before posting and emits one public-safe receipt per published post.
- Keeps connector refs, raw provider payloads, credentials, raw post content, and client-identifying material out of public projections.

## Verification
- `bun run --cwd apps/openagents.com/workers/api test -- src/business-social-publishing-connector.test.ts` PASS (5 tests)
- `bun run --cwd apps/openagents.com/workers/api typecheck` PASS
- `bun run check:deploy` PASS
