### PR TITLE
BF-5.3: add client comms cadence receipts

### DIFF
--- a/apps/openagents.com/workers/api/migrations/0275_business_fulfillment_comms_cadence.sql
+++ b/apps/openagents.com/workers/api/migrations/0275_business_fulfillment_comms_cadence.sql
@@ -1,0 +1,78 @@
+-- BF-5.3: per-promise client comms cadence and customer-visible workroom
+-- update refs. Outbound email remains approval-gated; this records the
+-- ledger refs needed for customers to see forward motion without asking.
+
+PRAGMA foreign_keys = OFF;
+
+CREATE TABLE business_service_promises_0275 (
+  id TEXT PRIMARY KEY NOT NULL,
+  promise_ref TEXT NOT NULL UNIQUE,
+  accepted_outcome_contract_id TEXT
+    REFERENCES omni_accepted_outcome_contracts(id) ON DELETE SET NULL,
+  workspace_ref TEXT NOT NULL,
+  crm_state_ref TEXT NOT NULL,
+  stakeholder_refs_json TEXT NOT NULL DEFAULT '[]',
+  state TEXT NOT NULL CHECK (
+    state IN ('active', 'paused', 'blocked', 'closed')
+  ),
+  cadence TEXT NOT NULL CHECK (cadence IN ('daily', 'weekly')),
+  next_motion_due_at TEXT,
+  last_motion_receipt_ref TEXT,
+  source_refs_json TEXT NOT NULL DEFAULT '[]',
+  metadata_json TEXT NOT NULL DEFAULT '{}',
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+);
+
+INSERT INTO business_service_promises_0275 (
+  id,
+  promise_ref,
+  accepted_outcome_contract_id,
+  workspace_ref,
+  crm_state_ref,
+  stakeholder_refs_json,
+  state,
+  cadence,
+  next_motion_due_at,
+  last_motion_receipt_ref,
+  source_refs_json,
+  metadata_json,
+  created_at,
+  updated_at
+)
+SELECT id,
+       promise_ref,
+       accepted_outcome_contract_id,
+       workspace_ref,
+       crm_state_ref,
+       stakeholder_refs_json,
+       state,
+       cadence,
+       next_motion_due_at,
+       last_motion_receipt_ref,
+       source_refs_json,
+       metadata_json,
+       created_at,
+       updated_at
+  FROM business_service_promises;
+
+DROP TABLE business_service_promises;
+ALTER TABLE business_service_promises_0275 RENAME TO business_service_promises;
+
+CREATE INDEX IF NOT EXISTS idx_business_service_promises_due
+  ON business_service_promises(state, next_motion_due_at, updated_at DESC);
+
+PRAGMA foreign_keys = ON;
+
+ALTER TABLE business_fulfillment_motion_receipts
+  ADD COLUMN cadence TEXT NOT NULL DEFAULT 'daily'
+    CHECK (cadence IN ('daily', 'weekly'));
+
+ALTER TABLE business_fulfillment_motion_receipts
+  ADD COLUMN client_comms_email_ledger_ref TEXT;
+
+ALTER TABLE business_fulfillment_motion_receipts
+  ADD COLUMN customer_visible_workroom_update_ref TEXT;
+
+CREATE INDEX IF NOT EXISTS idx_business_fulfillment_motion_receipts_cadence
+  ON business_fulfillment_motion_receipts(cadence, created_at DESC);

--- a/apps/openagents.com/workers/api/src/business-fulfillment-loop.test.ts
+++ b/apps/openagents.com/workers/api/src/business-fulfillment-loop.test.ts
@@ -88,6 +88,7 @@ const makeDb = (): D1Database => {
   const db = new DatabaseSync(':memory:')
   db.exec(migration('0091_omni_accepted_outcome_contracts.sql'))
   db.exec(migration('0274_business_fulfillment_loop.sql'))
+  db.exec(migration('0275_business_fulfillment_comms_cadence.sql'))
   return new SqliteD1(db) as unknown as D1Database
 }
 
@@ -103,7 +104,7 @@ class MemoryFulfillmentLoopStore implements BusinessFulfillmentLoopStore {
     private readonly promises: ReadonlyArray<BusinessServicePromiseRecord>,
   ) {}
 
-  async claimDailyMotionReceipt(receipt: {
+  async claimMotionReceipt(receipt: {
     motionDate: string
     promiseId: string
     receiptRef: string
@@ -147,9 +148,14 @@ describe('business fulfillment loop', () => {
       agentDefinitionRef: BUSINESS_FULFILLMENT_LOOP_AGENT_DEFINITION_REF,
       approvalGateRef:
         'approval_gate.business_fulfillment.client_comms.promise_business_fulfillment_001_2026_07_03',
+      cadence: 'daily',
       clientCommsDraftRef:
         'draft.business_fulfillment.client_comms.promise_business_fulfillment_001_2026_07_03',
+      clientCommsEmailLedgerRef:
+        'email_campaign_send.business_fulfillment.client_comms.promise_business_fulfillment_001_2026_07_03',
       crmStateRef: promise.crmStateRef,
+      customerVisibleWorkroomUpdateRef:
+        'workroom_update.business_fulfillment.customer_visible.promise_business_fulfillment_001_2026_07_03',
       forwardMotionRef:
         'motion.business_fulfillment.daily.promise_business_fulfillment_001_2026_07_03',
       motionDate: '2026-07-03',
@@ -178,6 +184,9 @@ describe('business fulfillment loop', () => {
       ],
       skippedDuplicateCount: 0,
       state: 'completed',
+      workroomUpdateRefs: [
+        'workroom_update.business_fulfillment.customer_visible.promise_business_fulfillment_001_2026_07_03',
+      ],
     })
     expect(store.updates).toEqual([
       {
@@ -196,7 +205,42 @@ describe('business fulfillment loop', () => {
       motionReceiptRefs: [],
       skippedDuplicateCount: 1,
       state: 'completed',
+      workroomUpdateRefs: [],
     })
+  })
+
+  test('weekly promises claim once and schedule the next weekly motion', async () => {
+    const store = new MemoryFulfillmentLoopStore([
+      activePromise({
+        cadence: 'weekly',
+        id: 'business_service_promise_weekly',
+        promiseRef: 'promise.business.fulfillment.weekly',
+      }),
+    ])
+
+    const result = await Effect.runPromise(
+      runBusinessFulfillmentLoop({ runtime, store }),
+    )
+
+    expect(result).toEqual({
+      duePromiseCount: 1,
+      motionReceiptRefs: [
+        'receipt.business_fulfillment.weekly_motion.promise_business_fulfillment_weekly_2026_07_03',
+      ],
+      skippedDuplicateCount: 0,
+      state: 'completed',
+      workroomUpdateRefs: [
+        'workroom_update.business_fulfillment.customer_visible.promise_business_fulfillment_weekly_2026_07_03',
+      ],
+    })
+    expect(store.updates).toEqual([
+      {
+        nextMotionDueAt: '2026-07-10T12:00:00.000Z',
+        promiseId: 'business_service_promise_weekly',
+        receiptRef:
+          'receipt.business_fulfillment.weekly_motion.promise_business_fulfillment_weekly_2026_07_03',
+      },
+    ])
   })
 
   test('ignores paused promises and unsafe CRM refs', async () => {
@@ -209,6 +253,7 @@ describe('business fulfillment loop', () => {
       duePromiseCount: 0,
       motionReceiptRefs: [],
       state: 'skipped',
+      workroomUpdateRefs: [],
     })
 
     let caught: unknown
@@ -277,14 +322,20 @@ describe('business fulfillment loop', () => {
         `SELECT receipt_ref,
                 outbound_allowed,
                 approval_gate_ref,
-                client_comms_draft_ref
+                cadence,
+                client_comms_draft_ref,
+                client_comms_email_ledger_ref,
+                customer_visible_workroom_update_ref
            FROM business_fulfillment_motion_receipts
           WHERE promise_id = ?`,
       )
       .bind('business_service_promise_d1')
       .first<{
         approval_gate_ref: string
+        cadence: string
         client_comms_draft_ref: string
+        client_comms_email_ledger_ref: string
+        customer_visible_workroom_update_ref: string
         outbound_allowed: number
         receipt_ref: string
       }>()
@@ -307,18 +358,27 @@ describe('business fulfillment loop', () => {
       ],
       skippedDuplicateCount: 0,
       state: 'completed',
+      workroomUpdateRefs: [
+        'workroom_update.business_fulfillment.customer_visible.promise_business_fulfillment_d1_2026_07_03',
+      ],
     })
     expect(second).toMatchObject({
       duePromiseCount: 0,
       motionReceiptRefs: [],
       skippedDuplicateCount: 0,
       state: 'skipped',
+      workroomUpdateRefs: [],
     })
     expect(receiptRow).toMatchObject({
       approval_gate_ref:
         'approval_gate.business_fulfillment.client_comms.promise_business_fulfillment_d1_2026_07_03',
+      cadence: 'daily',
       client_comms_draft_ref:
         'draft.business_fulfillment.client_comms.promise_business_fulfillment_d1_2026_07_03',
+      client_comms_email_ledger_ref:
+        'email_campaign_send.business_fulfillment.client_comms.promise_business_fulfillment_d1_2026_07_03',
+      customer_visible_workroom_update_ref:
+        'workroom_update.business_fulfillment.customer_visible.promise_business_fulfillment_d1_2026_07_03',
       outbound_allowed: 0,
       receipt_ref:
         'receipt.business_fulfillment.daily_motion.promise_business_fulfillment_d1_2026_07_03',

--- a/apps/openagents.com/workers/api/src/business-fulfillment-loop.ts
+++ b/apps/openagents.com/workers/api/src/business-fulfillment-loop.ts
@@ -21,9 +21,13 @@ export const BusinessServicePromiseState = S.Literals([
 export type BusinessServicePromiseState =
   typeof BusinessServicePromiseState.Type
 
+export const BusinessServicePromiseCadence = S.Literals(['daily', 'weekly'])
+export type BusinessServicePromiseCadence =
+  typeof BusinessServicePromiseCadence.Type
+
 export const BusinessServicePromiseRecord = S.Struct({
   acceptedOutcomeContractId: S.NullOr(S.String),
-  cadence: S.Literal('daily'),
+  cadence: BusinessServicePromiseCadence,
   createdAt: S.String,
   crmStateRef: S.String,
   id: S.String,
@@ -43,9 +47,12 @@ export const BusinessFulfillmentMotionReceipt = S.Struct({
   agentDefinitionRef: S.String,
   approvalGateRef: S.String,
   blockerRefs: S.Array(S.String),
+  cadence: BusinessServicePromiseCadence,
   clientCommsDraftRef: S.String,
+  clientCommsEmailLedgerRef: S.String,
   createdAt: S.String,
   crmStateRef: S.String,
+  customerVisibleWorkroomUpdateRef: S.String,
   forwardMotionRef: S.String,
   id: S.String,
   motionDate: S.String,
@@ -61,7 +68,7 @@ export type BusinessFulfillmentMotionReceipt =
   typeof BusinessFulfillmentMotionReceipt.Type
 
 export type BusinessFulfillmentLoopStore = Readonly<{
-  claimDailyMotionReceipt: (
+  claimMotionReceipt: (
     receipt: BusinessFulfillmentMotionReceipt,
   ) => Promise<Readonly<{ claimed: boolean }>>
   listDuePromises: (
@@ -86,6 +93,7 @@ export type BusinessFulfillmentLoopResult = Readonly<{
   motionReceiptRefs: ReadonlyArray<string>
   skippedDuplicateCount: number
   state: 'completed' | 'skipped'
+  workroomUpdateRefs: ReadonlyArray<string>
 }>
 
 export class BusinessFulfillmentLoopValidationError extends S.TaggedErrorClass<BusinessFulfillmentLoopValidationError>()(
@@ -145,7 +153,6 @@ const promiseFromRow = (
     typeof row.accepted_outcome_contract_id === 'string'
       ? row.accepted_outcome_contract_id
       : null,
-  cadence: 'daily',
   createdAt: String(row.created_at),
   crmStateRef: String(row.crm_state_ref),
   id: String(row.id),
@@ -160,6 +167,7 @@ const promiseFromRow = (
   stakeholderRefs: parseJsonStringArray(
     String(row.stakeholder_refs_json ?? '[]'),
   ),
+  cadence: S.decodeUnknownSync(BusinessServicePromiseCadence)(row.cadence),
   state: S.decodeUnknownSync(BusinessServicePromiseState)(row.state),
   updatedAt: String(row.updated_at),
   workspaceRef: String(row.workspace_ref),
@@ -168,7 +176,7 @@ const promiseFromRow = (
 export const makeD1BusinessFulfillmentLoopStore = (
   db: D1Database,
 ): BusinessFulfillmentLoopStore => ({
-  claimDailyMotionReceipt: async receipt => {
+  claimMotionReceipt: async receipt => {
     const result = await db
       .prepare(
         `INSERT OR IGNORE INTO business_fulfillment_motion_receipts (
@@ -178,17 +186,20 @@ export const makeD1BusinessFulfillmentLoopStore = (
           motion_date,
           receipt_ref,
           agent_definition_ref,
+          cadence,
           crm_state_ref,
           stakeholder_refs_json,
           stakeholder_flag_refs_json,
           forward_motion_ref,
           client_comms_draft_ref,
+          client_comms_email_ledger_ref,
+          customer_visible_workroom_update_ref,
           approval_gate_ref,
           outbound_allowed,
           blocker_refs_json,
           source_refs_json,
           created_at
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
       )
       .bind(
         receipt.id,
@@ -197,11 +208,14 @@ export const makeD1BusinessFulfillmentLoopStore = (
         receipt.motionDate,
         receipt.receiptRef,
         receipt.agentDefinitionRef,
+        receipt.cadence,
         receipt.crmStateRef,
         JSON.stringify(receipt.stakeholderRefs),
         JSON.stringify(receipt.stakeholderFlagRefs),
         receipt.forwardMotionRef,
         receipt.clientCommsDraftRef,
+        receipt.clientCommsEmailLedgerRef,
+        receipt.customerVisibleWorkroomUpdateRef,
         receipt.approvalGateRef,
         receipt.outboundAllowed ? 1 : 0,
         JSON.stringify(receipt.blockerRefs),
@@ -218,7 +232,7 @@ export const makeD1BusinessFulfillmentLoopStore = (
         `SELECT *
            FROM business_service_promises
           WHERE state = 'active'
-            AND cadence = 'daily'
+            AND cadence IN ('daily', 'weekly')
             AND (next_motion_due_at IS NULL OR next_motion_due_at <= ?)
           ORDER BY COALESCE(next_motion_due_at, created_at) ASC, updated_at ASC
           LIMIT ?`,
@@ -250,8 +264,13 @@ export const makeD1BusinessFulfillmentLoopStore = (
 const refSuffix = (value: string): string =>
   value.toLowerCase().replace(/[^a-z0-9]+/g, '_').replace(/^_+|_+$/g, '')
 
-const nextDailyDueAt = (nowIso: string): string =>
-  isoTimestampAfterIso(nowIso, 24 * 60 * 60 * 1000)
+const cadenceIntervalMs = (cadence: BusinessServicePromiseCadence): number =>
+  cadence === 'weekly' ? 7 * 24 * 60 * 60 * 1000 : 24 * 60 * 60 * 1000
+
+const nextDueAtForCadence = (
+  cadence: BusinessServicePromiseCadence,
+  nowIso: string,
+): string => isoTimestampAfterIso(nowIso, cadenceIntervalMs(cadence))
 
 const validatePromise = (promise: BusinessServicePromiseRecord): void => {
   assertSafeRef('promiseRef', promise.promiseRef)
@@ -276,6 +295,7 @@ export const buildBusinessFulfillmentMotionReceipt = (
   const sourceRefs = [
     ...promise.sourceRefs,
     'docs/fable/ROADMAP_BIZ.md#BF-5.1',
+    'docs/fable/ROADMAP_BIZ.md#BF-5.3',
     'docs/fable/2026-07-02-business-fulfillment-engine-meditations.md#fulfillment-agents',
   ]
 
@@ -283,16 +303,19 @@ export const buildBusinessFulfillmentMotionReceipt = (
     agentDefinitionRef: BUSINESS_FULFILLMENT_LOOP_AGENT_DEFINITION_REF,
     approvalGateRef: `approval_gate.business_fulfillment.client_comms.${suffix}`,
     blockerRefs: [],
+    cadence: promise.cadence,
     clientCommsDraftRef: `draft.business_fulfillment.client_comms.${suffix}`,
+    clientCommsEmailLedgerRef: `email_campaign_send.business_fulfillment.client_comms.${suffix}`,
     createdAt: nowIso,
     crmStateRef: promise.crmStateRef,
-    forwardMotionRef: `motion.business_fulfillment.daily.${suffix}`,
+    customerVisibleWorkroomUpdateRef: `workroom_update.business_fulfillment.customer_visible.${suffix}`,
+    forwardMotionRef: `motion.business_fulfillment.${promise.cadence}.${suffix}`,
     id: runtime.makeId('business_fulfillment_motion'),
     motionDate,
     outboundAllowed: false,
     promiseId: promise.id,
     promiseRef: promise.promiseRef,
-    receiptRef: `receipt.business_fulfillment.daily_motion.${suffix}`,
+    receiptRef: `receipt.business_fulfillment.${promise.cadence}_motion.${suffix}`,
     sourceRefs,
     stakeholderFlagRefs: promise.stakeholderRefs.map(
       stakeholderRef =>
@@ -327,12 +350,13 @@ export const runBusinessFulfillmentLoop = (
               buildBusinessFulfillmentMotionReceipt(promise, input.runtime),
           })
           const claim = yield* tryLoopPromise(() =>
-            input.store.claimDailyMotionReceipt(receipt),
+            input.store.claimMotionReceipt(receipt),
           )
 
           if (!claim.claimed) {
             return {
               maybeReceiptRef: null,
+              maybeWorkroomUpdateRef: null,
               skippedDuplicateCount: 1,
             }
           }
@@ -341,13 +365,14 @@ export const runBusinessFulfillmentLoop = (
             input.store.markPromiseMotionRecorded(
               promise.id,
               receipt.receiptRef,
-              nextDailyDueAt(nowIso),
+              nextDueAtForCadence(promise.cadence, nowIso),
               nowIso,
             ),
           )
 
           return {
             maybeReceiptRef: receipt.receiptRef,
+            maybeWorkroomUpdateRef: receipt.customerVisibleWorkroomUpdateRef,
             skippedDuplicateCount: 0,
           }
         }),
@@ -361,12 +386,19 @@ export const runBusinessFulfillmentLoop = (
       (sum, outcome) => sum + outcome.skippedDuplicateCount,
       0,
     )
+    const workroomUpdateRefs = outcomes.flatMap(outcome =>
+      outcome.maybeWorkroomUpdateRef === undefined ||
+      outcome.maybeWorkroomUpdateRef === null
+        ? []
+        : [outcome.maybeWorkroomUpdateRef],
+    )
 
     return {
       duePromiseCount: duePromises.length,
       motionReceiptRefs,
       skippedDuplicateCount,
       state: duePromises.length === 0 ? 'skipped' : 'completed',
+      workroomUpdateRefs,
     }
   })
 
@@ -387,6 +419,7 @@ export const runBusinessFulfillmentLoopScheduled = (
         motionReceiptRefs: [],
         skippedDuplicateCount: 0,
         state: 'skipped' as const,
+        workroomUpdateRefs: [],
       }),
     ),
   )


### PR DESCRIPTION
Closes #8098.

## Summary
- Generalizes business service promise cadence from daily-only to daily or weekly.
- Records approval-gated client comms email ledger refs and customer-visible workroom update refs on fulfillment motion receipts.
- Adds D1 migration coverage and regression tests for daily and weekly promise motion.

## Verification
- `bun run --cwd apps/openagents.com/workers/api test -- src/business-fulfillment-loop.test.ts` — 5 tests passed.
- `bun run --cwd apps/openagents.com/workers/api typecheck` — passed.
- `bun run check:deploy` — passed.
