### PR TITLE
BF-5.4: page blocked service promises

### DIFF
--- a/apps/openagents.com/workers/api/migrations/0275_business_fulfillment_escalation_pages.sql
+++ b/apps/openagents.com/workers/api/migrations/0275_business_fulfillment_escalation_pages.sql
@@ -1,0 +1,33 @@
+ALTER TABLE business_service_promises
+  ADD COLUMN blocking_reason_ref TEXT;
+
+ALTER TABLE business_service_promises
+  ADD COLUMN blocked_at TEXT;
+
+ALTER TABLE business_service_promises
+  ADD COLUMN last_escalation_page_ref TEXT;
+
+CREATE INDEX IF NOT EXISTS idx_business_service_promises_blocked
+  ON business_service_promises(state, blocked_at, updated_at ASC);
+
+CREATE TABLE IF NOT EXISTS business_fulfillment_escalation_pages (
+  id TEXT PRIMARY KEY NOT NULL,
+  promise_id TEXT NOT NULL
+    REFERENCES business_service_promises(id) ON DELETE CASCADE,
+  promise_ref TEXT NOT NULL,
+  escalation_date TEXT NOT NULL,
+  receipt_ref TEXT NOT NULL UNIQUE,
+  page_ref TEXT NOT NULL UNIQUE,
+  owner_notification_ref TEXT NOT NULL,
+  agent_definition_ref TEXT NOT NULL,
+  blocking_reason_ref TEXT NOT NULL,
+  blocked_at TEXT NOT NULL,
+  workspace_ref TEXT NOT NULL,
+  stakeholder_refs_json TEXT NOT NULL DEFAULT '[]',
+  source_refs_json TEXT NOT NULL DEFAULT '[]',
+  created_at TEXT NOT NULL,
+  UNIQUE (promise_id, escalation_date)
+);
+
+CREATE INDEX IF NOT EXISTS idx_business_fulfillment_escalation_pages_promise
+  ON business_fulfillment_escalation_pages(promise_id, created_at DESC);

--- a/apps/openagents.com/workers/api/src/business-fulfillment-loop.test.ts
+++ b/apps/openagents.com/workers/api/src/business-fulfillment-loop.test.ts
@@ -9,6 +9,7 @@ import {
   type BusinessServicePromiseRecord,
   BUSINESS_FULFILLMENT_LOOP_AGENT_DEFINITION_REF,
   BusinessFulfillmentLoopValidationError,
+  buildBusinessFulfillmentEscalationPageReceipt,
   buildBusinessFulfillmentMotionReceipt,
   makeD1BusinessFulfillmentLoopStore,
   runBusinessFulfillmentLoop,
@@ -20,10 +21,13 @@ const activePromise = (
   overrides?: Partial<BusinessServicePromiseRecord>,
 ): BusinessServicePromiseRecord => ({
   acceptedOutcomeContractId: 'omni_accepted_outcome_contract.business_001',
+  blockedAt: null,
+  blockingReasonRef: null,
   cadence: 'daily',
   createdAt: '2026-07-02T00:00:00.000Z',
   crmStateRef: 'crm_state.business.promise_001.public_safe',
   id: 'business_service_promise_001',
+  lastEscalationPageRef: null,
   lastMotionReceiptRef: null,
   nextMotionDueAt: '2026-07-03T00:00:00.000Z',
   promiseRef: 'promise.business.fulfillment.001',
@@ -88,10 +92,16 @@ const makeDb = (): D1Database => {
   const db = new DatabaseSync(':memory:')
   db.exec(migration('0091_omni_accepted_outcome_contracts.sql'))
   db.exec(migration('0274_business_fulfillment_loop.sql'))
+  db.exec(migration('0275_business_fulfillment_escalation_pages.sql'))
   return new SqliteD1(db) as unknown as D1Database
 }
 
 class MemoryFulfillmentLoopStore implements BusinessFulfillmentLoopStore {
+  public readonly escalationPages = new Map<string, string>()
+  public readonly escalationUpdates: Array<{
+    pageRef: string
+    promiseId: string
+  }> = []
   public readonly receipts = new Map<string, string>()
   public readonly updates: Array<{
     nextMotionDueAt: string
@@ -102,6 +112,19 @@ class MemoryFulfillmentLoopStore implements BusinessFulfillmentLoopStore {
   constructor(
     private readonly promises: ReadonlyArray<BusinessServicePromiseRecord>,
   ) {}
+
+  async claimBlockedPromisePage(receipt: {
+    escalationDate: string
+    pageRef: string
+    promiseId: string
+  }): Promise<Readonly<{ claimed: boolean }>> {
+    const key = `${receipt.promiseId}:${receipt.escalationDate}`
+    if (this.escalationPages.has(key)) {
+      return { claimed: false }
+    }
+    this.escalationPages.set(key, receipt.pageRef)
+    return { claimed: true }
+  }
 
   async claimDailyMotionReceipt(receipt: {
     motionDate: string
@@ -116,6 +139,19 @@ class MemoryFulfillmentLoopStore implements BusinessFulfillmentLoopStore {
     return { claimed: true }
   }
 
+  async listBlockedPromises(
+    nowIso: string,
+    limit: number,
+  ): Promise<ReadonlyArray<BusinessServicePromiseRecord>> {
+    void nowIso
+    return this.promises
+      .filter(
+        promise =>
+          promise.state === 'blocked' && promise.blockingReasonRef !== null,
+      )
+      .slice(0, limit)
+  }
+
   async listDuePromises(
     nowIso: string,
     limit: number,
@@ -127,6 +163,13 @@ class MemoryFulfillmentLoopStore implements BusinessFulfillmentLoopStore {
           (promise.nextMotionDueAt === null || promise.nextMotionDueAt <= nowIso),
       )
       .slice(0, limit)
+  }
+
+  async markPromiseEscalationRecorded(
+    promiseId: string,
+    pageRef: string,
+  ): Promise<void> {
+    this.escalationUpdates.push({ pageRef, promiseId })
   }
 
   async markPromiseMotionRecorded(
@@ -172,7 +215,10 @@ describe('business fulfillment loop', () => {
     )
 
     expect(result).toEqual({
+      blockedPromiseCount: 0,
       duePromiseCount: 1,
+      escalationPageRefs: [],
+      escalationSkippedDuplicateCount: 0,
       motionReceiptRefs: [
         'receipt.business_fulfillment.daily_motion.promise_business_fulfillment_001_2026_07_03',
       ],
@@ -192,7 +238,10 @@ describe('business fulfillment loop', () => {
       runBusinessFulfillmentLoop({ runtime, store }),
     )
     expect(duplicate).toMatchObject({
+      blockedPromiseCount: 0,
       duePromiseCount: 1,
+      escalationPageRefs: [],
+      escalationSkippedDuplicateCount: 0,
       motionReceiptRefs: [],
       skippedDuplicateCount: 1,
       state: 'completed',
@@ -206,7 +255,10 @@ describe('business fulfillment loop', () => {
     await expect(
       Effect.runPromise(runBusinessFulfillmentLoop({ runtime, store: pausedStore })),
     ).resolves.toMatchObject({
+      blockedPromiseCount: 0,
       duePromiseCount: 0,
+      escalationPageRefs: [],
+      escalationSkippedDuplicateCount: 0,
       motionReceiptRefs: [],
       state: 'skipped',
     })
@@ -224,6 +276,62 @@ describe('business fulfillment loop', () => {
     expect((caught as BusinessFulfillmentLoopValidationError).reason).toContain(
       'opaque public-safe ref',
     )
+  })
+
+  test('blocked promises page the operator with the blocking reason ref', async () => {
+    const promise = activePromise({
+      blockedAt: '2026-07-03T09:00:00.000Z',
+      blockingReasonRef: 'blocker.business_fulfillment.customer_asset_missing',
+      state: 'blocked',
+    })
+    const receipt = buildBusinessFulfillmentEscalationPageReceipt(promise, runtime)
+
+    expect(receipt).toMatchObject({
+      agentDefinitionRef: BUSINESS_FULFILLMENT_LOOP_AGENT_DEFINITION_REF,
+      blockedAt: '2026-07-03T09:00:00.000Z',
+      blockingReasonRef:
+        'blocker.business_fulfillment.customer_asset_missing',
+      ownerNotificationRef:
+        'notification.owner.business_fulfillment.blocked_promise.promise_business_fulfillment_001_2026_07_03',
+      pageRef:
+        'page.owner.business_fulfillment.blocked_promise.promise_business_fulfillment_001_2026_07_03',
+      receiptRef:
+        'receipt.business_fulfillment.blocked_promise_page.promise_business_fulfillment_001_2026_07_03',
+    })
+    expect(JSON.stringify(receipt)).not.toMatch(/@|customer_email|raw_crm/i)
+
+    const store = new MemoryFulfillmentLoopStore([promise])
+    const first = await Effect.runPromise(
+      runBusinessFulfillmentLoop({ runtime, store }),
+    )
+    const second = await Effect.runPromise(
+      runBusinessFulfillmentLoop({ runtime, store }),
+    )
+
+    expect(first).toEqual({
+      blockedPromiseCount: 1,
+      duePromiseCount: 0,
+      escalationPageRefs: [
+        'page.owner.business_fulfillment.blocked_promise.promise_business_fulfillment_001_2026_07_03',
+      ],
+      escalationSkippedDuplicateCount: 0,
+      motionReceiptRefs: [],
+      skippedDuplicateCount: 0,
+      state: 'completed',
+    })
+    expect(store.escalationUpdates).toEqual([
+      {
+        pageRef:
+          'page.owner.business_fulfillment.blocked_promise.promise_business_fulfillment_001_2026_07_03',
+        promiseId: 'business_service_promise_001',
+      },
+    ])
+    expect(second).toMatchObject({
+      blockedPromiseCount: 1,
+      escalationPageRefs: [],
+      escalationSkippedDuplicateCount: 1,
+      state: 'completed',
+    })
   })
 
   test('D1 store claims one daily receipt per active service promise', async () => {
@@ -301,7 +409,10 @@ describe('business fulfillment loop', () => {
       }>()
 
     expect(first).toEqual({
+      blockedPromiseCount: 0,
       duePromiseCount: 1,
+      escalationPageRefs: [],
+      escalationSkippedDuplicateCount: 0,
       motionReceiptRefs: [
         'receipt.business_fulfillment.daily_motion.promise_business_fulfillment_d1_2026_07_03',
       ],
@@ -309,7 +420,10 @@ describe('business fulfillment loop', () => {
       state: 'completed',
     })
     expect(second).toMatchObject({
+      blockedPromiseCount: 0,
       duePromiseCount: 0,
+      escalationPageRefs: [],
+      escalationSkippedDuplicateCount: 0,
       motionReceiptRefs: [],
       skippedDuplicateCount: 0,
       state: 'skipped',
@@ -327,6 +441,113 @@ describe('business fulfillment loop', () => {
       last_motion_receipt_ref:
         'receipt.business_fulfillment.daily_motion.promise_business_fulfillment_d1_2026_07_03',
       next_motion_due_at: '2026-07-04T12:00:00.000Z',
+    })
+  })
+
+  test('D1 store claims one blocked-promise page per day', async () => {
+    const db = makeDb()
+    await db
+      .prepare(
+        `INSERT INTO business_service_promises (
+          id,
+          promise_ref,
+          accepted_outcome_contract_id,
+          workspace_ref,
+          crm_state_ref,
+          stakeholder_refs_json,
+          state,
+          cadence,
+          next_motion_due_at,
+          last_motion_receipt_ref,
+          blocking_reason_ref,
+          blocked_at,
+          last_escalation_page_ref,
+          source_refs_json,
+          metadata_json,
+          created_at,
+          updated_at
+        ) VALUES (?, ?, NULL, ?, ?, ?, 'blocked', 'daily', NULL, NULL, ?, ?, NULL, ?, '{}', ?, ?)`,
+      )
+      .bind(
+        'business_service_promise_blocked_d1',
+        'promise.business.fulfillment.blocked_d1',
+        'workspace.business.fulfillment.blocked_d1',
+        'crm_state.business.promise_blocked_d1.public_safe',
+        JSON.stringify(['stakeholder.business.operator']),
+        'blocker.business_fulfillment.operator_decision_needed',
+        '2026-07-03T09:00:00.000Z',
+        JSON.stringify(['docs/fable/ROADMAP_BIZ.md#BF-5.4']),
+        '2026-07-02T00:00:00.000Z',
+        '2026-07-03T09:00:00.000Z',
+      )
+      .run()
+
+    const first = await Effect.runPromise(
+      runBusinessFulfillmentLoop({
+        runtime,
+        store: makeD1BusinessFulfillmentLoopStore(db),
+      }),
+    )
+    const second = await Effect.runPromise(
+      runBusinessFulfillmentLoop({
+        runtime,
+        store: makeD1BusinessFulfillmentLoopStore(db),
+      }),
+    )
+    const pageRow = await db
+      .prepare(
+        `SELECT page_ref,
+                owner_notification_ref,
+                blocking_reason_ref,
+                blocked_at
+           FROM business_fulfillment_escalation_pages
+          WHERE promise_id = ?`,
+      )
+      .bind('business_service_promise_blocked_d1')
+      .first<{
+        blocked_at: string
+        blocking_reason_ref: string
+        owner_notification_ref: string
+        page_ref: string
+      }>()
+    const promiseRow = await db
+      .prepare(
+        `SELECT last_escalation_page_ref
+           FROM business_service_promises
+          WHERE id = ?`,
+      )
+      .bind('business_service_promise_blocked_d1')
+      .first<{ last_escalation_page_ref: string }>()
+
+    expect(first).toEqual({
+      blockedPromiseCount: 1,
+      duePromiseCount: 0,
+      escalationPageRefs: [
+        'page.owner.business_fulfillment.blocked_promise.promise_business_fulfillment_blocked_d1_2026_07_03',
+      ],
+      escalationSkippedDuplicateCount: 0,
+      motionReceiptRefs: [],
+      skippedDuplicateCount: 0,
+      state: 'completed',
+    })
+    expect(second).toMatchObject({
+      blockedPromiseCount: 1,
+      escalationPageRefs: [],
+      escalationSkippedDuplicateCount: 1,
+      state: 'completed',
+    })
+    expect(pageRow).toMatchObject({
+      blocked_at: '2026-07-03T09:00:00.000Z',
+      blocking_reason_ref:
+        'blocker.business_fulfillment.operator_decision_needed',
+      owner_notification_ref:
+        'notification.owner.business_fulfillment.blocked_promise.promise_business_fulfillment_blocked_d1_2026_07_03',
+      page_ref:
+        'page.owner.business_fulfillment.blocked_promise.promise_business_fulfillment_blocked_d1_2026_07_03',
+    })
+    expect(promiseRow).toMatchObject({
+      last_escalation_page_ref:
+        'page.owner.business_fulfillment.blocked_promise.promise_business_fulfillment_blocked_d1_2026_07_03',
     })
   })
 })

--- a/apps/openagents.com/workers/api/src/business-fulfillment-loop.ts
+++ b/apps/openagents.com/workers/api/src/business-fulfillment-loop.ts
@@ -23,10 +23,13 @@ export type BusinessServicePromiseState =
 
 export const BusinessServicePromiseRecord = S.Struct({
   acceptedOutcomeContractId: S.NullOr(S.String),
+  blockedAt: S.NullOr(S.String),
+  blockingReasonRef: S.NullOr(S.String),
   cadence: S.Literal('daily'),
   createdAt: S.String,
   crmStateRef: S.String,
   id: S.String,
+  lastEscalationPageRef: S.NullOr(S.String),
   lastMotionReceiptRef: S.NullOr(S.String),
   nextMotionDueAt: S.NullOr(S.String),
   promiseRef: S.String,
@@ -60,14 +63,45 @@ export const BusinessFulfillmentMotionReceipt = S.Struct({
 export type BusinessFulfillmentMotionReceipt =
   typeof BusinessFulfillmentMotionReceipt.Type
 
+export const BusinessFulfillmentEscalationPageReceipt = S.Struct({
+  agentDefinitionRef: S.String,
+  blockedAt: S.String,
+  blockingReasonRef: S.String,
+  createdAt: S.String,
+  escalationDate: S.String,
+  id: S.String,
+  ownerNotificationRef: S.String,
+  pageRef: S.String,
+  promiseId: S.String,
+  promiseRef: S.String,
+  receiptRef: S.String,
+  sourceRefs: S.Array(S.String),
+  stakeholderRefs: S.Array(S.String),
+  workspaceRef: S.String,
+})
+export type BusinessFulfillmentEscalationPageReceipt =
+  typeof BusinessFulfillmentEscalationPageReceipt.Type
+
 export type BusinessFulfillmentLoopStore = Readonly<{
+  claimBlockedPromisePage: (
+    receipt: BusinessFulfillmentEscalationPageReceipt,
+  ) => Promise<Readonly<{ claimed: boolean }>>
   claimDailyMotionReceipt: (
     receipt: BusinessFulfillmentMotionReceipt,
   ) => Promise<Readonly<{ claimed: boolean }>>
+  listBlockedPromises: (
+    nowIso: string,
+    limit: number,
+  ) => Promise<ReadonlyArray<BusinessServicePromiseRecord>>
   listDuePromises: (
     nowIso: string,
     limit: number,
   ) => Promise<ReadonlyArray<BusinessServicePromiseRecord>>
+  markPromiseEscalationRecorded: (
+    promiseId: string,
+    pageRef: string,
+    nowIso: string,
+  ) => Promise<void>
   markPromiseMotionRecorded: (
     promiseId: string,
     receiptRef: string,
@@ -82,7 +116,10 @@ export type BusinessFulfillmentLoopRuntime = Readonly<{
 }>
 
 export type BusinessFulfillmentLoopResult = Readonly<{
+  blockedPromiseCount: number
   duePromiseCount: number
+  escalationPageRefs: ReadonlyArray<string>
+  escalationSkippedDuplicateCount: number
   motionReceiptRefs: ReadonlyArray<string>
   skippedDuplicateCount: number
   state: 'completed' | 'skipped'
@@ -145,10 +182,19 @@ const promiseFromRow = (
     typeof row.accepted_outcome_contract_id === 'string'
       ? row.accepted_outcome_contract_id
       : null,
+  blockedAt: typeof row.blocked_at === 'string' ? row.blocked_at : null,
+  blockingReasonRef:
+    typeof row.blocking_reason_ref === 'string'
+      ? row.blocking_reason_ref
+      : null,
   cadence: 'daily',
   createdAt: String(row.created_at),
   crmStateRef: String(row.crm_state_ref),
   id: String(row.id),
+  lastEscalationPageRef:
+    typeof row.last_escalation_page_ref === 'string'
+      ? row.last_escalation_page_ref
+      : null,
   lastMotionReceiptRef:
     typeof row.last_motion_receipt_ref === 'string'
       ? row.last_motion_receipt_ref
@@ -168,6 +214,46 @@ const promiseFromRow = (
 export const makeD1BusinessFulfillmentLoopStore = (
   db: D1Database,
 ): BusinessFulfillmentLoopStore => ({
+  claimBlockedPromisePage: async receipt => {
+    const result = await db
+      .prepare(
+        `INSERT OR IGNORE INTO business_fulfillment_escalation_pages (
+          id,
+          promise_id,
+          promise_ref,
+          escalation_date,
+          receipt_ref,
+          page_ref,
+          owner_notification_ref,
+          agent_definition_ref,
+          blocking_reason_ref,
+          blocked_at,
+          workspace_ref,
+          stakeholder_refs_json,
+          source_refs_json,
+          created_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .bind(
+        receipt.id,
+        receipt.promiseId,
+        receipt.promiseRef,
+        receipt.escalationDate,
+        receipt.receiptRef,
+        receipt.pageRef,
+        receipt.ownerNotificationRef,
+        receipt.agentDefinitionRef,
+        receipt.blockingReasonRef,
+        receipt.blockedAt,
+        receipt.workspaceRef,
+        JSON.stringify(receipt.stakeholderRefs),
+        JSON.stringify(receipt.sourceRefs),
+        receipt.createdAt,
+      )
+      .run()
+
+    return { claimed: (result.meta.changes ?? 0) > 0 }
+  },
   claimDailyMotionReceipt: async receipt => {
     const result = await db
       .prepare(
@@ -212,6 +298,21 @@ export const makeD1BusinessFulfillmentLoopStore = (
 
     return { claimed: (result.meta.changes ?? 0) > 0 }
   },
+  listBlockedPromises: async (_nowIso, limit) => {
+    const rows = await db
+      .prepare(
+        `SELECT *
+           FROM business_service_promises
+          WHERE state = 'blocked'
+            AND blocking_reason_ref IS NOT NULL
+          ORDER BY COALESCE(blocked_at, updated_at) ASC, updated_at ASC
+          LIMIT ?`,
+      )
+      .bind(limit)
+      .all<Record<string, unknown>>()
+
+    return (rows.results ?? []).map(promiseFromRow)
+  },
   listDuePromises: async (nowIso, limit) => {
     const rows = await db
       .prepare(
@@ -227,6 +328,17 @@ export const makeD1BusinessFulfillmentLoopStore = (
       .all<Record<string, unknown>>()
 
     return (rows.results ?? []).map(promiseFromRow)
+  },
+  markPromiseEscalationRecorded: async (promiseId, pageRef, nowIso) => {
+    await db
+      .prepare(
+        `UPDATE business_service_promises
+            SET last_escalation_page_ref = ?,
+                updated_at = ?
+          WHERE id = ?`,
+      )
+      .bind(pageRef, nowIso, promiseId)
+      .run()
   },
   markPromiseMotionRecorded: async (
     promiseId,
@@ -257,11 +369,57 @@ const validatePromise = (promise: BusinessServicePromiseRecord): void => {
   assertSafeRef('promiseRef', promise.promiseRef)
   assertSafeRef('crmStateRef', promise.crmStateRef)
   assertSafeRef('workspaceRef', promise.workspaceRef)
+  if (promise.blockingReasonRef !== null) {
+    assertSafeRef('blockingReasonRef', promise.blockingReasonRef)
+  }
   if (promise.acceptedOutcomeContractId !== null) {
     assertSafeRef('acceptedOutcomeContractId', promise.acceptedOutcomeContractId)
   }
   assertSafeRefs('stakeholderRefs', promise.stakeholderRefs)
   assertSafeRefs('sourceRefs', promise.sourceRefs)
+}
+
+export const buildBusinessFulfillmentEscalationPageReceipt = (
+  promise: BusinessServicePromiseRecord,
+  runtime: BusinessFulfillmentLoopRuntime,
+): BusinessFulfillmentEscalationPageReceipt => {
+  validatePromise(promise)
+  if (promise.state !== 'blocked') {
+    throw new BusinessFulfillmentLoopValidationError({
+      reason: 'blocked-promise escalation requires state=blocked',
+    })
+  }
+  if (promise.blockingReasonRef === null) {
+    throw new BusinessFulfillmentLoopValidationError({
+      reason: 'blocked-promise escalation requires blockingReasonRef',
+    })
+  }
+
+  const nowIso = runtime.nowIso()
+  const escalationDate = nowIso.slice(0, 10)
+  const suffix = refSuffix(`${promise.promiseRef}.${escalationDate}`)
+  const sourceRefs = [
+    ...promise.sourceRefs,
+    'docs/fable/ROADMAP_BIZ.md#BF-5.4',
+    'docs/fable/2026-07-02-business-fulfillment-engine-meditations.md#fulfillment-agents',
+  ]
+
+  return {
+    agentDefinitionRef: BUSINESS_FULFILLMENT_LOOP_AGENT_DEFINITION_REF,
+    blockedAt: promise.blockedAt ?? promise.updatedAt,
+    blockingReasonRef: promise.blockingReasonRef,
+    createdAt: nowIso,
+    escalationDate,
+    id: runtime.makeId('business_fulfillment_escalation'),
+    ownerNotificationRef: `notification.owner.business_fulfillment.blocked_promise.${suffix}`,
+    pageRef: `page.owner.business_fulfillment.blocked_promise.${suffix}`,
+    promiseId: promise.id,
+    promiseRef: promise.promiseRef,
+    receiptRef: `receipt.business_fulfillment.blocked_promise_page.${suffix}`,
+    sourceRefs,
+    stakeholderRefs: promise.stakeholderRefs,
+    workspaceRef: promise.workspaceRef,
+  }
 }
 
 export const buildBusinessFulfillmentMotionReceipt = (
@@ -311,13 +469,14 @@ export const runBusinessFulfillmentLoop = (
 ): Effect.Effect<BusinessFulfillmentLoopResult, BusinessFulfillmentLoopError> =>
   Effect.gen(function* () {
     const nowIso = input.runtime.nowIso()
+    const limit = input.limit ?? BUSINESS_FULFILLMENT_LOOP_DEFAULT_LIMIT
     const duePromises = yield* tryLoopPromise(() =>
-      input.store.listDuePromises(
-        nowIso,
-        input.limit ?? BUSINESS_FULFILLMENT_LOOP_DEFAULT_LIMIT,
-      ),
+      input.store.listDuePromises(nowIso, limit),
     )
-    const outcomes = yield* Effect.forEach(
+    const blockedPromises = yield* tryLoopPromise(() =>
+      input.store.listBlockedPromises(nowIso, limit),
+    )
+    const motionOutcomes = yield* Effect.forEach(
       duePromises,
       promise =>
         Effect.gen(function* () {
@@ -353,20 +512,71 @@ export const runBusinessFulfillmentLoop = (
         }),
       { concurrency: 1 },
     )
+    const escalationOutcomes = yield* Effect.forEach(
+      blockedPromises,
+      promise =>
+        Effect.gen(function* () {
+          const receipt = yield* Effect.try({
+            catch: businessFulfillmentLoopErrorFromUnknown,
+            try: () =>
+              buildBusinessFulfillmentEscalationPageReceipt(
+                promise,
+                input.runtime,
+              ),
+          })
+          const claim = yield* tryLoopPromise(() =>
+            input.store.claimBlockedPromisePage(receipt),
+          )
 
-    const motionReceiptRefs = outcomes.flatMap(outcome =>
+          if (!claim.claimed) {
+            return {
+              maybePageRef: null,
+              skippedDuplicateCount: 1,
+            }
+          }
+
+          yield* tryLoopPromise(() =>
+            input.store.markPromiseEscalationRecorded(
+              promise.id,
+              receipt.pageRef,
+              nowIso,
+            ),
+          )
+
+          return {
+            maybePageRef: receipt.pageRef,
+            skippedDuplicateCount: 0,
+          }
+        }),
+      { concurrency: 1 },
+    )
+
+    const motionReceiptRefs = motionOutcomes.flatMap(outcome =>
       outcome.maybeReceiptRef === null ? [] : [outcome.maybeReceiptRef],
     )
-    const skippedDuplicateCount = outcomes.reduce(
+    const skippedDuplicateCount = motionOutcomes.reduce(
+      (sum, outcome) => sum + outcome.skippedDuplicateCount,
+      0,
+    )
+    const escalationPageRefs = escalationOutcomes.flatMap(outcome =>
+      outcome.maybePageRef === null ? [] : [outcome.maybePageRef],
+    )
+    const escalationSkippedDuplicateCount = escalationOutcomes.reduce(
       (sum, outcome) => sum + outcome.skippedDuplicateCount,
       0,
     )
 
     return {
+      blockedPromiseCount: blockedPromises.length,
       duePromiseCount: duePromises.length,
+      escalationPageRefs,
+      escalationSkippedDuplicateCount,
       motionReceiptRefs,
       skippedDuplicateCount,
-      state: duePromises.length === 0 ? 'skipped' : 'completed',
+      state:
+        duePromises.length === 0 && blockedPromises.length === 0
+          ? 'skipped'
+          : 'completed',
     }
   })
 
@@ -383,7 +593,10 @@ export const runBusinessFulfillmentLoopScheduled = (
   }).pipe(
     Effect.catch(() =>
       Effect.succeed({
+        blockedPromiseCount: 0,
         duePromiseCount: 0,
+        escalationPageRefs: [],
+        escalationSkippedDuplicateCount: 0,
         motionReceiptRefs: [],
         skippedDuplicateCount: 0,
         state: 'skipped' as const,


### PR DESCRIPTION
Closes #8099.

## Summary
- Adds blocked-promise escalation metadata and a durable `business_fulfillment_escalation_pages` ledger.
- Extends the scheduled business fulfillment loop to page the owner/operator once per blocked promise per day using public-safe opaque refs and blocking reason refs.
- Covers in-memory and D1 idempotency paths so blocked promises cannot silently stall without a page receipt.

## Verification
- `bun run --cwd apps/openagents.com/workers/api test -- src/business-fulfillment-loop.test.ts` passed: 1 file, 6 tests.
- `bun run --cwd apps/openagents.com/workers/api typecheck` passed.
- `bun run check:deploy` passed.
