### PR TITLE
Add customer-owned payment account seam

### DIFF
--- a/apps/openagents.com/workers/api/src/site-payment-catalog.test.ts
+++ b/apps/openagents.com/workers/api/src/site-payment-catalog.test.ts
@@ -151,12 +151,15 @@ describe('OpenAgents Site payment catalog', () => {
       'sha256:abcdef123456',
       'workroom.otec',
     ])
-    expect(S.decodeUnknownSync(OpenAgentsSitePaymentCatalogProjection)(
-      publicProjection,
-    )).toEqual(publicProjection)
+    expect(
+      S.decodeUnknownSync(OpenAgentsSitePaymentCatalogProjection)(
+        publicProjection,
+      ),
+    ).toEqual(publicProjection)
     expect(JSON.stringify(publicProjection)).not.toContain('order.otec')
-    expect(openAgentsSitePaymentCatalogHasPrivateMaterial(publicProjection))
-      .toBe(false)
+    expect(
+      openAgentsSitePaymentCatalogHasPrivateMaterial(publicProjection),
+    ).toBe(false)
   })
 
   test('hides public-hidden catalog records from public projection only', () => {
@@ -223,9 +226,8 @@ describe('OpenAgents Site payment catalog', () => {
       catalog,
       'public',
     )
-    const endpointProduct = openAgentsPaidEndpointProductFromSitePaymentCatalogItem(
-      catalog.items[0]!,
-    )
+    const endpointProduct =
+      openAgentsPaidEndpointProductFromSitePaymentCatalogItem(catalog.items[0]!)
 
     expect(catalog.items[0]).toMatchObject({
       itemKind: 'product',
@@ -234,9 +236,7 @@ describe('OpenAgents Site payment catalog', () => {
         billingKind: 'retainer',
         entitlementRenewalMode: 'renew_on_payment_receipt',
         interval: 'month',
-        renewalReceiptScopeRefs: [
-          'receipt_scope.business.retainer.renewal',
-        ],
+        renewalReceiptScopeRefs: ['receipt_scope.business.retainer.renewal'],
       },
     })
     expect(publicProjection.items[0]).toMatchObject({
@@ -257,14 +257,90 @@ describe('OpenAgents Site payment catalog', () => {
     ])
   })
 
+  test('carries BF-6.4 customer-owned processor binding while keeping OpenAgents metering separate', () => {
+    const catalog = sitePaymentCatalogFromManifest({
+      ...catalogInput,
+      manifest: {
+        payments: {
+          ...sitePaymentManifest.payments,
+          customerOwnedProcessor: {
+            chargeDestination: 'customer_account',
+            customerProcessorAccountRef: 'processor_account.vertical_checkout',
+            openAgentsMeteringRefs: [
+              'metering.openagents.business_fulfillment.site_payment',
+            ],
+            processor: 'stripe_connect',
+            processorConnectionRef: 'processor_connection.vertical_checkout',
+            revenueOwner: 'customer',
+          },
+          provider: 'customer_owned_processor',
+        },
+      },
+    })
+    const publicProjection = projectOpenAgentsSitePaymentCatalog(
+      catalog,
+      'public',
+    )
+    const endpointProduct =
+      openAgentsPaidEndpointProductFromSitePaymentCatalogItem(catalog.items[0]!)
+
+    expect(catalog.items[0]).toMatchObject({
+      customerOwnedProcessor: {
+        chargeDestination: 'customer_account',
+        customerProcessorAccountRef: 'processor_account.vertical_checkout',
+        openAgentsMeteringRefs: [
+          'metering.openagents.business_fulfillment.site_payment',
+        ],
+        processor: 'stripe_connect',
+        processorConnectionRef: 'processor_connection.vertical_checkout',
+        revenueOwner: 'customer',
+      },
+      provider: 'customer_owned_processor',
+    })
+    expect(publicProjection.items[0]).toMatchObject({
+      customerOwnedProcessor: {
+        chargeDestination: 'customer_account',
+        meteringSeparated: true,
+        openAgentsMeteringRefs: [
+          'metering.openagents.business_fulfillment.site_payment',
+        ],
+        processor: 'stripe_connect',
+        revenueOwner: 'customer',
+      },
+      provider: 'customer_owned_processor',
+    })
+    expect(JSON.stringify(publicProjection)).not.toContain(
+      'processor_account.vertical_checkout',
+    )
+    expect(JSON.stringify(publicProjection)).not.toContain(
+      'processor_connection.vertical_checkout',
+    )
+    expect(endpointProduct.providerBindingRefs).toEqual([
+      'provider_binding.customer_owned_processor',
+      'processor.stripe_connect',
+      'metering.openagents.business_fulfillment.site_payment',
+    ])
+    expect(endpointProduct.operatorNoteRefs).toEqual(
+      expect.arrayContaining([
+        'operator_note.site_payment.customer_revenue_owner',
+      ]),
+    )
+    expect(
+      decodeOpenAgentsPaidEndpointProductCatalog({
+        products: [endpointProduct],
+      }).products[0],
+    ).toEqual(endpointProduct)
+    expect(
+      openAgentsSitePaymentCatalogHasPrivateMaterial(publicProjection),
+    ).toBe(false)
+  })
+
   test('integrates with paid endpoint product records and hosted checkout plans', () => {
     const catalog = sitePaymentCatalogFromManifest(catalogInput)
-    const productRecord = openAgentsPaidEndpointProductFromSitePaymentCatalogItem(
-      catalog.items[0]!,
-    )
-    const actionRecord = openAgentsPaidEndpointProductFromSitePaymentCatalogItem(
-      catalog.items[1]!,
-    )
+    const productRecord =
+      openAgentsPaidEndpointProductFromSitePaymentCatalogItem(catalog.items[0]!)
+    const actionRecord =
+      openAgentsPaidEndpointProductFromSitePaymentCatalogItem(catalog.items[1]!)
     const endpointCatalog = paidEndpointCatalogFromSitePaymentCatalog(catalog)
     const hostedPlan = {
       catalogRecord: catalog.items[0]!,
@@ -305,11 +381,14 @@ describe('OpenAgents Site payment catalog', () => {
       surface: 'site_checkout',
     })
     expect(endpointCatalog.products).toHaveLength(2)
-    expect(decodeOpenAgentsPaidEndpointProductCatalog(endpointCatalog))
-      .toEqual(endpointCatalog)
-    expect(S.decodeUnknownSync(OpenAgentsSitePaymentCatalogHostedCheckoutPlan)(
-      hostedPlan,
-    )).toEqual(hostedPlan)
+    expect(decodeOpenAgentsPaidEndpointProductCatalog(endpointCatalog)).toEqual(
+      endpointCatalog,
+    )
+    expect(
+      S.decodeUnknownSync(OpenAgentsSitePaymentCatalogHostedCheckoutPlan)(
+        hostedPlan,
+      ),
+    ).toEqual(hostedPlan)
   })
 
   test('rejects duplicate refs, unsafe metadata, raw payment material, and unsafe paths', () => {
@@ -367,6 +446,46 @@ describe('OpenAgents Site payment catalog', () => {
               interval: 'month',
               renewalReceiptScopeRefs: ['raw_invoice.lnbc2500n1unsafe'],
             },
+          },
+        ],
+      }),
+    ).toThrow(OpenAgentsSitePaymentCatalogUnsafe)
+    expect(() =>
+      decodeOpenAgentsSitePaymentCatalog({
+        items: [
+          {
+            ...catalog.items[0]!,
+            customerOwnedProcessor: {
+              chargeDestination: 'customer_account',
+              customerProcessorAccountRef:
+                'processor_account.vertical_checkout',
+              openAgentsMeteringRefs: [
+                'metering.openagents.business_fulfillment.site_payment',
+              ],
+              processor: 'stripe_connect',
+              processorConnectionRef: 'processor_connection.vertical_checkout',
+              revenueOwner: 'customer',
+            },
+          },
+        ],
+      }),
+    ).toThrow(OpenAgentsSitePaymentCatalogUnsafe)
+    expect(() =>
+      decodeOpenAgentsSitePaymentCatalog({
+        items: [
+          {
+            ...catalog.items[0]!,
+            customerOwnedProcessor: {
+              chargeDestination: 'customer_account',
+              customerProcessorAccountRef: 'acct_123raw',
+              openAgentsMeteringRefs: [
+                'metering.openagents.business_fulfillment.site_payment',
+              ],
+              processor: 'stripe_connect',
+              processorConnectionRef: 'processor_connection.vertical_checkout',
+              revenueOwner: 'customer',
+            },
+            provider: 'customer_owned_processor',
           },
         ],
       }),

--- a/apps/openagents.com/workers/api/src/site-payment-catalog.ts
+++ b/apps/openagents.com/workers/api/src/site-payment-catalog.ts
@@ -11,12 +11,15 @@ import { OpenAgentsPaymentPolicyAudience } from './payment-limit-policy'
 import { openAgentsRunnerGatewayPayloadHasPrivateMaterial } from './runner-gateway'
 import {
   OpenAgentsSitePaymentCustomerDataRequirement,
-  OpenAgentsSitePaymentRecurringBilling,
+  OpenAgentsSitePaymentCustomerOwnedProcessorBinding,
+  OpenAgentsSitePaymentCustomerOwnedProcessorKind,
   OpenAgentsSitePaymentEntitlementScope,
   OpenAgentsSitePaymentManifest,
   OpenAgentsSitePaymentPaidAction,
   OpenAgentsSitePaymentProduct,
+  OpenAgentsSitePaymentProvider,
   OpenAgentsSitePaymentPublicProjectionState,
+  OpenAgentsSitePaymentRecurringBilling,
   OpenAgentsSitePaymentSettlementMode,
   decodeOpenAgentsSitePaymentManifest,
 } from './site-payment-manifest'
@@ -58,6 +61,9 @@ const OpenAgentsSitePaymentCatalogCommonRecord = S.Struct({
   customerDataRequirements: S.Array(
     OpenAgentsSitePaymentCustomerDataRequirement,
   ),
+  customerOwnedProcessor: S.NullOr(
+    OpenAgentsSitePaymentCustomerOwnedProcessorBinding,
+  ),
   deploymentId: S.NullOr(S.String),
   displayRef: S.String,
   entitlementScope: OpenAgentsSitePaymentEntitlementScope,
@@ -67,6 +73,7 @@ const OpenAgentsSitePaymentCatalogCommonRecord = S.Struct({
   orderRef: S.NullOr(S.String),
   price: OpenAgentsPaidEndpointProductRecord.fields.price,
   publicProjectionState: OpenAgentsSitePaymentPublicProjectionState,
+  provider: OpenAgentsSitePaymentProvider,
   recurringBilling: S.NullOr(OpenAgentsSitePaymentRecurringBilling),
   sandbox: S.Boolean,
   settlementMode: OpenAgentsSitePaymentSettlementMode,
@@ -134,6 +141,15 @@ export const OpenAgentsSitePaymentCatalogItemProjection = S.Struct({
   customerDataRequirements: S.Array(
     OpenAgentsSitePaymentCustomerDataRequirement,
   ),
+  customerOwnedProcessor: S.NullOr(
+    S.Struct({
+      chargeDestination: S.Literal('customer_account'),
+      meteringSeparated: S.Boolean,
+      openAgentsMeteringRefs: S.Array(S.String),
+      processor: OpenAgentsSitePaymentCustomerOwnedProcessorKind,
+      revenueOwner: S.Literal('customer'),
+    }),
+  ),
   displayRef: S.String,
   entitlementScope: OpenAgentsSitePaymentEntitlementScope,
   itemKind: OpenAgentsSitePaymentCatalogItemKind,
@@ -141,6 +157,7 @@ export const OpenAgentsSitePaymentCatalogItemProjection = S.Struct({
   operatorRefs: S.Array(S.String),
   price: OpenAgentsPaidEndpointProductRecord.fields.price,
   publicProjectionState: OpenAgentsSitePaymentPublicProjectionState,
+  provider: OpenAgentsSitePaymentProvider,
   recurringBilling: S.NullOr(OpenAgentsSitePaymentRecurringBilling),
   sandbox: S.Boolean,
   settlementMode: OpenAgentsSitePaymentSettlementMode,
@@ -201,13 +218,15 @@ const stableCatalogRefPattern = /^[A-Za-z0-9][A-Za-z0-9_.:/-]{0,180}$/
 const unsafeCatalogKeyPattern =
   /(access[_-]?token|bearer|callback[_-]?token|cookie|customer[_-]?(email|name|value)|email[_-]?body|grant|invoice|mdk[_-]?(access[_-]?token|mnemonic|webhook[_-]?secret)|mnemonic|oauth|payment[_-]?(hash|preimage)|preimage|private[_-]?key|provider[_-]?(account|grant|payload|token)|raw[_-]?(invoice|payment|prompt|runner|run[_-]?log)|secret|source[_-]?archive|wallet|webhook)/i
 const unsafeCatalogValuePattern =
-  /(bearer\s+|checkout_id=|gho_[a-z0-9_]+|ghp_[a-z0-9_]+|github[_-]?pat_[a-z0-9_]+|lnbc|lntb|lnbcrt|lno1|mdk[_-]?(access[_-]?token|mnemonic|webhook[_-]?secret)|mnemonic|payment_hash=|payment_preimage=|preimage=[A-Za-z0-9_-]+|provider[_-]?token|raw[_-]?(invoice|payment|payload|prompt|runner|run[_-]?log)|secret|sk-[a-z0-9]|\S+@\S+|wallet[_-]?state)/i
+  /(acct_[a-z0-9]+|bearer\s+|checkout_id=|gho_[a-z0-9_]+|ghp_[a-z0-9_]+|github[_-]?pat_[a-z0-9_]+|lnbc|lntb|lnbcrt|lno1|mdk[_-]?(access[_-]?token|mnemonic|webhook[_-]?secret)|mnemonic|payment_hash=|payment_preimage=|preimage=[A-Za-z0-9_-]+|provider[_-]?token|raw[_-]?(invoice|payment|payload|prompt|runner|run[_-]?log)|secret|sk-[a-z0-9]|stripe[_-]?(account|secret|webhook)|\S+@\S+|wallet[_-]?state)/i
 
 const valueHasPrivateMaterial = (value: unknown): boolean => {
   if (typeof value === 'string') {
-    return containsProviderSecretMaterial(value) ||
+    return (
+      containsProviderSecretMaterial(value) ||
       unsafeCatalogValuePattern.test(value) ||
       openAgentsRunnerGatewayPayloadHasPrivateMaterial(value)
+    )
   }
 
   if (Array.isArray(value)) {
@@ -215,10 +234,13 @@ const valueHasPrivateMaterial = (value: unknown): boolean => {
   }
 
   if (value !== null && typeof value === 'object') {
-    return openAgentsRunnerGatewayPayloadHasPrivateMaterial(value) ||
-      Object.entries(value).some(([key, item]) =>
-        unsafeCatalogKeyPattern.test(key) || valueHasPrivateMaterial(item),
+    return (
+      openAgentsRunnerGatewayPayloadHasPrivateMaterial(value) ||
+      Object.entries(value).some(
+        ([key, item]) =>
+          unsafeCatalogKeyPattern.test(key) || valueHasPrivateMaterial(item),
       )
+    )
   }
 
   return false
@@ -254,22 +276,18 @@ const priceIsSupported = (
 ): boolean =>
   Number.isInteger(price.amountMinorUnits) &&
   price.amountMinorUnits > 0 &&
-  (
-    (price.asset === 'usd' && price.denomination === 'usd_cent') ||
+  ((price.asset === 'usd' && price.denomination === 'usd_cent') ||
     (price.asset === 'bitcoin' &&
       price.denomination === 'bitcoin_millisatoshi') ||
-    (price.asset === 'credits' && price.denomination === 'credit')
-  )
+    (price.asset === 'credits' && price.denomination === 'credit'))
 
 const recurringBillingIsSafe = (
   recurringBilling: OpenAgentsSitePaymentRecurringBilling | null,
 ): boolean =>
   recurringBilling === null ||
-  (
-    recurringBilling.entitlementRenewalMode === 'renew_on_payment_receipt' &&
+  (recurringBilling.entitlementRenewalMode === 'renew_on_payment_receipt' &&
     recurringBilling.renewalReceiptScopeRefs.length > 0 &&
-    recurringBilling.renewalReceiptScopeRefs.every(stableRefIsSafe)
-  )
+    recurringBilling.renewalReceiptScopeRefs.every(stableRefIsSafe))
 
 const catalogIdSegment = (value: string, fallback: string): string => {
   const normalized = value
@@ -315,7 +333,7 @@ const commonRecord = (
   const linkage = linkageFromInput(input)
   const recurringBilling =
     itemKind === 'product' && 'recurringBilling' in item
-      ? item.recurringBilling ?? null
+      ? (item.recurringBilling ?? null)
       : null
 
   return {
@@ -325,6 +343,8 @@ const commonRecord = (
     checkoutPath: item.checkoutPath,
     createdAt: input.createdAt,
     customerDataRequirements: item.customerDataRequirements,
+    customerOwnedProcessor:
+      input.manifest.payments.customerOwnedProcessor ?? null,
     deploymentId: input.deploymentId,
     displayRef: item.displayRef,
     entitlementScope: item.entitlementScope,
@@ -337,6 +357,7 @@ const commonRecord = (
     orderRef: input.orderRef,
     price: item.price,
     publicProjectionState: item.publicProjectionState,
+    provider: input.manifest.payments.provider,
     recurringBilling,
     sandbox: item.sandbox || input.manifest.payments.sandboxDefault,
     settlementMode: item.settlementMode,
@@ -383,8 +404,7 @@ const itemVisibleToAudience = (
   }
 
   if (audience === 'public') {
-    return item.status === 'active' &&
-      item.publicProjectionState !== 'hidden'
+    return item.status === 'active' && item.publicProjectionState !== 'hidden'
   }
 
   if (audience === 'agent') {
@@ -400,12 +420,12 @@ const operatorRefsForItem = (
 ): ReadonlyArray<string> =>
   audience === 'operator'
     ? safeRefs([
-      item.deploymentId ?? '',
-      item.manifestRef ?? '',
-      item.orderRef ?? '',
-      item.sourceManifestDigest ?? '',
-      item.workroomRef ?? '',
-    ])
+        item.deploymentId ?? '',
+        item.manifestRef ?? '',
+        item.orderRef ?? '',
+        item.sourceManifestDigest ?? '',
+        item.workroomRef ?? '',
+      ])
     : []
 
 const metadataRefsForItem = (
@@ -428,9 +448,20 @@ const commonProjection = (
     : '/checkout/redacted',
   customerDataRequirements: item.customerDataRequirements.filter(
     requirement =>
-      stableIdIsSafe(requirement.key) &&
-      stableRefIsSafe(requirement.labelRef),
+      stableIdIsSafe(requirement.key) && stableRefIsSafe(requirement.labelRef),
   ),
+  customerOwnedProcessor:
+    item.customerOwnedProcessor === null
+      ? null
+      : {
+          chargeDestination: item.customerOwnedProcessor.chargeDestination,
+          meteringSeparated: true,
+          openAgentsMeteringRefs: safeRefs(
+            item.customerOwnedProcessor.openAgentsMeteringRefs,
+          ),
+          processor: item.customerOwnedProcessor.processor,
+          revenueOwner: item.customerOwnedProcessor.revenueOwner,
+        },
   displayRef: safeRefOrFallback(item.displayRef, 'display.redacted'),
   entitlementScope: item.entitlementScope,
   itemKind: item.itemKind,
@@ -438,6 +469,7 @@ const commonProjection = (
   operatorRefs: operatorRefsForItem(item, audience),
   price: item.price,
   publicProjectionState: item.publicProjectionState,
+  provider: item.provider,
   recurringBilling: item.recurringBilling,
   sandbox: item.sandbox,
   settlementMode: item.settlementMode,
@@ -452,18 +484,18 @@ const projectCatalogItem = (
 ): OpenAgentsSitePaymentCatalogProjection['items'][number] =>
   item.itemKind === 'product'
     ? {
-      ...commonProjection(item, audience),
-      itemKind: 'product',
-      productId: safeRefOrFallback(item.productId, 'product.redacted'),
-    }
+        ...commonProjection(item, audience),
+        itemKind: 'product',
+        productId: safeRefOrFallback(item.productId, 'product.redacted'),
+      }
     : {
-      ...commonProjection(item, audience),
-      actionId: safeRefOrFallback(item.actionId, 'action.redacted'),
-      actionRef: safeRefOrFallback(item.actionRef, 'action.redacted'),
-      itemKind: 'paid_action',
-      method: item.method,
-      path: checkoutPathIsSafe(item.path) ? item.path : '/api/redacted',
-    }
+        ...commonProjection(item, audience),
+        actionId: safeRefOrFallback(item.actionId, 'action.redacted'),
+        actionRef: safeRefOrFallback(item.actionRef, 'action.redacted'),
+        itemKind: 'paid_action',
+        method: item.method,
+        path: checkoutPathIsSafe(item.path) ? item.path : '/api/redacted',
+      }
 
 const projectionPolicyForItem = (
   item: OpenAgentsSitePaymentCatalogRecord,
@@ -487,11 +519,12 @@ const paidEndpointStatusForItem = (
 const entitlementForItem = (
   item: OpenAgentsSitePaymentCatalogRecord,
 ): OpenAgentsPaidEndpointEntitlement => ({
-  durationSeconds: item.recurringBilling?.interval === 'month'
-    ? 2_678_400
-    : item.recurringBilling?.interval === 'year'
-      ? 31_536_000
-      : null,
+  durationSeconds:
+    item.recurringBilling?.interval === 'month'
+      ? 2_678_400
+      : item.recurringBilling?.interval === 'year'
+        ? 31_536_000
+        : null,
   kind: 'resource',
   quotaUnits: null,
   scopeRefs: [
@@ -520,19 +553,19 @@ const paidEndpointBindingForItem = (
 ): OpenAgentsPaidEndpointProductRecord['binding'] =>
   item.itemKind === 'product'
     ? {
-      actionRef: item.productId,
-      kind: 'site_checkout',
-      method: null,
-      pathTemplate: item.checkoutPath,
-      resourceRef: item.catalogRef,
-    }
+        actionRef: item.productId,
+        kind: 'site_checkout',
+        method: null,
+        pathTemplate: item.checkoutPath,
+        resourceRef: item.catalogRef,
+      }
     : {
-      actionRef: item.actionRef,
-      kind: 'site_paid_action',
-      method: item.method,
-      pathTemplate: item.path,
-      resourceRef: item.catalogRef,
-    }
+        actionRef: item.actionRef,
+        kind: 'site_paid_action',
+        method: item.method,
+        pathTemplate: item.path,
+        resourceRef: item.catalogRef,
+      }
 
 export const openAgentsSitePaymentCatalogHasPrivateMaterial =
   valueHasPrivateMaterial
@@ -556,33 +589,45 @@ export const decodeOpenAgentsSitePaymentCatalog = (
     })
   }
 
-  const unsafeItem = catalog.items.find(item =>
-    !stableRefIsSafe(item.siteId) ||
-    !stableRefIsSafe(item.siteVersionId) ||
-    !stableIdIsSafe(item.itemKind === 'product' ? item.productId : item.actionId) ||
-    !stableRefIsSafe(item.catalogRef) ||
-    !stableRefIsSafe(item.displayRef) ||
-    !checkoutPathIsSafe(item.checkoutPath) ||
-    !optionalRefIsSafe(item.deploymentId) ||
-    !optionalRefIsSafe(item.manifestRef) ||
-    !optionalRefIsSafe(item.orderRef) ||
-    !optionalRefIsSafe(item.sourceManifestDigest) ||
-    !optionalRefIsSafe(item.workroomRef) ||
-    !priceIsSupported(item.price) ||
-    !recurringBillingIsSafe(item.recurringBilling) ||
-    item.metadataRefs.some(ref => !stableRefIsSafe(ref)) ||
-    item.customerDataRequirements.some(
-      requirement =>
-        !stableIdIsSafe(requirement.key) ||
-        !stableRefIsSafe(requirement.labelRef),
-    ) ||
-    (
-      item.itemKind === 'paid_action' &&
-      (
-        !stableRefIsSafe(item.actionRef) ||
-        !checkoutPathIsSafe(item.path)
-      )
-    ),
+  const unsafeItem = catalog.items.find(
+    item =>
+      !stableRefIsSafe(item.siteId) ||
+      !stableRefIsSafe(item.siteVersionId) ||
+      !stableIdIsSafe(
+        item.itemKind === 'product' ? item.productId : item.actionId,
+      ) ||
+      !stableRefIsSafe(item.catalogRef) ||
+      !stableRefIsSafe(item.displayRef) ||
+      !checkoutPathIsSafe(item.checkoutPath) ||
+      !optionalRefIsSafe(item.deploymentId) ||
+      !optionalRefIsSafe(item.manifestRef) ||
+      !optionalRefIsSafe(item.orderRef) ||
+      !optionalRefIsSafe(item.sourceManifestDigest) ||
+      !optionalRefIsSafe(item.workroomRef) ||
+      !priceIsSupported(item.price) ||
+      (item.provider === 'customer_owned_processor' &&
+        (item.customerOwnedProcessor === null ||
+          !stableRefIsSafe(
+            item.customerOwnedProcessor.customerProcessorAccountRef,
+          ) ||
+          !stableRefIsSafe(
+            item.customerOwnedProcessor.processorConnectionRef,
+          ) ||
+          item.customerOwnedProcessor.openAgentsMeteringRefs.length === 0 ||
+          item.customerOwnedProcessor.openAgentsMeteringRefs.some(
+            ref => !stableRefIsSafe(ref),
+          ))) ||
+      (item.provider !== 'customer_owned_processor' &&
+        item.customerOwnedProcessor !== null) ||
+      !recurringBillingIsSafe(item.recurringBilling) ||
+      item.metadataRefs.some(ref => !stableRefIsSafe(ref)) ||
+      item.customerDataRequirements.some(
+        requirement =>
+          !stableIdIsSafe(requirement.key) ||
+          !stableRefIsSafe(requirement.labelRef),
+      ) ||
+      (item.itemKind === 'paid_action' &&
+        (!stableRefIsSafe(item.actionRef) || !checkoutPathIsSafe(item.path))),
   )
 
   if (unsafeItem !== undefined) {
@@ -600,10 +645,16 @@ export const sitePaymentCatalogFromManifest = (
 ): OpenAgentsSitePaymentCatalog =>
   decodeOpenAgentsSitePaymentCatalog({
     items: [
-      ...decodeOpenAgentsSitePaymentManifest(input.manifest).payments.products
-        .map(product => productRecordFromManifest(input, product)),
-      ...decodeOpenAgentsSitePaymentManifest(input.manifest).payments.paidActions
-        .map(action => paidActionRecordFromManifest(input, action)),
+      ...decodeOpenAgentsSitePaymentManifest(
+        input.manifest,
+      ).payments.products.map(product =>
+        productRecordFromManifest(input, product),
+      ),
+      ...decodeOpenAgentsSitePaymentManifest(
+        input.manifest,
+      ).payments.paidActions.map(action =>
+        paidActionRecordFromManifest(input, action),
+      ),
     ],
   })
 
@@ -628,18 +679,28 @@ export const openAgentsPaidEndpointProductFromSitePaymentCatalogItem = (
   ],
   operatorNoteRefs: [
     `operator_note.site_payment.${item.settlementMode}`,
+    ...(item.provider === 'customer_owned_processor'
+      ? ['operator_note.site_payment.customer_revenue_owner']
+      : []),
   ],
   price: item.price,
   productId: item.catalogRef,
   projectionPolicy: projectionPolicyForItem(item),
-  providerBindingRefs: ['provider_binding.openagents.hosted_mdk'],
+  providerBindingRefs:
+    item.provider === 'customer_owned_processor'
+      ? [
+          'provider_binding.customer_owned_processor',
+          `processor.${item.customerOwnedProcessor?.processor ?? 'unknown'}`,
+          ...safeRefs(
+            item.customerOwnedProcessor?.openAgentsMeteringRefs ?? [],
+          ),
+        ]
+      : ['provider_binding.openagents.hosted_mdk'],
   publicAgentDocRefs: item.agentReadable
     ? ['docs.openagents.site_payments']
     : [],
   publicSummaryRef: `summary.${item.catalogRef}`,
-  spendCapHintRefs: [
-    `spend_cap.${item.price.asset}.${item.entitlementScope}`,
-  ],
+  spendCapHintRefs: [`spend_cap.${item.price.asset}.${item.entitlementScope}`],
   status: paidEndpointStatusForItem(item),
   surface: 'site_checkout',
 })
@@ -647,5 +708,7 @@ export const openAgentsPaidEndpointProductFromSitePaymentCatalogItem = (
 export const paidEndpointCatalogFromSitePaymentCatalog = (
   catalog: OpenAgentsSitePaymentCatalog,
 ): typeof OpenAgentsPaidEndpointProductCatalog.Type => ({
-  products: catalog.items.map(openAgentsPaidEndpointProductFromSitePaymentCatalogItem),
+  products: catalog.items.map(
+    openAgentsPaidEndpointProductFromSitePaymentCatalogItem,
+  ),
 })

--- a/apps/openagents.com/workers/api/src/site-payment-manifest.test.ts
+++ b/apps/openagents.com/workers/api/src/site-payment-manifest.test.ts
@@ -187,30 +187,70 @@ describe('OpenAgents Site payment manifest', () => {
       'public',
     )
 
-    expect(publicProjection.products.map(product => product.recurringBilling))
-      .toEqual([
-        {
-          billingKind: 'retainer',
-          entitlementRenewalMode: 'renew_on_payment_receipt',
-          interval: 'month',
-          renewalReceiptScopeRefs: [
-            'receipt_scope.business.retainer.renewal',
-          ],
-        },
-        {
-          billingKind: 'subscription',
-          entitlementRenewalMode: 'renew_on_payment_receipt',
-          interval: 'year',
-          renewalReceiptScopeRefs: [
-            'receipt_scope.business.membership.renewal',
-          ],
-        },
-      ])
+    expect(
+      publicProjection.products.map(product => product.recurringBilling),
+    ).toEqual([
+      {
+        billingKind: 'retainer',
+        entitlementRenewalMode: 'renew_on_payment_receipt',
+        interval: 'month',
+        renewalReceiptScopeRefs: ['receipt_scope.business.retainer.renewal'],
+      },
+      {
+        billingKind: 'subscription',
+        entitlementRenewalMode: 'renew_on_payment_receipt',
+        interval: 'year',
+        renewalReceiptScopeRefs: ['receipt_scope.business.membership.renewal'],
+      },
+    ])
     expect(
       S.decodeUnknownSync(OpenAgentsSitePaymentManifestProjection)(
         publicProjection,
       ),
     ).toEqual(publicProjection)
+  })
+
+  test('projects customer-owned processor funnels with separate OpenAgents metering refs', () => {
+    const manifest = decodeOpenAgentsSitePaymentManifest({
+      payments: {
+        ...validManifest.payments,
+        customerOwnedProcessor: {
+          chargeDestination: 'customer_account',
+          customerProcessorAccountRef: 'processor_account.vertical_checkout',
+          openAgentsMeteringRefs: [
+            'metering.openagents.business_fulfillment.site_payment',
+          ],
+          processor: 'stripe_connect',
+          processorConnectionRef: 'processor_connection.vertical_checkout',
+          revenueOwner: 'customer',
+        },
+        provider: 'customer_owned_processor',
+      },
+    })
+    const publicProjection = projectOpenAgentsSitePaymentManifest(
+      manifest,
+      'public',
+    )
+
+    expect(publicProjection.provider).toBe('customer_owned_processor')
+    expect(publicProjection.customerOwnedProcessor).toEqual({
+      chargeDestination: 'customer_account',
+      meteringSeparated: true,
+      openAgentsMeteringRefs: [
+        'metering.openagents.business_fulfillment.site_payment',
+      ],
+      processor: 'stripe_connect',
+      revenueOwner: 'customer',
+    })
+    expect(JSON.stringify(publicProjection)).not.toContain(
+      'processor_connection.vertical_checkout',
+    )
+    expect(JSON.stringify(publicProjection)).not.toContain(
+      'processor_account.vertical_checkout',
+    )
+    expect(
+      openAgentsSitePaymentManifestHasPrivateMaterial(publicProjection),
+    ).toBe(false)
   })
 
   test('rejects raw payment material and unsafe checkout paths', () => {
@@ -263,6 +303,65 @@ describe('OpenAgents Site payment manifest', () => {
               },
             },
           ],
+        },
+      }),
+    ).toThrow(OpenAgentsSitePaymentManifestUnsafe)
+    expect(() =>
+      decodeOpenAgentsSitePaymentManifest({
+        payments: {
+          ...validManifest.payments,
+          customerOwnedProcessor: {
+            chargeDestination: 'customer_account',
+            customerProcessorAccountRef: 'acct_123raw',
+            openAgentsMeteringRefs: [
+              'metering.openagents.business_fulfillment.site_payment',
+            ],
+            processor: 'stripe_connect',
+            processorConnectionRef: 'processor_connection.vertical_checkout',
+            revenueOwner: 'customer',
+          },
+          provider: 'customer_owned_processor',
+        },
+      }),
+    ).toThrow(OpenAgentsSitePaymentManifestUnsafe)
+    expect(() =>
+      decodeOpenAgentsSitePaymentManifest({
+        payments: {
+          ...validManifest.payments,
+          customerOwnedProcessor: {
+            chargeDestination: 'customer_account',
+            customerProcessorAccountRef: 'processor_account.vertical_checkout',
+            openAgentsMeteringRefs: [],
+            processor: 'stripe_connect',
+            processorConnectionRef: 'processor_connection.vertical_checkout',
+            revenueOwner: 'customer',
+          },
+          provider: 'customer_owned_processor',
+        },
+      }),
+    ).toThrow(OpenAgentsSitePaymentManifestUnsafe)
+    expect(() =>
+      decodeOpenAgentsSitePaymentManifest({
+        payments: {
+          ...validManifest.payments,
+          provider: 'customer_owned_processor',
+        },
+      }),
+    ).toThrow(OpenAgentsSitePaymentManifestUnsafe)
+    expect(() =>
+      decodeOpenAgentsSitePaymentManifest({
+        payments: {
+          ...validManifest.payments,
+          customerOwnedProcessor: {
+            chargeDestination: 'customer_account',
+            customerProcessorAccountRef: 'processor_account.vertical_checkout',
+            openAgentsMeteringRefs: [
+              'metering.openagents.business_fulfillment.site_payment',
+            ],
+            processor: 'stripe_connect',
+            processorConnectionRef: 'processor_connection.vertical_checkout',
+            revenueOwner: 'customer',
+          },
         },
       }),
     ).toThrow(OpenAgentsSitePaymentManifestUnsafe)

--- a/apps/openagents.com/workers/api/src/site-payment-manifest.ts
+++ b/apps/openagents.com/workers/api/src/site-payment-manifest.ts
@@ -12,9 +12,29 @@ import {
 import { OpenAgentsPaymentPolicyAudience } from './payment-limit-policy'
 import { openAgentsRunnerGatewayPayloadHasPrivateMaterial } from './runner-gateway'
 
-export const OpenAgentsSitePaymentProvider = S.Literal('openagents_hosted_mdk')
+export const OpenAgentsSitePaymentProvider = S.Literals([
+  'customer_owned_processor',
+  'openagents_hosted_mdk',
+])
 export type OpenAgentsSitePaymentProvider =
   typeof OpenAgentsSitePaymentProvider.Type
+
+export const OpenAgentsSitePaymentCustomerOwnedProcessorKind = S.Literals([
+  'stripe_connect',
+])
+export type OpenAgentsSitePaymentCustomerOwnedProcessorKind =
+  typeof OpenAgentsSitePaymentCustomerOwnedProcessorKind.Type
+
+export const OpenAgentsSitePaymentCustomerOwnedProcessorBinding = S.Struct({
+  chargeDestination: S.Literal('customer_account'),
+  customerProcessorAccountRef: S.String,
+  openAgentsMeteringRefs: S.Array(S.String),
+  processor: OpenAgentsSitePaymentCustomerOwnedProcessorKind,
+  processorConnectionRef: S.String,
+  revenueOwner: S.Literal('customer'),
+})
+export type OpenAgentsSitePaymentCustomerOwnedProcessorBinding =
+  typeof OpenAgentsSitePaymentCustomerOwnedProcessorBinding.Type
 
 export const OpenAgentsSitePaymentSettlementMode = S.Literals([
   'accepted_work_linked',
@@ -87,7 +107,9 @@ export const OpenAgentsSitePaymentProduct = S.Struct({
   metadataRefs: S.Array(S.String),
   price: OpenAgentsPaidEndpointPrice,
   publicProjectionState: OpenAgentsSitePaymentPublicProjectionState,
-  recurringBilling: S.optionalKey(S.NullOr(OpenAgentsSitePaymentRecurringBilling)),
+  recurringBilling: S.optionalKey(
+    S.NullOr(OpenAgentsSitePaymentRecurringBilling),
+  ),
   sandbox: S.Boolean,
   settlementMode: OpenAgentsSitePaymentSettlementMode,
 })
@@ -117,6 +139,9 @@ export type OpenAgentsSitePaymentPaidAction =
 
 export const OpenAgentsSitePaymentBlock = S.Struct({
   agentReadable: S.Boolean,
+  customerOwnedProcessor: S.optionalKey(
+    S.NullOr(OpenAgentsSitePaymentCustomerOwnedProcessorBinding),
+  ),
   enabled: S.Boolean,
   metadataRefs: S.Array(S.String),
   paidActions: S.Array(OpenAgentsSitePaymentPaidAction),
@@ -167,6 +192,15 @@ export type OpenAgentsSitePaymentPaidActionProjection =
 export const OpenAgentsSitePaymentManifestProjection = S.Struct({
   agentReadable: S.Boolean,
   audience: OpenAgentsPaymentPolicyAudience,
+  customerOwnedProcessor: S.NullOr(
+    S.Struct({
+      chargeDestination: S.Literal('customer_account'),
+      meteringSeparated: S.Boolean,
+      openAgentsMeteringRefs: S.Array(S.String),
+      processor: OpenAgentsSitePaymentCustomerOwnedProcessorKind,
+      revenueOwner: S.Literal('customer'),
+    }),
+  ),
   enabled: S.Boolean,
   paidActions: S.Array(OpenAgentsSitePaymentPaidActionProjection),
   payoutModeGate: MdkPayoutModeGateProjection,
@@ -187,7 +221,7 @@ export class OpenAgentsSitePaymentManifestUnsafe extends S.TaggedErrorClass<Open
 const stableSitePaymentIdPattern = /^[a-z][a-z0-9]*(?:[._:-][a-z0-9]+)*$/
 const stableSitePaymentRefPattern = /^[A-Za-z0-9][A-Za-z0-9_.:/-]{0,180}$/
 const unsafeSitePaymentValuePattern =
-  /(bearer\s+|checkout_id=|gho_[a-z0-9_]+|ghp_[a-z0-9_]+|github[_-]?pat_[a-z0-9_]+|lnbc|lntb|lnbcrt|lno1|mdk[_-]?(access[_-]?token|mnemonic|webhook[_-]?secret)|mnemonic|payment_hash=|payment_preimage=|preimage=[A-Za-z0-9_-]+|provider[_-]?token|raw[_-]?(invoice|payment|payload|preimage|prompt|runner|run[_-]?log)|secret|sk-[a-z0-9]|\S+@\S+|wallet[_-]?state)/i
+  /(acct_[a-z0-9]+|bearer\s+|checkout_id=|gho_[a-z0-9_]+|ghp_[a-z0-9_]+|github[_-]?pat_[a-z0-9_]+|lnbc|lntb|lnbcrt|lno1|mdk[_-]?(access[_-]?token|mnemonic|webhook[_-]?secret)|mnemonic|payment_hash=|payment_preimage=|preimage=[A-Za-z0-9_-]+|provider[_-]?token|raw[_-]?(invoice|payment|payload|preimage|prompt|runner|run[_-]?log)|secret|sk-[a-z0-9]|stripe[_-]?(account|secret|webhook)|\S+@\S+|wallet[_-]?state)/i
 
 const valueHasPrivateMaterial = (value: unknown): boolean =>
   typeof value === 'string'
@@ -235,11 +269,17 @@ const recurringBillingIsSafe = (
 ): boolean =>
   recurringBilling === null ||
   recurringBilling === undefined ||
-  (
-    recurringBilling.entitlementRenewalMode === 'renew_on_payment_receipt' &&
+  (recurringBilling.entitlementRenewalMode === 'renew_on_payment_receipt' &&
     recurringBilling.renewalReceiptScopeRefs.length > 0 &&
-    recurringBilling.renewalReceiptScopeRefs.every(stableRefIsSafe)
-  )
+    recurringBilling.renewalReceiptScopeRefs.every(stableRefIsSafe))
+
+const customerOwnedProcessorBindingIsSafe = (
+  binding: OpenAgentsSitePaymentCustomerOwnedProcessorBinding,
+): boolean =>
+  stableRefIsSafe(binding.customerProcessorAccountRef) &&
+  stableRefIsSafe(binding.processorConnectionRef) &&
+  binding.openAgentsMeteringRefs.length > 0 &&
+  binding.openAgentsMeteringRefs.every(stableRefIsSafe)
 
 const productIsSafe = (product: OpenAgentsSitePaymentProduct): boolean =>
   stableIdIsSafe(product.id) &&
@@ -285,6 +325,30 @@ const validateOpenAgentsSitePaymentManifest = (
         'Site payment products and paid actions must use stable IDs, supported prices, clean local checkout paths, and public-safe refs.',
     })
   }
+
+  const customerOwnedProcessor =
+    manifest.payments.customerOwnedProcessor ?? null
+
+  if (
+    manifest.payments.provider === 'customer_owned_processor' &&
+    (customerOwnedProcessor === null ||
+      !customerOwnedProcessorBindingIsSafe(customerOwnedProcessor))
+  ) {
+    throw new OpenAgentsSitePaymentManifestUnsafe({
+      reason:
+        'Customer-owned processor manifests must carry only opaque customer processor refs and separate OpenAgents metering refs.',
+    })
+  }
+
+  if (
+    manifest.payments.provider !== 'customer_owned_processor' &&
+    customerOwnedProcessor !== null
+  ) {
+    throw new OpenAgentsSitePaymentManifestUnsafe({
+      reason:
+        'Customer-owned processor binding is only valid for customer_owned_processor manifests.',
+    })
+  }
 }
 
 export const decodeOpenAgentsSitePaymentManifest = (
@@ -299,50 +363,66 @@ export const decodeOpenAgentsSitePaymentManifest = (
 export const projectOpenAgentsSitePaymentManifest = (
   manifest: OpenAgentsSitePaymentManifest,
   audience: typeof OpenAgentsPaymentPolicyAudience.Type,
-): OpenAgentsSitePaymentManifestProjection => ({
-  agentReadable: manifest.payments.agentReadable,
-  audience,
-  enabled: manifest.payments.enabled,
-  paidActions: manifest.payments.paidActions
-    .filter(
-      action =>
-        audience !== 'public' || action.publicProjectionState !== 'hidden',
-    )
-    .map(action => ({
-      actionRef: action.actionRef,
-      agentReadable: action.agentReadable,
-      checkoutPath: action.checkoutPath,
-      displayRef: action.displayRef,
-      entitlementScope: action.entitlementScope,
-      id: action.id,
-      method: action.method,
-      path: action.path,
-      price: action.price,
-      publicProjectionState: action.publicProjectionState,
-      sandbox: action.sandbox,
-      settlementMode: action.settlementMode,
-    })),
-  payoutModeGate: hostedMdkDirectPayoutDisabledGate(),
-  products: manifest.payments.products
-    .filter(
-      product =>
-        audience !== 'public' || product.publicProjectionState !== 'hidden',
-    )
-    .map(product => ({
-      agentReadable: product.agentReadable,
-      checkoutPath: product.checkoutPath,
-      displayRef: product.displayRef,
-      entitlementScope: product.entitlementScope,
-      id: product.id,
-      price: product.price,
-      publicProjectionState: product.publicProjectionState,
-      recurringBilling: product.recurringBilling ?? null,
-      sandbox: product.sandbox,
-      settlementMode: product.settlementMode,
-    })),
-  provider: manifest.payments.provider,
-  sandboxDefault: manifest.payments.sandboxDefault,
-})
+): OpenAgentsSitePaymentManifestProjection => {
+  const customerOwnedProcessor =
+    manifest.payments.customerOwnedProcessor ?? null
+
+  return {
+    agentReadable: manifest.payments.agentReadable,
+    audience,
+    customerOwnedProcessor:
+      customerOwnedProcessor === null
+        ? null
+        : {
+            chargeDestination: customerOwnedProcessor.chargeDestination,
+            meteringSeparated: true,
+            openAgentsMeteringRefs:
+              customerOwnedProcessor.openAgentsMeteringRefs,
+            processor: customerOwnedProcessor.processor,
+            revenueOwner: customerOwnedProcessor.revenueOwner,
+          },
+    enabled: manifest.payments.enabled,
+    paidActions: manifest.payments.paidActions
+      .filter(
+        action =>
+          audience !== 'public' || action.publicProjectionState !== 'hidden',
+      )
+      .map(action => ({
+        actionRef: action.actionRef,
+        agentReadable: action.agentReadable,
+        checkoutPath: action.checkoutPath,
+        displayRef: action.displayRef,
+        entitlementScope: action.entitlementScope,
+        id: action.id,
+        method: action.method,
+        path: action.path,
+        price: action.price,
+        publicProjectionState: action.publicProjectionState,
+        sandbox: action.sandbox,
+        settlementMode: action.settlementMode,
+      })),
+    payoutModeGate: hostedMdkDirectPayoutDisabledGate(),
+    products: manifest.payments.products
+      .filter(
+        product =>
+          audience !== 'public' || product.publicProjectionState !== 'hidden',
+      )
+      .map(product => ({
+        agentReadable: product.agentReadable,
+        checkoutPath: product.checkoutPath,
+        displayRef: product.displayRef,
+        entitlementScope: product.entitlementScope,
+        id: product.id,
+        price: product.price,
+        publicProjectionState: product.publicProjectionState,
+        recurringBilling: product.recurringBilling ?? null,
+        sandbox: product.sandbox,
+        settlementMode: product.settlementMode,
+      })),
+    provider: manifest.payments.provider,
+    sandboxDefault: manifest.payments.sandboxDefault,
+  }
+}
 
 export const openAgentsSitePaymentManifestHasPrivateMaterial = (
   value: unknown,


### PR DESCRIPTION
Closes #8103

## Summary
- Add a schema-backed `customer_owned_processor` site payment provider for deliverable funnels.
- Require customer-owned processor manifests to carry opaque customer processor refs plus separate OpenAgents metering refs.
- Carry the provider binding into site payment catalog and paid-endpoint product projections without exposing processor account/connection refs publicly.
- Add manifest/catalog regression coverage for customer-owned processor projection, metering separation, and raw processor account rejection.

## Verification
- `bun test apps/openagents.com/workers/api/src/site-payment-manifest.test.ts apps/openagents.com/workers/api/src/site-payment-catalog.test.ts` — 13 pass, 0 fail
- `bun run --cwd apps/openagents.com/workers/api typecheck` — pass
- `bun run check:deploy` — pass, exit code 0
