### PR TITLE
feat(khala-code-desktop): TUI mode — terminal chat over the same Codex harness

### DIFF
--- a/clients/khala-code-desktop/scripts/khala-code-tui.ts
+++ b/clients/khala-code-desktop/scripts/khala-code-tui.ts
@@ -1,0 +1,172 @@
+#!/usr/bin/env bun
+// Khala Code TUI — interactive terminal chat over the same local Codex
+// app-server harness the desktop window uses. No window, no preview server:
+// one readline loop, streamed deltas, multi-turn thread continuity.
+//
+// Usage:
+//   bun scripts/khala-code-tui.ts                    # interactive REPL
+//   echo "prompt" | bun scripts/khala-code-tui.ts    # piped turns, exit at EOF
+//
+// Slash commands: /new (fresh thread), /status (harness readiness), /exit
+
+import { createInterface } from "node:readline/promises"
+
+import { createCodexAppServerChatRuntime } from "../src/bun/codex-app-server-chat-runtime.js"
+import { createCodexAppServerHost } from "../src/bun/codex-app-server-client.js"
+import { inspectCodexHarnessStatus } from "../src/bun/codex-harness-status.js"
+import { projectKhalaCodeDesktopEventToThreadEvents } from "../src/shared/headless-events.js"
+import type { KhalaCodeDesktopChatTurnEvent } from "../src/shared/rpc.js"
+
+const interactive = process.stdin.isTTY === true && process.stdout.isTTY === true
+const workingDirectory = process.cwd()
+const env = Bun.env
+
+let sessionId = `khala-code-tui-${Date.now().toString(36)}`
+let threadId: string | undefined
+let activeTurnId: string | undefined
+let messageCounter = 0
+
+const host = createCodexAppServerHost({ env })
+
+const onEvent = (event: KhalaCodeDesktopChatTurnEvent): void => {
+  for (const threadEvent of projectKhalaCodeDesktopEventToThreadEvents(event)) {
+    const projected = threadEvent as { readonly delta?: string; readonly type?: string }
+    if (projected.type === "item.delta" && typeof projected.delta === "string") {
+      process.stdout.write(projected.delta)
+    }
+  }
+}
+
+const runtime = createCodexAppServerChatRuntime({
+  env,
+  host,
+  onEvent,
+  workingDirectory,
+})
+
+const printStatus = async (): Promise<boolean> => {
+  const status = await inspectCodexHarnessStatus({ env })
+  const auth = status.auth as
+    | { readonly blockerRefs?: readonly string[]; readonly state?: string }
+    | undefined
+  if (status.available) {
+    if (interactive) {
+      process.stdout.write(
+        `khala-code tui — codex harness ready (${status.binary?.version ?? "codex"}, home ${
+          status.home?.path ?? "?"
+        })\n`,
+      )
+    }
+    return true
+  }
+  process.stderr.write(
+    `khala-code tui: codex harness unavailable (${auth?.state ?? status.status}).\n` +
+      `${status.reason ?? ""}\n` +
+      (auth?.blockerRefs?.length ? `blockers: ${auth.blockerRefs.join(", ")}\n` : ""),
+  )
+  return false
+}
+
+const ensureThread = async (): Promise<void> => {
+  if (threadId !== undefined) return
+  const thread = await runtime.startThread({ cwd: workingDirectory, sessionId })
+  threadId = thread.threadId
+}
+
+const runTurn = async (prompt: string): Promise<void> => {
+  await ensureThread()
+  const turnId = `turn-${Date.now().toString(36)}`
+  activeTurnId = turnId
+  messageCounter += 1
+  try {
+    const response = await runtime.startTurn({
+      cwd: workingDirectory,
+      messages: [{ body: prompt, id: `tui-user-${messageCounter}`, role: "user" }],
+      sessionId,
+      ...(threadId === undefined ? {} : { threadId }),
+      turnId,
+    })
+    threadId = response.backend.threadId ?? threadId
+    if (response.ok) {
+      process.stdout.write("\n")
+      return
+    }
+    const backend = response.backend as { readonly blockerRefs?: readonly string[] }
+    const blockers = backend.blockerRefs?.length ? ` — ${backend.blockerRefs.join(", ")}` : ""
+    process.stdout.write(`\n[turn ${response.backend.turnStatus ?? "failed"}${blockers}]\n`)
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    process.stdout.write(`\n[turn failed: ${message}]\n`)
+  } finally {
+    activeTurnId = undefined
+  }
+}
+
+const shutdown = (code: number): never => {
+  try {
+    host.dispose()
+  } catch {
+    // already stopped
+  }
+  process.exit(code)
+}
+
+process.on("SIGINT", () => {
+  if (activeTurnId !== undefined) {
+    const turnId = activeTurnId
+    process.stdout.write("\n[interrupting turn]\n")
+    void runtime.interruptTurn({ sessionId, turnId }).catch(() => undefined)
+    return
+  }
+  process.stdout.write("\n")
+  shutdown(0)
+})
+
+const ready = await printStatus()
+if (!ready) shutdown(2)
+
+if (interactive) {
+  process.stdout.write("multi-turn thread; /new /status /exit; Ctrl-C interrupts a turn\n\n")
+}
+
+const handleLine = async (line: string): Promise<"continue" | "exit"> => {
+  const trimmed = line.trim()
+  if (trimmed.length === 0) return "continue"
+  if (trimmed === "/exit" || trimmed === "/quit") return "exit"
+  if (trimmed === "/new") {
+    sessionId = `khala-code-tui-${Date.now().toString(36)}`
+    threadId = undefined
+    if (interactive) process.stdout.write("[new thread]\n")
+    return "continue"
+  }
+  if (trimmed === "/status") {
+    await printStatus()
+    return "continue"
+  }
+  await runTurn(trimmed)
+  return "continue"
+}
+
+if (interactive) {
+  // Interactive REPL: readline owns the prompt.
+  const rl = createInterface({ input: process.stdin, output: process.stdout })
+  while (true) {
+    let line: string
+    try {
+      line = await rl.question("you › ")
+    } catch {
+      break
+    }
+    if ((await handleLine(line)) === "exit") break
+  }
+  rl.close()
+} else {
+  // Piped mode: drain stdin first, then run each line as a sequential turn —
+  // readline would drop lines that arrive while a turn is still streaming.
+  const text = await new Response(process.stdin).text()
+  for (const line of text.split("\n")) {
+    if ((await handleLine(line)) === "exit") break
+  }
+}
+
+shutdown(0)


### PR DESCRIPTION
## What

A minimal TUI for Khala Code: an interactive terminal REPL over the exact same local Codex app-server harness the desktop window uses (`createCodexAppServerHost` + `createCodexAppServerChatRuntime`). One new file, no dependencies added, no shared files touched.

```
cd clients/khala-code-desktop
bun scripts/khala-code-tui.ts                  # interactive REPL, streamed deltas
echo "prompt" | bun scripts/khala-code-tui.ts  # piped turns, exit at EOF
```

- Streams assistant deltas live to stdout; multi-turn thread continuity (one app-server thread per session)
- `/new` (fresh thread), `/status` (harness readiness), `/exit`; Ctrl-C interrupts an in-flight turn, exits when idle
- Honest gating: if the harness is unavailable it prints the typed blockers from `inspectCodexHarnessStatus` and exits 2
- Piped mode drains stdin first and runs lines as sequential turns (readline would drop lines that arrive mid-stream)

## Why

Operator feature request relayed from the Discord ask for human feedback on Khala Code Desktop: power users coming from Codex CLI / Claude Code want the same engine reachable from a terminal without launching the window. The JSONL headless mode (`code --json`) is single-shot and machine-oriented; this adds the interactive human loop.

## Validation (live, signed-in Codex, macOS)

- `printf 'Remember the codeword: PYLON42\nWhat was the codeword I just told you? Reply with only it.\n' | bun scripts/khala-code-tui.ts` -> streamed `Got it.` then `PYLON42`, exit 0 — proves streaming + cross-turn thread continuity on the live harness.
- Single piped turn -> exact requested reply, exit 0.
- Signed-out behavior returns the typed `blocker.codex.credentials_missing` path via `inspectCodexHarnessStatus` (same semantics as the desktop).

## Intentionally not changed

- No `package.json` script entry (shared hot file; happy to add `"tui": "bun scripts/khala-code-tui.ts"` in a follow-up or if maintainers prefer it here).
- No new dependencies, no changes to the app window, RPC bridge, or headless JSONL mode.

---
*Filed by Lathe (operator agent). Feature requested by the operator after hands-on desktop use.*