### PR TITLE
Wire business referral engagement attribution

### DIFF
--- a/apps/openagents.com/workers/api/migrations/0275_business_funnel_referred_engagement_stage.sql
+++ b/apps/openagents.com/workers/api/migrations/0275_business_funnel_referred_engagement_stage.sql
@@ -1,0 +1,66 @@
+-- BF-8.4 honest referral attribution loop.
+--
+-- Extend the public-safe business funnel event ledger with the multiply-stage
+-- receipt for a referred engagement. The table still stores only opaque refs
+-- and coarse source buckets; payout/settlement truth remains in the existing
+-- site_referral_payout_ledger_entries table.
+
+CREATE TABLE IF NOT EXISTS business_funnel_events_0275 (
+  id TEXT PRIMARY KEY NOT NULL,
+  event_ref TEXT NOT NULL UNIQUE,
+  stage TEXT NOT NULL CHECK (
+    stage IN (
+      'visit',
+      'signup',
+      'intake_spec',
+      'payment',
+      'provisioned',
+      'first_outcome',
+      'retained',
+      'referred_engagement'
+    )
+  ),
+  source_kind TEXT NOT NULL CHECK (
+    source_kind IN (
+      'content',
+      'outbound',
+      'ai_search',
+      'referral',
+      'direct',
+      'unknown'
+    )
+  ),
+  source_ref TEXT,
+  occurred_at TEXT NOT NULL,
+  observed_at TEXT NOT NULL
+);
+
+INSERT OR IGNORE INTO business_funnel_events_0275 (
+  id,
+  event_ref,
+  stage,
+  source_kind,
+  source_ref,
+  occurred_at,
+  observed_at
+)
+SELECT
+  id,
+  event_ref,
+  stage,
+  source_kind,
+  source_ref,
+  occurred_at,
+  observed_at
+FROM business_funnel_events;
+
+DROP TABLE business_funnel_events;
+
+ALTER TABLE business_funnel_events_0275
+  RENAME TO business_funnel_events;
+
+CREATE INDEX IF NOT EXISTS business_funnel_events_stage_time_idx
+  ON business_funnel_events(stage, occurred_at DESC);
+
+CREATE INDEX IF NOT EXISTS business_funnel_events_source_time_idx
+  ON business_funnel_events(source_kind, occurred_at DESC);

--- a/apps/openagents.com/workers/api/src/business-funnel-dashboard.test.ts
+++ b/apps/openagents.com/workers/api/src/business-funnel-dashboard.test.ts
@@ -139,5 +139,8 @@ describe('business funnel dashboard', () => {
     expect(
       signup?.sourceBreakdown.find(source => source.sourceKind === 'ai_search'),
     ).toEqual({ sourceKind: 'ai_search', count: 1 })
+    expect(body.stages.map(stage => stage.stage)).toContain(
+      'referred_engagement',
+    )
   })
 })

--- a/apps/openagents.com/workers/api/src/business-funnel-dashboard.ts
+++ b/apps/openagents.com/workers/api/src/business-funnel-dashboard.ts
@@ -17,6 +17,7 @@ export const BusinessFunnelStage = S.Literals([
   'provisioned',
   'first_outcome',
   'retained',
+  'referred_engagement',
 ])
 export type BusinessFunnelStage = typeof BusinessFunnelStage.Type
 
@@ -39,6 +40,7 @@ export const BUSINESS_FUNNEL_STAGE_ORDER: ReadonlyArray<BusinessFunnelStage> = [
   'provisioned',
   'first_outcome',
   'retained',
+  'referred_engagement',
 ]
 
 export const BUSINESS_FUNNEL_SOURCE_KINDS: ReadonlyArray<BusinessFunnelSourceKind> =
@@ -244,6 +246,11 @@ const buildEmptyStageMap = (): Record<
     lastOccurredAt: null,
   },
   retained: {
+    count: 0,
+    sourceCounts: emptySourceCounts(),
+    lastOccurredAt: null,
+  },
+  referred_engagement: {
     count: 0,
     sourceCounts: emptySourceCounts(),
     lastOccurredAt: null,

--- a/apps/openagents.com/workers/api/src/business-referral-engagement-feed.test.ts
+++ b/apps/openagents.com/workers/api/src/business-referral-engagement-feed.test.ts
@@ -1,0 +1,319 @@
+import { describe, expect, test } from 'vitest'
+
+import { recordBusinessReferralEngagement } from './business-referral-engagement-feed'
+import type { SiteReferralPayoutState } from './site-referral-payout-ledger'
+
+type StoredPayoutEntry = Readonly<{
+  amount_sats: number
+  archived_at: string | null
+  caveat_refs_json: string
+  created_at: string
+  evidence_refs_json: string
+  id: string
+  idempotency_key: string
+  payout_ref: string
+  period_key: string
+  policy_refs_json: string
+  previous_entry_id: string | null
+  qualifying_amount_sats: number
+  qualifying_event_kind: string
+  qualifying_event_ref: string
+  referred_user_id: string | null
+  referral_attribution_id: string
+  referral_invite_id: string | null
+  referral_source_id: string
+  referrer_user_id: string
+  reversal_of_entry_id: string | null
+  state: SiteReferralPayoutState
+  state_reason_ref: string | null
+}>
+
+type BusinessAttributionJoinRow = Readonly<{
+  business_signup_request_id: string
+  referral_attribution_id: string
+  referral_invite_id: string | null
+  referral_source_id: string
+  referrer_user_id: string
+  bsra_active: boolean
+  src_active: boolean
+}>
+
+type FunnelEventRow = Readonly<{
+  event_ref: string
+  stage: string
+  source_kind: string
+  source_ref: string | null
+}>
+
+class BusinessReferralStore {
+  rows: Array<StoredPayoutEntry> = []
+  attributions: Array<BusinessAttributionJoinRow> = []
+  funnelEvents: Array<FunnelEventRow> = []
+}
+
+class BusinessReferralStatement {
+  private values: ReadonlyArray<unknown> = []
+
+  constructor(
+    private readonly query: string,
+    private readonly store: BusinessReferralStore,
+  ) {}
+
+  bind(...values: ReadonlyArray<unknown>): BusinessReferralStatement {
+    this.values = values
+
+    return this
+  }
+
+  first<T = unknown>(colName: string): Promise<T | null>
+  first<T = Record<string, unknown>>(): Promise<T | null>
+  first<T = unknown>(): Promise<T | null> {
+    if (this.query.includes('FROM business_signup_referral_attributions')) {
+      const businessSignupId = String(this.values[0])
+      const row =
+        this.store.attributions.find(
+          entry =>
+            entry.business_signup_request_id === businessSignupId &&
+            entry.bsra_active &&
+            entry.src_active,
+        ) ?? null
+
+      return Promise.resolve(
+        row === null
+          ? null
+          : ({
+              referral_attribution_id: row.referral_attribution_id,
+              referral_invite_id: row.referral_invite_id,
+              referral_source_id: row.referral_source_id,
+              referrer_user_id: row.referrer_user_id,
+            } as T),
+      )
+    }
+
+    if (this.query.includes('WHERE idempotency_key = ?')) {
+      const row =
+        this.store.rows.find(
+          entry =>
+            entry.idempotency_key === String(this.values[0]) &&
+            entry.archived_at === null,
+        ) ?? null
+
+      return Promise.resolve(row as T | null)
+    }
+
+    if (this.query.includes('WHERE payout_ref = ?')) {
+      const row =
+        this.store.rows
+          .filter(
+            entry =>
+              entry.payout_ref === String(this.values[0]) &&
+              entry.archived_at === null,
+          )
+          .sort((left, right) =>
+            right.created_at === left.created_at
+              ? right.id.localeCompare(left.id)
+              : right.created_at.localeCompare(left.created_at),
+          )[0] ?? null
+
+      return Promise.resolve(row as T | null)
+    }
+
+    if (this.query.includes('COUNT(*) AS payout_count')) {
+      const [referrerUserId, periodKey] = this.values
+      const rows = this.store.rows.filter(
+        entry =>
+          entry.referrer_user_id === referrerUserId &&
+          entry.period_key === periodKey &&
+          entry.amount_sats > 0 &&
+          entry.archived_at === null &&
+          ['eligible', 'approved', 'dispatched', 'settled'].includes(
+            entry.state,
+          ),
+      )
+
+      return Promise.resolve({
+        payout_count: rows.length,
+        payout_sats: rows.reduce((total, row) => total + row.amount_sats, 0),
+      } as T)
+    }
+
+    return Promise.reject(new Error(`Unexpected first: ${this.query}`))
+  }
+
+  run<T = Record<string, unknown>>(): Promise<D1Result<T>> {
+    if (this.query.includes('INSERT INTO site_referral_payout_ledger_entries')) {
+      const existing = this.store.rows.find(
+        row => row.idempotency_key === String(this.values[2]),
+      )
+      if (existing === undefined) {
+        this.store.rows.push({
+          amount_sats: Number(this.values[11]),
+          archived_at: null,
+          caveat_refs_json: String(this.values[19]),
+          created_at: String(this.values[20]),
+          evidence_refs_json: String(this.values[17]),
+          id: String(this.values[0]),
+          idempotency_key: String(this.values[2]),
+          payout_ref: String(this.values[1]),
+          period_key: String(this.values[12]),
+          policy_refs_json: String(this.values[18]),
+          previous_entry_id: this.values[15] as string | null,
+          qualifying_amount_sats: Number(this.values[10]),
+          qualifying_event_kind: String(this.values[9]),
+          qualifying_event_ref: String(this.values[8]),
+          referred_user_id: this.values[7] as string | null,
+          referral_attribution_id: String(this.values[3]),
+          referral_invite_id: this.values[5] as string | null,
+          referral_source_id: String(this.values[4]),
+          referrer_user_id: String(this.values[6]),
+          reversal_of_entry_id: this.values[16] as string | null,
+          state: this.values[13] as SiteReferralPayoutState,
+          state_reason_ref: this.values[14] as string | null,
+        })
+      }
+
+      return Promise.resolve({ success: true } as D1Result<T>)
+    }
+
+    if (this.query.includes('INSERT OR IGNORE INTO business_funnel_events')) {
+      const eventRef = String(this.values[1])
+      if (!this.store.funnelEvents.some(row => row.event_ref === eventRef)) {
+        this.store.funnelEvents.push({
+          event_ref: eventRef,
+          source_kind: String(this.values[3]),
+          source_ref: this.values[4] as string | null,
+          stage: String(this.values[2]),
+        })
+      }
+
+      return Promise.resolve({ success: true } as D1Result<T>)
+    }
+
+    return Promise.reject(new Error(`Unexpected run: ${this.query}`))
+  }
+
+  all<T = Record<string, unknown>>(): Promise<D1Result<T>> {
+    return Promise.reject(new Error(`Unexpected all: ${this.query}`))
+  }
+
+  raw<T = unknown[]>(): Promise<Array<T>> {
+    return Promise.reject(new Error(`Unexpected raw: ${this.query}`))
+  }
+}
+
+class BusinessReferralD1 {
+  constructor(private readonly store: BusinessReferralStore) {}
+
+  prepare(query: string): BusinessReferralStatement {
+    return new BusinessReferralStatement(query, this.store)
+  }
+
+  batch<T = unknown>(): Promise<Array<D1Result<T>>> {
+    return Promise.reject(new Error('Unexpected batch'))
+  }
+
+  dump(): Promise<ArrayBuffer> {
+    return Promise.reject(new Error('Unexpected dump'))
+  }
+
+  exec(): Promise<D1ExecResult> {
+    return Promise.reject(new Error('Unexpected exec'))
+  }
+}
+
+const dbFor = (store: BusinessReferralStore): D1Database =>
+  new BusinessReferralD1(store) as unknown as D1Database
+
+const seedAttribution = (
+  store: BusinessReferralStore,
+  overrides: Partial<BusinessAttributionJoinRow> = {},
+) => {
+  store.attributions.push({
+    bsra_active: true,
+    business_signup_request_id: 'business_signup_001',
+    referral_attribution_id: 'referral_attr_001',
+    referral_invite_id: null,
+    referral_source_id: 'referral_source_001',
+    referrer_user_id: 'github:referrer',
+    src_active: true,
+    ...overrides,
+  })
+}
+
+const paidBusinessEngagement = (
+  businessSignupId: string,
+  overrides: Partial<Parameters<typeof recordBusinessReferralEngagement>[1]> = {},
+) => ({
+  businessSignupId,
+  idempotencyKey: `business_referral_engagement.${businessSignupId}`,
+  nowIso: '2026-07-03T12:00:00.000Z',
+  periodKey: '2026-07',
+  qualifyingAmountSats: 20_000,
+  qualifyingEventKind: 'business_referred_engagement_paid',
+  qualifyingEventRef: `evidence.business_referred_engagement.${businessSignupId}`,
+  revenueAsset: 'bitcoin' as const,
+  referredUserId: 'github:buyer',
+  ...overrides,
+})
+
+describe('business referral engagement feed', () => {
+  test('records an attributed engagement on the existing referral payout ledger', async () => {
+    const store = new BusinessReferralStore()
+    seedAttribution(store)
+
+    const result = await recordBusinessReferralEngagement(
+      dbFor(store),
+      paidBusinessEngagement('business_signup_001'),
+    )
+
+    expect(result._tag).toBe('recorded')
+
+    if (result._tag !== 'recorded') {
+      throw new Error('expected recorded')
+    }
+
+    expect(result.payout).toMatchObject({
+      amountSats: 1000,
+      qualifyingEventKind: 'business_referred_engagement_paid',
+      referredUserId: 'github:buyer',
+      referralAttributionId: 'referral_attr_001',
+      referrerUserId: 'github:referrer',
+      state: 'eligible',
+    })
+    expect(result.funnelEvent).toMatchObject({
+      eventRef:
+        'business_referral_engagement:evidence.business_referred_engagement.business_signup_001',
+      sourceKind: 'referral',
+      sourceRef: 'referral_source_001',
+      stage: 'referred_engagement',
+    })
+    expect(store.rows).toHaveLength(1)
+    expect(store.funnelEvents).toHaveLength(1)
+  })
+
+  test('records nothing when a business signup has no referral attribution', async () => {
+    const store = new BusinessReferralStore()
+
+    const result = await recordBusinessReferralEngagement(
+      dbFor(store),
+      paidBusinessEngagement('business_signup_002'),
+    )
+
+    expect(result._tag).toBe('no_attribution')
+    expect(store.rows).toHaveLength(0)
+    expect(store.funnelEvents).toHaveLength(0)
+  })
+
+  test('keeps checkout retries idempotent across payout and funnel rows', async () => {
+    const store = new BusinessReferralStore()
+    seedAttribution(store)
+    const db = dbFor(store)
+    const input = paidBusinessEngagement('business_signup_001')
+
+    await recordBusinessReferralEngagement(db, input)
+    await recordBusinessReferralEngagement(db, input)
+
+    expect(store.rows).toHaveLength(1)
+    expect(store.funnelEvents).toHaveLength(1)
+  })
+})

--- a/apps/openagents.com/workers/api/src/business-referral-engagement-feed.ts
+++ b/apps/openagents.com/workers/api/src/business-referral-engagement-feed.ts
@@ -1,0 +1,145 @@
+import {
+  validateAssetBoundary,
+  type AssetBoundaryAsset,
+} from './asset-bitcoin-boundary'
+import {
+  recordBusinessFunnelEvent,
+  type BusinessFunnelEventRecord,
+} from './business-funnel-dashboard'
+import {
+  createReferralPayoutEligibility,
+  type CreateReferralPayoutEligibilityInput,
+  type SiteReferralPayoutLedgerEntry,
+  type SiteReferralPayoutLedgerStorageError,
+  type SiteReferralPayoutLedgerValidationError,
+} from './site-referral-payout-ledger'
+import {
+  referralRevenueAssetToBoundaryAsset,
+  type SiteReferralRevenueAsset,
+} from './site-referral-payout-feed'
+
+export type BusinessReferralEngagementInput = Readonly<{
+  businessSignupId: string
+  idempotencyKey: string
+  nowIso: string
+  periodKey: string
+  qualifyingAmountSats: number
+  qualifyingEventKind: string
+  qualifyingEventRef: string
+  revenueAsset: SiteReferralRevenueAsset
+  referredUserId?: string | null
+}>
+
+export type BusinessReferralEngagementResult =
+  | Readonly<{ _tag: 'no_attribution' }>
+  | Readonly<{ _tag: 'self_attribution' }>
+  | Readonly<{
+      _tag: 'boundary_refused'
+      reasonRef: string
+    }>
+  | Readonly<{
+      _tag: 'recorded'
+      funnelEvent: BusinessFunnelEventRecord
+      payout: SiteReferralPayoutLedgerEntry
+    }>
+
+export type BusinessReferralEngagementError =
+  | SiteReferralPayoutLedgerStorageError
+  | SiteReferralPayoutLedgerValidationError
+
+type BusinessSignupAttributionRow = Readonly<{
+  referral_attribution_id: string
+  referral_invite_id: string | null
+  referral_source_id: string
+  referrer_user_id: string
+}>
+
+const SAFE_SIGNUP_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9_.:-]{0,190}$/
+
+const readBusinessSignupAttribution = async (
+  db: D1Database,
+  businessSignupId: string,
+): Promise<BusinessSignupAttributionRow | null> => {
+  if (!SAFE_SIGNUP_ID_PATTERN.test(businessSignupId)) {
+    return null
+  }
+
+  return db
+    .prepare(
+      `SELECT bsra.referral_attribution_id AS referral_attribution_id,
+              bsra.referral_invite_id AS referral_invite_id,
+              bsra.referral_source_id AS referral_source_id,
+              src.referrer_user_id AS referrer_user_id
+         FROM business_signup_referral_attributions AS bsra
+         JOIN site_referral_sources AS src
+           ON src.id = bsra.referral_source_id
+        WHERE bsra.business_signup_request_id = ?
+          AND bsra.archived_at IS NULL
+          AND bsra.policy_state = 'active'
+          AND src.archived_at IS NULL
+          AND src.policy_state = 'active'
+        LIMIT 1`,
+    )
+    .bind(businessSignupId)
+    .first<BusinessSignupAttributionRow>()
+}
+
+const revshareContributorAssetFor = (
+  revenueAsset: SiteReferralRevenueAsset,
+): AssetBoundaryAsset => (revenueAsset === 'bitcoin' ? 'bitcoin' : 'credit')
+
+export const recordBusinessReferralEngagement = async (
+  db: D1Database,
+  input: BusinessReferralEngagementInput,
+): Promise<BusinessReferralEngagementResult> => {
+  const attribution = await readBusinessSignupAttribution(
+    db,
+    input.businessSignupId,
+  )
+
+  if (attribution === null) {
+    return { _tag: 'no_attribution' }
+  }
+
+  if (
+    input.referredUserId !== undefined &&
+    input.referredUserId !== null &&
+    input.referredUserId === attribution.referrer_user_id
+  ) {
+    return { _tag: 'self_attribution' }
+  }
+
+  const boundaryViolation = validateAssetBoundary({
+    contributorAsset: revshareContributorAssetFor(input.revenueAsset),
+    movement: 'revshare',
+    revenueAsset: referralRevenueAssetToBoundaryAsset(input.revenueAsset),
+  })
+
+  if (boundaryViolation !== null) {
+    return { _tag: 'boundary_refused', reasonRef: boundaryViolation.reasonRef }
+  }
+
+  const createInput: CreateReferralPayoutEligibilityInput = {
+    idempotencyKey: input.idempotencyKey,
+    nowIso: input.nowIso,
+    periodKey: input.periodKey,
+    qualifyingAmountSats: input.qualifyingAmountSats,
+    qualifyingEventKind: input.qualifyingEventKind,
+    qualifyingEventRef: input.qualifyingEventRef,
+    referredUserId: input.referredUserId ?? null,
+    referralAttributionId: attribution.referral_attribution_id,
+    referralInviteId: attribution.referral_invite_id,
+    referralSourceId: attribution.referral_source_id,
+    referrerUserId: attribution.referrer_user_id,
+  }
+  const payout = await createReferralPayoutEligibility(db, createInput)
+  const funnelEvent = await recordBusinessFunnelEvent(db, {
+    eventRef: `business_referral_engagement:${input.qualifyingEventRef}`,
+    occurredAt: input.nowIso,
+    sourceKind: 'referral',
+    sourceRef: attribution.referral_source_id,
+    stage: 'referred_engagement',
+  })
+
+  return { _tag: 'recorded', funnelEvent, payout }
+}

--- a/apps/openagents.com/workers/api/src/stripe-billing.ts
+++ b/apps/openagents.com/workers/api/src/stripe-billing.ts
@@ -20,6 +20,7 @@ import { parseJsonWithSchema } from './json-boundary'
 import { type PartnerQualifyingPaidEvent } from './partner-attribution-eligibility'
 import { recordPartnerPayoutForPaidEvent } from './partner-payout-feed'
 import { provisionBusinessCheckoutKickoff } from './business-checkout-kickoff'
+import { recordBusinessReferralEngagement } from './business-referral-engagement-feed'
 import { recordReferralPayoutForPaidEvent } from './site-referral-payout-feed'
 
 export const STRIPE_API_VERSION = '2026-05-27.dahlia'
@@ -872,6 +873,22 @@ const fulfillCheckoutSession = async (
       totalAmountCents: pack.amountCents,
       userId,
     })
+
+    try {
+      await recordBusinessReferralEngagement(input.db, {
+        businessSignupId,
+        idempotencyKey: `business_referral_engagement.stripe_checkout.${input.sessionId}`,
+        nowIso: now,
+        periodKey: now.slice(0, 7),
+        qualifyingAmountSats: 0,
+        qualifyingEventKind: 'business_stripe_checkout_paid',
+        qualifyingEventRef: `evidence.business_stripe_checkout_paid.${input.sessionId}`,
+        revenueAsset: 'usd',
+        referredUserId: userId,
+      })
+    } catch {
+      // Swallow: referral attribution must not block checkout fulfillment.
+    }
   }
 
   // RL-1 (openagents #5458): FEED the referral payout ledger from this real


### PR DESCRIPTION
Closes #8112.

## Summary
- Add a business referral engagement feed that resolves `business_signup_referral_attributions` into the existing site referral payout ledger.
- Record a `referred_engagement` business funnel event for attributed engagements without exposing client-identifying data.
- Wire business checkout kickoff to best-effort referral engagement recording while keeping payout settlement authority on the existing ledger.

## Verification
- `bun run --cwd apps/openagents.com/workers/api test -- src/business-referral-engagement-feed.test.ts src/business-funnel-dashboard.test.ts` — 2 files passed, 4 tests passed.
- `bun run --cwd apps/openagents.com/workers/api typecheck` — passed.
- `bun run check:deploy` — passed.
