### PR TITLE
BF-7.2 locked business factory metrics

### DIFF
--- a/apps/openagents.com/workers/api/src/business-factory-metrics.sql
+++ b/apps/openagents.com/workers/api/src/business-factory-metrics.sql
@@ -1,0 +1,203 @@
+-- BF-7.2 locked business factory + engagement metric queries.
+--
+-- Bind parameters:
+--   ?1 = inclusive window_start ISO timestamp
+--   ?2 = exclusive window_end ISO timestamp
+--
+-- The query emits a normalized row set matching
+-- docs/fable/2026-07-03-bf-7-2-locked-business-factory-metrics.md.
+-- It intentionally returns not_measured rows for unauditable empty-rate
+-- windows instead of fabricating zeros.
+
+WITH
+  params(window_start, window_end) AS (
+    SELECT ?1, ?2
+  ),
+  work_kinds(work_kind) AS (
+    VALUES
+      ('adjustment'),
+      ('business'),
+      ('coding'),
+      ('existing_project_import'),
+      ('legal_sensitive'),
+      ('site')
+  ),
+  accepted_contracts AS (
+    SELECT
+      c.work_kind,
+      c.id,
+      c.created_at,
+      c.updated_at
+    FROM omni_accepted_outcome_contracts c, params p
+    WHERE c.archived_at IS NULL
+      AND c.acceptance_state = 'accepted'
+      AND c.updated_at >= p.window_start
+      AND c.updated_at < p.window_end
+  ),
+  terminal_contracts AS (
+    SELECT
+      c.work_kind,
+      c.acceptance_state,
+      c.id
+    FROM omni_accepted_outcome_contracts c, params p
+    WHERE c.archived_at IS NULL
+      AND c.acceptance_state IN (
+        'accepted',
+        'rejected',
+        'revision_requested',
+        'unavailable'
+      )
+      AND c.updated_at >= p.window_start
+      AND c.updated_at < p.window_end
+  ),
+  economics_rows AS (
+    SELECT
+      e.id,
+      e.work_kind,
+      e.accepted_outcome_contract_id,
+      e.review_minutes,
+      e.updated_at
+    FROM omni_accepted_outcome_economics e, params p
+    WHERE e.archived_at IS NULL
+      AND e.updated_at >= p.window_start
+      AND e.updated_at < p.window_end
+  ),
+  engagement_review_rows AS (
+    SELECT
+      COALESCE(NULLIF(c.customer_ref, ''), c.subject_ref) AS engagement_ref,
+      e.review_minutes,
+      e.id AS economics_id
+    FROM economics_rows e
+    INNER JOIN omni_accepted_outcome_contracts c
+      ON c.id = e.accepted_outcome_contract_id
+    WHERE c.archived_at IS NULL
+      AND COALESCE(NULLIF(c.customer_ref, ''), c.subject_ref) IS NOT NULL
+  )
+SELECT
+  'business_factory.throughput.accepted_outcomes.v1' AS metric_ref,
+  'accepted outcome throughput' AS metric_name,
+  'work_kind' AS grain,
+  wk.work_kind AS work_kind,
+  NULL AS engagement_ref,
+  p.window_start AS window_start,
+  p.window_end AS window_end,
+  COUNT(ac.id) AS numerator,
+  NULL AS denominator,
+  COUNT(ac.id) AS value,
+  'outcomes' AS unit,
+  'measured' AS measurement_state,
+  '["table.omni_accepted_outcome_contracts"]' AS evidence_refs_json,
+  '[]' AS caveat_refs_json
+FROM work_kinds wk
+CROSS JOIN params p
+LEFT JOIN accepted_contracts ac
+  ON ac.work_kind = wk.work_kind
+GROUP BY wk.work_kind
+
+UNION ALL
+
+SELECT
+  'business_factory.cycle_time.accepted_minutes.v1' AS metric_ref,
+  'accepted outcome cycle time' AS metric_name,
+  'work_kind' AS grain,
+  wk.work_kind AS work_kind,
+  NULL AS engagement_ref,
+  p.window_start AS window_start,
+  p.window_end AS window_end,
+  COUNT(ac.id) AS numerator,
+  COUNT(ac.id) AS denominator,
+  CASE
+    WHEN COUNT(ac.id) = 0 THEN NULL
+    ELSE ROUND(AVG((julianday(ac.updated_at) - julianday(ac.created_at)) * 1440.0), 2)
+  END AS value,
+  'minutes' AS unit,
+  CASE WHEN COUNT(ac.id) = 0 THEN 'not_measured' ELSE 'measured' END AS measurement_state,
+  '["table.omni_accepted_outcome_contracts"]' AS evidence_refs_json,
+  CASE
+    WHEN COUNT(ac.id) = 0
+      THEN '["caveat.business_metrics.no_accepted_outcomes_in_window"]'
+    ELSE '[]'
+  END AS caveat_refs_json
+FROM work_kinds wk
+CROSS JOIN params p
+LEFT JOIN accepted_contracts ac
+  ON ac.work_kind = wk.work_kind
+GROUP BY wk.work_kind
+
+UNION ALL
+
+SELECT
+  'business_factory.pass_rate.terminal_outcomes_bps.v1' AS metric_ref,
+  'terminal outcome pass rate' AS metric_name,
+  'work_kind' AS grain,
+  wk.work_kind AS work_kind,
+  NULL AS engagement_ref,
+  p.window_start AS window_start,
+  p.window_end AS window_end,
+  SUM(CASE WHEN tc.acceptance_state = 'accepted' THEN 1 ELSE 0 END) AS numerator,
+  COUNT(tc.id) AS denominator,
+  CASE
+    WHEN COUNT(tc.id) = 0 THEN NULL
+    ELSE ROUND(
+      SUM(CASE WHEN tc.acceptance_state = 'accepted' THEN 1 ELSE 0 END) * 10000.0
+      / COUNT(tc.id),
+      0
+    )
+  END AS value,
+  'basis_points' AS unit,
+  CASE WHEN COUNT(tc.id) = 0 THEN 'not_measured' ELSE 'measured' END AS measurement_state,
+  '["table.omni_accepted_outcome_contracts"]' AS evidence_refs_json,
+  CASE
+    WHEN COUNT(tc.id) = 0
+      THEN '["caveat.business_metrics.no_terminal_outcomes_in_window"]'
+    ELSE '[]'
+  END AS caveat_refs_json
+FROM work_kinds wk
+CROSS JOIN params p
+LEFT JOIN terminal_contracts tc
+  ON tc.work_kind = wk.work_kind
+GROUP BY wk.work_kind
+
+UNION ALL
+
+SELECT
+  'business_factory.review_minutes.v1' AS metric_ref,
+  'ledgered review minutes' AS metric_name,
+  'work_kind' AS grain,
+  wk.work_kind AS work_kind,
+  NULL AS engagement_ref,
+  p.window_start AS window_start,
+  p.window_end AS window_end,
+  COALESCE(SUM(er.review_minutes), 0) AS numerator,
+  COUNT(er.accepted_outcome_contract_id) AS denominator,
+  COALESCE(SUM(er.review_minutes), 0) AS value,
+  'minutes' AS unit,
+  'measured' AS measurement_state,
+  '["table.omni_accepted_outcome_economics"]' AS evidence_refs_json,
+  '[]' AS caveat_refs_json
+FROM work_kinds wk
+CROSS JOIN params p
+LEFT JOIN economics_rows er
+  ON er.work_kind = wk.work_kind
+GROUP BY wk.work_kind
+
+UNION ALL
+
+SELECT
+  'business_engagement.operator_minutes.review_ledger_floor.v1' AS metric_ref,
+  'operator minutes per engagement review-ledger floor' AS metric_name,
+  'engagement' AS grain,
+  NULL AS work_kind,
+  engagement_ref AS engagement_ref,
+  p.window_start AS window_start,
+  p.window_end AS window_end,
+  SUM(review_minutes) AS numerator,
+  COUNT(economics_id) AS denominator,
+  SUM(review_minutes) AS value,
+  'minutes' AS unit,
+  'measured' AS measurement_state,
+  '["table.omni_accepted_outcome_economics","table.omni_accepted_outcome_contracts"]' AS evidence_refs_json,
+  '["caveat.business_metrics.operator_minutes_review_only_until_labor_ledger"]' AS caveat_refs_json
+FROM engagement_review_rows, params p
+GROUP BY engagement_ref
+ORDER BY metric_ref, grain, work_kind, engagement_ref;

--- a/apps/openagents.com/workers/api/src/business-factory-metrics.test.ts
+++ b/apps/openagents.com/workers/api/src/business-factory-metrics.test.ts
@@ -1,0 +1,240 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { DatabaseSync } from 'node:sqlite'
+import { describe, expect, test } from 'vitest'
+
+import {
+  BUSINESS_FACTORY_METRICS_SQL,
+  selectBusinessFactoryMetrics,
+} from './business-factory-metrics'
+
+type Row = Record<string, unknown>
+
+class SqliteD1Statement {
+  private bound: ReadonlyArray<unknown> = []
+
+  constructor(
+    private readonly db: DatabaseSync,
+    private readonly sql: string,
+  ) {}
+
+  bind(...values: ReadonlyArray<unknown>): SqliteD1Statement {
+    this.bound = values.map(value => (value === undefined ? null : value))
+    return this
+  }
+
+  async all<T = Row>(): Promise<{ results: Array<T> }> {
+    return {
+      results: this.db.prepare(this.sql).all(...(this.bound as never[])) as Array<T>,
+    }
+  }
+}
+
+class SqliteD1 {
+  constructor(private readonly db: DatabaseSync) {}
+
+  prepare(sql: string): SqliteD1Statement {
+    return new SqliteD1Statement(this.db, sql)
+  }
+}
+
+const migration = (name: string): string =>
+  readFileSync(join(__dirname, '..', 'migrations', name), 'utf8')
+
+const makeDb = (): D1Database => {
+  const db = new DatabaseSync(':memory:')
+  db.exec('PRAGMA foreign_keys = OFF')
+  db.exec(migration('0091_omni_accepted_outcome_contracts.sql'))
+  db.exec(migration('0095_omni_accepted_outcome_economics.sql'))
+  return new SqliteD1(db) as unknown as D1Database
+}
+
+describe('business factory metrics', () => {
+  test('commits the BF-7.2 query pack with the locked metric refs', () => {
+    expect(BUSINESS_FACTORY_METRICS_SQL).toContain(
+      'business_factory.throughput.accepted_outcomes.v1',
+    )
+    expect(BUSINESS_FACTORY_METRICS_SQL).toContain(
+      'business_factory.cycle_time.accepted_minutes.v1',
+    )
+    expect(BUSINESS_FACTORY_METRICS_SQL).toContain(
+      'business_factory.pass_rate.terminal_outcomes_bps.v1',
+    )
+    expect(BUSINESS_FACTORY_METRICS_SQL).toContain(
+      'business_factory.review_minutes.v1',
+    )
+    expect(BUSINESS_FACTORY_METRICS_SQL).toContain(
+      'business_engagement.operator_minutes.review_ledger_floor.v1',
+    )
+  })
+
+  test('returns measured rows from auditable outcome and economics ledgers', async () => {
+    const raw = new DatabaseSync(':memory:')
+    raw.exec('PRAGMA foreign_keys = OFF')
+    raw.exec(migration('0091_omni_accepted_outcome_contracts.sql'))
+    raw.exec(migration('0095_omni_accepted_outcome_economics.sql'))
+    raw.prepare(
+      `INSERT INTO omni_accepted_outcome_contracts (
+        id, idempotency_key, work_kind, subject_ref, customer_ref,
+        expected_artifacts_json, review_policy, acceptance_state, proof_policy,
+        economic_state, closeout_requirements_json, legal_sensitive,
+        public_receipt_ref, metadata_json, created_at, updated_at, archived_at
+      ) VALUES (?, ?, ?, ?, ?, '[]', 'operator_review', ?, 'public_safe_proof',
+        'paid_required', '[]', 0, ?, '{}', ?, ?, NULL)`,
+    ).run(
+      'contract_1',
+      'idem_contract_1',
+      'business',
+      'business_engagement.opaque.1',
+      'business_engagement.opaque.1',
+      'accepted',
+      'receipt.public.contract_1',
+      '2026-07-03T10:00:00.000Z',
+      '2026-07-03T11:30:00.000Z',
+    )
+    raw.prepare(
+      `INSERT INTO omni_accepted_outcome_contracts (
+        id, idempotency_key, work_kind, subject_ref, customer_ref,
+        expected_artifacts_json, review_policy, acceptance_state, proof_policy,
+        economic_state, closeout_requirements_json, legal_sensitive,
+        public_receipt_ref, metadata_json, created_at, updated_at, archived_at
+      ) VALUES (?, ?, ?, ?, ?, '[]', 'operator_review', ?, 'public_safe_proof',
+        'paid_required', '[]', 0, ?, '{}', ?, ?, NULL)`,
+    ).run(
+      'contract_2',
+      'idem_contract_2',
+      'business',
+      'business_engagement.opaque.2',
+      'business_engagement.opaque.2',
+      'rejected',
+      'receipt.public.contract_2',
+      '2026-07-03T10:20:00.000Z',
+      '2026-07-03T12:00:00.000Z',
+    )
+    raw.prepare(
+      `INSERT INTO omni_accepted_outcome_economics (
+        id, idempotency_key, workroom_id, accepted_outcome_contract_id,
+        work_kind, funding_mode, buyer_price_asset, buyer_price_cents,
+        credits_charged, sats_charged, runner_cost_cents,
+        provider_cost_cents, retry_cost_cents, review_minutes,
+        review_cost_cents, artifact_cost_cents, total_cost_cents,
+        accepted_value_cents, gross_margin_cents, public_caveat_ref,
+        internal_caveat_ref, no_settlement_implication, metadata_json,
+        created_at, updated_at, archived_at
+      ) VALUES (?, ?, ?, ?, 'business', 'credit_funded', 'usd', 10000,
+        0, 0, 1000, 2000, 0, 17, 3000, 0, 6000, 10000, 4000,
+        'caveat.public.fixture', NULL, 1, '{}', ?, ?, NULL)`,
+    ).run(
+      'economics_1',
+      'idem_economics_1',
+      'workroom_1',
+      'contract_1',
+      '2026-07-03T11:40:00.000Z',
+      '2026-07-03T11:45:00.000Z',
+    )
+
+    const rows = await selectBusinessFactoryMetrics(
+      new SqliteD1(raw) as unknown as D1Database,
+      {
+        windowStart: '2026-07-03T00:00:00.000Z',
+        windowEnd: '2026-07-04T00:00:00.000Z',
+      },
+    )
+
+    const businessThroughput = rows.find(
+      row =>
+        row.metric_ref === 'business_factory.throughput.accepted_outcomes.v1'
+        && row.work_kind === 'business',
+    )
+    const businessCycleTime = rows.find(
+      row =>
+        row.metric_ref === 'business_factory.cycle_time.accepted_minutes.v1'
+        && row.work_kind === 'business',
+    )
+    const businessPassRate = rows.find(
+      row =>
+        row.metric_ref === 'business_factory.pass_rate.terminal_outcomes_bps.v1'
+        && row.work_kind === 'business',
+    )
+    const businessReviewMinutes = rows.find(
+      row =>
+        row.metric_ref === 'business_factory.review_minutes.v1'
+        && row.work_kind === 'business',
+    )
+    const engagementOperatorMinutes = rows.find(
+      row =>
+        row.metric_ref ===
+          'business_engagement.operator_minutes.review_ledger_floor.v1'
+        && row.engagement_ref === 'business_engagement.opaque.1',
+    )
+
+    expect(businessThroughput).toMatchObject({
+      value: 1,
+      unit: 'outcomes',
+      measurement_state: 'measured',
+    })
+    expect(businessCycleTime).toMatchObject({
+      value: 90,
+      unit: 'minutes',
+      measurement_state: 'measured',
+    })
+    expect(businessPassRate).toMatchObject({
+      numerator: 1,
+      denominator: 2,
+      value: 5000,
+      unit: 'basis_points',
+      measurement_state: 'measured',
+    })
+    expect(businessReviewMinutes).toMatchObject({
+      value: 17,
+      unit: 'minutes',
+      measurement_state: 'measured',
+    })
+    expect(engagementOperatorMinutes).toMatchObject({
+      value: 17,
+      caveat_refs_json:
+        '["caveat.business_metrics.operator_minutes_review_only_until_labor_ledger"]',
+    })
+    expect(JSON.stringify(rows)).not.toContain('lead@example.com')
+  })
+
+  test('marks empty rate windows as not measured instead of fake zero rates', async () => {
+    const rows = await selectBusinessFactoryMetrics(makeDb(), {
+      windowStart: '2026-07-03T00:00:00.000Z',
+      windowEnd: '2026-07-04T00:00:00.000Z',
+    })
+
+    const siteCycleTime = rows.find(
+      row =>
+        row.metric_ref === 'business_factory.cycle_time.accepted_minutes.v1'
+        && row.work_kind === 'site',
+    )
+    const sitePassRate = rows.find(
+      row =>
+        row.metric_ref === 'business_factory.pass_rate.terminal_outcomes_bps.v1'
+        && row.work_kind === 'site',
+    )
+    const siteThroughput = rows.find(
+      row =>
+        row.metric_ref === 'business_factory.throughput.accepted_outcomes.v1'
+        && row.work_kind === 'site',
+    )
+
+    expect(siteThroughput).toMatchObject({
+      value: 0,
+      measurement_state: 'measured',
+    })
+    expect(siteCycleTime).toMatchObject({
+      value: null,
+      measurement_state: 'not_measured',
+      caveat_refs_json:
+        '["caveat.business_metrics.no_accepted_outcomes_in_window"]',
+    })
+    expect(sitePassRate).toMatchObject({
+      value: null,
+      measurement_state: 'not_measured',
+      caveat_refs_json:
+        '["caveat.business_metrics.no_terminal_outcomes_in_window"]',
+    })
+  })
+})

--- a/apps/openagents.com/workers/api/src/business-factory-metrics.ts
+++ b/apps/openagents.com/workers/api/src/business-factory-metrics.ts
@@ -1,0 +1,230 @@
+export type BusinessFactoryMetricMeasurementState =
+  | 'measured'
+  | 'not_measured'
+
+export type BusinessFactoryMetricRow = Readonly<{
+  metric_ref: string
+  metric_name: string
+  grain: 'window' | 'work_kind' | 'engagement'
+  work_kind: string | null
+  engagement_ref: string | null
+  window_start: string
+  window_end: string
+  numerator: number | null
+  denominator: number | null
+  value: number | null
+  unit: 'outcomes' | 'minutes' | 'basis_points'
+  measurement_state: BusinessFactoryMetricMeasurementState
+  evidence_refs_json: string
+  caveat_refs_json: string
+}>
+
+export const BUSINESS_FACTORY_METRICS_SQL = `
+WITH
+  params(window_start, window_end) AS (
+    SELECT ?1, ?2
+  ),
+  work_kinds(work_kind) AS (
+    VALUES
+      ('adjustment'),
+      ('business'),
+      ('coding'),
+      ('existing_project_import'),
+      ('legal_sensitive'),
+      ('site')
+  ),
+  accepted_contracts AS (
+    SELECT
+      c.work_kind,
+      c.id,
+      c.created_at,
+      c.updated_at
+    FROM omni_accepted_outcome_contracts c, params p
+    WHERE c.archived_at IS NULL
+      AND c.acceptance_state = 'accepted'
+      AND c.updated_at >= p.window_start
+      AND c.updated_at < p.window_end
+  ),
+  terminal_contracts AS (
+    SELECT
+      c.work_kind,
+      c.acceptance_state,
+      c.id
+    FROM omni_accepted_outcome_contracts c, params p
+    WHERE c.archived_at IS NULL
+      AND c.acceptance_state IN (
+        'accepted',
+        'rejected',
+        'revision_requested',
+        'unavailable'
+      )
+      AND c.updated_at >= p.window_start
+      AND c.updated_at < p.window_end
+  ),
+  economics_rows AS (
+    SELECT
+      e.id,
+      e.work_kind,
+      e.accepted_outcome_contract_id,
+      e.review_minutes,
+      e.updated_at
+    FROM omni_accepted_outcome_economics e, params p
+    WHERE e.archived_at IS NULL
+      AND e.updated_at >= p.window_start
+      AND e.updated_at < p.window_end
+  ),
+  engagement_review_rows AS (
+    SELECT
+      COALESCE(NULLIF(c.customer_ref, ''), c.subject_ref) AS engagement_ref,
+      e.review_minutes,
+      e.id AS economics_id
+    FROM economics_rows e
+    INNER JOIN omni_accepted_outcome_contracts c
+      ON c.id = e.accepted_outcome_contract_id
+    WHERE c.archived_at IS NULL
+      AND COALESCE(NULLIF(c.customer_ref, ''), c.subject_ref) IS NOT NULL
+  )
+SELECT
+  'business_factory.throughput.accepted_outcomes.v1' AS metric_ref,
+  'accepted outcome throughput' AS metric_name,
+  'work_kind' AS grain,
+  wk.work_kind AS work_kind,
+  NULL AS engagement_ref,
+  p.window_start AS window_start,
+  p.window_end AS window_end,
+  COUNT(ac.id) AS numerator,
+  NULL AS denominator,
+  COUNT(ac.id) AS value,
+  'outcomes' AS unit,
+  'measured' AS measurement_state,
+  '["table.omni_accepted_outcome_contracts"]' AS evidence_refs_json,
+  '[]' AS caveat_refs_json
+FROM work_kinds wk
+CROSS JOIN params p
+LEFT JOIN accepted_contracts ac
+  ON ac.work_kind = wk.work_kind
+GROUP BY wk.work_kind
+
+UNION ALL
+
+SELECT
+  'business_factory.cycle_time.accepted_minutes.v1' AS metric_ref,
+  'accepted outcome cycle time' AS metric_name,
+  'work_kind' AS grain,
+  wk.work_kind AS work_kind,
+  NULL AS engagement_ref,
+  p.window_start AS window_start,
+  p.window_end AS window_end,
+  COUNT(ac.id) AS numerator,
+  COUNT(ac.id) AS denominator,
+  CASE
+    WHEN COUNT(ac.id) = 0 THEN NULL
+    ELSE ROUND(AVG((julianday(ac.updated_at) - julianday(ac.created_at)) * 1440.0), 2)
+  END AS value,
+  'minutes' AS unit,
+  CASE WHEN COUNT(ac.id) = 0 THEN 'not_measured' ELSE 'measured' END AS measurement_state,
+  '["table.omni_accepted_outcome_contracts"]' AS evidence_refs_json,
+  CASE
+    WHEN COUNT(ac.id) = 0
+      THEN '["caveat.business_metrics.no_accepted_outcomes_in_window"]'
+    ELSE '[]'
+  END AS caveat_refs_json
+FROM work_kinds wk
+CROSS JOIN params p
+LEFT JOIN accepted_contracts ac
+  ON ac.work_kind = wk.work_kind
+GROUP BY wk.work_kind
+
+UNION ALL
+
+SELECT
+  'business_factory.pass_rate.terminal_outcomes_bps.v1' AS metric_ref,
+  'terminal outcome pass rate' AS metric_name,
+  'work_kind' AS grain,
+  wk.work_kind AS work_kind,
+  NULL AS engagement_ref,
+  p.window_start AS window_start,
+  p.window_end AS window_end,
+  SUM(CASE WHEN tc.acceptance_state = 'accepted' THEN 1 ELSE 0 END) AS numerator,
+  COUNT(tc.id) AS denominator,
+  CASE
+    WHEN COUNT(tc.id) = 0 THEN NULL
+    ELSE ROUND(
+      SUM(CASE WHEN tc.acceptance_state = 'accepted' THEN 1 ELSE 0 END) * 10000.0
+      / COUNT(tc.id),
+      0
+    )
+  END AS value,
+  'basis_points' AS unit,
+  CASE WHEN COUNT(tc.id) = 0 THEN 'not_measured' ELSE 'measured' END AS measurement_state,
+  '["table.omni_accepted_outcome_contracts"]' AS evidence_refs_json,
+  CASE
+    WHEN COUNT(tc.id) = 0
+      THEN '["caveat.business_metrics.no_terminal_outcomes_in_window"]'
+    ELSE '[]'
+  END AS caveat_refs_json
+FROM work_kinds wk
+CROSS JOIN params p
+LEFT JOIN terminal_contracts tc
+  ON tc.work_kind = wk.work_kind
+GROUP BY wk.work_kind
+
+UNION ALL
+
+SELECT
+  'business_factory.review_minutes.v1' AS metric_ref,
+  'ledgered review minutes' AS metric_name,
+  'work_kind' AS grain,
+  wk.work_kind AS work_kind,
+  NULL AS engagement_ref,
+  p.window_start AS window_start,
+  p.window_end AS window_end,
+  COALESCE(SUM(er.review_minutes), 0) AS numerator,
+  COUNT(er.accepted_outcome_contract_id) AS denominator,
+  COALESCE(SUM(er.review_minutes), 0) AS value,
+  'minutes' AS unit,
+  'measured' AS measurement_state,
+  '["table.omni_accepted_outcome_economics"]' AS evidence_refs_json,
+  '[]' AS caveat_refs_json
+FROM work_kinds wk
+CROSS JOIN params p
+LEFT JOIN economics_rows er
+  ON er.work_kind = wk.work_kind
+GROUP BY wk.work_kind
+
+UNION ALL
+
+SELECT
+  'business_engagement.operator_minutes.review_ledger_floor.v1' AS metric_ref,
+  'operator minutes per engagement review-ledger floor' AS metric_name,
+  'engagement' AS grain,
+  NULL AS work_kind,
+  engagement_ref AS engagement_ref,
+  p.window_start AS window_start,
+  p.window_end AS window_end,
+  SUM(review_minutes) AS numerator,
+  COUNT(economics_id) AS denominator,
+  SUM(review_minutes) AS value,
+  'minutes' AS unit,
+  'measured' AS measurement_state,
+  '["table.omni_accepted_outcome_economics","table.omni_accepted_outcome_contracts"]' AS evidence_refs_json,
+  '["caveat.business_metrics.operator_minutes_review_only_until_labor_ledger"]' AS caveat_refs_json
+FROM engagement_review_rows, params p
+GROUP BY engagement_ref
+ORDER BY metric_ref, grain, work_kind, engagement_ref
+`
+
+export const selectBusinessFactoryMetrics = async (
+  db: D1Database,
+  input: Readonly<{
+    windowStart: string
+    windowEnd: string
+  }>,
+): Promise<ReadonlyArray<BusinessFactoryMetricRow>> => {
+  const result = await db
+    .prepare(BUSINESS_FACTORY_METRICS_SQL)
+    .bind(input.windowStart, input.windowEnd)
+    .all<BusinessFactoryMetricRow>()
+
+  return result.results
+}

--- a/docs/fable/2026-07-03-bf-7-2-locked-business-factory-metrics.md
+++ b/docs/fable/2026-07-03-bf-7-2-locked-business-factory-metrics.md
@@ -1,0 +1,149 @@
+# BF-7.2 Locked Business Factory Metrics
+
+Date: 2026-07-03
+Status: definitions and query contract for
+[`ROADMAP_BIZ.md`](./ROADMAP_BIZ.md) BF-7.2 / issue #8106. This document
+does not flip promise state, broaden product copy, or publish a dashboard.
+
+The rule is simple: a metric can appear on a dashboard only when the backing
+query returns an auditable row with `measurement_state = 'measured'`. If the
+ledger needed for a metric does not exist, the query must return
+`measurement_state = 'not_measured'` with a caveat ref instead of emitting a
+zero, estimate, or manually-entered value.
+
+## Privacy Boundary
+
+Metric rows may contain only:
+
+- opaque refs such as `business_engagement.*`, `contract.*`, `workroom.*`, or
+  public receipt refs;
+- coarse work kind, source kind, stage, and time-window labels;
+- aggregate counts, minutes, basis points, and rates.
+
+Metric rows must not contain names, emails, phone numbers, raw client prompts,
+raw provider payloads, wallet material, customer documents, local paths, or
+client-identifying free text. If a source table carries sensitive data, the
+metric query must use its opaque ref columns only.
+
+## Metric Contract
+
+Every query row uses the same shape:
+
+| Field | Meaning |
+| --- | --- |
+| `metric_ref` | Stable metric id, e.g. `business_factory.throughput.accepted_outcomes.v1`. |
+| `grain` | `window`, `work_kind`, or `engagement`. |
+| `work_kind` | Work class when grouped; otherwise `NULL`. |
+| `engagement_ref` | Opaque engagement ref when grouped; otherwise `NULL`. |
+| `window_start`, `window_end` | Inclusive lower bound and exclusive upper bound used by the query. |
+| `numerator`, `denominator`, `value` | Raw count/minute/rate components. Rates are basis points unless the unit says otherwise. |
+| `unit` | `outcomes`, `minutes`, or `basis_points`. |
+| `measurement_state` | `measured` or `not_measured`. No unaudited metric may report as measured. |
+| `evidence_refs_json` | JSON array of source-table/query refs. |
+| `caveat_refs_json` | JSON array of public-safe caveats. Empty for fully audited rows. |
+
+## Locked Definitions
+
+### Throughput
+
+`business_factory.throughput.accepted_outcomes.v1`
+
+Accepted outcome count in the window, grouped by `work_kind`.
+
+Formula:
+
+```text
+count(omni_accepted_outcome_contracts)
+where acceptance_state = 'accepted'
+  and archived_at is null
+  and updated_at in [window_start, window_end)
+```
+
+Unit: `outcomes`. A zero count is measured because the contract ledger is the
+source of truth.
+
+### Cycle Time
+
+`business_factory.cycle_time.accepted_minutes.v1`
+
+Average minutes from accepted-outcome contract creation to accepted closeout,
+grouped by `work_kind`.
+
+Formula:
+
+```text
+avg(updated_at - created_at in minutes)
+where acceptance_state = 'accepted'
+  and archived_at is null
+  and updated_at in [window_start, window_end)
+```
+
+Unit: `minutes`. If there are no accepted outcomes in the window, the row is
+`not_measured`; it is not zero minutes.
+
+### Pass Rate
+
+`business_factory.pass_rate.terminal_outcomes_bps.v1`
+
+Accepted outcomes divided by terminal reviewed outcomes, grouped by
+`work_kind`.
+
+Formula:
+
+```text
+accepted_count / terminal_count * 10000
+where terminal states are accepted, rejected, revision_requested, unavailable
+```
+
+Unit: `basis_points`. If there are no terminal outcomes in the window, the row
+is `not_measured`; it is not a 0% or 100% pass rate.
+
+### Review Minutes
+
+`business_factory.review_minutes.v1`
+
+Ledgered human review minutes recorded on accepted-outcome economics rows,
+grouped by `work_kind`.
+
+Formula:
+
+```text
+sum(omni_accepted_outcome_economics.review_minutes)
+where archived_at is null
+  and updated_at in [window_start, window_end)
+```
+
+Unit: `minutes`. The economics row is the audit receipt; no review-minute
+dashboard may use issue comments, free-form notes, or estimates.
+
+### Operator Minutes Per Engagement
+
+`business_engagement.operator_minutes.review_ledger_floor.v1`
+
+Current auditable lower bound for operator minutes per engagement. It sums
+ledgered review minutes by opaque engagement ref. Until a broader
+operator-labor event ledger exists, this metric must carry
+`caveat.business_metrics.operator_minutes_review_only_until_labor_ledger`.
+
+Formula:
+
+```text
+sum(omni_accepted_outcome_economics.review_minutes)
+joined to omni_accepted_outcome_contracts
+grouped by coalesce(customer_ref, subject_ref)
+```
+
+Unit: `minutes`. This is dashboard-eligible only with the caveat shown next to
+it. Any future broader operator-minute metric must add a first-class labor
+ledger and update this document and the query pack in the same PR.
+
+## Instrumented Query Pack
+
+The SQL source of truth is
+[`apps/openagents.com/workers/api/src/business-factory-metrics.sql`](../../apps/openagents.com/workers/api/src/business-factory-metrics.sql).
+The Worker helper
+[`business-factory-metrics.ts`](../../apps/openagents.com/workers/api/src/business-factory-metrics.ts)
+runs the same queries against D1, and
+[`business-factory-metrics.test.ts`](../../apps/openagents.com/workers/api/src/business-factory-metrics.test.ts)
+asserts measured rows, `not_measured` rows, and public-safe refs.
+


### PR DESCRIPTION
## Summary

Closes #8106.

- Adds the BF-7.2 locked metric definitions doc for throughput, cycle time, pass rate, review-minutes, and operator-minutes per engagement.
- Adds an auditable SQL query pack plus a Worker D1 helper for the normalized metric rows.
- Adds regression coverage that measured rows come from existing ledgers and empty rate windows return `not_measured` instead of fake zero rates.

## Verification

- `bun run --cwd apps/openagents.com/workers/api test -- src/business-factory-metrics.test.ts` PASS: 3 tests passed.
- `bun run --cwd apps/openagents.com/workers/api typecheck` PASS.
- `bun run check:deploy` PASS: completed the pinned deploy check, including architecture/contract/freshness guards, web/API typechecks, and the listed web/API test suites.
