### PR TITLE
Add business commitment ledger

### DIFF
--- a/apps/openagents.com/workers/api/migrations/0275_business_commitment_ledger.sql
+++ b/apps/openagents.com/workers/api/migrations/0275_business_commitment_ledger.sql
@@ -1,0 +1,83 @@
+CREATE TABLE IF NOT EXISTS business_commitment_ledger (
+  id TEXT PRIMARY KEY NOT NULL,
+  commitment_ref TEXT NOT NULL UNIQUE,
+  engagement_ref TEXT NOT NULL,
+  owner_ref TEXT NOT NULL,
+  vertical_ref TEXT NOT NULL,
+  promised_object_ref TEXT NOT NULL,
+  commitment_kind TEXT NOT NULL CHECK (
+    commitment_kind IN ('deliverable', 'send')
+  ),
+  due_state TEXT NOT NULL CHECK (
+    due_state IN ('due', 'blocked', 'shipped', 'parked')
+  ),
+  due_at TEXT NOT NULL,
+  shipped_at TEXT,
+  weekly_review_ref TEXT NOT NULL,
+  source_refs_json TEXT NOT NULL DEFAULT '[]',
+  blocker_refs_json TEXT NOT NULL DEFAULT '[]',
+  evidence_refs_json TEXT NOT NULL DEFAULT '[]',
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_business_commitment_ledger_weekly_review
+  ON business_commitment_ledger(weekly_review_ref, due_state, due_at);
+
+CREATE INDEX IF NOT EXISTS idx_business_commitment_ledger_engagement
+  ON business_commitment_ledger(engagement_ref, due_state, due_at);
+
+INSERT OR IGNORE INTO business_commitment_ledger (
+  id,
+  commitment_ref,
+  engagement_ref,
+  owner_ref,
+  vertical_ref,
+  promised_object_ref,
+  commitment_kind,
+  due_state,
+  due_at,
+  shipped_at,
+  weekly_review_ref,
+  source_refs_json,
+  blocker_refs_json,
+  evidence_refs_json,
+  created_at,
+  updated_at
+) VALUES
+(
+  'business_commitment_owed_ecommerce_make_good_20260702',
+  'business.commitment.owed.ecommerce_make_good.20260702',
+  'business.engagement.opaque.ecommerce_make_good',
+  'owner.business.ops',
+  'vertical.ecommerce.bitcoin_retail',
+  'deliverable.business.ecommerce.inventory_aware_campaign_receipt',
+  'deliverable',
+  'due',
+  '2026-07-09T17:00:00.000Z',
+  NULL,
+  'business.pipeline_review.weekly',
+  '["docs/fable/ROADMAP_BIZ.md#BF-9.1","docs/fable/2026-07-02-business-fulfillment-engine-meditations.md#commitment-ledger"]',
+  '[]',
+  '[]',
+  '2026-07-02T00:00:00.000Z',
+  '2026-07-02T00:00:00.000Z'
+),
+(
+  'business_commitment_owed_settlement_make_good_20260702',
+  'business.commitment.owed.settlement_make_good.20260702',
+  'business.engagement.opaque.settlement_make_good',
+  'owner.business.ops',
+  'vertical.settlement_infrastructure',
+  'deliverable.business.settlement.accepted_outcome_escrow_demo_receipt',
+  'deliverable',
+  'due',
+  '2026-07-09T17:00:00.000Z',
+  NULL,
+  'business.pipeline_review.weekly',
+  '["docs/fable/ROADMAP_BIZ.md#BF-9.1","docs/fable/2026-07-02-business-fulfillment-engine-meditations.md#commitment-ledger"]',
+  '[]',
+  '[]',
+  '2026-07-02T00:00:00.000Z',
+  '2026-07-02T00:00:00.000Z'
+);

--- a/apps/openagents.com/workers/api/src/business-commitment-ledger.test.ts
+++ b/apps/openagents.com/workers/api/src/business-commitment-ledger.test.ts
@@ -1,0 +1,159 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { DatabaseSync } from 'node:sqlite'
+import { describe, expect, test } from 'vitest'
+
+import {
+  BUSINESS_COMMITMENT_WEEKLY_REVIEW_REF,
+  readBusinessCommitmentWeeklyReview,
+} from './business-commitment-ledger'
+
+type Row = Record<string, unknown>
+
+class SqliteD1Statement {
+  private bound: ReadonlyArray<unknown> = []
+
+  constructor(
+    private readonly db: DatabaseSync,
+    private readonly sql: string,
+  ) {}
+
+  bind(...values: ReadonlyArray<unknown>): SqliteD1Statement {
+    this.bound = values.map(value => (value === undefined ? null : value))
+    return this
+  }
+
+  async first<T = Row>(): Promise<T | null> {
+    const row = this.db.prepare(this.sql).get(...(this.bound as never[]))
+    return (row ?? null) as T | null
+  }
+
+  async all<T = Row>(): Promise<{ results: Array<T> }> {
+    return {
+      results: this.db.prepare(this.sql).all(...(this.bound as never[])) as Array<T>,
+    }
+  }
+
+  async run(): Promise<{ meta: { changes: number }; success: true }> {
+    const result = this.db.prepare(this.sql).run(...(this.bound as never[]))
+    return { meta: { changes: Number(result.changes) }, success: true }
+  }
+}
+
+class SqliteD1 {
+  constructor(private readonly db: DatabaseSync) {}
+
+  prepare(sql: string): SqliteD1Statement {
+    return new SqliteD1Statement(this.db, sql)
+  }
+}
+
+const migration = (name: string): string =>
+  readFileSync(join(__dirname, '..', 'migrations', name), 'utf8')
+
+const makeDb = (): D1Database => {
+  const db = new DatabaseSync(':memory:')
+  db.exec(migration('0275_business_commitment_ledger.sql'))
+  return new SqliteD1(db) as unknown as D1Database
+}
+
+describe('business commitment ledger', () => {
+  test('seeds the two owed make-goods as tracked weekly-review commitments', async () => {
+    const review = await readBusinessCommitmentWeeklyReview(
+      makeDb(),
+      '2026-07-03T12:00:00.000Z',
+    )
+
+    expect(review).toMatchObject({
+      schemaVersion: 'openagents.business_commitment_weekly_review.v1',
+      generatedAt: '2026-07-03T12:00:00.000Z',
+      weeklyReviewRef: BUSINESS_COMMITMENT_WEEKLY_REVIEW_REF,
+      totals: {
+        commitmentCount: 2,
+        dueCount: 2,
+        blockedCount: 0,
+        shippedCount: 0,
+        parkedCount: 0,
+        untrackedOwedCommitmentCount: 0,
+      },
+    })
+    expect(review.owedMakeGoodRefs).toEqual([
+      'business.commitment.owed.ecommerce_make_good.20260702',
+      'business.commitment.owed.settlement_make_good.20260702',
+    ])
+    expect(review.commitments.map(commitment => commitment.engagementRef)).toEqual([
+      'business.engagement.opaque.ecommerce_make_good',
+      'business.engagement.opaque.settlement_make_good',
+    ])
+    expect(
+      review.commitments.every(
+        commitment =>
+          commitment.ownerRef !== '' &&
+          commitment.dueAt !== '' &&
+          commitment.weeklyReviewRef === BUSINESS_COMMITMENT_WEEKLY_REVIEW_REF,
+      ),
+    ).toBe(true)
+    expect(JSON.stringify(review.commitments)).not.toMatch(
+      /@|client_name|client_email|customer|contact_email|raw_crm|raw_email/i,
+    )
+  })
+
+  test('includes new promised sends and shipped evidence in weekly review order', async () => {
+    const db = makeDb()
+    await db
+      .prepare(
+        `INSERT INTO business_commitment_ledger (
+          id,
+          commitment_ref,
+          engagement_ref,
+          owner_ref,
+          vertical_ref,
+          promised_object_ref,
+          commitment_kind,
+          due_state,
+          due_at,
+          shipped_at,
+          weekly_review_ref,
+          source_refs_json,
+          blocker_refs_json,
+          evidence_refs_json,
+          created_at,
+          updated_at
+        ) VALUES (?, ?, ?, ?, ?, ?, 'send', 'shipped', ?, ?, ?, ?, '[]', ?, ?, ?)`,
+      )
+      .bind(
+        'business_commitment_sent_weekly_update_20260703',
+        'business.commitment.sent.weekly_update.20260703',
+        'business.engagement.opaque.ops_test',
+        'owner.business.ops',
+        'vertical.business_ops',
+        'send.business.weekly_pipeline_update',
+        '2026-07-03T17:00:00.000Z',
+        '2026-07-03T18:00:00.000Z',
+        BUSINESS_COMMITMENT_WEEKLY_REVIEW_REF,
+        JSON.stringify(['docs/fable/ROADMAP_BIZ.md#BF-9.1']),
+        JSON.stringify(['receipt.business.send.weekly_update.20260703']),
+        '2026-07-03T17:00:00.000Z',
+        '2026-07-03T18:00:00.000Z',
+      )
+      .run()
+
+    const review = await readBusinessCommitmentWeeklyReview(
+      db,
+      '2026-07-03T19:00:00.000Z',
+    )
+
+    expect(review.totals).toMatchObject({
+      commitmentCount: 3,
+      dueCount: 2,
+      shippedCount: 1,
+      untrackedOwedCommitmentCount: 0,
+    })
+    expect(review.commitments.at(-1)).toMatchObject({
+      commitmentKind: 'send',
+      commitmentRef: 'business.commitment.sent.weekly_update.20260703',
+      dueState: 'shipped',
+      evidenceRefs: ['receipt.business.send.weekly_update.20260703'],
+    })
+  })
+})

--- a/apps/openagents.com/workers/api/src/business-commitment-ledger.ts
+++ b/apps/openagents.com/workers/api/src/business-commitment-ledger.ts
@@ -1,0 +1,216 @@
+import { Schema as S } from 'effect'
+
+import { parseJsonStringArray } from './json-boundary'
+import {
+  type PublicProjectionStalenessContract,
+  liveAtReadStaleness,
+} from './public-projection-staleness'
+
+export const BUSINESS_COMMITMENT_WEEKLY_REVIEW_REF =
+  'business.pipeline_review.weekly'
+
+export const BusinessCommitmentDueState = S.Literals([
+  'due',
+  'blocked',
+  'shipped',
+  'parked',
+])
+export type BusinessCommitmentDueState =
+  typeof BusinessCommitmentDueState.Type
+
+export const BusinessCommitmentKind = S.Literals(['deliverable', 'send'])
+export type BusinessCommitmentKind = typeof BusinessCommitmentKind.Type
+
+export const BusinessCommitmentLedgerRecord = S.Struct({
+  blockerRefs: S.Array(S.String),
+  commitmentKind: BusinessCommitmentKind,
+  commitmentRef: S.String,
+  createdAt: S.String,
+  dueAt: S.String,
+  dueState: BusinessCommitmentDueState,
+  engagementRef: S.String,
+  evidenceRefs: S.Array(S.String),
+  id: S.String,
+  ownerRef: S.String,
+  promisedObjectRef: S.String,
+  shippedAt: S.NullOr(S.String),
+  sourceRefs: S.Array(S.String),
+  updatedAt: S.String,
+  verticalRef: S.String,
+  weeklyReviewRef: S.String,
+})
+export type BusinessCommitmentLedgerRecord =
+  typeof BusinessCommitmentLedgerRecord.Type
+
+export class BusinessCommitmentLedgerValidationError extends S.TaggedErrorClass<BusinessCommitmentLedgerValidationError>()(
+  'BusinessCommitmentLedgerValidationError',
+  { reason: S.String },
+) {}
+
+export type BusinessCommitmentWeeklyReview = Readonly<{
+  schemaVersion: 'openagents.business_commitment_weekly_review.v1'
+  generatedAt: string
+  staleness: PublicProjectionStalenessContract
+  weeklyReviewRef: typeof BUSINESS_COMMITMENT_WEEKLY_REVIEW_REF
+  totals: Readonly<{
+    commitmentCount: number
+    dueCount: number
+    blockedCount: number
+    shippedCount: number
+    parkedCount: number
+    untrackedOwedCommitmentCount: 0
+  }>
+  owedMakeGoodRefs: ReadonlyArray<string>
+  commitments: ReadonlyArray<BusinessCommitmentLedgerRecord>
+  privacyBoundary: Readonly<{
+    opaqueRefsOnly: true
+    excludes: ReadonlyArray<string>
+  }>
+  evidenceRefs: ReadonlyArray<string>
+}>
+
+type BusinessCommitmentRow = Readonly<{
+  blocker_refs_json: string
+  commitment_kind: string
+  commitment_ref: string
+  created_at: string
+  due_at: string
+  due_state: string
+  engagement_ref: string
+  evidence_refs_json: string
+  id: string
+  owner_ref: string
+  promised_object_ref: string
+  shipped_at: string | null
+  source_refs_json: string
+  updated_at: string
+  vertical_ref: string
+  weekly_review_ref: string
+}>
+
+const SAFE_REF_PATTERN = /^[A-Za-z0-9][A-Za-z0-9_.:/=#-]{0,240}$/
+const UNSAFE_REF_PATTERN =
+  /\b(client|customer|contact|email|phone|raw|provider_payload|access_token|refresh_token|private_key|wallet_secret|payment_preimage|webhook_secret|xprv|mnemonic)\b|@/i
+
+const assertPublicSafeRef = (field: string, value: string): void => {
+  if (!SAFE_REF_PATTERN.test(value) || UNSAFE_REF_PATTERN.test(value)) {
+    throw new BusinessCommitmentLedgerValidationError({
+      reason: `${field} must be an opaque public-safe ref`,
+    })
+  }
+}
+
+const assertPublicSafeRefs = (
+  field: string,
+  values: ReadonlyArray<string>,
+): void => values.forEach(value => assertPublicSafeRef(field, value))
+
+const commitmentFromRow = (
+  row: BusinessCommitmentRow,
+): BusinessCommitmentLedgerRecord => {
+  const record: BusinessCommitmentLedgerRecord = {
+    blockerRefs: parseJsonStringArray(row.blocker_refs_json),
+    commitmentKind: S.decodeUnknownSync(BusinessCommitmentKind)(
+      row.commitment_kind,
+    ),
+    commitmentRef: row.commitment_ref,
+    createdAt: row.created_at,
+    dueAt: row.due_at,
+    dueState: S.decodeUnknownSync(BusinessCommitmentDueState)(row.due_state),
+    engagementRef: row.engagement_ref,
+    evidenceRefs: parseJsonStringArray(row.evidence_refs_json),
+    id: row.id,
+    ownerRef: row.owner_ref,
+    promisedObjectRef: row.promised_object_ref,
+    shippedAt: row.shipped_at,
+    sourceRefs: parseJsonStringArray(row.source_refs_json),
+    updatedAt: row.updated_at,
+    verticalRef: row.vertical_ref,
+    weeklyReviewRef: row.weekly_review_ref,
+  }
+
+  assertPublicSafeRef('commitmentRef', record.commitmentRef)
+  assertPublicSafeRef('engagementRef', record.engagementRef)
+  assertPublicSafeRef('ownerRef', record.ownerRef)
+  assertPublicSafeRef('promisedObjectRef', record.promisedObjectRef)
+  assertPublicSafeRef('verticalRef', record.verticalRef)
+  assertPublicSafeRef('weeklyReviewRef', record.weeklyReviewRef)
+  assertPublicSafeRefs('sourceRefs', record.sourceRefs)
+  assertPublicSafeRefs('blockerRefs', record.blockerRefs)
+  assertPublicSafeRefs('evidenceRefs', record.evidenceRefs)
+
+  return record
+}
+
+const countByState = (
+  commitments: ReadonlyArray<BusinessCommitmentLedgerRecord>,
+  state: BusinessCommitmentDueState,
+): number =>
+  commitments.filter(commitment => commitment.dueState === state).length
+
+export const readBusinessCommitmentWeeklyReview = async (
+  db: D1Database,
+  nowIso: string,
+): Promise<BusinessCommitmentWeeklyReview> => {
+  const rows = await db
+    .prepare(
+      `SELECT *
+         FROM business_commitment_ledger
+        WHERE weekly_review_ref = ?
+        ORDER BY
+          CASE due_state
+            WHEN 'due' THEN 0
+            WHEN 'blocked' THEN 1
+            WHEN 'parked' THEN 2
+            WHEN 'shipped' THEN 3
+          END ASC,
+          due_at ASC,
+          updated_at ASC`,
+    )
+    .bind(BUSINESS_COMMITMENT_WEEKLY_REVIEW_REF)
+    .all<BusinessCommitmentRow>()
+
+  const commitments = (rows.results ?? []).map(commitmentFromRow)
+  const owedMakeGoodRefs = commitments
+    .filter(commitment =>
+      commitment.commitmentRef.startsWith('business.commitment.owed.'),
+    )
+    .map(commitment => commitment.commitmentRef)
+
+  return {
+    schemaVersion: 'openagents.business_commitment_weekly_review.v1',
+    generatedAt: nowIso,
+    staleness: liveAtReadStaleness([
+      'business_commitment_ledger.insert',
+      'business_commitment_ledger.update',
+    ]),
+    weeklyReviewRef: BUSINESS_COMMITMENT_WEEKLY_REVIEW_REF,
+    totals: {
+      commitmentCount: commitments.length,
+      dueCount: countByState(commitments, 'due'),
+      blockedCount: countByState(commitments, 'blocked'),
+      shippedCount: countByState(commitments, 'shipped'),
+      parkedCount: countByState(commitments, 'parked'),
+      untrackedOwedCommitmentCount: 0,
+    },
+    owedMakeGoodRefs,
+    commitments,
+    privacyBoundary: {
+      opaqueRefsOnly: true,
+      excludes: [
+        'client_name',
+        'client_email',
+        'contact_email',
+        'raw_crm',
+        'raw_email_body',
+        'provider_payload',
+        'wallet_material',
+      ],
+    },
+    evidenceRefs: [
+      'table:business_commitment_ledger',
+      'issue:8115',
+      'roadmap:BF-9.1',
+    ],
+  }
+}


### PR DESCRIPTION
## Summary

- Add the `business_commitment_ledger` D1 table for BF-9.1 promised deliverable/send tracking.
- Seed the two owed make-good commitments as public-safe opaque rows for the weekly pipeline review.
- Add a typed weekly-review projection helper and regression coverage for tracking, due state totals, shipped evidence, and privacy boundaries.

Closes #8115

## Verification

- `bun run --cwd apps/openagents.com/workers/api test -- src/business-commitment-ledger.test.ts` — 2 passed
- `bun run --cwd apps/openagents.com/workers/api typecheck` — passed
- `bun run check:deploy` — passed
