### PR TITLE
BF-9.2 weekly pipeline review artifact

### DIFF
--- a/docs/fable/2026-07-03-bf-9-2-weekly-pipeline-review.md
+++ b/docs/fable/2026-07-03-bf-9-2-weekly-pipeline-review.md
@@ -1,0 +1,121 @@
+# BF-9.2 Weekly Pipeline Review
+
+Date: 2026-07-03
+Status: BF-9.2 operating artifact; no promise state flip; no public copy change
+Source issue: OpenAgentsInc/openagents#8116
+Roadmap refs: [`ROADMAP_BIZ.md`](./ROADMAP_BIZ.md) BF-9.2 and
+[`ROADMAP_AFTER.md`](./ROADMAP_AFTER.md) AW-0 A0.3
+
+This is the public-safe weekly review artifact for the business pipeline:
+intake -> scope -> receipt-plan -> close. It turns the sales motion into a
+queue with instruments instead of an ad hoc owner memory. It records only
+vertical descriptors and opaque refs. Client names, contact details, raw call
+notes, private requirements, payment identifiers, and shared-channel content do
+not belong in this file.
+
+## Review Cadence
+
+- Owner review: weekly, before any public case-study or promise-copy decision.
+- Review window: trailing seven days, closed at the review timestamp.
+- Source of truth: structured intake rows, scoped-call notes after redaction,
+  receipt-plan records, payment or close receipts, and commitment-ledger rows.
+- Output: one dated review entry with metric deltas, queue movements, blockers,
+  commitment checks, and next actions.
+
+## Stage Contract
+
+| Stage | Queue state | Entry receipt | Exit receipt | Primary metric |
+| --- | --- | --- | --- | --- |
+| Intake | `intake_received` | Business signup, vertical form, referred lead, or operator-entered opaque lead ref | Qualified or rejected intake decision | qualified intakes |
+| Scope | `scope_scheduled` / `scope_completed` | Qualified intake with source attribution | Buyer-confirmed scope summary | intake-to-scope rate |
+| Receipt plan | `receipt_plan_sent` | Confirmed scope summary | Receipt plan accepted or rejected | time-to-receipt-plan |
+| Close | `closed_won` / `closed_lost` | Accepted receipt plan | Payment, signed kickoff, or explicit lost reason | close rate |
+| Quick win | `quick_win_started` / `quick_win_delivered` | Closed-won engagement | First accepted outcome receipt | time-to-quick-win |
+
+Every row must carry:
+
+- `pipelineRef`: opaque stable ref, for example `biz-pipe-2026w27-001`.
+- `vertical`: non-identifying descriptor such as `legal`, `agency`,
+  `e-commerce`, `health`, or `internal`.
+- `sourceRef`: public-safe attribution ref, not raw UTM or private contact data.
+- `stage`: one of the queue states above.
+- `ownerRole`: role label only, such as `operator`, `reviewer`, or
+  `fulfillment-agent`.
+- `nextActionDueAt`: date or `none`.
+- `blockerRef`: typed blocker or `none`.
+- `receiptRefs`: public-safe refs for the current stage receipts.
+
+## Weekly Metrics
+
+| Metric | Definition | Review rule |
+| --- | --- | --- |
+| Qualified intakes | Count of `intake_received` rows accepted into scope during the window | Split by vertical and source; rejected rows need a typed reason. |
+| Scope calls completed | Count of qualified intakes that reached `scope_completed` | Any no-show or reschedule older than seven days gets a blocker. |
+| Intake-to-scope rate | `scope_completed / qualified_intakes` | Report as `pending` when denominator is zero; never fabricate a rate. |
+| Receipt plans sent | Count of `receipt_plan_sent` rows | Each plan must name deliverables, review gates, receipts, and non-goals. |
+| Scope-to-plan time | Median elapsed time from `scope_completed` to `receipt_plan_sent` | Use `pending` until at least one completed elapsed interval exists. |
+| Close rate | `closed_won / receipt_plan_decisions` | Decisions are `closed_won + closed_lost`; parked rows are not decisions. |
+| Time-to-quick-win | Median elapsed time from `closed_won` to first accepted outcome receipt | Use `not_started` when no closed-won row has reached delivery. |
+| Commitment coverage | Count of promised sends/deliverables with commitment-ledger rows | Must be 100%; missing rows are defects under BF-9.1. |
+| Overclaim incidents | Count of public or buyer-facing statements not backed by a receipt/promise gate | Target is zero; any incident creates a copy-gate follow-up. |
+
+## Review Entry: 2026-W27
+
+Status: scaffolded baseline review. The queue instrumentation exists as a
+review artifact; live data rows are not asserted by this document.
+
+| Metric | Value | Evidence |
+| --- | --- | --- |
+| Qualified intakes | `pending` | Instrument defined above; awaiting first redacted weekly data pull. |
+| Scope calls completed | `pending` | Instrument defined above. |
+| Intake-to-scope rate | `pending` | No denominator asserted in this public checkout. |
+| Receipt plans sent | `pending` | Receipt-plan contract defined above. |
+| Scope-to-plan time | `pending` | No completed elapsed interval asserted. |
+| Close rate | `pending` | No receipt-plan decisions asserted. |
+| Time-to-quick-win | `not_started` | No closed-won quick-win row asserted. |
+| Commitment coverage | `pending` | BF-9.1 ledger rows must be reviewed in this packet once live. |
+| Overclaim incidents | `0 asserted` | This artifact adds no claim-bearing public copy. |
+
+### Queue Movements
+
+No live pipeline movements are asserted in this public checkout. Future weekly
+entries should use this shape:
+
+| Pipeline ref | Vertical | From | To | Receipt ref | Next action |
+| --- | --- | --- | --- | --- | --- |
+| `biz-pipe-YYYYwNN-000` | `vertical` | `stage` | `stage` | `receipt.ref` | `role: action by YYYY-MM-DD` |
+
+### Commitment Check
+
+Every promised deliverable, follow-up send, or buyer-facing receipt-plan item
+must have a commitment-ledger row before the review can close. A missing row is
+reported as:
+
+```text
+BLOCKER: commitment.untracked pipelineRef=<opaque-ref> vertical=<descriptor>
+```
+
+### Copy And Promise Gate
+
+- Do not publish buyer-facing copy from this review.
+- Do not imply self-serve service delivery, guaranteed outcomes, referral
+  payouts, or regulated-professional service capability unless the matching
+  promise record and receipt gate are green for that exact claim.
+- Case-study candidates require public-safe receipts, opaque refs, and a
+  separate copy-gate pass before publication.
+
+## Weekly Closeout Checklist
+
+- [ ] All active pipeline rows have a current queue state.
+- [ ] Every stage movement has a receipt ref.
+- [ ] Every parked or blocked row has a typed blocker and next review date.
+- [ ] Every promised send or deliverable has a commitment-ledger row.
+- [ ] Metrics use `pending`, `not_started`, or `not_measured` instead of
+      invented values when data is absent.
+- [ ] No client-identifying information appears in the review.
+- [ ] No public copy or promise state is broadened by the review.
+
+BF-9.2 is satisfied for this issue by the existence of this review artifact and
+the instrument definitions above. Future implementation work can replace the
+manual review values with generated rows, but the public-safety and receipt
+rules stay the contract.

--- a/docs/fable/README.md
+++ b/docs/fable/README.md
@@ -61,6 +61,11 @@ each source doc.
   — BF-3.4 receipt-first spec for the planned private/sovereign compute tier:
   opaque per-customer workroom refs, regulated-private placement, lifecycle
   hooks, metering receipt shape, and copy/promise gates for issue #8087.
+- [`2026-07-03-bf-9-2-weekly-pipeline-review.md`](./2026-07-03-bf-9-2-weekly-pipeline-review.md)
+  — BF-9.2 weekly pipeline review artifact for AW-0 A0.3: a public-safe
+  intake -> scope -> receipt-plan -> close queue contract, metric definitions
+  for qualified intakes, scope calls, close rate, time-to-quick-win, commitment
+  coverage, and the weekly closeout checklist.
 - [`EXECUTION.md`](./EXECUTION.md) — how the roadmap is executed: Artanis
   (fleet-manager role) supervises; **Khala Code fleet delegation is the
   primary mechanism**; one GitHub issue per roadmap task, closed only via a

--- a/docs/fable/ROADMAP_BIZ.md
+++ b/docs/fable/ROADMAP_BIZ.md
@@ -134,7 +134,7 @@ each service promise gets standing agents with name/goal/enforced-toolset.
 | Task | Description | Receipt/gate |
 | --- | --- | --- |
 | BF-9.1 | **Commitment ledger**: every promised deliverable/send is a tracked object (owner, due state, engagement ref) surfaced in weekly pipeline review — two silently-dropped partner commitments is the standing warning | Zero untracked commitments; the two owed make-goods shipped |
-| BF-9.2 | **Pipeline ops** (= AW-0 A0.3): intake→scope→receipt-plan→close instrumented; weekly review exists | Weekly pipeline review artifact |
+| BF-9.2 | **Pipeline ops** (= AW-0 A0.3): intake→scope→receipt-plan→close instrumented; weekly review exists | Weekly pipeline review artifact: [`2026-07-03-bf-9-2-weekly-pipeline-review.md`](./2026-07-03-bf-9-2-weekly-pipeline-review.md) |
 | BF-9.3 | **Compliance profiles per vertical**: encoded guardrails (consent channels, provenance, regulated-data handling, no-scraped-outreach, advertising-rule constraints) attached to vertical config packs and enforced at send/publish gates | Profile checks run on every outbound action |
 | BF-9.4 | **Operator-minutes metric**: measured per accepted engagement, reviewed monthly, falling — the agency-trap falsifier wired as instrumentation | Monthly ratio series exists |
 


### PR DESCRIPTION
## Summary

Closes #8116.

- Adds the BF-9.2 weekly pipeline review artifact for intake -> scope -> receipt-plan -> close.
- Defines public-safe queue states, required opaque refs, weekly metrics, and closeout checklist.
- Links the artifact from ROADMAP_BIZ and the fable docs index.

## Verification

```sh
bun run check:deploy
```

Result: passed. The first run exposed a missing local workspace install/linkage for `effect` and workspace packages in this bounded checkout; after `bun install` restored links with no dependency changes, the full command passed.

## Public-safety notes

- No client-identifying information added.
- No product promise state flipped.
- No public copy broadened.