### PR TITLE
BF-9.3: enforce vertical compliance profiles

### DIFF
--- a/apps/openagents.com/workers/api/src/blueprint/vertical-pack.test.ts
+++ b/apps/openagents.com/workers/api/src/blueprint/vertical-pack.test.ts
@@ -10,7 +10,9 @@ import {
   VerticalPackStageTemplate,
   VerticalPackStarterWorkflow,
   VerticalPackVerificationRubric,
+  VerticalPackOutboundComplianceCheckInput,
   agencyVerticalPack,
+  decideVerticalPackOutboundCompliance,
   ecommerceVerticalPack,
   getVerticalPack,
   healthVerticalPack,
@@ -149,10 +151,21 @@ describe('vertical config packs', () => {
           'consent.outbound_action_approval',
         ]),
       )
+      expect(pack.complianceProfile.provenanceRequirementRefs).toEqual(
+        expect.arrayContaining([
+          'provenance.customer_or_public_source_receipt',
+          'provenance.deliverable_source_map_receipt',
+        ]),
+      )
+      expect(pack.complianceProfile.noScrapedOutreach).toBe(true)
+      expect(
+        pack.complianceProfile.advertisingRuleConstraintRefs.length,
+      ).toBeGreaterThan(0)
       expect(pack.complianceProfile.outboundActionGateRefs).toEqual(
         expect.arrayContaining([
           'gate.human_approval_before_send_publish_file_or_spend',
           'gate.provenance_before_customer_delivery',
+          'gate.vertical_compliance_profile_before_outbound_action',
         ]),
       )
       expect(
@@ -172,6 +185,67 @@ describe('vertical config packs', () => {
     expect(
       ecommerceVerticalPack.complianceProfile.professionalReviewRequired,
     ).toBe(false)
+  })
+
+  test('compliance profile decisions allow outbound actions only with consent, provenance, regulated-data, and advertising evidence', () => {
+    const decision = decideVerticalPackOutboundCompliance(
+      agencyVerticalPack.complianceProfile,
+      new VerticalPackOutboundComplianceCheckInput({
+        actionRef: 'outbound_action.agency.email_sequence.send.001',
+        advertisingRuleConstraintRefs:
+          agencyVerticalPack.complianceProfile.advertisingRuleConstraintRefs,
+        consentChannelRefs:
+          agencyVerticalPack.complianceProfile.consentChannelRefs,
+        outboundActionKind: 'send',
+        proposedActionRefs: ['action.customer_channel_send.approved'],
+        provenanceReceiptRefs:
+          agencyVerticalPack.complianceProfile.provenanceRequirementRefs,
+        regulatedDataHandlingRefs: [
+          agencyVerticalPack.complianceProfile.regulatedDataHandlingRef,
+        ],
+        sourceRefs: ['source.customer.brand_kit', 'source.public.site'],
+        verticalPackId: agencyVerticalPack.id,
+      }),
+    )
+
+    expect(decision.outboundActionAllowed).toBe(true)
+    expect(decision.blockerRefs).toEqual([])
+    expect(decision.profileRef).toBe('compliance_profile.agency')
+  })
+
+  test('compliance profile decisions block prohibited actions, scraped outreach, and missing evidence', () => {
+    const decision = decideVerticalPackOutboundCompliance(
+      ecommerceVerticalPack.complianceProfile,
+      new VerticalPackOutboundComplianceCheckInput({
+        actionRef: 'outbound_action.ecommerce.campaign.publish.001',
+        advertisingRuleConstraintRefs: [
+          'advertising_rule.ecommerce.inventory_claims_match_sources',
+        ],
+        consentChannelRefs: ['consent.customer_provided_sources'],
+        outboundActionKind: 'publish',
+        proposedActionRefs: [
+          'prohibited.out_of_stock_or_unavailable_offer',
+        ],
+        provenanceReceiptRefs: [
+          'provenance.customer_or_public_source_receipt',
+        ],
+        regulatedDataHandlingRefs: [],
+        sourceRefs: ['source.raw_scrape.lead_list'],
+        verticalPackId: ecommerceVerticalPack.id,
+      }),
+    )
+
+    expect(decision.outboundActionAllowed).toBe(false)
+    expect(decision.blockerRefs).toEqual(
+      expect.arrayContaining([
+        'blocker.vertical_compliance.missing.consent.outbound_action_approval',
+        'blocker.vertical_compliance.missing.provenance.deliverable_source_map_receipt',
+        'blocker.vertical_compliance.missing.regulated_data.commerce_customer_sources',
+        'blocker.vertical_compliance.missing.advertising_rule.ecommerce.price_and_discount_claims_match_sources',
+        'blocker.vertical_compliance.prohibited.out_of_stock_or_unavailable_offer',
+        'blocker.vertical_compliance.no_scraped_outreach',
+      ]),
+    )
   })
 
   test('new verticals onboard through shared screens only', () => {

--- a/apps/openagents.com/workers/api/src/blueprint/vertical-pack.ts
+++ b/apps/openagents.com/workers/api/src/blueprint/vertical-pack.ts
@@ -69,11 +69,55 @@ export const VerticalPackComplianceProfile = S.Struct({
   requiresHumanReview: S.Boolean,
   professionalReviewRequired: S.Boolean,
   consentChannelRefs: S.Array(S.String),
+  provenanceRequirementRefs: S.Array(S.String),
+  noScrapedOutreach: S.Boolean,
+  advertisingRuleConstraintRefs: S.Array(S.String),
   outboundActionGateRefs: S.Array(S.String),
   prohibitedActionRefs: S.Array(S.String),
 })
 export type VerticalPackComplianceProfile =
   typeof VerticalPackComplianceProfile.Type
+
+export const VerticalPackOutboundActionKind = S.Literals([
+  'send',
+  'publish',
+  'file',
+  'spend',
+])
+export type VerticalPackOutboundActionKind =
+  typeof VerticalPackOutboundActionKind.Type
+
+export class VerticalPackOutboundComplianceCheckInput extends S.Class<VerticalPackOutboundComplianceCheckInput>(
+  'VerticalPackOutboundComplianceCheckInput',
+)({
+  actionRef: S.String,
+  advertisingRuleConstraintRefs: S.Array(S.String),
+  consentChannelRefs: S.Array(S.String),
+  outboundActionKind: VerticalPackOutboundActionKind,
+  proposedActionRefs: S.Array(S.String),
+  provenanceReceiptRefs: S.Array(S.String),
+  regulatedDataHandlingRefs: S.Array(S.String),
+  sourceRefs: S.Array(S.String),
+  verticalPackId: S.String,
+}) {}
+
+export class VerticalPackOutboundComplianceDecision extends S.Class<VerticalPackOutboundComplianceDecision>(
+  'VerticalPackOutboundComplianceDecision',
+)({
+  actionRef: S.String,
+  advertisingRuleConstraintRefs: S.Array(S.String),
+  blockedOutboundAction: S.Boolean,
+  blockerRefs: S.Array(S.String),
+  consentChannelRefs: S.Array(S.String),
+  outboundActionAllowed: S.Boolean,
+  outboundActionKind: VerticalPackOutboundActionKind,
+  profileRef: S.String,
+  prohibitedActionRefs: S.Array(S.String),
+  provenanceReceiptRefs: S.Array(S.String),
+  regulatedDataHandlingRefs: S.Array(S.String),
+  sourceRefs: S.Array(S.String),
+  verticalPackId: S.String,
+}) {}
 
 export const VerticalPackScreenPolicy = S.Struct({
   policyRef: S.String,
@@ -218,21 +262,100 @@ const complianceProfile = (
   regulatedDataHandlingRef: string,
   professionalReviewRequired: boolean,
   prohibitedActionRefs: ReadonlyArray<string>,
+  advertisingRuleConstraintRefs: ReadonlyArray<string>,
 ): VerticalPackComplianceProfile => ({
+  advertisingRuleConstraintRefs: [...advertisingRuleConstraintRefs],
   consentChannelRefs: [
     'consent.customer_provided_sources',
     'consent.outbound_action_approval',
   ],
+  noScrapedOutreach: true,
   outboundActionGateRefs: [
     'gate.human_approval_before_send_publish_file_or_spend',
     'gate.provenance_before_customer_delivery',
+    'gate.vertical_compliance_profile_before_outbound_action',
   ],
   professionalReviewRequired,
   prohibitedActionRefs: [...prohibitedActionRefs],
   profileRef: `compliance_profile.${vertical}`,
+  provenanceRequirementRefs: [
+    'provenance.customer_or_public_source_receipt',
+    'provenance.deliverable_source_map_receipt',
+  ],
   regulatedDataHandlingRef,
   requiresHumanReview: true,
 })
+
+const uniqueSorted = (refs: ReadonlyArray<string>): ReadonlyArray<string> =>
+  [...new Set(refs)].sort()
+
+const outboundActionUsesAdvertisingRules = (
+  actionKind: VerticalPackOutboundActionKind,
+): boolean => actionKind === 'send' || actionKind === 'publish'
+
+const hasScrapedOutreachSource = (refs: ReadonlyArray<string>): boolean =>
+  refs.some(ref => /(^|[_.:/-])scraped([_.:/-]|$)|scraped_outreach|raw_scrape/i.test(ref))
+
+export const decideVerticalPackOutboundCompliance = (
+  profile: VerticalPackComplianceProfile,
+  input: VerticalPackOutboundComplianceCheckInput,
+): VerticalPackOutboundComplianceDecision => {
+  const missingConsentRefs = profile.consentChannelRefs.filter(
+    ref => !input.consentChannelRefs.includes(ref),
+  )
+  const missingProvenanceRefs = profile.provenanceRequirementRefs.filter(
+    ref => !input.provenanceReceiptRefs.includes(ref),
+  )
+  const missingAdvertisingRuleRefs = outboundActionUsesAdvertisingRules(
+    input.outboundActionKind,
+  )
+    ? profile.advertisingRuleConstraintRefs.filter(
+        ref => !input.advertisingRuleConstraintRefs.includes(ref),
+      )
+    : []
+  const prohibitedActionRefs = input.proposedActionRefs.filter(ref =>
+    profile.prohibitedActionRefs.includes(ref),
+  )
+  const regulatedDataHandlingRecorded =
+    input.regulatedDataHandlingRefs.includes(profile.regulatedDataHandlingRef)
+  const scrapedOutreachBlocked =
+    profile.noScrapedOutreach && hasScrapedOutreachSource(input.sourceRefs)
+
+  const blockerRefs = uniqueSorted([
+    ...missingConsentRefs.map(ref => `blocker.vertical_compliance.missing.${ref}`),
+    ...missingProvenanceRefs.map(ref => `blocker.vertical_compliance.missing.${ref}`),
+    ...(!regulatedDataHandlingRecorded
+      ? [
+          `blocker.vertical_compliance.missing.${profile.regulatedDataHandlingRef}`,
+        ]
+      : []),
+    ...missingAdvertisingRuleRefs.map(
+      ref => `blocker.vertical_compliance.missing.${ref}`,
+    ),
+    ...prohibitedActionRefs.map(ref => `blocker.vertical_compliance.${ref}`),
+    ...(scrapedOutreachBlocked
+      ? ['blocker.vertical_compliance.no_scraped_outreach']
+      : []),
+  ])
+
+  return new VerticalPackOutboundComplianceDecision({
+    actionRef: input.actionRef,
+    advertisingRuleConstraintRefs: uniqueSorted(
+      input.advertisingRuleConstraintRefs,
+    ),
+    blockedOutboundAction: blockerRefs.length > 0,
+    blockerRefs,
+    consentChannelRefs: uniqueSorted(input.consentChannelRefs),
+    outboundActionAllowed: blockerRefs.length === 0,
+    outboundActionKind: input.outboundActionKind,
+    profileRef: profile.profileRef,
+    prohibitedActionRefs: uniqueSorted(prohibitedActionRefs),
+    provenanceReceiptRefs: uniqueSorted(input.provenanceReceiptRefs),
+    regulatedDataHandlingRefs: uniqueSorted(input.regulatedDataHandlingRefs),
+    sourceRefs: uniqueSorted(input.sourceRefs),
+    verticalPackId: input.verticalPackId,
+  })
+}
 
 const verificationRubric = (
   vertical: string,
@@ -356,6 +479,10 @@ export const legalVerticalPack: VerticalPack = {
       'prohibited.legal_advice_without_reviewer',
       'prohibited.unapproved_filing_or_client_send',
     ],
+    [
+      'advertising_rule.legal.no_outcome_guarantees',
+      'advertising_rule.legal.no_attorney_client_relationship_claim_without_review',
+    ],
   ),
   ethicalMarketingPolicy: ethicalMarketingPolicy('legal'),
   screenPolicy: screenPolicy('legal'),
@@ -441,6 +568,10 @@ export const healthVerticalPack: VerticalPack = {
     [
       'prohibited.external_inference_before_redaction',
       'prohibited.medical_advice_without_reviewer',
+    ],
+    [
+      'advertising_rule.health.no_diagnosis_or_treatment_claim',
+      'advertising_rule.health.no_sensitive_condition_targeting',
     ],
   ),
   ethicalMarketingPolicy: ethicalMarketingPolicy('health'),
@@ -536,6 +667,10 @@ export const agencyVerticalPack: VerticalPack = {
       'prohibited.fabricated_case_study_or_testimonial',
       'prohibited.unapproved_customer_channel_send',
     ],
+    [
+      'advertising_rule.agency.no_fabricated_results',
+      'advertising_rule.agency.channel_terms_checked',
+    ],
   ),
   ethicalMarketingPolicy: ethicalMarketingPolicy('agency'),
   screenPolicy: screenPolicy('agency'),
@@ -629,6 +764,10 @@ export const ecommerceVerticalPack: VerticalPack = {
     [
       'prohibited.out_of_stock_or_unavailable_offer',
       'prohibited.unapproved_ad_spend_or_channel_publish',
+    ],
+    [
+      'advertising_rule.ecommerce.inventory_claims_match_sources',
+      'advertising_rule.ecommerce.price_and_discount_claims_match_sources',
     ],
   ),
   ethicalMarketingPolicy: ethicalMarketingPolicy('ecommerce'),

--- a/apps/openagents.com/workers/api/src/omni-workroom-approval-gates.test.ts
+++ b/apps/openagents.com/workers/api/src/omni-workroom-approval-gates.test.ts
@@ -8,6 +8,11 @@ import {
   OmniWorkroomOutboundDeliverableReviewInput,
   decideOmniWorkroomOutboundDeliverableReview,
 } from './omni-workroom-approval-gates'
+import {
+  VerticalPackOutboundComplianceCheckInput,
+  agencyVerticalPack,
+  legalVerticalPack,
+} from './blueprint/vertical-pack'
 
 const policy = (
   overrides: Partial<OmniWorkroomApprovalGatePolicy> = {},
@@ -26,6 +31,22 @@ const input = (
 ): OmniWorkroomOutboundDeliverableReviewInput =>
   new OmniWorkroomOutboundDeliverableReviewInput({
     approvalDecisionReceiptRefs: ['receipt.review.operator_approved.001'],
+    complianceCheck: new VerticalPackOutboundComplianceCheckInput({
+      actionRef: 'outbound_action.business_site_revision.publish.001',
+      advertisingRuleConstraintRefs:
+        agencyVerticalPack.complianceProfile.advertisingRuleConstraintRefs,
+      consentChannelRefs: agencyVerticalPack.complianceProfile.consentChannelRefs,
+      outboundActionKind: 'publish',
+      proposedActionRefs: ['action.customer_channel_publish.approved'],
+      provenanceReceiptRefs:
+        agencyVerticalPack.complianceProfile.provenanceRequirementRefs,
+      regulatedDataHandlingRefs: [
+        agencyVerticalPack.complianceProfile.regulatedDataHandlingRef,
+      ],
+      sourceRefs: ['source.customer.brand_kit', 'source.public.marketing_site'],
+      verticalPackId: agencyVerticalPack.id,
+    }),
+    complianceProfile: agencyVerticalPack.complianceProfile,
     deliverableRef: 'deliverable.business_site_revision.001',
     evidenceRefs: ['evidence.workroom.preview.001'],
     outboundActionKind: 'publish',
@@ -52,6 +73,10 @@ describe('Omni workroom approval gates', () => {
       approvalLevel: 'execute_with_approval',
       blockedExternalAction: false,
       blockerRefs: [],
+      complianceDecision: expect.objectContaining({
+        outboundActionAllowed: true,
+        profileRef: 'compliance_profile.agency',
+      }),
       externalActionAllowed: true,
       outboundActionKind: 'publish',
       professionalReviewRecorded: true,
@@ -62,6 +87,54 @@ describe('Omni workroom approval gates', () => {
       'issue.8090',
       'policy.business_fulfillment.approval_ladder.v1',
     ])
+  })
+
+  test('blocks send and publish when the vertical compliance profile is not satisfied', () => {
+    const decision = decideOmniWorkroomOutboundDeliverableReview(
+      input({
+        complianceCheck: new VerticalPackOutboundComplianceCheckInput({
+          actionRef: 'outbound_action.legal.packet.send.001',
+          advertisingRuleConstraintRefs: [
+            'advertising_rule.legal.no_outcome_guarantees',
+          ],
+          consentChannelRefs: ['consent.customer_provided_sources'],
+          outboundActionKind: 'send',
+          proposedActionRefs: ['prohibited.unapproved_filing_or_client_send'],
+          provenanceReceiptRefs: [
+            'provenance.customer_or_public_source_receipt',
+          ],
+          regulatedDataHandlingRefs: [],
+          sourceRefs: ['source.scraped_outreach.lead_list'],
+          verticalPackId: legalVerticalPack.id,
+        }),
+        complianceProfile: legalVerticalPack.complianceProfile,
+        outboundActionKind: 'send',
+        policy: policy({
+          professionalReviewRequired: true,
+          professionalReviewerRole: 'licensed_practitioner',
+        }),
+        professionalReviewReceiptRefs: [
+          'receipt.professional_review.licensed_practitioner.legal_packet',
+        ],
+        reviewerRoleRefs: [
+          'role.licensed_practitioner.verified.legal_packet',
+        ],
+        workKind: 'legal_sensitive',
+      }),
+    )
+
+    expect(decision.externalActionAllowed).toBe(false)
+    expect(decision.complianceDecision?.outboundActionAllowed).toBe(false)
+    expect(decision.blockerRefs).toEqual(
+      expect.arrayContaining([
+        'blocker.vertical_compliance.missing.consent.outbound_action_approval',
+        'blocker.vertical_compliance.missing.provenance.deliverable_source_map_receipt',
+        'blocker.vertical_compliance.missing.regulated_data.legal_confidential',
+        'blocker.vertical_compliance.missing.advertising_rule.legal.no_attorney_client_relationship_claim_without_review',
+        'blocker.vertical_compliance.prohibited.unapproved_filing_or_client_send',
+        'blocker.vertical_compliance.no_scraped_outreach',
+      ]),
+    )
   })
 
   test('blocks draft and suggest ladder levels from external send, publish, file, or spend actions', () => {

--- a/apps/openagents.com/workers/api/src/omni-workroom-approval-gates.ts
+++ b/apps/openagents.com/workers/api/src/omni-workroom-approval-gates.ts
@@ -2,6 +2,12 @@ import { containsProviderSecretMaterial } from '@openagentsinc/provider-account-
 import { Schema as S } from 'effect'
 
 import { OmniAcceptedOutcomeWorkKind as OmniAcceptedOutcomeWorkKindSchema } from './omni-accepted-outcome-contracts'
+import {
+  VerticalPackComplianceProfile,
+  VerticalPackOutboundComplianceCheckInput,
+  VerticalPackOutboundComplianceDecision,
+  decideVerticalPackOutboundCompliance,
+} from './blueprint/vertical-pack'
 
 export const OmniWorkroomApprovalLadderLevel = S.Literals([
   'draft',
@@ -42,6 +48,8 @@ export class OmniWorkroomOutboundDeliverableReviewInput extends S.Class<OmniWork
   'OmniWorkroomOutboundDeliverableReviewInput',
 )({
   approvalDecisionReceiptRefs: S.Array(S.String),
+  complianceCheck: S.NullOr(VerticalPackOutboundComplianceCheckInput),
+  complianceProfile: S.NullOr(VerticalPackComplianceProfile),
   deliverableRef: S.String,
   evidenceRefs: S.Array(S.String),
   outboundActionKind: OmniWorkroomOutboundActionKind,
@@ -60,6 +68,7 @@ export class OmniWorkroomOutboundDeliverableReviewDecision extends S.Class<OmniW
   approvalLevel: OmniWorkroomApprovalLadderLevel,
   blockedExternalAction: S.Boolean,
   blockerRefs: S.Array(S.String),
+  complianceDecision: S.NullOr(VerticalPackOutboundComplianceDecision),
   deliverableRef: S.String,
   evidenceRefs: S.Array(S.String),
   externalActionAllowed: S.Boolean,
@@ -146,10 +155,52 @@ const validateInputRefs = (
   assertSafeRefs('reviewerRoleRefs', input.reviewerRoleRefs)
   assertSafeRefs('sourceRefs', input.sourceRefs)
   assertSafeRefs('policy.sourceRefs', input.policy.sourceRefs)
+  if (input.complianceCheck !== null) {
+    assertSafeRef('complianceCheck.actionRef', input.complianceCheck.actionRef)
+    assertSafeRef(
+      'complianceCheck.verticalPackId',
+      input.complianceCheck.verticalPackId,
+    )
+    assertSafeRefs(
+      'complianceCheck.advertisingRuleConstraintRefs',
+      input.complianceCheck.advertisingRuleConstraintRefs,
+    )
+    assertSafeRefs(
+      'complianceCheck.consentChannelRefs',
+      input.complianceCheck.consentChannelRefs,
+    )
+    assertSafeRefs(
+      'complianceCheck.proposedActionRefs',
+      input.complianceCheck.proposedActionRefs,
+    )
+    assertSafeRefs(
+      'complianceCheck.provenanceReceiptRefs',
+      input.complianceCheck.provenanceReceiptRefs,
+    )
+    assertSafeRefs(
+      'complianceCheck.regulatedDataHandlingRefs',
+      input.complianceCheck.regulatedDataHandlingRefs,
+    )
+    assertSafeRefs('complianceCheck.sourceRefs', input.complianceCheck.sourceRefs)
+  }
+}
+
+const complianceDecisionFor = (
+  input: OmniWorkroomOutboundDeliverableReviewInput,
+): VerticalPackOutboundComplianceDecision | null => {
+  if (input.complianceProfile === null || input.complianceCheck === null) {
+    return null
+  }
+
+  return decideVerticalPackOutboundCompliance(
+    input.complianceProfile,
+    input.complianceCheck,
+  )
 }
 
 const blockerRefsFor = (
   input: OmniWorkroomOutboundDeliverableReviewInput,
+  complianceDecision: VerticalPackOutboundComplianceDecision | null,
 ): ReadonlyArray<string> => {
   const approvalLevelAllowsExternalAction =
     levelAllowsExternalAction[input.policy.approvalLevel]
@@ -181,6 +232,7 @@ const blockerRefsFor = (
     ...(!requiredReviewerRoleRecorded
       ? ['blocker.workroom_approval_ladder.professional_reviewer_role_missing']
       : []),
+    ...(complianceDecision?.blockerRefs ?? []),
   ].sort()
 }
 
@@ -189,7 +241,8 @@ export const decideOmniWorkroomOutboundDeliverableReview = (
 ): OmniWorkroomOutboundDeliverableReviewDecision => {
   validateInputRefs(input)
 
-  const blockerRefs = blockerRefsFor(input)
+  const complianceDecision = complianceDecisionFor(input)
+  const blockerRefs = blockerRefsFor(input, complianceDecision)
   const professionalReviewRequired = professionalReviewRequiredFor(input)
   const professionalReviewerRole = requiredProfessionalReviewerRoleFor(input)
   const professionalReviewRecorded =
@@ -203,6 +256,7 @@ export const decideOmniWorkroomOutboundDeliverableReview = (
     approvalLevel: input.policy.approvalLevel,
     blockedExternalAction: !externalActionAllowed,
     blockerRefs,
+    complianceDecision,
     deliverableRef: input.deliverableRef,
     evidenceRefs: uniqueSorted(input.evidenceRefs),
     externalActionAllowed,


### PR DESCRIPTION
Closes #8117

## Summary
- Extend vertical pack compliance profiles with provenance requirements, no-scraped-outreach policy, and advertising-rule constraint refs.
- Add a pure vertical outbound compliance decision that blocks missing consent/provenance/regulated-data evidence, prohibited action refs, scraped outreach sources, and missing advertising constraints for send/publish actions.
- Thread vertical compliance decisions into the omni workroom outbound approval gate so send/publish/file/spend review includes profile blockers alongside approval and professional-review blockers.

## Verification
- `bun run --cwd apps/openagents.com/workers/api test src/blueprint/vertical-pack.test.ts src/omni-workroom-approval-gates.test.ts` ✅ 2 files, 19 tests passed
- `bun run --cwd apps/openagents.com/workers/api typecheck` ✅
- `bun run check:deploy` ✅

Pinned base: `main@9743d617db14d744bf9732c4e53516eef11e0ec0`.
