### PR TITLE
Register background-agent behavior contracts

### DIFF
--- a/docs/fable/background-agent-behavior-contracts.md
+++ b/docs/fable/background-agent-behavior-contracts.md
@@ -1,0 +1,72 @@
+# Background-Agent Behavior Contracts
+
+This document is the human rendering of the background-agent contract registry
+in `packages/behavior-contracts/src/background-agents.ts` (schema:
+`packages/behavior-contracts`, `@openagentsinc/behavior-contracts`).
+
+Issue #8218 registers the headline invariants from
+`docs/fable/ROADMAP_BACKGROUND_AGENTS.md` before their sibling implementation
+oracles land. Every entry below is intentionally `pending` until the owning
+task PR adds the oracle test and flips that exact contract to `enforced`.
+
+Registry version: `2026-07-03.2` (schema `openagents.behavior_contracts.v1`)
+
+### `background_agents.dispatch.budget_caps_enforced.v1` - PENDING
+
+- **Surface:** openagents.com-worker (background agent dispatch)
+- **Stated by:** owner via issue_list on 2026-07-03
+- **Statement:** Auto-pause after N consecutive failures; maxRunsPerDay / maxRunSeconds / maxCreditsPerDay enforced at dispatch with typed refusals - a buggy background watcher must never be a money pump.
+- **Enforcement tier:** unenforced
+- **Verification:** Pending BA-B4: add dispatch budget and auto-pause tests, then flip this contract to enforced with those tests as bun-test oracles in the relevant sweep.
+- **Blockers:** `blocker.background_agents.ba_b4.oracle_not_landed`
+- **Authority boundary:** This contract binds dispatch budget enforcement for background-agent definitions. It does not authorize public budget or reliability claims until the BA-B4 dispatch oracles exist and run in the normal sweep.
+
+### `background_agents.toolset.compiled_policy_enforced.v1` - PENDING
+
+- **Surface:** openagents.com-worker (background agent tool policy)
+- **Stated by:** owner via issue_list on 2026-07-03
+- **Statement:** Definition toolset compiles to the ADR-0012 tool-runtime policy object (local lane) and to Forge tenant-token scopes for git access; ask entries route to escalation instead of failing; no lane may reach tools outside compiled policy.
+- **Enforcement tier:** unenforced
+- **Verification:** Pending BA-A5: add enforcement tests at both the local lane and Forge tenant-token boundary, then flip this contract to enforced with those tests as bun-test oracles.
+- **Blockers:** `blocker.background_agents.ba_a5.oracle_not_landed`
+- **Authority boundary:** This contract binds compiled background-agent tool policy at the local-lane and Forge git-token boundaries. It does not widen any runtime tool authority beyond the compiled policy.
+
+### `background_agents.credentials.no_long_lived_tokens_in_workspaces.v1` - PENDING
+
+- **Surface:** pylon-worker (background agent credentials)
+- **Stated by:** owner via issue_list on 2026-07-03
+- **Statement:** No long-lived SCM tokens exist in worker workspaces/homes across materialize/run/closeout.
+- **Enforcement tier:** unenforced
+- **Verification:** Pending BA-D3: BA-D3's tests are this contract's oracle; flip this contract to enforced only when those tests exist and run in the Pylon sweep.
+- **Blockers:** `blocker.background_agents.ba_d3.oracle_not_landed`
+- **Authority boundary:** This contract binds worker workspace credential hygiene only. It does not claim that owner subscription custody or provider-account refresh flows are complete.
+
+### `background_agents.definitions.harness_swap.v1` - PENDING
+
+- **Surface:** pylon-worker (background agent definitions)
+- **Stated by:** owner via issue_list on 2026-07-03
+- **Statement:** One unchanged background-agent definition runs on Codex and Claude; harness is a field, never load-bearing.
+- **Enforcement tier:** unenforced
+- **Verification:** Pending BA-A4: add the parity fixture proving one unchanged definition runs on both harnesses, then flip this contract to enforced with that fixture as the oracle.
+- **Blockers:** `blocker.background_agents.ba_a4.oracle_not_landed`
+- **Authority boundary:** This contract binds harness portability for unchanged background-agent definitions. It does not claim semantic parity between all provider outputs beyond the parity fixture's asserted behavior.
+
+### `background_agents.agents_panel.run_status_indicators_truthful.v1` - PENDING
+
+- **Surface:** khala-code-desktop (Khala Code Agents panel)
+- **Stated by:** owner via issue_list on 2026-07-03
+- **Statement:** Agents panel run-status indicators must be truthful: an in-progress, queued, failed, complete, or blocked indicator means exactly that run state and nothing else.
+- **Enforcement tier:** unenforced
+- **Verification:** Pending BA-G4: write the indicator-truthfulness contract before the Agents panel ships, with DOM or source oracles in the Khala Code Desktop sweep.
+- **Blockers:** `blocker.background_agents.ba_g4.oracle_not_landed`
+- **Authority boundary:** This contract binds truthfulness of run-status indicators in the Khala Code Agents panel. It does not prescribe the final panel layout, copy, or visual treatment.
+
+### `background_agents.warm_dispatch.honest_no_op_without_warm_path.v1` - PENDING
+
+- **Surface:** khala-code-desktop (warm dispatch)
+- **Stated by:** owner via issue_list on 2026-07-03
+- **Statement:** Khala Code composer emits a typed, debounced, owner-scoped pre-materialize signal while a fleet/background run is being composed; honest no-op when the target lane has no warm path.
+- **Enforcement tier:** unenforced
+- **Verification:** Pending BA-E3: add debounce and gating tests for the composer pre-materialize signal, then flip this contract to enforced with those tests as bun-test oracles.
+- **Blockers:** `blocker.background_agents.ba_e3.oracle_not_landed`
+- **Authority boundary:** This contract binds the warm-on-intent pre-materialize signal path. It does not require every lane to implement a warm path.

--- a/packages/behavior-contracts/src/background-agents.ts
+++ b/packages/behavior-contracts/src/background-agents.ts
@@ -1,0 +1,177 @@
+import {
+  BehaviorContractSchemaVersion,
+  type BehaviorContractRegistryDocument,
+} from "./contract"
+
+export const BACKGROUND_AGENTS_CONTRACT_DOC_PATH =
+  "docs/fable/background-agent-behavior-contracts.md"
+
+const pendingOracleBlocker = (task: string): string =>
+  `blocker.background_agents.${task}.oracle_not_landed`
+
+/**
+ * Background-agent behavior contracts.
+ *
+ * These entries record the headline invariants from
+ * docs/fable/ROADMAP_BACKGROUND_AGENTS.md and issue #8218 before the owning
+ * implementation tasks land their oracles. Sibling task PRs should replace the
+ * matching pending entry with an enforced one in the same change that adds the
+ * oracle test.
+ */
+export const backgroundAgentsContractRegistry: BehaviorContractRegistryDocument = {
+  contracts: [
+    {
+      authorityBoundary:
+        "This contract binds dispatch budget enforcement for background-agent definitions. It does not authorize public budget or reliability claims until the BA-B4 dispatch oracles exist and run in the normal sweep.",
+      blockerRefs: [pendingOracleBlocker("ba_b4")],
+      contractId: "background_agents.dispatch.budget_caps_enforced.v1",
+      enforcementTier: "unenforced",
+      evidenceRefs: [
+        "https://github.com/OpenAgentsInc/openagents/issues/8196",
+        "https://github.com/OpenAgentsInc/openagents/issues/8218",
+        "docs/fable/ROADMAP_BACKGROUND_AGENTS.md",
+      ],
+      oracles: [],
+      productArea: "background agent dispatch",
+      source: {
+        channel: "issue_list",
+        statedBy: "owner",
+        statedOn: "2026-07-03",
+      },
+      state: "pending",
+      statement:
+        "Auto-pause after N consecutive failures; maxRunsPerDay / maxRunSeconds / maxCreditsPerDay enforced at dispatch with typed refusals - a buggy background watcher must never be a money pump.",
+      surface: "openagents.com-worker",
+      verification:
+        "Pending BA-B4: add dispatch budget and auto-pause tests, then flip this contract to enforced with those tests as bun-test oracles in the relevant sweep.",
+    },
+    {
+      authorityBoundary:
+        "This contract binds compiled background-agent tool policy at the local-lane and Forge git-token boundaries. It does not widen any runtime tool authority beyond the compiled policy.",
+      blockerRefs: [pendingOracleBlocker("ba_a5")],
+      contractId: "background_agents.toolset.compiled_policy_enforced.v1",
+      enforcementTier: "unenforced",
+      evidenceRefs: [
+        "https://github.com/OpenAgentsInc/openagents/issues/8192",
+        "https://github.com/OpenAgentsInc/openagents/issues/8218",
+        "docs/fable/ROADMAP_BACKGROUND_AGENTS.md",
+      ],
+      oracles: [],
+      productArea: "background agent tool policy",
+      source: {
+        channel: "issue_list",
+        statedBy: "owner",
+        statedOn: "2026-07-03",
+      },
+      state: "pending",
+      statement:
+        "Definition toolset compiles to the ADR-0012 tool-runtime policy object (local lane) and to Forge tenant-token scopes for git access; ask entries route to escalation instead of failing; no lane may reach tools outside compiled policy.",
+      surface: "openagents.com-worker",
+      verification:
+        "Pending BA-A5: add enforcement tests at both the local lane and Forge tenant-token boundary, then flip this contract to enforced with those tests as bun-test oracles.",
+    },
+    {
+      authorityBoundary:
+        "This contract binds worker workspace credential hygiene only. It does not claim that owner subscription custody or provider-account refresh flows are complete.",
+      blockerRefs: [pendingOracleBlocker("ba_d3")],
+      contractId: "background_agents.credentials.no_long_lived_tokens_in_workspaces.v1",
+      enforcementTier: "unenforced",
+      evidenceRefs: [
+        "https://github.com/OpenAgentsInc/openagents/issues/8202",
+        "https://github.com/OpenAgentsInc/openagents/issues/8218",
+        "docs/fable/ROADMAP_BACKGROUND_AGENTS.md",
+      ],
+      oracles: [],
+      productArea: "background agent credentials",
+      source: {
+        channel: "issue_list",
+        statedBy: "owner",
+        statedOn: "2026-07-03",
+      },
+      state: "pending",
+      statement:
+        "No long-lived SCM tokens exist in worker workspaces/homes across materialize/run/closeout.",
+      surface: "pylon-worker",
+      verification:
+        "Pending BA-D3: BA-D3's tests are this contract's oracle; flip this contract to enforced only when those tests exist and run in the Pylon sweep.",
+    },
+    {
+      authorityBoundary:
+        "This contract binds harness portability for unchanged background-agent definitions. It does not claim semantic parity between all provider outputs beyond the parity fixture's asserted behavior.",
+      blockerRefs: [pendingOracleBlocker("ba_a4")],
+      contractId: "background_agents.definitions.harness_swap.v1",
+      enforcementTier: "unenforced",
+      evidenceRefs: [
+        "https://github.com/OpenAgentsInc/openagents/issues/8191",
+        "https://github.com/OpenAgentsInc/openagents/issues/8218",
+        "docs/fable/ROADMAP_BACKGROUND_AGENTS.md",
+      ],
+      oracles: [],
+      productArea: "background agent definitions",
+      source: {
+        channel: "issue_list",
+        statedBy: "owner",
+        statedOn: "2026-07-03",
+      },
+      state: "pending",
+      statement:
+        "One unchanged background-agent definition runs on Codex and Claude; harness is a field, never load-bearing.",
+      surface: "pylon-worker",
+      verification:
+        "Pending BA-A4: add the parity fixture proving one unchanged definition runs on both harnesses, then flip this contract to enforced with that fixture as the oracle.",
+    },
+    {
+      authorityBoundary:
+        "This contract binds truthfulness of run-status indicators in the Khala Code Agents panel. It does not prescribe the final panel layout, copy, or visual treatment.",
+      blockerRefs: [pendingOracleBlocker("ba_g4")],
+      contractId: "background_agents.agents_panel.run_status_indicators_truthful.v1",
+      enforcementTier: "unenforced",
+      evidenceRefs: [
+        "https://github.com/OpenAgentsInc/openagents/issues/8211",
+        "https://github.com/OpenAgentsInc/openagents/issues/8218",
+        "contract:khala_code.chat.sidebar_spinner_streaming_only.v1",
+        "docs/fable/ROADMAP_BACKGROUND_AGENTS.md",
+      ],
+      oracles: [],
+      productArea: "Khala Code Agents panel",
+      source: {
+        channel: "issue_list",
+        statedBy: "owner",
+        statedOn: "2026-07-03",
+      },
+      state: "pending",
+      statement:
+        "Agents panel run-status indicators must be truthful: an in-progress, queued, failed, complete, or blocked indicator means exactly that run state and nothing else.",
+      surface: "khala-code-desktop",
+      verification:
+        "Pending BA-G4: write the indicator-truthfulness contract before the Agents panel ships, with DOM or source oracles in the Khala Code Desktop sweep.",
+    },
+    {
+      authorityBoundary:
+        "This contract binds the warm-on-intent pre-materialize signal path. It does not require every lane to implement a warm path.",
+      blockerRefs: [pendingOracleBlocker("ba_e3")],
+      contractId: "background_agents.warm_dispatch.honest_no_op_without_warm_path.v1",
+      enforcementTier: "unenforced",
+      evidenceRefs: [
+        "https://github.com/OpenAgentsInc/openagents/issues/8205",
+        "https://github.com/OpenAgentsInc/openagents/issues/8218",
+        "docs/fable/ROADMAP_BACKGROUND_AGENTS.md",
+      ],
+      oracles: [],
+      productArea: "warm dispatch",
+      source: {
+        channel: "issue_list",
+        statedBy: "owner",
+        statedOn: "2026-07-03",
+      },
+      state: "pending",
+      statement:
+        "Khala Code composer emits a typed, debounced, owner-scoped pre-materialize signal while a fleet/background run is being composed; honest no-op when the target lane has no warm path.",
+      surface: "khala-code-desktop",
+      verification:
+        "Pending BA-E3: add debounce and gating tests for the composer pre-materialize signal, then flip this contract to enforced with those tests as bun-test oracles.",
+    },
+  ],
+  schemaVersion: BehaviorContractSchemaVersion,
+  version: "2026-07-03.2",
+}

--- a/packages/behavior-contracts/src/behavior-contracts.test.ts
+++ b/packages/behavior-contracts/src/behavior-contracts.test.ts
@@ -7,6 +7,10 @@ import {
   type BehaviorContractRegistryDocument,
 } from "./contract"
 import {
+  BACKGROUND_AGENTS_CONTRACT_DOC_PATH,
+  backgroundAgentsContractRegistry,
+} from "./background-agents"
+import {
   checkBehaviorContractCoverage,
   inMemoryOracleSourceLayer,
 } from "./coverage"
@@ -201,5 +205,60 @@ describe("behavior contract report", () => {
     expect(markdown).toContain("Example stated behavior.")
     expect(markdown).toContain("test-sweep")
     expect(markdown).toContain("clients/khala-code-desktop/tests/ux-contracts.test.ts")
+  })
+})
+
+const repoPath = (ref: string): string =>
+  new URL(`../../../${ref}`, import.meta.url).pathname
+
+describe("background agent contract registry", () => {
+  test("registers the headline background-agent invariants as pending contracts", () => {
+    const validation = validateBehaviorContractRegistry(backgroundAgentsContractRegistry)
+    expect(validation.issues).toEqual([])
+    expect(validation.ok).toBe(true)
+    expect(backgroundAgentsContractRegistry.contracts.map(contract => contract.contractId)).toEqual([
+      "background_agents.dispatch.budget_caps_enforced.v1",
+      "background_agents.toolset.compiled_policy_enforced.v1",
+      "background_agents.credentials.no_long_lived_tokens_in_workspaces.v1",
+      "background_agents.definitions.harness_swap.v1",
+      "background_agents.agents_panel.run_status_indicators_truthful.v1",
+      "background_agents.warm_dispatch.honest_no_op_without_warm_path.v1",
+    ])
+    expect(
+      backgroundAgentsContractRegistry.contracts.every(
+        contract =>
+          contract.state === "pending" &&
+          contract.enforcementTier === "unenforced" &&
+          contract.blockerRefs.length > 0,
+      ),
+    ).toBe(true)
+  })
+
+  test("pending background-agent contracts are skipped by oracle coverage until their sibling task oracles land", async () => {
+    const report = await Effect.runPromise(
+      checkBehaviorContractCoverage(backgroundAgentsContractRegistry).pipe(
+        Effect.provide(inMemoryOracleSourceLayer({})),
+      ),
+    )
+    expect(report.ok).toBe(true)
+    expect(report.results).toEqual([])
+  })
+
+  test("the background-agent human contract doc stays in sync with the registry", async () => {
+    const doc = await Bun.file(repoPath(BACKGROUND_AGENTS_CONTRACT_DOC_PATH)).text()
+    expect(doc).toContain(
+      `Registry version: \`${backgroundAgentsContractRegistry.version}\``,
+    )
+    expect(doc).toContain(
+      renderBehaviorContractMarkdown(backgroundAgentsContractRegistry).split("\n")[0] ??
+        "",
+    )
+    for (const contract of backgroundAgentsContractRegistry.contracts) {
+      expect(doc).toContain(contract.contractId)
+      expect(doc).toContain(contract.statement)
+      for (const blockerRef of contract.blockerRefs) {
+        expect(doc).toContain(blockerRef)
+      }
+    }
   })
 })

--- a/packages/behavior-contracts/src/index.ts
+++ b/packages/behavior-contracts/src/index.ts
@@ -1,3 +1,4 @@
+export * from "./background-agents"
 export * from "./contract"
 export * from "./coverage"
 export * from "./registry"


### PR DESCRIPTION
Closes #8218.

## Summary
- Add the background_agents behavior-contract registry to @openagentsinc/behavior-contracts.
- Register the six headline BA invariants from #8218 as pending contracts with explicit oracle blocker refs.
- Add a human registry doc and package tests that validate the registry, pending coverage behavior, and doc sync.

## Verification
- bun run --cwd packages/behavior-contracts test
- bun run --cwd packages/behavior-contracts typecheck
- bun run check:deploy

FleetRun claim scope: github:OpenAgentsInc/openagents:issue:8218 only.