### PR TITLE
Add QA Swarm customer behavior contract pilot

### DIFF
--- a/docs/qa-demo/README.md
+++ b/docs/qa-demo/README.md
@@ -19,6 +19,7 @@ distill → test → video chain is reviewer-verifiable, not asserted:
 | `distilled-login-verify.e2e.test.ts` | the committed **e2e test distilled from that session** |
 | `khala-autonomous-qa.mp4` | the composed **video** of that same run (title card → recording → verdict card) |
 | `title-card.png` / `verdict-card.png` | the compose-layer cards |
+| `customer-behavior-contract-pilot.json` | the first customer-facing behavior-contract engagement seed for issue #8186, using this public demo target while signed-client registries stay private by default |
 
 `result.json` also names the run's raw local Playwright artifacts
 (`session.mp4`, `trace.zip`, `00-login-page.png`); the **public-safe**
@@ -48,3 +49,12 @@ shareable video + trace as the deviation-loop evidence. A customer
 engagement's contract oracles produce exactly this artifact chain per sweep;
 the registry entry supplies the statement and the enforcement gate, and this
 demo supplies the receipt format.
+
+## Public-demo behavior-contract pilot
+
+`customer-behavior-contract-pilot.json` is the first QA Swarm customer-style
+contract registry. It deliberately uses `visibility: "public-demo"` rather than
+claiming a signed customer. Each stated expectation starts `pending` with an
+explicit blocker until its oracle runs in the customer cadence and emits a
+per-contract receipt. Real client registries use the same schema but default to
+`client-private`; public evidence requires an explicit opt-in ref.

--- a/docs/qa-demo/customer-behavior-contract-pilot.json
+++ b/docs/qa-demo/customer-behavior-contract-pilot.json
@@ -1,0 +1,201 @@
+{
+  "schemaVersion": "openagents.customer_behavior_contract_engagement.v1",
+  "version": "2026-07-03.1",
+  "engagementId": "qa_swarm.public_demo_login.v1",
+  "target": {
+    "clientRef": "public-demo.openagents",
+    "surface": "openagents.com/login",
+    "environment": "production-public-demo",
+    "baseUrl": "https://openagents.com/login",
+    "visibility": "public-demo",
+    "evidenceUrl": "/qa/qa-run.public-demo.behavior-contracts.latest"
+  },
+  "selectedCatalogCategories": [
+    "stated-flow-availability",
+    "error-state-honesty",
+    "copy-claim-safety",
+    "stated-expectation-pinning",
+    "accessibility-floor"
+  ],
+  "cadence": {
+    "tiers": ["nightly", "weekly"],
+    "alertChannel": "private-forum-thread",
+    "alertDestinationRef": "forum.private.qa-swarm.public-demo.behavior-contracts"
+  },
+  "registry": {
+    "schemaVersion": "openagents.behavior_contracts.v1",
+    "version": "2026-07-03.1",
+    "contracts": [
+      {
+        "contractId": "qa_swarm_demo.login.page_loads_named_form.v1",
+        "surface": "openagents.com/login",
+        "productArea": "login flow",
+        "state": "pending",
+        "statement": "When I open the public OpenAgents login page, the page loads and clearly says 'Log in to OpenAgents' before I try to authenticate.",
+        "source": {
+          "channel": "qa-swarm-public-demo-intake",
+          "statedBy": "pilot-demo-operator",
+          "statedOn": "2026-07-03"
+        },
+        "enforcementTier": "unenforced",
+        "oracles": [
+          {
+            "id": "login_page_loads.planned",
+            "kind": "planned",
+            "mode": "headless",
+            "ref": "docs/qa-demo/distilled-login-verify.e2e.test.ts",
+            "description": "Promote the existing distilled login verify test into the customer cadence runner and bind its receipt to this contract id."
+          }
+        ],
+        "evidenceRefs": [
+          "docs/qa-demo/session-trace.json",
+          "docs/qa-demo/result.json",
+          "docs/qa-demo/distilled-login-verify.e2e.test.ts",
+          "docs/qa-demo/khala-autonomous-qa.mp4"
+        ],
+        "verification": "Pending until the distilled login test is wired into the QA Swarm customer cadence runner and emits per-contract receipts.",
+        "blockerRefs": [
+          "blocker.qa_swarm.public_demo_login.customer_cadence_binding_pending"
+        ],
+        "authorityBoundary": "This contract checks the public login page copy and load behavior only. It does not prove authentication, account creation, hosted QA Swarm availability, pricing, SLA, or customer-data handling."
+      },
+      {
+        "contractId": "qa_swarm_demo.login.failure_copy_honest.v1",
+        "surface": "openagents.com/login",
+        "productArea": "login error state",
+        "state": "pending",
+        "statement": "If login cannot continue, the page should show an honest visible error instead of acting like login succeeded or spinning forever.",
+        "source": {
+          "channel": "qa-swarm-public-demo-intake",
+          "statedBy": "pilot-demo-operator",
+          "statedOn": "2026-07-03"
+        },
+        "enforcementTier": "unenforced",
+        "oracles": [
+          {
+            "id": "login_failure_copy.planned",
+            "kind": "planned",
+            "mode": "headless",
+            "ref": "scenario.qa_swarm_demo.login_failure_copy.v1",
+            "description": "Inject a failed auth continuation and assert the visible error copy never claims success."
+          }
+        ],
+        "evidenceRefs": [
+          "docs/fable/2026-07-03-behavior-contracts-and-customer-invariants.md#2-the-invariant-catalog"
+        ],
+        "verification": "Pending until the fault-injection scenario is implemented in the QA harness and scheduled in the customer cadence.",
+        "blockerRefs": [
+          "blocker.qa_swarm.public_demo_login.failure_injection_oracle_pending"
+        ],
+        "authorityBoundary": "This contract binds error-state honesty on the demo login surface only. It grants no auth-provider mutation, production credential access, or payment authority."
+      },
+      {
+        "contractId": "qa_swarm_demo.login.copy_claims_only_verified_access.v1",
+        "surface": "openagents.com/login",
+        "productArea": "login copy",
+        "state": "pending",
+        "statement": "The login page should not promise access, onboarding, or account state that the page itself has not verified yet.",
+        "source": {
+          "channel": "qa-swarm-public-demo-intake",
+          "statedBy": "pilot-demo-operator",
+          "statedOn": "2026-07-03"
+        },
+        "enforcementTier": "unenforced",
+        "oracles": [
+          {
+            "id": "login_copy_claims.planned",
+            "kind": "planned",
+            "mode": "dom",
+            "ref": "scenario.qa_swarm_demo.login_copy_claims.v1",
+            "description": "Scan the rendered login copy for claims beyond verified state and compare it with the allowed-copy ledger."
+          }
+        ],
+        "evidenceRefs": [
+          "docs/promises/registry.md",
+          "docs/qa/qa-swarm-khala-code-standing-engagement.md"
+        ],
+        "verification": "Pending until an allowed-copy ledger and DOM oracle are attached to the demo target.",
+        "blockerRefs": [
+          "blocker.qa_swarm.public_demo_login.copy_claim_ledger_pending"
+        ],
+        "authorityBoundary": "This contract is a copy-safety gate only; it does not approve broader product-promise copy or public QA Swarm launch claims."
+      },
+      {
+        "contractId": "qa_swarm_demo.login.keyboard_focus_floor.v1",
+        "surface": "openagents.com/login",
+        "productArea": "login accessibility",
+        "state": "pending",
+        "statement": "A keyboard user should be able to reach the login controls in a sensible order and know which control is focused.",
+        "source": {
+          "channel": "qa-swarm-public-demo-intake",
+          "statedBy": "pilot-demo-operator",
+          "statedOn": "2026-07-03"
+        },
+        "enforcementTier": "unenforced",
+        "oracles": [
+          {
+            "id": "login_keyboard_focus.planned",
+            "kind": "planned",
+            "mode": "headless",
+            "ref": "scenario.qa_swarm_demo.login_keyboard_focus.v1",
+            "description": "Drive keyboard navigation through the login controls and assert labels, focus visibility, and order."
+          }
+        ],
+        "evidenceRefs": [
+          "docs/fable/2026-07-03-behavior-contracts-and-customer-invariants.md#2-the-invariant-catalog"
+        ],
+        "verification": "Pending until the headless accessibility scenario is implemented and produces a receipt in the customer cadence.",
+        "blockerRefs": [
+          "blocker.qa_swarm.public_demo_login.keyboard_oracle_pending"
+        ],
+        "authorityBoundary": "This contract is limited to the public demo login accessibility floor and does not certify the whole application."
+      }
+    ]
+  },
+  "receiptPack": {
+    "latestSweepRef": "receipt.qa_swarm.public_demo_login.seed.20260703",
+    "receipts": [
+      {
+        "receiptRef": "receipt.qa_swarm.public_demo_login.page_loads_named_form.seed.20260703",
+        "contractId": "qa_swarm_demo.login.page_loads_named_form.v1",
+        "status": "pending",
+        "checkedAt": "2026-07-03T00:00:00.000Z",
+        "summary": "Existing QA demo artifacts prove the candidate oracle shape, but the customer cadence binding has not landed, so this contract remains pending.",
+        "evidenceRefs": [
+          "docs/qa-demo/result.json",
+          "docs/qa-demo/distilled-login-verify.e2e.test.ts"
+        ]
+      },
+      {
+        "receiptRef": "receipt.qa_swarm.public_demo_login.failure_copy_honest.seed.20260703",
+        "contractId": "qa_swarm_demo.login.failure_copy_honest.v1",
+        "status": "pending",
+        "checkedAt": "2026-07-03T00:00:00.000Z",
+        "summary": "Fault-injection oracle is specified but not yet implemented.",
+        "evidenceRefs": [
+          "docs/fable/2026-07-03-behavior-contracts-and-customer-invariants.md"
+        ]
+      },
+      {
+        "receiptRef": "receipt.qa_swarm.public_demo_login.copy_claims.seed.20260703",
+        "contractId": "qa_swarm_demo.login.copy_claims_only_verified_access.v1",
+        "status": "pending",
+        "checkedAt": "2026-07-03T00:00:00.000Z",
+        "summary": "Allowed-copy ledger and DOM scan are specified but not yet implemented.",
+        "evidenceRefs": [
+          "docs/promises/registry.md"
+        ]
+      },
+      {
+        "receiptRef": "receipt.qa_swarm.public_demo_login.keyboard_focus.seed.20260703",
+        "contractId": "qa_swarm_demo.login.keyboard_focus_floor.v1",
+        "status": "pending",
+        "checkedAt": "2026-07-03T00:00:00.000Z",
+        "summary": "Keyboard-focus oracle is specified but not yet implemented.",
+        "evidenceRefs": [
+          "docs/fable/2026-07-03-behavior-contracts-and-customer-invariants.md"
+        ]
+      }
+    ]
+  }
+}

--- a/packages/behavior-contracts/package.json
+++ b/packages/behavior-contracts/package.json
@@ -6,6 +6,7 @@
   "exports": {
     ".": "./src/index.ts",
     "./contract": "./src/contract.ts",
+    "./customer-engagement": "./src/customer-engagement.ts",
     "./registry": "./src/registry.ts",
     "./coverage": "./src/coverage.ts",
     "./report": "./src/report.ts"

--- a/packages/behavior-contracts/src/behavior-contracts.test.ts
+++ b/packages/behavior-contracts/src/behavior-contracts.test.ts
@@ -10,6 +10,13 @@ import {
   checkBehaviorContractCoverage,
   inMemoryOracleSourceLayer,
 } from "./coverage"
+import {
+  CustomerBehaviorContractEngagementSchemaVersion,
+  decodeCustomerBehaviorContractEngagementDocument,
+  renderCustomerBehaviorContractEngagementMarkdown,
+  validateCustomerBehaviorContractEngagement,
+  type CustomerBehaviorContractEngagementDocument,
+} from "./customer-engagement"
 import { validateBehaviorContractRegistry } from "./registry"
 import { renderBehaviorContractMarkdown } from "./report"
 
@@ -47,6 +54,77 @@ const document = (
   schemaVersion: BehaviorContractSchemaVersion,
   version: "2026-07-03.1",
 })
+
+const engagement = (
+  overrides: Partial<CustomerBehaviorContractEngagementDocument> = {},
+): CustomerBehaviorContractEngagementDocument => {
+  const registry = document([
+    contract({
+      blockerRefs: ["blocker.qa_swarm.example.oracle_pending"],
+      contractId: "qa_swarm_demo.login.example_behavior.v1",
+      enforcementTier: "unenforced",
+      oracles: [
+        {
+          description: "Planned customer cadence oracle",
+          id: "example.planned",
+          kind: "planned",
+          mode: "headless",
+          ref: "scenario.qa_swarm_demo.login.example_behavior.v1",
+        },
+      ],
+      productArea: "login flow",
+      source: {
+        channel: "qa-swarm-public-demo-intake",
+        statedBy: "pilot-demo-operator",
+        statedOn: "2026-07-03",
+      },
+      state: "pending",
+      statement: "The public demo login page loads with the expected title.",
+      surface: "openagents.com/login",
+      verification:
+        "Pending until the planned oracle runs in the customer cadence.",
+    }),
+  ])
+
+  return {
+    cadence: {
+      alertChannel: "private-forum-thread",
+      alertDestinationRef: "forum.private.qa-swarm.public-demo",
+      tiers: ["nightly", "weekly"],
+    },
+    engagementId: "qa_swarm.public_demo_login.v1",
+    receiptPack: {
+      latestSweepRef: "receipt.qa_swarm.public_demo_login.seed.20260703",
+      receipts: [
+        {
+          checkedAt: "2026-07-03T00:00:00.000Z",
+          contractId: "qa_swarm_demo.login.example_behavior.v1",
+          evidenceRefs: ["docs/qa-demo/result.json"],
+          receiptRef:
+            "receipt.qa_swarm.public_demo_login.example_behavior.seed.20260703",
+          status: "pending",
+          summary: "Oracle specified but not yet wired into the customer cadence.",
+        },
+      ],
+    },
+    registry,
+    schemaVersion: CustomerBehaviorContractEngagementSchemaVersion,
+    selectedCatalogCategories: [
+      "stated-flow-availability",
+      "stated-expectation-pinning",
+    ],
+    target: {
+      baseUrl: "https://openagents.com/login",
+      clientRef: "public-demo.openagents",
+      environment: "production-public-demo",
+      evidenceUrl: "/qa/qa-run.public-demo.behavior-contracts.latest",
+      surface: "openagents.com/login",
+      visibility: "public-demo",
+    },
+    version: "2026-07-03.1",
+    ...overrides,
+  }
+}
 
 describe("behavior contract registry", () => {
   test("decodes a well-formed registry document", () => {
@@ -201,5 +279,103 @@ describe("behavior contract report", () => {
     expect(markdown).toContain("Example stated behavior.")
     expect(markdown).toContain("test-sweep")
     expect(markdown).toContain("clients/khala-code-desktop/tests/ux-contracts.test.ts")
+  })
+})
+
+describe("customer behavior contract engagements", () => {
+  test("accepts a public-demo pilot with pending blocker-backed contracts", () => {
+    const validation = validateCustomerBehaviorContractEngagement(engagement())
+    expect(validation.issues).toEqual([])
+    expect(validation.ok).toBe(true)
+  })
+
+  test("keeps public customer registries opt-in and cadence-backed", () => {
+    const validation = validateCustomerBehaviorContractEngagement(
+      engagement({
+        cadence: {
+          alertChannel: "manual",
+          alertDestinationRef: "manual.qa-swarm.public-demo",
+          tiers: [],
+        },
+        target: {
+          baseUrl: "https://client.example.test",
+          clientRef: "client.example",
+          environment: "staging",
+          evidenceUrl: "",
+          surface: "client-web",
+          visibility: "public-opt-in",
+        },
+      }),
+    )
+    expect(validation.ok).toBe(false)
+    expect(validation.issues.map(issue => issue.kind)).toEqual(
+      expect.arrayContaining([
+        "empty_cadence",
+        "empty_evidence_url",
+        "public_opt_in_without_evidence",
+      ]),
+    )
+  })
+
+  test("requires pending customer contracts to name blocker refs", () => {
+    const base = engagement()
+    const validation = validateCustomerBehaviorContractEngagement({
+      ...base,
+      registry: document([
+        contract({
+          contractId: "qa_swarm_demo.login.missing_blocker.v1",
+          enforcementTier: "unenforced",
+          oracles: [],
+          state: "pending",
+        }),
+      ]),
+      receiptPack: {
+        latestSweepRef: "receipt.qa_swarm.public_demo_login.seed.20260703",
+        receipts: [
+          {
+            checkedAt: "2026-07-03T00:00:00.000Z",
+            contractId: "qa_swarm_demo.login.missing_blocker.v1",
+            evidenceRefs: [],
+            receiptRef: "receipt.qa_swarm.public_demo_login.missing_blocker",
+            status: "pending",
+            summary: "No oracle yet.",
+          },
+        ],
+      },
+    })
+    expect(validation.ok).toBe(false)
+    expect(validation.issues.map(issue => issue.kind)).toContain(
+      "pending_without_blocker",
+    )
+  })
+
+  test("validates the committed public-demo pilot registry for issue 8186", async () => {
+    const raw = await Bun.file(
+      new URL("../../../docs/qa-demo/customer-behavior-contract-pilot.json", import.meta.url),
+    ).json()
+    const pilot = decodeCustomerBehaviorContractEngagementDocument(raw)
+    const validation = validateCustomerBehaviorContractEngagement(pilot)
+
+    expect(validation.issues).toEqual([])
+    expect(validation.ok).toBe(true)
+    expect(pilot.engagementId).toBe("qa_swarm.public_demo_login.v1")
+    expect(pilot.target.visibility).toBe("public-demo")
+    expect(pilot.registry.contracts.every(contract => contract.state === "pending")).toBe(
+      true,
+    )
+    expect(pilot.receiptPack.receipts.map(receipt => receipt.status)).toEqual([
+      "pending",
+      "pending",
+      "pending",
+      "pending",
+    ])
+  })
+
+  test("renders customer engagement evidence without private raw artifacts", () => {
+    const markdown = renderCustomerBehaviorContractEngagementMarkdown(engagement())
+    expect(markdown).toContain("qa_swarm.public_demo_login.v1")
+    expect(markdown).toContain("Visibility: `public-demo`")
+    expect(markdown).toContain("/qa/qa-run.public-demo.behavior-contracts.latest")
+    expect(markdown).not.toContain("raw")
   })
 })

--- a/packages/behavior-contracts/src/contract.ts
+++ b/packages/behavior-contracts/src/contract.ts
@@ -41,12 +41,14 @@ export const BehaviorContractOracleKind = S.Literals([
   "qa-scenario",
   "visual-smoke",
   "manual-check",
+  "planned",
 ])
 export type BehaviorContractOracleKind =
   | "bun-test"
   | "qa-scenario"
   | "visual-smoke"
   | "manual-check"
+  | "planned"
 
 /** Driver mode vocabulary shared with the khala-qa-harness scenario DSL. */
 export const BehaviorContractOracleMode = S.Literals([

--- a/packages/behavior-contracts/src/customer-engagement.ts
+++ b/packages/behavior-contracts/src/customer-engagement.ts
@@ -1,0 +1,328 @@
+import { Schema as S } from "effect"
+import {
+  BehaviorContractRegistryDocument,
+  type BehaviorContractRegistryDocument as BehaviorContractRegistryDocumentType,
+} from "./contract"
+import {
+  validateBehaviorContractRegistry,
+  type BehaviorContractRegistryIssue,
+} from "./registry"
+
+export const CustomerBehaviorContractEngagementSchemaVersion =
+  "openagents.customer_behavior_contract_engagement.v1"
+
+export const BehaviorContractCatalogCategory = S.Literals([
+  "indicator-truthfulness",
+  "stated-flow-availability",
+  "latency-budget",
+  "error-state-honesty",
+  "dead-control-detection",
+  "cross-surface-consistency",
+  "copy-claim-safety",
+  "stated-expectation-pinning",
+  "accessibility-floor",
+  "money-path-integrity",
+])
+export type BehaviorContractCatalogCategory =
+  | "indicator-truthfulness"
+  | "stated-flow-availability"
+  | "latency-budget"
+  | "error-state-honesty"
+  | "dead-control-detection"
+  | "cross-surface-consistency"
+  | "copy-claim-safety"
+  | "stated-expectation-pinning"
+  | "accessibility-floor"
+  | "money-path-integrity"
+
+export const CustomerBehaviorContractVisibility = S.Literals([
+  "client-private",
+  "public-demo",
+  "public-opt-in",
+])
+export type CustomerBehaviorContractVisibility =
+  | "client-private"
+  | "public-demo"
+  | "public-opt-in"
+
+export const CustomerBehaviorContractCadenceTier = S.Literals([
+  "on-deploy",
+  "nightly",
+  "weekly",
+  "manual",
+])
+export type CustomerBehaviorContractCadenceTier =
+  | "on-deploy"
+  | "nightly"
+  | "weekly"
+  | "manual"
+
+export const CustomerBehaviorContractAlertChannel = S.Literals([
+  "client-webhook",
+  "client-email",
+  "private-forum-thread",
+  "manual",
+])
+export type CustomerBehaviorContractAlertChannel =
+  | "client-webhook"
+  | "client-email"
+  | "private-forum-thread"
+  | "manual"
+
+export const BehaviorContractOracleReceiptStatus = S.Literals([
+  "pass",
+  "fail",
+  "pending",
+  "blocked",
+])
+export type BehaviorContractOracleReceiptStatus =
+  | "pass"
+  | "fail"
+  | "pending"
+  | "blocked"
+
+export const CustomerBehaviorContractTarget = S.Struct({
+  baseUrl: S.String,
+  clientRef: S.String,
+  environment: S.String,
+  evidenceUrl: S.String,
+  optInEvidenceRef: S.optional(S.String),
+  surface: S.String,
+  visibility: CustomerBehaviorContractVisibility,
+})
+export type CustomerBehaviorContractTarget = {
+  readonly baseUrl: string
+  readonly clientRef: string
+  readonly environment: string
+  readonly evidenceUrl: string
+  readonly optInEvidenceRef?: string
+  readonly surface: string
+  readonly visibility: CustomerBehaviorContractVisibility
+}
+
+export const CustomerBehaviorContractCadence = S.Struct({
+  alertChannel: CustomerBehaviorContractAlertChannel,
+  alertDestinationRef: S.String,
+  tiers: S.Array(CustomerBehaviorContractCadenceTier),
+})
+export type CustomerBehaviorContractCadence = {
+  readonly alertChannel: CustomerBehaviorContractAlertChannel
+  readonly alertDestinationRef: string
+  readonly tiers: ReadonlyArray<CustomerBehaviorContractCadenceTier>
+}
+
+export const BehaviorContractOracleReceipt = S.Struct({
+  checkedAt: S.String,
+  contractId: S.String,
+  evidenceRefs: S.Array(S.String),
+  receiptRef: S.String,
+  status: BehaviorContractOracleReceiptStatus,
+  summary: S.String,
+})
+export type BehaviorContractOracleReceipt = {
+  readonly checkedAt: string
+  readonly contractId: string
+  readonly evidenceRefs: ReadonlyArray<string>
+  readonly receiptRef: string
+  readonly status: BehaviorContractOracleReceiptStatus
+  readonly summary: string
+}
+
+export const BehaviorContractReceiptPack = S.Struct({
+  latestSweepRef: S.String,
+  receipts: S.Array(BehaviorContractOracleReceipt),
+})
+export type BehaviorContractReceiptPack = {
+  readonly latestSweepRef: string
+  readonly receipts: ReadonlyArray<BehaviorContractOracleReceipt>
+}
+
+export const CustomerBehaviorContractEngagementDocument = S.Struct({
+  cadence: CustomerBehaviorContractCadence,
+  engagementId: S.String,
+  registry: BehaviorContractRegistryDocument,
+  receiptPack: BehaviorContractReceiptPack,
+  schemaVersion: S.Literal(CustomerBehaviorContractEngagementSchemaVersion),
+  selectedCatalogCategories: S.Array(BehaviorContractCatalogCategory),
+  target: CustomerBehaviorContractTarget,
+  version: S.String,
+})
+export type CustomerBehaviorContractEngagementDocument = {
+  readonly cadence: CustomerBehaviorContractCadence
+  readonly engagementId: string
+  readonly registry: BehaviorContractRegistryDocumentType
+  readonly receiptPack: BehaviorContractReceiptPack
+  readonly schemaVersion: typeof CustomerBehaviorContractEngagementSchemaVersion
+  readonly selectedCatalogCategories: ReadonlyArray<BehaviorContractCatalogCategory>
+  readonly target: CustomerBehaviorContractTarget
+  readonly version: string
+}
+
+export const decodeCustomerBehaviorContractEngagementDocument = (
+  input: unknown,
+): CustomerBehaviorContractEngagementDocument =>
+  S.decodeUnknownSync(CustomerBehaviorContractEngagementDocument)(
+    input,
+  ) as CustomerBehaviorContractEngagementDocument
+
+export type CustomerBehaviorContractEngagementIssue = {
+  readonly contractId: string | null
+  readonly detail: string
+  readonly kind:
+    | "duplicate_receipt_contract"
+    | "empty_cadence"
+    | "empty_catalog_categories"
+    | "empty_evidence_url"
+    | "enforced_without_pass_receipt"
+    | "invalid_engagement_id"
+    | "invalid_version"
+    | "pending_without_blocker"
+    | "public_opt_in_without_evidence"
+    | "receipt_for_unknown_contract"
+    | "registry_validation_failed"
+}
+
+export type CustomerBehaviorContractEngagementValidation = {
+  readonly issues: ReadonlyArray<CustomerBehaviorContractEngagementIssue>
+  readonly ok: boolean
+  readonly registryIssues: ReadonlyArray<BehaviorContractRegistryIssue>
+}
+
+export const validateCustomerBehaviorContractEngagement = (
+  document: CustomerBehaviorContractEngagementDocument,
+): CustomerBehaviorContractEngagementValidation => {
+  const issues: CustomerBehaviorContractEngagementIssue[] = []
+  const registryValidation = validateBehaviorContractRegistry(document.registry)
+
+  if (!/^qa_swarm\.[a-z0-9_]+(\.[a-z0-9_]+)*\.v[0-9]+$/u.test(document.engagementId)) {
+    issues.push({
+      contractId: null,
+      detail: "engagementId must match qa_swarm.<slug>.v<N>",
+      kind: "invalid_engagement_id",
+    })
+  }
+  if (!/^\d{4}-\d{2}-\d{2}\.\d+$/u.test(document.version)) {
+    issues.push({
+      contractId: null,
+      detail: `engagement version "${document.version}" is not YYYY-MM-DD.N`,
+      kind: "invalid_version",
+    })
+  }
+  if (document.selectedCatalogCategories.length === 0) {
+    issues.push({
+      contractId: null,
+      detail: "engagement must select at least one invariant catalog category",
+      kind: "empty_catalog_categories",
+    })
+  }
+  if (document.cadence.tiers.length === 0) {
+    issues.push({
+      contractId: null,
+      detail: "engagement must name the cadence tiers that run the oracle pack",
+      kind: "empty_cadence",
+    })
+  }
+  if (document.target.evidenceUrl.trim() === "") {
+    issues.push({
+      contractId: null,
+      detail: "engagement must carry a QA Swarm evidence URL",
+      kind: "empty_evidence_url",
+    })
+  }
+  if (
+    document.target.visibility === "public-opt-in" &&
+    document.target.optInEvidenceRef === undefined
+  ) {
+    issues.push({
+      contractId: null,
+      detail: "public customer evidence requires an explicit opt-in evidence ref",
+      kind: "public_opt_in_without_evidence",
+    })
+  }
+
+  if (!registryValidation.ok) {
+    for (const registryIssue of registryValidation.issues) {
+      issues.push({
+        contractId: registryIssue.contractId,
+        detail: registryIssue.detail,
+        kind: "registry_validation_failed",
+      })
+    }
+  }
+
+  const contractIds = new Set(
+    document.registry.contracts.map(contract => contract.contractId),
+  )
+  const receiptContractIds = new Set<string>()
+  for (const receipt of document.receiptPack.receipts) {
+    if (!contractIds.has(receipt.contractId)) {
+      issues.push({
+        contractId: receipt.contractId,
+        detail: "receipt contractId is not present in the registry",
+        kind: "receipt_for_unknown_contract",
+      })
+    }
+    if (receiptContractIds.has(receipt.contractId)) {
+      issues.push({
+        contractId: receipt.contractId,
+        detail: "receipt pack carries more than one latest receipt for the same contract",
+        kind: "duplicate_receipt_contract",
+      })
+    }
+    receiptContractIds.add(receipt.contractId)
+  }
+
+  for (const contract of document.registry.contracts) {
+    if (contract.state === "pending" && contract.blockerRefs.length === 0) {
+      issues.push({
+        contractId: contract.contractId,
+        detail: "pending customer contracts must name the blocker that keeps them non-green",
+        kind: "pending_without_blocker",
+      })
+    }
+    if (contract.state === "enforced") {
+      const receipt = document.receiptPack.receipts.find(
+        candidate => candidate.contractId === contract.contractId,
+      )
+      if (receipt?.status !== "pass") {
+        issues.push({
+          contractId: contract.contractId,
+          detail: "enforced customer contracts need a latest passing receipt",
+          kind: "enforced_without_pass_receipt",
+        })
+      }
+    }
+  }
+
+  return {
+    issues,
+    ok: issues.length === 0,
+    registryIssues: registryValidation.issues,
+  }
+}
+
+export const renderCustomerBehaviorContractEngagementMarkdown = (
+  document: CustomerBehaviorContractEngagementDocument,
+): string => {
+  const lines: string[] = []
+  lines.push(`# ${document.engagementId}`)
+  lines.push("")
+  lines.push(`Version: \`${document.version}\``)
+  lines.push(`Target: \`${document.target.clientRef}\` / \`${document.target.surface}\``)
+  lines.push(`Visibility: \`${document.target.visibility}\``)
+  lines.push(`Cadence: ${document.cadence.tiers.map(tier => `\`${tier}\``).join(", ")}`)
+  lines.push(`Alert channel: \`${document.cadence.alertChannel}\``)
+  lines.push(`Evidence URL: \`${document.target.evidenceUrl}\``)
+  lines.push("")
+  lines.push("## Contracts")
+  lines.push("")
+  for (const contract of document.registry.contracts) {
+    const receipt = document.receiptPack.receipts.find(
+      candidate => candidate.contractId === contract.contractId,
+    )
+    lines.push(`- \`${contract.contractId}\` — ${contract.state}`)
+    lines.push(`  Statement: ${contract.statement}`)
+    lines.push(`  Latest receipt: ${receipt?.status ?? "none"} (${receipt?.receiptRef ?? "none"})`)
+  }
+  return lines.join("\n")
+}

--- a/packages/behavior-contracts/src/index.ts
+++ b/packages/behavior-contracts/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./contract"
 export * from "./coverage"
+export * from "./customer-engagement"
 export * from "./registry"
 export * from "./report"


### PR DESCRIPTION
## Summary
- Add a customer-engagement schema for behavior contracts covering privacy mode, cadence, selected invariant categories, alert channel, and per-contract receipt packs.
- Seed the first customer-facing/public-demo behavior-contract registry for issue #8186 at `docs/qa-demo/customer-behavior-contract-pilot.json`, with all contracts starting `pending` and blocker-backed.
- Add tests validating the committed pilot registry, client-private/public-opt-in rules, cadence requirements, and receipt rendering.

Closes #8186.

## Verification
- `bun run --cwd packages/behavior-contracts test`
- `bun run --cwd packages/behavior-contracts typecheck`
- `bun run check:deploy`

`bun run check:deploy` completed with exit code 0. The contract drift test prints expected planted-drift failure text while asserting the guard catches it; the overall command passed.