### PR TITLE
Hide internal Codex models from settings picker

### DIFF
--- a/clients/khala-code-desktop/src/ui/codex-settings-panel.ts
+++ b/clients/khala-code-desktop/src/ui/codex-settings-panel.ts
@@ -210,8 +210,8 @@ export const mountCodexSettingsPanel = (
       renderSelect({
         label: "Model",
         selected: selectedModel?.id ?? current.config.model,
-        options: current.models.options.map(model => ({
-          label: model.hidden ? `${model.displayName} (hidden)` : model.displayName,
+        options: current.models.options.filter(model => !model.hidden).map(model => ({
+          label: model.displayName,
           value: model.id,
         })),
         onChange: value => void write("model", value),

--- a/clients/khala-code-desktop/tests/codex-settings-panel.test.ts
+++ b/clients/khala-code-desktop/tests/codex-settings-panel.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, test } from "bun:test"
+import { Window } from "happy-dom"
+
+import { projectKhalaCodeDesktopCodexSettings } from "../src/shared/codex-settings"
+import { mountCodexSettingsPanel } from "../src/ui/codex-settings-panel"
+
+const setGlobal = (key: string, value: unknown): void => {
+  Object.defineProperty(globalThis, key, {
+    configurable: true,
+    value,
+    writable: true,
+  })
+}
+
+const installDom = (): {
+  readonly container: HTMLElement
+  readonly cleanup: () => void
+  readonly window: Window
+} => {
+  const window = new Window()
+  const previousWindow = globalThis.window
+  const previousDocument = globalThis.document
+  const previousHTMLElement = globalThis.HTMLElement
+
+  setGlobal("window", window)
+  setGlobal("document", window.document)
+  setGlobal("HTMLElement", window.HTMLElement)
+
+  const container = window.document.createElement("section")
+  window.document.body.append(container)
+
+  return {
+    container: container as unknown as HTMLElement,
+    window,
+    cleanup: () => {
+      Object.defineProperty(globalThis, "window", { configurable: true, value: previousWindow })
+      Object.defineProperty(globalThis, "document", { configurable: true, value: previousDocument })
+      Object.defineProperty(globalThis, "HTMLElement", { configurable: true, value: previousHTMLElement })
+      window.close()
+    },
+  }
+}
+
+describe("Codex settings panel", () => {
+  test("does not expose hidden Codex models as selectable chat models", async () => {
+    const { cleanup, container, window } = installDom()
+    const writes: unknown[] = []
+    const settings = projectKhalaCodeDesktopCodexSettings({
+      configRead: {
+        config: {
+          model: "gpt-5.5-codex",
+        },
+      },
+      modelList: {
+        data: [
+          {
+            id: "gpt-5.5-codex",
+            model: "gpt-5.5-codex",
+            displayName: "GPT-5.5",
+            hidden: false,
+          },
+          {
+            id: "codex-auto-review",
+            model: "codex-auto-review",
+            displayName: "Codex Auto Review",
+            hidden: true,
+          },
+          {
+            id: "gpt-5.4-mini",
+            model: "gpt-5.4-mini",
+            displayName: "GPT-5.4-Mini",
+            hidden: false,
+          },
+        ],
+      },
+    })
+
+    try {
+      const panel = mountCodexSettingsPanel(container, {
+        fetch: async () => settings,
+        write: async request => {
+          writes.push(request)
+          return { ok: true, settings }
+        },
+      })
+
+      await panel.refresh()
+
+      const modelSelect = container.querySelector("select")
+      expect(modelSelect).not.toBeNull()
+      const options = Array.from(modelSelect?.options ?? [])
+
+      expect(options.map(option => option.textContent)).toEqual(["GPT-5.5", "GPT-5.4-Mini"])
+      expect(options.some(option => option.value === "codex-auto-review")).toBe(false)
+      expect(container.textContent).not.toContain("Codex Auto Review")
+      expect(container.textContent).not.toContain("(hidden)")
+
+      if (modelSelect !== null) {
+        modelSelect.value = "gpt-5.4-mini"
+        modelSelect.dispatchEvent(new window.Event("change") as unknown as Event)
+      }
+
+      await Promise.resolve()
+
+      expect(writes).toEqual([{ keyPath: "model", value: "gpt-5.4-mini" }])
+    } finally {
+      cleanup()
+    }
+  })
+})


### PR DESCRIPTION
## Problem

Settings > Model exposed Codex `hidden` models, including internal auto-review models, as selectable chat models.

Fixes #8230.

## Change

- Filters hidden Codex model options out of the Settings model picker.
- Keeps the shared settings projection unchanged so hidden metadata is still available to non-picker consumers.
- Adds a DOM regression test proving the hidden model is absent from the select and cannot be chosen through that control.

## Validation

- `bun run typecheck`
- `bun test tests/codex-settings.test.ts tests/codex-settings-panel.test.ts tests/app-shell.test.ts`
- `git diff --check`

## Maintenance / Product Value

This keeps internal Codex workflow models out of the first-run Khala Code Desktop settings path, preventing users from selecting an internal auto-review model as their primary chat model.

## Not Changed

- Did not change the shared Codex settings projection.
- Did not address the separate Claude duplicate reply, Claude home isolation, or History filtering issues.
