### PR TITLE
Behavior contracts: cover QA scenario oracles

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -575,6 +575,7 @@
       "name": "@openagentsinc/khala-qa-harness",
       "version": "0.0.1",
       "dependencies": {
+        "@openagentsinc/behavior-contracts": "workspace:*",
         "@openagentsinc/khala-code-desktop": "workspace:*",
         "effect": "catalog:",
       },

--- a/clients/khala-code-desktop/src/contracts/ux-contracts.ts
+++ b/clients/khala-code-desktop/src/contracts/ux-contracts.ts
@@ -31,6 +31,7 @@ export const khalaCodeUxContractRegistry: BehaviorContractRegistryDocument = {
         "clients/khala-code-desktop/src/ui/codex-thread-sidebar.ts",
         "clients/khala-code-desktop/src/ui/main.ts",
         "docs/khala-code/khala-code-ux-contract.md",
+        "packages/khala-qa-harness/src/seed-corpus.ts",
       ],
       oracles: [
         {
@@ -48,6 +49,14 @@ export const khalaCodeUxContractRegistry: BehaviorContractRegistryDocument = {
           kind: "bun-test",
           mode: "unit",
           ref: "clients/khala-code-desktop/tests/ux-contracts.test.ts",
+        },
+        {
+          description:
+            "Runs the seed-corpus fixture RPC-driver scenario that lists threads, selects the fixture thread, and reads it back without using the row streaming spinner as load state.",
+          id: "thread_select_fixture_rpc.scenario",
+          kind: "qa-scenario",
+          mode: "rpc",
+          ref: "scenario.khala_code.seed.rpc_thread_select_fixture_driver.v1",
         },
       ],
       productArea: "chat thread sidebar",
@@ -762,5 +771,5 @@ export const khalaCodeUxContractRegistry: BehaviorContractRegistryDocument = {
     },
   ],
   schemaVersion: BehaviorContractSchemaVersion,
-  version: "2026-07-03.5",
+  version: "2026-07-03.6",
 }

--- a/clients/khala-code-desktop/tests/ux-contracts.test.ts
+++ b/clients/khala-code-desktop/tests/ux-contracts.test.ts
@@ -4,10 +4,10 @@ import { Window } from "happy-dom"
 
 import {
   checkBehaviorContractCoverage,
-  fileOracleSourceLayer,
   renderBehaviorContractMarkdown,
   validateBehaviorContractRegistry,
 } from "@openagentsinc/behavior-contracts"
+import { khalaCodeQaSeedScenarioOracleSourceLayer } from "@openagentsinc/khala-qa-harness/behavior-contract-oracles"
 import {
   KHALA_CODE_UX_CONTRACT_DOC_PATH,
   khalaCodeUxContractRegistry,
@@ -99,7 +99,10 @@ describe("khala code ux contract registry", () => {
     const report = await Effect.runPromise(
       checkBehaviorContractCoverage(khalaCodeUxContractRegistry).pipe(
         Effect.provide(
-          fileOracleSourceLayer(path => Bun.file(path).text(), repoPath),
+          khalaCodeQaSeedScenarioOracleSourceLayer({
+            readFile: path => Bun.file(path).text(),
+            resolvePath: repoPath,
+          }),
         ),
       ),
     )

--- a/docs/khala-code/khala-code-ux-contract.md
+++ b/docs/khala-code/khala-code-ux-contract.md
@@ -39,7 +39,8 @@ sweep if this doc, the registry, or the oracle tests drift apart.
 - The registry validation mirrors promise-transition checks
   (`validateBehaviorContractRegistry`), and the coverage check
   (`checkBehaviorContractCoverage`) proves every enforced `bun-test` oracle
-  file exists and references its contract id.
+  file exists and references its contract id, and every enforced `qa-scenario`
+  oracle resolves against the Khala QA seed corpus.
 - QA-harness integration: contracts may also carry `qa-scenario` oracles
   referencing `packages/khala-qa-harness` seed-corpus scenario ids; those run
   under the harness runner rather than this package's test glob.
@@ -52,7 +53,7 @@ sweep if this doc, the registry, or the oracle tests drift apart.
 
 ## Registry
 
-Registry version: `2026-07-03.5` (schema `openagents.behavior_contracts.v1`)
+Registry version: `2026-07-03.6` (schema `openagents.behavior_contracts.v1`)
 
 ### `khala_code.chat.sidebar_spinner_streaming_only.v1` — ENFORCED
 
@@ -62,6 +63,7 @@ Registry version: `2026-07-03.5` (schema `openagents.behavior_contracts.v1`)
 - **Enforcement tier:** test-sweep
 - **Oracle** `sidebar_spinner.dom` (bun-test, dom): Mounts the real thread sidebar in a DOM: selecting a thread while the resume RPC is in flight renders no spinner anywhere in the list, while a genuinely streaming thread renders the spinner in its time slot. — `clients/khala-code-desktop/tests/ux-contracts.test.ts`
 - **Oracle** `transcript_loading.source` (bun-test, unit): Pins the transcript-level 'Loading messages' indicator wiring for cache-miss thread switches (source-level until the full shell boots under the DOM harness). — `clients/khala-code-desktop/tests/ux-contracts.test.ts`
+- **Oracle** `thread_select_fixture_rpc.scenario` (qa-scenario, rpc): Runs the seed-corpus fixture RPC-driver scenario that lists threads, selects the fixture thread, and reads it back without using the row streaming spinner as load state. — `scenario.khala_code.seed.rpc_thread_select_fixture_driver.v1`
 - **Verification:** bun test tests/ux-contracts.test.ts inside clients/khala-code-desktop; runs in the package test glob, the package verify chain, and the repo test:khala-code-desktop sweep before pushes to main.
 - **Authority boundary:** This contract binds indicator semantics only. Thread-switch latency budgets stay owned by docs/qa/khala-code-latency-budgets.md, and it makes no claim about streaming correctness itself.
 

--- a/packages/behavior-contracts/src/behavior-contracts.test.ts
+++ b/packages/behavior-contracts/src/behavior-contracts.test.ts
@@ -162,7 +162,7 @@ describe("behavior contract coverage", () => {
     expect(report.results[0]?.status).toBe("missing_contract_reference")
   })
 
-  test("skips non-bun-test oracles and non-enforced contracts", async () => {
+  test("covers qa-scenario oracles when the scenario source exists", async () => {
     const registry = document([
       contract({
         oracles: [
@@ -172,6 +172,58 @@ describe("behavior contract coverage", () => {
             kind: "qa-scenario",
             mode: "rpc",
             ref: "scenario.khala_code.seed.example.v1",
+          },
+        ],
+      }),
+    ])
+    const report = await Effect.runPromise(
+      checkBehaviorContractCoverage(registry).pipe(
+        Effect.provide(
+          inMemoryOracleSourceLayer({
+            "scenario.khala_code.seed.example.v1": JSON.stringify({
+              id: "scenario.khala_code.seed.example.v1",
+            }),
+          }),
+        ),
+      ),
+    )
+    expect(report.ok).toBe(true)
+    expect(report.results[0]?.status).toBe("covered")
+  })
+
+  test("fails qa-scenario oracles when the scenario source is missing", async () => {
+    const registry = document([
+      contract({
+        oracles: [
+          {
+            description: "qa harness scenario",
+            id: "example.scenario",
+            kind: "qa-scenario",
+            mode: "rpc",
+            ref: "scenario.khala_code.seed.example.v1",
+          },
+        ],
+      }),
+    ])
+    const report = await Effect.runPromise(
+      checkBehaviorContractCoverage(registry).pipe(
+        Effect.provide(inMemoryOracleSourceLayer({})),
+      ),
+    )
+    expect(report.ok).toBe(false)
+    expect(report.results[0]?.status).toBe("missing_source")
+  })
+
+  test("skips non-source-backed oracles and non-enforced contracts", async () => {
+    const registry = document([
+      contract({
+        oracles: [
+          {
+            description: "manual acceptance check",
+            id: "example.manual",
+            kind: "manual-check",
+            mode: "unit",
+            ref: "manual.example",
           },
         ],
       }),

--- a/packages/behavior-contracts/src/coverage.ts
+++ b/packages/behavior-contracts/src/coverage.ts
@@ -74,11 +74,12 @@ export type BehaviorContractCoverageReport = {
 
 /**
  * Prove the registry and the test sweep agree: every enforced contract's
- * `bun-test` oracle file must exist and must reference the owning contractId,
- * so a contract cannot silently drift away from the tests that claim to
- * enforce it. Oracle kinds other than `bun-test` are reported as skipped
- * here; they are covered by their own runners (qa-harness scenarios, visual
- * smokes).
+ * source-backed oracle must resolve. `bun-test` oracle files must also
+ * reference the owning contractId, so a contract cannot silently drift away
+ * from the tests that claim to enforce it. `qa-scenario` oracle refs are
+ * resolved by a harness-specific oracle source layer and are covered when the
+ * named scenario still exists in that corpus. Visual and manual oracles are
+ * reported as skipped here; they are covered by their own runners.
  */
 export const checkBehaviorContractCoverage = (
   document: BehaviorContractRegistryDocument,
@@ -98,7 +99,7 @@ export const checkBehaviorContractCoverage = (
           })
           continue
         }
-        if (oracle.kind !== "bun-test") {
+        if (oracle.kind !== "bun-test" && oracle.kind !== "qa-scenario") {
           results.push({
             contractId: contract.contractId,
             oracleId: oracle.id,
@@ -117,9 +118,9 @@ export const checkBehaviorContractCoverage = (
           status:
             source === null
               ? "missing_source"
-              : source.includes(contract.contractId)
-                ? "covered"
-                : "missing_contract_reference",
+              : oracle.kind === "bun-test" && !source.includes(contract.contractId)
+                ? "missing_contract_reference"
+                : "covered",
         })
       }
     }

--- a/packages/khala-qa-harness/package.json
+++ b/packages/khala-qa-harness/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "exports": {
     ".": "./src/index.ts",
+    "./behavior-contract-oracles": "./src/behavior-contract-oracles.ts",
     "./coverage-ledger": "./src/coverage-ledger.ts",
     "./deterministic-env": "./src/deterministic-env.ts",
     "./desktop-smoke-helpers": "./src/desktop-smoke-helpers.ts",
@@ -32,6 +33,7 @@
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {
+    "@openagentsinc/behavior-contracts": "workspace:*",
     "@openagentsinc/khala-code-desktop": "workspace:*",
     "effect": "catalog:"
   },

--- a/packages/khala-qa-harness/src/behavior-contract-oracles.ts
+++ b/packages/khala-qa-harness/src/behavior-contract-oracles.ts
@@ -1,0 +1,34 @@
+import {
+  BehaviorContractOracleSource,
+  BehaviorContractOracleSourceError,
+} from "@openagentsinc/behavior-contracts"
+import { Effect, Layer } from "effect"
+import { KHALA_CODE_QA_SEED_SCENARIOS } from "./seed-corpus.js"
+
+const seedScenariosById = new Map(
+  KHALA_CODE_QA_SEED_SCENARIOS.map((scenario) => [scenario.id, scenario] as const),
+)
+
+export const khalaCodeQaSeedScenarioOracleSourceLayer = (options: {
+  readonly readFile?: (path: string) => Promise<string>
+  readonly resolvePath?: (ref: string) => string
+} = {}): Layer.Layer<BehaviorContractOracleSource> =>
+  Layer.succeed(BehaviorContractOracleSource, {
+    read: ref => {
+      const scenario = seedScenariosById.get(ref)
+      if (scenario !== undefined) {
+        return Effect.succeed(JSON.stringify(scenario))
+      }
+      if (options.readFile !== undefined) {
+        return Effect.tryPromise({
+          try: () => options.readFile?.(options.resolvePath?.(ref) ?? ref) ?? Promise.resolve(""),
+          catch: error =>
+            new BehaviorContractOracleSourceError(
+              ref,
+              error instanceof Error ? error.message : String(error),
+            ),
+        })
+      }
+      return Effect.fail(new BehaviorContractOracleSourceError(ref, "qa scenario not found"))
+    },
+  })

--- a/packages/khala-qa-harness/src/index.ts
+++ b/packages/khala-qa-harness/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./desktop-smoke-helpers.js"
+export * from "./behavior-contract-oracles.js"
 export * from "./coverage-ledger.js"
 export * from "./cross-mode.js"
 export * from "./deterministic-env.js"

--- a/packages/khala-qa-harness/src/runner.ts
+++ b/packages/khala-qa-harness/src/runner.ts
@@ -599,7 +599,8 @@ const evaluateOracle = (
 
   if (
     expectation.oracle === "invariant" &&
-    (expectation.id === "advisor-advisory-severity" ||
+    (expectation.id?.startsWith("fixture-evidence.") === true ||
+      expectation.id === "advisor-advisory-severity" ||
       expectation.id === "advisor-dedupe-guard" ||
       expectation.id === "advisor-interrupt-budget" ||
       expectation.id === "judge-verdict-card" ||

--- a/packages/khala-qa-harness/src/seed-corpus.ts
+++ b/packages/khala-qa-harness/src/seed-corpus.ts
@@ -295,6 +295,37 @@ const groupedRpcScenarios: readonly GroupedScenario[] = [
     ],
   ),
   groupedFixtureScenario(
+    "rpc.threads",
+    "scenario.khala_code.seed.rpc_thread_select_fixture_driver.v1",
+    [
+      {
+        name: "thread-select",
+        act: [
+          { kind: "rpc_call", method: "codexThreadList", args: [{ sessionId: desktopSessionId }] },
+          { kind: "thread_select", target: threadId },
+          { kind: "rpc_call", method: "codexThreadRead", args: [{ threadId, includeTurns: true }] },
+        ],
+        expect: [
+          schema("codexThreadList"),
+          schema("codexThreadRead"),
+          { id: "fixture-evidence.thread-select", match: threadId, oracle: "invariant" },
+          crash(),
+        ],
+      },
+    ],
+    [
+      commitment(
+        "contract.khala_code.chat.sidebar_spinner_streaming_only.v1",
+        "khala_code.chat.sidebar_spinner_streaming_only.v1 is covered by a fixture RPC-driver thread-select scenario",
+        "thread-select:invariant",
+      ),
+      runPass(
+        "seed.rpc_threads.thread_select.pass",
+        "thread-select over the fixture RPC driver passes",
+      ),
+    ],
+  ),
+  groupedFixtureScenario(
     "rpc.turns",
     "scenario.khala_code.seed.rpc_turns_lifecycle.v1",
     [


### PR DESCRIPTION
Fixes #8185.

## Summary
- Teach behavior-contract coverage to treat enforced `qa-scenario` refs as source-backed oracles.
- Add a Khala QA seed-corpus oracle source layer and a fixture RPC thread-select seed scenario.
- Wire `khala_code.chat.sidebar_spinner_streaming_only.v1` to the new scenario and update the UX contract doc.

## Verification
- `bun run --cwd packages/behavior-contracts test`
- `bun test clients/khala-code-desktop/tests/ux-contracts.test.ts`
- `bun test packages/khala-qa-harness/src/seed-corpus.test.ts`
- `bun run --cwd packages/behavior-contracts typecheck`
- `bun run --cwd packages/khala-qa-harness typecheck`
- `bun run --cwd clients/khala-code-desktop typecheck`
- `bun run check:deploy`
