### PR TITLE
Add behavior contract nightly receipts

### DIFF
--- a/docs/qa/khala-code-nightly-matrix.md
+++ b/docs/qa/khala-code-nightly-matrix.md
@@ -29,7 +29,13 @@ validation, coverage, and doc-sync run inside the desktop `verify` step, and
 the registry/coverage machinery's own suite runs as the dedicated
 `behavior-contracts` step. Per-contract receipts and deviation alerts
 (#8184) derive from these nightly runs; the eventual trigger-engine carrier
-is ROADMAP_BACKGROUND_AGENTS WS-B.
+is ROADMAP_BACKGROUND_AGENTS WS-B. The matrix now emits
+`behavior-contracts/behavior-contract-receipts.json`: one receipt per contract
+with `checks`, `evidenceRefs`, and `checkedAt`. Receipts record evidence only;
+they never flip registry state. The latest sweep summary is also copied into
+`qa-nightly-report.json` as `behaviorContractRun` and into
+`qa-status-surface.json` as `behaviorContracts`, which is the QA Swarm evidence
+board lookup for "contract X was green on date Y".
 
 The default monkey settings produce 1024 deterministic fixture actions, meeting
 the Q1.1 >=1000 action floor. Override with `OA_QA_NIGHTLY_MONKEY_RUNS` and
@@ -46,6 +52,8 @@ Each run writes:
 - `qa-nightly-report.md`
 - `qa-status-surface.json`
 - `qa-status-surface.md`
+- the per-contract receipt set under
+  `behavior-contracts/behavior-contract-receipts.json`
 - `latencyBudgetRun` inside `qa-nightly-report.json`, derived from current
   `qaMetrics` snapshots found under the run artifact directory
 - one log per step under `logs/`
@@ -63,6 +71,13 @@ If the matrix fails and `OA_QA_NIGHTLY_FILE_ISSUE=1` is set, the runner files a
 strict bug issue through `gh issue create` with public-safe report refs and the
 failed step IDs. Raw command logs stay in the owned-runner artifact directory and
 must be redaction-reviewed before external publication.
+
+If any enforced behavior-contract receipt fails and
+`OA_QA_NIGHTLY_FILE_CONTRACT_DEVIATION_ISSUE=1` is set, the runner files a
+strict bug with the contract id, the statement, failed checks, and the receipt
+artifact ref. The generated issue body is
+`qa-nightly-behavior-contract-deviation-issue.md` under the current run
+artifact directory.
 
 ## Perf Trends And Regressions
 

--- a/docs/qa/qa-swarm-khala-code-standing-engagement.md
+++ b/docs/qa/qa-swarm-khala-code-standing-engagement.md
@@ -38,10 +38,13 @@ Khala Code QA loop as a weekly report:
   surface (ids + statements from
   `clients/khala-code-desktop/src/contracts/ux-contracts.ts`, human doc
   `docs/khala-code/khala-code-ux-contract.md`) with the latest sweep verdict
-  per contract. The oracles run in the nightly matrix (desktop `verify` step
-  plus the dedicated `behavior-contracts` step), so contract status follows
-  the same evidence rules as every other count. This is the customer-one
-  instance of the invariant catalog the QA Swarm sells — see
+  per contract. The nightly matrix writes the receipt set at
+  `behavior-contracts/behavior-contract-receipts.json` and mirrors the latest
+  pass/fail counts plus failed contract ids into `qa-status-surface.json` under
+  `behaviorContracts`. The oracles run in the nightly matrix (desktop `verify`
+  step plus the dedicated `behavior-contracts` step), so contract status
+  follows the same evidence rules as every other count. This is the
+  customer-one instance of the invariant catalog the QA Swarm sells — see
   `docs/fable/2026-07-03-behavior-contracts-and-customer-invariants.md`.
 - Keep raw logs, local paths, account identifiers, provider payloads, customer
   records, and private traces out of the projection.

--- a/packages/behavior-contracts/package.json
+++ b/packages/behavior-contracts/package.json
@@ -8,6 +8,7 @@
     "./contract": "./src/contract.ts",
     "./registry": "./src/registry.ts",
     "./coverage": "./src/coverage.ts",
+    "./receipt": "./src/receipt.ts",
     "./report": "./src/report.ts"
   },
   "scripts": {

--- a/packages/behavior-contracts/src/behavior-contracts.test.ts
+++ b/packages/behavior-contracts/src/behavior-contracts.test.ts
@@ -10,6 +10,7 @@ import {
   checkBehaviorContractCoverage,
   inMemoryOracleSourceLayer,
 } from "./coverage"
+import { buildBehaviorContractReceipts } from "./receipt"
 import { validateBehaviorContractRegistry } from "./registry"
 import { renderBehaviorContractMarkdown } from "./report"
 
@@ -201,5 +202,46 @@ describe("behavior contract report", () => {
     expect(markdown).toContain("Example stated behavior.")
     expect(markdown).toContain("test-sweep")
     expect(markdown).toContain("clients/khala-code-desktop/tests/ux-contracts.test.ts")
+  })
+})
+
+describe("behavior contract receipts", () => {
+  test("records per-contract pass and fail checks without changing registry state", async () => {
+    const registry = document([contract()])
+    const registryValidation = validateBehaviorContractRegistry(registry)
+    const coverage = await Effect.runPromise(
+      checkBehaviorContractCoverage(registry).pipe(
+        Effect.provide(
+          inMemoryOracleSourceLayer({
+            "clients/khala-code-desktop/tests/ux-contracts.test.ts":
+              "// khala_code.chat.example_behavior.v1 oracle body",
+          }),
+        ),
+      ),
+    )
+
+    const [receipt] = buildBehaviorContractReceipts(registry, {
+      checkedAt: "2026-07-03T12:00:00.000Z",
+      coverage,
+      registryValidation,
+      runId: "nightly-1",
+      sweepChecks: [
+        {
+          evidenceRefs: ["var/qa-nightly/nightly-1/logs/desktop-verify.log"],
+          id: "nightly_step.desktop_verify",
+          status: "fail",
+          summary: "desktop verify failed",
+        },
+      ],
+    })
+
+    expect(receipt?.schema).toBe("openagents.behavior_contract_receipt.v1")
+    expect(receipt?.contractId).toBe("khala_code.chat.example_behavior.v1")
+    expect(receipt?.statement).toBe("Example stated behavior.")
+    expect(receipt?.status).toBe("fail")
+    expect(receipt?.checks.map(check => check.id)).toContain("registry_entry_valid")
+    expect(receipt?.checks.map(check => check.id)).toContain("oracle_coverage_linked")
+    expect(receipt?.checks.map(check => check.id)).toContain("nightly_step.desktop_verify")
+    expect(registry.contracts[0]?.state).toBe("enforced")
   })
 })

--- a/packages/behavior-contracts/src/coverage.ts
+++ b/packages/behavior-contracts/src/coverage.ts
@@ -132,3 +132,14 @@ export const checkBehaviorContractCoverage = (
     )
     return { ok, results }
   })
+
+export const checkBehaviorContractCoverageFromFiles = (
+  document: BehaviorContractRegistryDocument,
+  readFile: (path: string) => Promise<string>,
+  resolvePath: (ref: string) => string = ref => ref,
+): Promise<BehaviorContractCoverageReport> =>
+  Effect.runPromise(
+    checkBehaviorContractCoverage(document).pipe(
+      Effect.provide(fileOracleSourceLayer(readFile, resolvePath)),
+    ),
+  )

--- a/packages/behavior-contracts/src/index.ts
+++ b/packages/behavior-contracts/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./contract"
 export * from "./coverage"
+export * from "./receipt"
 export * from "./registry"
 export * from "./report"

--- a/packages/behavior-contracts/src/receipt.ts
+++ b/packages/behavior-contracts/src/receipt.ts
@@ -1,0 +1,126 @@
+import type {
+  BehaviorContract,
+  BehaviorContractRegistryDocument,
+} from "./contract"
+import type { BehaviorContractCoverageReport } from "./coverage"
+import type { BehaviorContractRegistryValidation } from "./registry"
+
+export const BehaviorContractReceiptSchemaVersion =
+  "openagents.behavior_contract_receipt.v1"
+
+export type BehaviorContractReceiptCheckStatus = "pass" | "fail" | "skipped"
+
+export type BehaviorContractReceiptCheck = Readonly<{
+  checkedAt: string
+  evidenceRefs: readonly string[]
+  id: string
+  status: BehaviorContractReceiptCheckStatus
+  summary: string
+}>
+
+export type BehaviorContractReceiptStatus = "pass" | "fail" | "skipped"
+
+export type BehaviorContractReceipt = Readonly<{
+  checkedAt: string
+  checks: readonly BehaviorContractReceiptCheck[]
+  contractId: string
+  evidenceRefs: readonly string[]
+  receiptId: string
+  registryVersion: string
+  schema: typeof BehaviorContractReceiptSchemaVersion
+  statement: string
+  status: BehaviorContractReceiptStatus
+  surface: string
+}>
+
+export type BehaviorContractReceiptSweepCheck = Readonly<{
+  evidenceRefs: readonly string[]
+  id: string
+  status: "pass" | "fail"
+  summary: string
+}>
+
+const contractIssues = (
+  validation: BehaviorContractRegistryValidation,
+  contractId: string,
+) => validation.issues.filter(issue => issue.contractId === contractId)
+
+const contractCoverageFailures = (
+  coverage: BehaviorContractCoverageReport,
+  contractId: string,
+) =>
+  coverage.results.filter(result =>
+    result.contractId === contractId &&
+    result.status !== "covered" &&
+    result.status !== "skipped_kind" &&
+    result.status !== "skipped_state"
+  )
+
+const receiptStatus = (
+  contract: BehaviorContract,
+  checks: readonly BehaviorContractReceiptCheck[],
+): BehaviorContractReceiptStatus => {
+  if (contract.state !== "enforced") return "skipped"
+  return checks.some(check => check.status === "fail") ? "fail" : "pass"
+}
+
+export const buildBehaviorContractReceipts = (
+  document: BehaviorContractRegistryDocument,
+  input: Readonly<{
+    checkedAt: string
+    coverage: BehaviorContractCoverageReport
+    registryValidation: BehaviorContractRegistryValidation
+    runId: string
+    sweepChecks: readonly BehaviorContractReceiptSweepCheck[]
+  }>,
+): readonly BehaviorContractReceipt[] =>
+  document.contracts.map(contract => {
+    const registryIssues = contractIssues(input.registryValidation, contract.contractId)
+    const coverageFailures = contractCoverageFailures(input.coverage, contract.contractId)
+    const checks: BehaviorContractReceiptCheck[] = [
+      {
+        checkedAt: input.checkedAt,
+        evidenceRefs: contract.evidenceRefs,
+        id: "registry_entry_valid",
+        status: registryIssues.length === 0 ? "pass" : "fail",
+        summary: registryIssues.length === 0
+          ? "Registry entry passed mechanical validation."
+          : registryIssues.map(issue => `${issue.kind}: ${issue.detail}`).join("; "),
+      },
+      {
+        checkedAt: input.checkedAt,
+        evidenceRefs: contract.oracles.map(oracle => oracle.ref),
+        id: "oracle_coverage_linked",
+        status: coverageFailures.length === 0 ? "pass" : "fail",
+        summary: coverageFailures.length === 0
+          ? "Oracle refs are linked to the owning contract or intentionally handled by their runner."
+          : coverageFailures.map(result => `${result.oracleId}: ${result.status} (${result.ref})`).join("; "),
+      },
+      ...input.sweepChecks.map((check): BehaviorContractReceiptCheck => ({
+        checkedAt: input.checkedAt,
+        evidenceRefs: check.evidenceRefs,
+        id: check.id,
+        status: contract.state === "enforced" ? check.status : "skipped",
+        summary: contract.state === "enforced"
+          ? check.summary
+          : `Contract state is ${contract.state}; nightly sweep check recorded but not used as a green claim.`,
+      })),
+    ]
+    const evidenceRefs = [
+      ...contract.evidenceRefs,
+      ...checks.flatMap(check => check.evidenceRefs),
+    ]
+
+    return {
+      checkedAt: input.checkedAt,
+      checks,
+      contractId: contract.contractId,
+      evidenceRefs: [...new Set(evidenceRefs)].sort(),
+      receiptId: `${input.runId}:${contract.contractId}`,
+      registryVersion: document.version,
+      schema: BehaviorContractReceiptSchemaVersion,
+      statement: contract.statement,
+      status: receiptStatus(contract, checks),
+      surface: contract.surface,
+    }
+  })

--- a/scripts/qa-nightly-matrix.test.ts
+++ b/scripts/qa-nightly-matrix.test.ts
@@ -91,11 +91,19 @@ describe("qa nightly matrix report", () => {
       expect(await readFile(join(root, report.quarantineLedgerPath), "utf8")).toContain(
         "qa_flake_quarantine_ledger",
       )
+      expect(await readFile(join(root, report.behaviorContractReceiptPath), "utf8")).toContain(
+        "openagents.behavior_contract_receipt.v1",
+      )
       const statusSurface = JSON.parse(await readFile(join(root, report.statusSurfaceJsonPath), "utf8"))
       const statusMarkdown = await readFile(join(root, report.statusSurfaceMarkdownPath), "utf8")
       expect(statusSurface.schema).toBe("openagents.khala_code.qa_status_surface.v1")
       expect(statusSurface.statusSummary).toBe("healthy")
       expect(statusSurface.liveTier.status).toBe("not_in_matrix")
+      expect(statusSurface.behaviorContracts).toMatchObject({
+        basis: "behavior_contract_receipts",
+        status: "pass",
+      })
+      expect(statusSurface.behaviorContracts.receiptCount).toBeGreaterThan(0)
       expect(statusSurface.coverage.counts.rpcMethods.total).toBeGreaterThan(0)
       expect(statusSurface.perfTrends.steps[0]).toMatchObject({
         latestDurationMs: 7,
@@ -116,6 +124,7 @@ describe("qa nightly matrix report", () => {
         trend: "no_samples",
       })
       expect(statusMarkdown).toContain("Khala Code QA Status")
+      expect(statusMarkdown).toContain("Behavior Contracts")
       expect(statusMarkdown).toContain("| rpcMethods |")
       expect(statusMarkdown).toContain("Latency Budgets")
       expect(statusMarkdown).toContain("Budget Trends")
@@ -208,6 +217,58 @@ describe("qa nightly matrix report", () => {
       expect(filed).toEqual([
         "[Bug]: Khala Code QA nightly failed khala-code-qa-nightly-2026-07-02t123000.000z",
       ])
+    } finally {
+      await rm(root, { force: true, recursive: true })
+    }
+  })
+
+  test("files a behavior-contract deviation issue when nightly receipts fail and opt-in is armed", async () => {
+    const root = await mkdtemp(join(tmpdir(), "qa-nightly-contract-deviation-"))
+    const filed: string[] = []
+    const commandRunner: QaNightlyCommandRunner = async step => ({
+      durationMs: 3,
+      exitCode: step.id === "desktop-verify" ? 1 : 0,
+      stderr: step.id === "desktop-verify" ? "contract oracle failure" : "",
+      stdout: "",
+    })
+    const issueFiler: QaNightlyIssueFiler = async input => {
+      filed.push(input.title)
+      const body = await readFile(input.bodyPath, "utf8")
+      if (input.title.includes("behavior contract deviated")) {
+        expect(body).toContain("### Failing checks")
+        expect(body).toContain("khala_code.chat.sidebar_spinner_streaming_only.v1")
+        expect(body).toContain("Behavior-contract receipts")
+      }
+      return {
+        issueUrl: "https://github.com/OpenAgentsInc/openagents/issues/10003",
+        status: "filed",
+      }
+    }
+
+    try {
+      const report = await runQaNightlyMatrix({
+        artifactRoot: join(root, "artifacts"),
+        commandRunner,
+        env: {
+          OA_QA_NIGHTLY_FILE_CONTRACT_DEVIATION_ISSUE: "1",
+        },
+        issueFiler,
+        now: () => "2026-07-02T14:00:00.000Z",
+        root,
+      })
+      const statusSurface = JSON.parse(await readFile(join(root, report.statusSurfaceJsonPath), "utf8"))
+
+      expect(report.behaviorContractRun.status).toBe("fail")
+      expect(report.behaviorContractDeviationIssueStatus).toEqual({
+        issueUrl: "https://github.com/OpenAgentsInc/openagents/issues/10003",
+        status: "filed",
+      })
+      expect(statusSurface.behaviorContracts.failedContractIds).toContain(
+        "khala_code.chat.sidebar_spinner_streaming_only.v1",
+      )
+      expect(filed).toContain(
+        "[Bug]: Khala Code behavior contract deviated khala_code.chat.sidebar_spinner_streaming_only.v1",
+      )
     } finally {
       await rm(root, { force: true, recursive: true })
     }
@@ -545,6 +606,18 @@ describe("qa nightly matrix report", () => {
   test("failure issue body contains strict-form sections and public-safe refs", () => {
     const body = buildQaNightlyFailureIssueBody({
       artifactDir: "var/qa-nightly/run",
+      behaviorContractReceiptPath: "var/qa-nightly/run/behavior-contracts/behavior-contract-receipts.json",
+      behaviorContractRun: {
+        checkedAt: "2026-07-02T12:00:00.000Z",
+        failedContractIds: [],
+        passCount: 1,
+        receiptCount: 1,
+        receiptRefs: ["var/qa-nightly/run/behavior-contracts/behavior-contract-receipts.json"],
+        registryVersion: "2026-07-03.1",
+        schema: "openagents.khala_code.behavior_contract_nightly_run.v1",
+        skippedCount: 0,
+        status: "pass",
+      },
       coverageFrontierReportPath: "var/qa-nightly/run/coverage/coverage-frontier-report.json",
       coverageLedgerPath: "var/qa-nightly/run/coverage/coverage-union-ledger.json",
       coverageLedgerSourcePaths: ["var/qa-nightly/run/monkey-night/monkey-night-coverage-ledger.json"],

--- a/scripts/qa-nightly-matrix.ts
+++ b/scripts/qa-nightly-matrix.ts
@@ -4,6 +4,12 @@ import { readdir, readFile, mkdir, writeFile } from "node:fs/promises"
 import { basename, dirname, join, relative, resolve } from "node:path"
 
 import {
+  buildBehaviorContractReceipts,
+  checkBehaviorContractCoverageFromFiles,
+  validateBehaviorContractRegistry,
+  type BehaviorContractReceipt,
+} from "../packages/behavior-contracts/src/index.js"
+import {
   KHALA_CODE_QA_SEED_CORPUS_MANIFEST,
   KhalaCodeRpcMethodNames,
   createEmptyKhalaCodeQaCoverageLedger,
@@ -23,6 +29,7 @@ import {
   type KhalaCodeQaMetricSample,
   type KhalaCodeQaMetricsSnapshot,
 } from "../clients/khala-code-desktop/src/shared/qa-metrics.js"
+import { khalaCodeUxContractRegistry } from "../clients/khala-code-desktop/src/contracts/ux-contracts.js"
 
 export const QA_NIGHTLY_MATRIX_SCHEMA =
   "openagents.khala_code.qa_nightly_matrix.v1"
@@ -86,14 +93,29 @@ export type QaNightlyReport = Readonly<{
   coverageLedgerSourcePaths: readonly string[]
   coverageFrontierReportPath: string
   coverageSteeringInputPath: string
+  behaviorContractReceiptPath: string
+  behaviorContractRun: QaNightlyBehaviorContractRun
   quarantineLedgerPath: string
   statusSurfaceJsonPath: string
   statusSurfaceMarkdownPath: string
   latencyBudgetRun: QaNightlyLatencyBudgetRun
   issueStatus?: QaNightlyIssueStatus | undefined
+  behaviorContractDeviationIssueStatus?: QaNightlyIssueStatus | undefined
   quarantineIssueStatus?: QaNightlyIssueStatus | undefined
   latencyBudgetRegressionIssueStatus?: QaNightlyIssueStatus | undefined
   zeroCoverageIssueStatus?: QaNightlyIssueStatus | undefined
+}>
+
+export type QaNightlyBehaviorContractRun = Readonly<{
+  schema: "openagents.khala_code.behavior_contract_nightly_run.v1"
+  checkedAt: string
+  failedContractIds: readonly string[]
+  passCount: number
+  receiptCount: number
+  receiptRefs: readonly string[]
+  registryVersion: string
+  skippedCount: number
+  status: "pass" | "fail"
 }>
 
 export type QaNightlyIssueStatus = Readonly<
@@ -220,6 +242,7 @@ export type QaNightlyStatusSurface = Readonly<{
     zeroForAWeekCount: number
   }>
   issueStatuses: Readonly<{
+    behaviorContractDeviation: QaNightlyIssueStatus | undefined
     latencyBudgetRegression: QaNightlyIssueStatus | undefined
     nightly: QaNightlyIssueStatus | undefined
     quarantine: QaNightlyIssueStatus | undefined
@@ -229,6 +252,18 @@ export type QaNightlyStatusSurface = Readonly<{
     evidenceRefs: readonly string[]
     reason: string
     status: "not_in_matrix"
+  }>
+  behaviorContracts: Readonly<{
+    basis: "behavior_contract_receipts"
+    checkedAt: string
+    evidenceBoard: "qa-swarm"
+    failedContractIds: readonly string[]
+    latestReceiptPath: string
+    passCount: number
+    receiptCount: number
+    registryVersion: string
+    skippedCount: number
+    status: QaNightlyBehaviorContractRun["status"]
   }>
   latencyBudgets: Readonly<{
     basis: "qaMetrics_budget_catalog"
@@ -781,6 +816,73 @@ const buildQaNightlyLatencyBudgetCatalog = (
   })
 }
 
+export const emitQaNightlyBehaviorContractArtifacts = async (input: Readonly<{
+  artifactDir: string
+  generatedAt: string
+  root: string
+  runId: string
+  steps: readonly QaNightlyStepResult[]
+}>): Promise<Readonly<{
+  receiptPath: string
+  receipts: readonly BehaviorContractReceipt[]
+  run: QaNightlyBehaviorContractRun
+}>> => {
+  const receiptPath = join(input.artifactDir, "behavior-contracts", "behavior-contract-receipts.json")
+  await mkdir(dirname(receiptPath), { recursive: true })
+
+  const registryValidation = validateBehaviorContractRegistry(khalaCodeUxContractRegistry)
+  const coverage = await checkBehaviorContractCoverageFromFiles(
+    khalaCodeUxContractRegistry,
+    path => readFile(path, "utf8"),
+    ref => resolve(process.cwd(), ref),
+  )
+  const behaviorStep = input.steps.find(step => step.id === "behavior-contracts")
+  const desktopVerifyStep = input.steps.find(step => step.id === "desktop-verify")
+  const stepCheck = (id: string, step: QaNightlyStepResult | undefined) => ({
+    evidenceRefs: step === undefined ? [] : [step.logRef],
+    id,
+    status: step?.status === "passed" ? "pass" as const : "fail" as const,
+    summary: step === undefined
+      ? "Nightly step did not run."
+      : `Nightly step ${step.id} finished with status ${step.status}.`,
+  })
+  const receipts = buildBehaviorContractReceipts(khalaCodeUxContractRegistry, {
+    checkedAt: input.generatedAt,
+    coverage,
+    registryValidation,
+    runId: input.runId,
+    sweepChecks: [
+      stepCheck("nightly_step.behavior_contracts", behaviorStep),
+      stepCheck("nightly_step.desktop_verify", desktopVerifyStep),
+    ],
+  })
+  await writeFile(receiptPath, `${JSON.stringify({
+    checkedAt: input.generatedAt,
+    receipts,
+    schema: "openagents.khala_code.behavior_contract_receipts.v1",
+  }, null, 2)}\n`)
+  const failedContractIds = receipts
+    .filter(receipt => receipt.status === "fail")
+    .map(receipt => receipt.contractId)
+  const run: QaNightlyBehaviorContractRun = {
+    checkedAt: input.generatedAt,
+    failedContractIds,
+    passCount: receipts.filter(receipt => receipt.status === "pass").length,
+    receiptCount: receipts.length,
+    receiptRefs: [repoRelative(input.root, receiptPath)],
+    registryVersion: khalaCodeUxContractRegistry.version,
+    schema: "openagents.khala_code.behavior_contract_nightly_run.v1",
+    skippedCount: receipts.filter(receipt => receipt.status === "skipped").length,
+    status: failedContractIds.length === 0 ? "pass" : "fail",
+  }
+
+  return {
+    receiptPath,
+    receipts,
+    run,
+  }
+}
+
 export const buildQaNightlyStatusSurface = (input: Readonly<{
   frontierReport: KhalaCodeQaCoverageFrontierReport
   history: readonly QaNightlyReportHistoryEntry[]
@@ -808,6 +910,7 @@ export const buildQaNightlyStatusSurface = (input: Readonly<{
     },
     generatedAt: input.report.generatedAt,
     issueStatuses: {
+      behaviorContractDeviation: input.report.behaviorContractDeviationIssueStatus,
       latencyBudgetRegression: input.report.latencyBudgetRegressionIssueStatus,
       nightly: input.report.issueStatus,
       quarantine: input.report.quarantineIssueStatus,
@@ -820,6 +923,18 @@ export const buildQaNightlyStatusSurface = (input: Readonly<{
       ],
       reason: "Live-tier Q5 smokes are not part of the Q1 nightly matrix yet; fixture tiers remain no-spend and account-isolated.",
       status: "not_in_matrix",
+    },
+    behaviorContracts: {
+      basis: "behavior_contract_receipts",
+      checkedAt: input.report.behaviorContractRun.checkedAt,
+      evidenceBoard: "qa-swarm",
+      failedContractIds: input.report.behaviorContractRun.failedContractIds,
+      latestReceiptPath: input.report.behaviorContractReceiptPath,
+      passCount: input.report.behaviorContractRun.passCount,
+      receiptCount: input.report.behaviorContractRun.receiptCount,
+      registryVersion: input.report.behaviorContractRun.registryVersion,
+      skippedCount: input.report.behaviorContractRun.skippedCount,
+      status: input.report.behaviorContractRun.status,
     },
     latencyBudgets: {
       basis: "qaMetrics_budget_catalog",
@@ -1121,6 +1236,11 @@ export const renderQaNightlyMarkdown = (report: QaNightlyReport): string => {
     : report.quarantineIssueStatus.status === "filed"
       ? `Filed: ${report.quarantineIssueStatus.issueUrl ?? "issue URL unavailable"}`
       : `${report.quarantineIssueStatus.status}: ${report.quarantineIssueStatus.reason}`
+  const behaviorContracts = report.behaviorContractDeviationIssueStatus === undefined
+    ? "Not evaluated."
+    : report.behaviorContractDeviationIssueStatus.status === "filed"
+      ? `Filed: ${report.behaviorContractDeviationIssueStatus.issueUrl ?? "issue URL unavailable"}`
+      : `${report.behaviorContractDeviationIssueStatus.status}: ${report.behaviorContractDeviationIssueStatus.reason}`
 
   return `# Khala Code QA Nightly Matrix
 
@@ -1129,6 +1249,7 @@ export const renderQaNightlyMarkdown = (report: QaNightlyReport): string => {
 - Status: \`${report.status}\`
 - Status surface JSON: \`${report.statusSurfaceJsonPath}\`
 - Status surface markdown: \`${report.statusSurfaceMarkdownPath}\`
+- Behavior-contract receipts: \`${report.behaviorContractReceiptPath}\`
 - Flake quarantine ledger: \`${report.quarantineLedgerPath}\`
 - Coverage union ledger: \`${report.coverageLedgerPath}\`
 - Coverage frontier report: \`${report.coverageFrontierReportPath}\`
@@ -1149,6 +1270,16 @@ ${failedLines}
 Policy: retry once, quarantine pass-after-fail, never silently retry green.
 
 Quarantine issue status: ${quarantine}
+
+## Behavior Contracts
+
+- Receipt status: \`${report.behaviorContractRun.status}\`
+- Registry version: \`${report.behaviorContractRun.registryVersion}\`
+- Receipts: \`${report.behaviorContractRun.receiptCount}\`
+- Passed: \`${report.behaviorContractRun.passCount}\`
+- Skipped: \`${report.behaviorContractRun.skippedCount}\`
+- Failed contracts: ${report.behaviorContractRun.failedContractIds.length === 0 ? "None." : report.behaviorContractRun.failedContractIds.map(id => `\`${id}\``).join(", ")}
+- Deviation issue status: ${behaviorContracts}
 
 ## Coverage Frontier
 
@@ -1211,6 +1342,20 @@ ${surface.liveTier.reason}
 Evidence refs:
 ${surface.liveTier.evidenceRefs.map(ref => `- \`${ref}\``).join("\n")}
 
+## Behavior Contracts
+
+Basis: \`${surface.behaviorContracts.basis}\`
+
+Status: \`${surface.behaviorContracts.status}\`
+
+- Registry version: \`${surface.behaviorContracts.registryVersion}\`
+- Checked at: \`${surface.behaviorContracts.checkedAt}\`
+- Latest receipts: \`${surface.behaviorContracts.latestReceiptPath}\`
+- Receipt count: \`${surface.behaviorContracts.receiptCount}\`
+- Passed: \`${surface.behaviorContracts.passCount}\`
+- Skipped: \`${surface.behaviorContracts.skippedCount}\`
+- Failed contracts: ${surface.behaviorContracts.failedContractIds.length === 0 ? "None." : surface.behaviorContracts.failedContractIds.map(id => `\`${id}\``).join(", ")}
+
 ## Coverage
 
 - Union runs: \`${surface.coverage.unionRunCount}\`
@@ -1260,6 +1405,7 @@ ${latencyTrendRows}
 ## Issues
 
 - Nightly: ${issueStatus(surface.issueStatuses.nightly)}
+- Behavior contract deviation: ${issueStatus(surface.issueStatuses.behaviorContractDeviation)}
 - Flake quarantine: ${issueStatus(surface.issueStatuses.quarantine)}
 - Latency budget regression: ${issueStatus(surface.issueStatuses.latencyBudgetRegression)}
 - Zero coverage: ${issueStatus(surface.issueStatuses.zeroCoverage)}
@@ -1418,6 +1564,70 @@ S2 - measured latency regression in the automated QA loop
 ### Safety and redaction
 
 The issue body includes budget IDs, metric names, numeric samples, timestamps, and repo-relative artifact refs only. It does not include raw command logs, local absolute paths, account identifiers, or provider payloads.
+`
+}
+
+export const buildQaNightlyBehaviorContractDeviationIssueBody = (
+  report: QaNightlyReport,
+  failedReceipts: readonly BehaviorContractReceipt[],
+): string => {
+  const rows = failedReceipts
+    .map(receipt =>
+      `| \`${receipt.contractId}\` | ${receipt.statement} | \`${receipt.status}\` | \`${receipt.receiptId}\` |`
+    )
+    .join("\n")
+  const checkRows = failedReceipts
+    .flatMap(receipt =>
+      receipt.checks
+        .filter(check => check.status === "fail")
+        .map(check =>
+          `| \`${receipt.contractId}\` | \`${check.id}\` | ${check.summary} | ${check.evidenceRefs.map(ref => `\`${ref}\``).join(", ") || "none"} |`
+        )
+    )
+    .join("\n")
+
+  return `### Affected surface
+
+Khala Code Desktop behavior-contract nightly enforcement.
+
+### Actual behavior
+
+Nightly run \`${report.runId}\` emitted failed behavior-contract receipts.
+
+| Contract | Statement | Receipt status | Receipt |
+| --- | --- | --- | --- |
+${rows}
+
+### Expected behavior
+
+Every enforced behavior contract should pass its registry, oracle-coverage, and nightly sweep checks. Receipts record evidence only and do not flip registry state.
+
+### Reproduction steps
+
+1. Check out the repository commit used by the owned runner.
+2. Run \`bun run qa:nightly\`.
+3. Inspect \`${report.behaviorContractReceiptPath}\` and the failed checks listed below.
+
+### Failing checks
+
+| Contract | Check | Summary | Evidence refs |
+| --- | --- | --- | --- |
+${checkRows || "| n/a | n/a | n/a | n/a |"}
+
+### Public-safe evidence
+
+- Report JSON: \`${report.reportJsonPath}\`
+- Status surface JSON: \`${report.statusSurfaceJsonPath}\`
+- Status surface markdown: \`${report.statusSurfaceMarkdownPath}\`
+- Behavior-contract receipts: \`${report.behaviorContractReceiptPath}\`
+
+### Severity
+
+S2 - stated product behavior contract deviation in the automated QA loop
+
+### Safety and redaction
+
+The issue body includes contract IDs, owner/customer statements already committed in the public registry, public-safe receipt IDs, and repo-relative evidence refs only. Raw command logs remain in the owned-runner artifact directory and must be redaction-reviewed before external publication.
 `
 }
 
@@ -1659,10 +1869,19 @@ export const runQaNightlyMatrix = async (input: Readonly<{
     generatedAt,
     root,
   })
+  const behaviorContractArtifacts = await emitQaNightlyBehaviorContractArtifacts({
+    artifactDir,
+    generatedAt,
+    root,
+    runId,
+    steps: results,
+  })
   const history = (await readQaNightlyReportHistory(artifactRoot))
     .filter(entry => entry.runId !== runId)
   const reportBase: QaNightlyReport = {
     artifactDir: repoRelative(root, artifactDir),
+    behaviorContractReceiptPath: repoRelative(root, behaviorContractArtifacts.receiptPath),
+    behaviorContractRun: behaviorContractArtifacts.run,
     coverageFrontierReportPath: repoRelative(root, coverageArtifacts.frontierReportPath),
     coverageLedgerPath: repoRelative(root, coverageArtifacts.unionLedgerPath),
     coverageLedgerSourcePaths: coverageArtifacts.sourceLedgerPaths.map(path => repoRelative(root, path)),
@@ -1743,10 +1962,28 @@ export const runQaNightlyMatrix = async (input: Readonly<{
       title: `[Bug]: Khala Code latency budget regressed ${latencyRegressions[0]?.budgetId ?? reportBase.runId}`,
     })
   })()
+  const behaviorContractDeviationIssueStatus = await (async (): Promise<QaNightlyIssueStatus | undefined> => {
+    const failedReceipts = behaviorContractArtifacts.receipts.filter(receipt => receipt.status === "fail")
+    if (failedReceipts.length === 0) {
+      return { reason: "no behavior contract deviation was observed", status: "disabled" }
+    }
+    if (env.OA_QA_NIGHTLY_FILE_CONTRACT_DEVIATION_ISSUE !== "1") {
+      return { reason: "OA_QA_NIGHTLY_FILE_CONTRACT_DEVIATION_ISSUE is not set", status: "disabled" }
+    }
+    const body = buildQaNightlyBehaviorContractDeviationIssueBody(reportBase, failedReceipts)
+    const issueBodyPath = join(artifactDir, "qa-nightly-behavior-contract-deviation-issue.md")
+    await writeFile(issueBodyPath, body)
+    return (input.issueFiler ?? fileQaNightlyFailureIssueWithGh)({
+      bodyPath: issueBodyPath,
+      report: reportBase,
+      title: `[Bug]: Khala Code behavior contract deviated ${failedReceipts[0]?.contractId ?? reportBase.runId}`,
+    })
+  })()
 
   const report: QaNightlyReport = {
     ...reportBase,
     ...(issueStatus === undefined ? {} : { issueStatus }),
+    ...(behaviorContractDeviationIssueStatus === undefined ? {} : { behaviorContractDeviationIssueStatus }),
     ...(quarantineIssueStatus === undefined ? {} : { quarantineIssueStatus }),
     ...(latencyBudgetRegressionIssueStatus === undefined ? {} : { latencyBudgetRegressionIssueStatus }),
     ...(zeroCoverageIssueStatus === undefined ? {} : { zeroCoverageIssueStatus }),


### PR DESCRIPTION
## Summary
- add behavior-contract receipt generation for nightly sweeps
- expose latest behavior contract receipt status on the QA nightly report and QA status surface
- add opt-in strict deviation issue filing and document the receipt artifact for QA Swarm evidence

Closes #8184.

## Verification
- bun run --cwd packages/behavior-contracts test
- bun run --cwd packages/behavior-contracts typecheck
- bun test scripts/qa-nightly-matrix.test.ts
- bun run check:deploy

## check:deploy evidence
- OpenAgents.com web tests: 22 files passed, 569 tests passed
- Workers API tests: 13 files passed, 240 tests passed
