### PR TITLE
Fix Khala Code Claude lane context isolation

### DIFF
--- a/clients/khala-code-desktop/src/bun/claude-app-sdk-chat-runtime.ts
+++ b/clients/khala-code-desktop/src/bun/claude-app-sdk-chat-runtime.ts
@@ -27,6 +27,8 @@ import type { KhalaCodeDesktopSlashCommandWithAvailability } from "../shared/cod
 import type { CodexAppServerChatRuntime } from "./codex-app-server-chat-runtime.js"
 import {
   createClaudeSessionStore,
+  ensureClaudeConfigDir,
+  resolveClaudeConfigDir,
   type ClaudeSessionStore,
 } from "./claude-session-store.js"
 import { createClaudeThreadItemProjector } from "./claude-thread-item-projector.js"
@@ -114,7 +116,7 @@ type ActiveClaudeTurn = {
 }
 
 const textFromRequest = (request: KhalaCodeDesktopChatTurnRequest): string =>
-  request.messages.map(message => message.body).filter(Boolean).join("\n\n").trim()
+  [...request.messages].reverse().find(message => message.role === "user")?.body.trim() ?? ""
 
 const claudeThinkingForEffort = (
   effort: KhalaCodeModelRoleEffort | undefined,
@@ -383,6 +385,8 @@ export function createClaudeAppSdkChatRuntime(
     const shouldResume = threadId !== undefined && stored?.lastTurnId !== undefined
     const controller = new AbortController()
     const query = await loadQuery(options)
+    const claudeConfigDir = resolveClaudeConfigDir(options.env)
+    await ensureClaudeConfigDir(claudeConfigDir)
     const projector = createClaudeThreadItemProjector({
       desktopSessionId: request.sessionId,
       turnId: desktopTurnId,
@@ -403,7 +407,7 @@ export function createClaudeAppSdkChatRuntime(
       ...(shouldResume ? { resume: threadId } : { sessionId: freshSessionId }),
       env: {
         ...options.env,
-        ...(options.env?.CLAUDE_CONFIG_DIR === undefined ? {} : { CLAUDE_CONFIG_DIR: options.env.CLAUDE_CONFIG_DIR }),
+        CLAUDE_CONFIG_DIR: claudeConfigDir,
       },
     }
     const queryOptions = withClaudeFleetMcpBridgeOptions({

--- a/clients/khala-code-desktop/src/bun/claude-session-store.ts
+++ b/clients/khala-code-desktop/src/bun/claude-session-store.ts
@@ -49,6 +49,19 @@ export function resolveClaudeSessionStorePath(
   return join(home, ".khala-code", "claude-sessions.json")
 }
 
+export function resolveClaudeConfigDir(
+  env: Readonly<Record<string, string | undefined>> = Bun.env,
+): string {
+  const override = env.KHALA_CODE_DESKTOP_CLAUDE_CONFIG_DIR?.trim()
+  if (override !== undefined && override.length > 0) return override
+  const home = env.HOME?.trim() || homedir()
+  return join(home, ".khala-code", "claude-config")
+}
+
+export async function ensureClaudeConfigDir(path: string): Promise<void> {
+  await mkdir(path, { recursive: true })
+}
+
 async function readStore(path: string): Promise<ClaudeSessionStoreFile> {
   try {
     const raw = await readFile(path, "utf8")

--- a/clients/khala-code-desktop/src/contracts/ux-contracts.ts
+++ b/clients/khala-code-desktop/src/contracts/ux-contracts.ts
@@ -198,6 +198,48 @@ export const khalaCodeUxContractRegistry: BehaviorContractRegistryDocument = {
     },
     {
       authorityBoundary:
+        "This binds the desktop Claude chat lane only. Fleet worker Claude accounts remain owned by Pylon's isolated-account registry, and an explicit KHALA_CODE_DESKTOP_CLAUDE_CONFIG_DIR override may intentionally point the desktop lane at a caller-selected app config directory.",
+      blockerRefs: [],
+      contractId: "khala_code.claude_lane.isolated_home_and_user_prompt_only.v1",
+      enforcementTier: "test-sweep",
+      evidenceRefs: [
+        "clients/khala-code-desktop/src/bun/claude-app-sdk-chat-runtime.ts",
+        "clients/khala-code-desktop/src/bun/claude-session-store.ts",
+        "docs/khala-code/khala-code-ux-contract.md",
+      ],
+      oracles: [
+        {
+          description:
+            "Starts a real Claude runtime with an ambient CLAUDE_CONFIG_DIR and proves query() receives Khala Code's app-managed config directory instead of the user's default/global Claude home.",
+          id: "claude_app_sdk_config_dir_isolated.unit",
+          kind: "bun-test",
+          mode: "unit",
+          ref: "clients/khala-code-desktop/tests/claude-app-sdk-chat-runtime.test.ts",
+        },
+        {
+          description:
+            "Submits a transcript containing system, tool, assistant, and older user rows and proves the Claude SDK prompt contains only the latest user-authored message.",
+          id: "claude_prompt_user_only.unit",
+          kind: "bun-test",
+          mode: "unit",
+          ref: "clients/khala-code-desktop/tests/claude-app-sdk-chat-runtime.test.ts",
+        },
+      ],
+      productArea: "Claude lane",
+      source: {
+        channel: "github-issue",
+        statedBy: "customer",
+        statedOn: "2026-07-03",
+      },
+      state: "enforced",
+      statement:
+        "The Claude lane starts from a clean Khala Code context rather than the user's global Claude Code memory/config. Non-user transcript system/error text must not be fed to the model as conversation.",
+      surface: "khala-code-desktop",
+      verification:
+        "bun test tests/claude-app-sdk-chat-runtime.test.ts tests/ux-contracts.test.ts inside clients/khala-code-desktop; runs in the package test glob, the package verify chain, and the repo test:khala-code-desktop sweep before pushes to main.",
+    },
+    {
+      authorityBoundary:
         "This binds control liveness only, not the exact reasoning-mode UI; that design is free to iterate as long as no control ships inert.",
       blockerRefs: ["blocker.khala_code_ux_mining.oracle_not_implemented_20260703"],
       contractId: "khala_code.composer.no_dead_controls.v1",
@@ -762,5 +804,5 @@ export const khalaCodeUxContractRegistry: BehaviorContractRegistryDocument = {
     },
   ],
   schemaVersion: BehaviorContractSchemaVersion,
-  version: "2026-07-03.5",
+  version: "2026-07-03.6",
 }

--- a/clients/khala-code-desktop/tests/claude-app-sdk-chat-runtime.test.ts
+++ b/clients/khala-code-desktop/tests/claude-app-sdk-chat-runtime.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test"
-import { mkdtemp, readFile, rm } from "node:fs/promises"
+import { mkdtemp, readFile, rm, stat } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { Effect } from "effect"
@@ -18,7 +18,10 @@ import {
   khalaCodeDesktopClaudeTokenUsageEvent,
   readKhalaCodeDesktopClaudeTokenUsageInboxFlags,
 } from "../src/bun/claude-token-usage-telemetry"
-import { createClaudeSessionStore } from "../src/bun/claude-session-store"
+import {
+  createClaudeSessionStore,
+  resolveClaudeConfigDir,
+} from "../src/bun/claude-session-store"
 import { createClaudeThreadItemProjector } from "../src/bun/claude-thread-item-projector"
 import {
   decodeKhalaCodeDesktopRpcResult,
@@ -284,6 +287,92 @@ describe("Claude Agent SDK chat runtime", () => {
       sessionId: "desktop-session-started",
     })
     expect((queryCalls[0] as { options: Record<string, unknown> }).options).not.toHaveProperty("resume")
+  })
+
+  // Oracle for khala_code.claude_lane.isolated_home_and_user_prompt_only.v1
+  test("scopes Claude SDK config to the app-managed home instead of ambient ~/.claude", async () => {
+    const statePath = await tempPath("claude-isolated-config-state.json")
+    const appHome = await tempPath("home")
+    const queryCalls: unknown[] = []
+    const runtime = createClaudeAppSdkChatRuntime({
+      env: {
+        CLAUDE_CONFIG_DIR: "/ambient-user-claude",
+        HOME: appHome,
+      },
+      query: input => {
+        queryCalls.push(input)
+        return messages([{ type: "result", subtype: "success", session_id: "claude-isolated-session" }])
+      },
+      sessionStore: createClaudeSessionStore({ path: statePath }),
+      workingDirectory: "/repo",
+    })
+
+    await runtime.startTurn({
+      messages: [{ body: "hello", id: "user-isolated", role: "user" }],
+      sessionId: "desktop-isolated",
+      turnId: "turn-isolated",
+    })
+
+    const queryEnv = (queryCalls[0] as { options: { readonly env: Record<string, string | undefined> } })
+      .options.env
+    expect(queryEnv.CLAUDE_CONFIG_DIR).toBe(resolveClaudeConfigDir({ HOME: appHome }))
+    expect(queryEnv.CLAUDE_CONFIG_DIR).not.toBe("/ambient-user-claude")
+    await expect(stat(queryEnv.CLAUDE_CONFIG_DIR).then(entry => entry.isDirectory())).resolves.toBe(true)
+  })
+
+  test("allows an explicit Khala Code Claude config directory override", async () => {
+    const statePath = await tempPath("claude-config-override-state.json")
+    const overrideDir = await tempPath("claude-config-override")
+    const queryCalls: unknown[] = []
+    const runtime = createClaudeAppSdkChatRuntime({
+      env: {
+        CLAUDE_CONFIG_DIR: "/ambient-user-claude",
+        KHALA_CODE_DESKTOP_CLAUDE_CONFIG_DIR: overrideDir,
+      },
+      query: input => {
+        queryCalls.push(input)
+        return messages([{ type: "result", subtype: "success", session_id: "claude-override-session" }])
+      },
+      sessionStore: createClaudeSessionStore({ path: statePath }),
+      workingDirectory: "/repo",
+    })
+
+    await runtime.startTurn({
+      messages: [{ body: "hello", id: "user-override", role: "user" }],
+      sessionId: "desktop-override",
+      turnId: "turn-override",
+    })
+
+    expect((queryCalls[0] as { options: { readonly env: Record<string, string | undefined> } }).options.env)
+      .toMatchObject({ CLAUDE_CONFIG_DIR: overrideDir })
+  })
+
+  // Oracle for khala_code.claude_lane.isolated_home_and_user_prompt_only.v1
+  test("sends only the latest user-authored message to Claude", async () => {
+    const statePath = await tempPath("claude-user-only-state.json")
+    const queryCalls: unknown[] = []
+    const runtime = createClaudeAppSdkChatRuntime({
+      query: input => {
+        queryCalls.push(input)
+        return messages([{ type: "result", subtype: "success", session_id: "claude-user-only-session" }])
+      },
+      sessionStore: createClaudeSessionStore({ path: statePath }),
+      workingDirectory: "/repo",
+    })
+
+    await runtime.startTurn({
+      messages: [
+        { body: "OPENAGENTS_AGENT_TOKEN is missing", id: "system-banner", role: "system" },
+        { body: "Earlier user text", id: "user-earlier", role: "user" },
+        { body: "Tool transcript", id: "tool-1", role: "tool" },
+        { body: "Assistant transcript", id: "assistant-1", role: "assistant" },
+        { body: "test - who are you?", id: "user-latest", role: "user" },
+      ],
+      sessionId: "desktop-user-only",
+      turnId: "turn-user-only",
+    })
+
+    expect((queryCalls[0] as { prompt: string }).prompt).toBe("test - who are you?")
   })
 
   test("interrupts the active SDK query handle", async () => {

--- a/docs/khala-code/khala-code-ux-contract.md
+++ b/docs/khala-code/khala-code-ux-contract.md
@@ -52,7 +52,7 @@ sweep if this doc, the registry, or the oracle tests drift apart.
 
 ## Registry
 
-Registry version: `2026-07-03.5` (schema `openagents.behavior_contracts.v1`)
+Registry version: `2026-07-03.6` (schema `openagents.behavior_contracts.v1`)
 
 ### `khala_code.chat.sidebar_spinner_streaming_only.v1` — ENFORCED
 
@@ -104,6 +104,17 @@ Registry version: `2026-07-03.5` (schema `openagents.behavior_contracts.v1`)
 - **Oracle** `sidebar_hotkey_hints.dom` (bun-test, dom): Mounts the real thread sidebar in a DOM: enabling hotkey hints replaces the time slot of the nine most recent chats with their command-digit hints in place (no separate pane appears anywhere in the document), and disabling hints restores the timestamps. — `clients/khala-code-desktop/tests/ux-contracts.test.ts`
 - **Verification:** bun test tests/ux-contracts.test.ts inside clients/khala-code-desktop; runs in the package test glob, the package verify chain, and the repo test:khala-code-desktop sweep before pushes to main.
 - **Authority boundary:** Cmd+0 additionally maps to the tenth most recent chat and Cmd+ArrowUp/ArrowDown cycle through recency; those are compatible extensions, not part of this contract. The generalized overlay-menu component remains available for future dialog menus but is not mounted for this feature.
+
+### `khala_code.claude_lane.isolated_home_and_user_prompt_only.v1` — ENFORCED
+
+- **Surface:** khala-code-desktop (Claude lane)
+- **Stated by:** customer via github-issue on 2026-07-03
+- **Statement:** The Claude lane starts from a clean Khala Code context rather than the user's global Claude Code memory/config. Non-user transcript system/error text must not be fed to the model as conversation.
+- **Enforcement tier:** test-sweep
+- **Oracle** `claude_app_sdk_config_dir_isolated.unit` (bun-test, unit): Starts a real Claude runtime with an ambient CLAUDE_CONFIG_DIR and proves query() receives Khala Code's app-managed config directory instead of the user's default/global Claude home. — `clients/khala-code-desktop/tests/claude-app-sdk-chat-runtime.test.ts`
+- **Oracle** `claude_prompt_user_only.unit` (bun-test, unit): Submits a transcript containing system, tool, assistant, and older user rows and proves the Claude SDK prompt contains only the latest user-authored message. — `clients/khala-code-desktop/tests/claude-app-sdk-chat-runtime.test.ts`
+- **Verification:** bun test tests/claude-app-sdk-chat-runtime.test.ts tests/ux-contracts.test.ts inside clients/khala-code-desktop; runs in the package test glob, the package verify chain, and the repo test:khala-code-desktop sweep before pushes to main.
+- **Authority boundary:** This binds the desktop Claude chat lane only. Fleet worker Claude accounts remain owned by Pylon's isolated-account registry, and an explicit KHALA_CODE_DESKTOP_CLAUDE_CONFIG_DIR override may intentionally point the desktop lane at a caller-selected app config directory.
 
 ### `khala_code.composer.no_dead_controls.v1` — PENDING
 


### PR DESCRIPTION
## Summary
- scope the desktop Claude Agent SDK lane to an app-managed config directory by default, ignoring ambient CLAUDE_CONFIG_DIR unless Khala Code's explicit override is set
- send only the latest user-authored message to Claude so system/error/tool/assistant transcript rows are not treated as user conversation
- add an enforced Khala Code UX behavior contract and regression oracles for issue #8232

Closes #8232

## Verification
- bun test tests/claude-app-sdk-chat-runtime.test.ts tests/ux-contracts.test.ts (35 pass)
- bun run check:deploy (green: web suite 22 files/569 tests, API worker suite 13 files/240 tests, plus preceding typecheck/guard steps)
