### PR TITLE
Fix Claude transcript assistant dedupe

### DIFF
--- a/clients/khala-code-desktop/src/bun/claude-thread-item-projector.ts
+++ b/clients/khala-code-desktop/src/bun/claude-thread-item-projector.ts
@@ -184,12 +184,43 @@ export function createClaudeThreadItemProjector(input: {
   let assistantCount = 0
   const streamBlockIds = new Map<number, string>()
   const streamBlockKinds = new Map<number, string>()
+  const streamMessageIds = new Set<string>()
+  const streamCompletedIds = new Set<string>()
+  const adoptedStreamIds = new Set<string>()
+  const finalAssistantBlockIds = new Map<string, string>()
 
   const appendMessage = (message: KhalaCodeDesktopMessage): void => {
     const existing = messages.findIndex(candidate => candidate.id === message.id)
     if (existing === -1) messages.push(message)
     else messages[existing] = message
   }
+
+  const assistantBlockKey = (
+    raw: Record<string, unknown>,
+    blockType: string,
+    index: number,
+    body: string,
+  ): string =>
+    `${stringField(raw, "uuid") ?? stringField(raw, "session_id") ?? input.turnId}:${blockType}:${index}:${body}`
+
+  const matchesAssistantBlockKind = (
+    message: KhalaCodeDesktopMessage,
+    blockType: string,
+  ): boolean =>
+    blockType === "thinking"
+      ? message.harnessItem?.itemType === "reasoning"
+      : message.harnessItem === undefined
+
+  const matchingCompletedStreamMessage = (
+    blockType: string,
+    body: string,
+  ): KhalaCodeDesktopMessage | undefined =>
+    messages.find(message =>
+      streamMessageIds.has(message.id) &&
+      !adoptedStreamIds.has(message.id) &&
+      message.role === "assistant" &&
+      message.body === body &&
+      matchesAssistantBlockKind(message, blockType))
 
   const projectAssistant = (decoded: {
     readonly message: { readonly content: readonly Record<string, unknown>[] }
@@ -203,7 +234,12 @@ export function createClaudeThreadItemProjector(input: {
       if (blockType === "text" || blockType === "thinking") {
         const body = contentText(block)
         if (body.length === 0) continue
-        const id = messageId(input.turnId, blockType, raw, assistantCount++)
+        const key = assistantBlockKey(raw, blockType, index, body)
+        const existingId = finalAssistantBlockIds.get(key)
+        const streamed = existingId === undefined
+          ? matchingCompletedStreamMessage(blockType, body)
+          : undefined
+        const id = existingId ?? streamed?.id ?? messageId(input.turnId, blockType, raw, assistantCount++)
         const message: KhalaCodeDesktopMessage = {
           body,
           id,
@@ -216,6 +252,24 @@ export function createClaudeThreadItemProjector(input: {
               title: "Claude reasoning",
             },
           } : {}),
+        }
+        finalAssistantBlockIds.set(key, id)
+        if (streamed !== undefined) {
+          adoptedStreamIds.add(streamed.id)
+          appendMessage(message)
+          if (blockType === "thinking") {
+            events.push({ message, turnId: input.turnId, type: "message_replace" })
+          }
+          if (!streamCompletedIds.has(streamed.id)) {
+            streamCompletedIds.add(streamed.id)
+            events.push({ messageId: streamed.id, turnId: input.turnId, type: "message_done" })
+          }
+          continue
+        }
+        if (existingId !== undefined) {
+          appendMessage(message)
+          events.push({ message, turnId: input.turnId, type: "message_replace" })
+          continue
         }
         appendMessage(message)
         events.push({ message: { ...message, body: "" }, turnId: input.turnId, type: "message_start" })
@@ -284,6 +338,7 @@ export function createClaudeThreadItemProjector(input: {
       const id = `${input.turnId}-claude-stream-${index}`
       streamBlockIds.set(index, id)
       streamBlockKinds.set(index, blockType)
+      streamMessageIds.add(id)
       const message: KhalaCodeDesktopMessage = {
         body: "",
         id,
@@ -311,6 +366,7 @@ export function createClaudeThreadItemProjector(input: {
       if (!streamBlockIds.has(index)) {
         streamBlockIds.set(index, id)
         streamBlockKinds.set(index, blockType)
+        streamMessageIds.add(id)
         const message: KhalaCodeDesktopMessage = {
           body: "",
           id,
@@ -338,7 +394,10 @@ export function createClaudeThreadItemProjector(input: {
 
     if (eventType === "content_block_stop") {
       const id = streamBlockIds.get(index)
-      if (id !== undefined) events.push({ messageId: id, turnId: input.turnId, type: "message_done" })
+      if (id !== undefined) {
+        streamCompletedIds.add(id)
+        events.push({ messageId: id, turnId: input.turnId, type: "message_done" })
+      }
       return { events, messages, status, toolNames: [...toolNames], usage }
     }
 

--- a/clients/khala-code-desktop/src/contracts/ux-contracts.ts
+++ b/clients/khala-code-desktop/src/contracts/ux-contracts.ts
@@ -198,6 +198,41 @@ export const khalaCodeUxContractRegistry: BehaviorContractRegistryDocument = {
     },
     {
       authorityBoundary:
+        "Binds duplicate visible assistant text for one Claude turn only. It does not change Claude SDK event ordering, token accounting, or the Codex lane projector.",
+      blockerRefs: [],
+      contractId: "khala_code.transcript.claude_assistant_turn_once.v1",
+      enforcementTier: "test-sweep",
+      evidenceRefs: [
+        "https://github.com/OpenAgentsInc/openagents/issues/8231",
+        "clients/khala-code-desktop/src/bun/claude-thread-item-projector.ts",
+        "clients/khala-code-desktop/tests/claude-app-sdk-chat-runtime.test.ts",
+        "docs/khala-code/khala-code-ux-contract.md",
+      ],
+      oracles: [
+        {
+          description:
+            "Feeds the Claude projector a streamed assistant text block followed by the final assistant snapshot with the same body, and asserts the transcript keeps exactly one assistant message.",
+          id: "claude_stream_final_snapshot_dedupe.unit",
+          kind: "bun-test",
+          mode: "unit",
+          ref: "clients/khala-code-desktop/tests/claude-app-sdk-chat-runtime.test.ts",
+        },
+      ],
+      productArea: "chat transcript",
+      source: {
+        channel: "github-issue",
+        statedBy: "operator-agent",
+        statedOn: "2026-07-03",
+      },
+      state: "enforced",
+      statement:
+        "An assistant turn can render twice in the transcript — the same reply body appears as two consecutive assistant blocks for a single user turn. Observed on the Claude lane.",
+      surface: "khala-code-desktop",
+      verification:
+        "bun test tests/claude-app-sdk-chat-runtime.test.ts tests/ux-contracts.test.ts inside clients/khala-code-desktop; runs in the package test glob, the package verify chain, and the repo test:khala-code-desktop sweep before pushes to main.",
+    },
+    {
+      authorityBoundary:
         "This binds control liveness only, not the exact reasoning-mode UI; that design is free to iterate as long as no control ships inert.",
       blockerRefs: ["blocker.khala_code_ux_mining.oracle_not_implemented_20260703"],
       contractId: "khala_code.composer.no_dead_controls.v1",
@@ -762,5 +797,5 @@ export const khalaCodeUxContractRegistry: BehaviorContractRegistryDocument = {
     },
   ],
   schemaVersion: BehaviorContractSchemaVersion,
-  version: "2026-07-03.5",
+  version: "2026-07-03.6",
 }

--- a/clients/khala-code-desktop/tests/claude-app-sdk-chat-runtime.test.ts
+++ b/clients/khala-code-desktop/tests/claude-app-sdk-chat-runtime.test.ts
@@ -158,6 +158,58 @@ describe("Claude Agent SDK chat runtime", () => {
     expect(projector.messages()).toMatchObject([{ body: "partial text" }])
   })
 
+  // Oracle for khala_code.transcript.claude_assistant_turn_once.v1
+  test("does not append a duplicate assistant message when a final snapshot repeats streamed text", () => {
+    const projector = createClaudeThreadItemProjector({
+      desktopSessionId: "desktop-session-no-duplicate",
+      turnId: "desktop-turn-no-duplicate",
+    })
+
+    projector.project({
+      event: {
+        content_block: { type: "text" },
+        index: 0,
+        type: "content_block_start",
+      },
+      session_id: "claude-session-no-duplicate",
+      type: "stream_event",
+      uuid: "stream-start-no-duplicate",
+    })
+    projector.project({
+      event: {
+        delta: { text: "Claude streamed reply", type: "text_delta" },
+        index: 0,
+        type: "content_block_delta",
+      },
+      session_id: "claude-session-no-duplicate",
+      type: "stream_event",
+      uuid: "stream-delta-no-duplicate",
+    })
+    projector.project({
+      event: {
+        index: 0,
+        type: "content_block_stop",
+      },
+      session_id: "claude-session-no-duplicate",
+      type: "stream_event",
+      uuid: "stream-stop-no-duplicate",
+    })
+    const finalSnapshot = projector.project({
+      message: {
+        content: [{ text: "Claude streamed reply", type: "text" }],
+      },
+      session_id: "claude-session-no-duplicate",
+      type: "assistant",
+      uuid: "assistant-final-no-duplicate",
+    })
+
+    expect(finalSnapshot.events).toEqual([])
+    expect(projector.messages()).toHaveLength(1)
+    expect(projector.messages().map(message => message.body)).toEqual([
+      "Claude streamed reply",
+    ])
+  })
+
   test("captures SDK modelUsage from interrupted results", () => {
     const projector = createClaudeThreadItemProjector({
       desktopSessionId: "desktop-session-usage",

--- a/docs/khala-code/khala-code-ux-contract.md
+++ b/docs/khala-code/khala-code-ux-contract.md
@@ -52,7 +52,7 @@ sweep if this doc, the registry, or the oracle tests drift apart.
 
 ## Registry
 
-Registry version: `2026-07-03.5` (schema `openagents.behavior_contracts.v1`)
+Registry version: `2026-07-03.6` (schema `openagents.behavior_contracts.v1`)
 
 ### `khala_code.chat.sidebar_spinner_streaming_only.v1` — ENFORCED
 
@@ -104,6 +104,16 @@ Registry version: `2026-07-03.5` (schema `openagents.behavior_contracts.v1`)
 - **Oracle** `sidebar_hotkey_hints.dom` (bun-test, dom): Mounts the real thread sidebar in a DOM: enabling hotkey hints replaces the time slot of the nine most recent chats with their command-digit hints in place (no separate pane appears anywhere in the document), and disabling hints restores the timestamps. — `clients/khala-code-desktop/tests/ux-contracts.test.ts`
 - **Verification:** bun test tests/ux-contracts.test.ts inside clients/khala-code-desktop; runs in the package test glob, the package verify chain, and the repo test:khala-code-desktop sweep before pushes to main.
 - **Authority boundary:** Cmd+0 additionally maps to the tenth most recent chat and Cmd+ArrowUp/ArrowDown cycle through recency; those are compatible extensions, not part of this contract. The generalized overlay-menu component remains available for future dialog menus but is not mounted for this feature.
+
+### `khala_code.transcript.claude_assistant_turn_once.v1` — ENFORCED
+
+- **Surface:** khala-code-desktop (chat transcript)
+- **Stated by:** operator-agent via github-issue on 2026-07-03
+- **Statement:** An assistant turn can render twice in the transcript — the same reply body appears as two consecutive assistant blocks for a single user turn. Observed on the Claude lane.
+- **Enforcement tier:** test-sweep
+- **Oracle** `claude_stream_final_snapshot_dedupe.unit` (bun-test, unit): Feeds the Claude projector a streamed assistant text block followed by the final assistant snapshot with the same body, and asserts the transcript keeps exactly one assistant message. — `clients/khala-code-desktop/tests/claude-app-sdk-chat-runtime.test.ts`
+- **Verification:** bun test tests/claude-app-sdk-chat-runtime.test.ts tests/ux-contracts.test.ts inside clients/khala-code-desktop; runs in the package test glob, the package verify chain, and the repo test:khala-code-desktop sweep before pushes to main.
+- **Authority boundary:** Binds duplicate visible assistant text for one Claude turn only. It does not change Claude SDK event ordering, token accounting, or the Codex lane projector.
 
 ### `khala_code.composer.no_dead_controls.v1` — PENDING
 


### PR DESCRIPTION
## Summary
- Prevent Claude final assistant snapshots from appending a second transcript message when they repeat an already-streamed assistant block.
- Keep final snapshot handling idempotent and close an adopted streamed block if the stream stop event has not arrived yet.
- Add enforced UX contract `khala_code.transcript.claude_assistant_turn_once.v1` with regression coverage for issue #8231.

Closes #8231.

## Verification
- `bun test clients/khala-code-desktop/tests/claude-app-sdk-chat-runtime.test.ts clients/khala-code-desktop/tests/ux-contracts.test.ts` — 33 pass
- `bun run --cwd clients/khala-code-desktop typecheck` — pass
- `bun run --cwd clients/khala-code-desktop test` — 571 pass
- `bun run check:deploy` — pass
