### PR TITLE
Fix Khala Code history app scope

### DIFF
--- a/clients/khala-code-desktop/scripts/thread-switch-benchmark.ts
+++ b/clients/khala-code-desktop/scripts/thread-switch-benchmark.ts
@@ -137,6 +137,7 @@ export const buildThreadSwitchBenchmarkSessionCatalog = (): Record<string, unkno
   entries: threadFixtures().map(sessionCatalogEntry),
   ok: true,
   schemaVersion: "khala-code-desktop.session-catalog.v1",
+  scope: "app",
 })
 
 const messagesForThread = (

--- a/clients/khala-code-desktop/src/bun/claude-session-store.ts
+++ b/clients/khala-code-desktop/src/bun/claude-session-store.ts
@@ -5,10 +5,12 @@ import { dirname, join } from "node:path"
 import { Schema as S } from "effect"
 
 const CLAUDE_SESSION_STORE_SCHEMA = "khala-code-desktop.claude-sessions.v1"
+const CLAUDE_SESSION_ORIGIN = "khala-code-desktop"
 
 const SessionEntry = S.Struct({
   sessionId: S.String,
   lastTurnId: S.optional(S.String),
+  origin: S.optional(S.Literal(CLAUDE_SESSION_ORIGIN)),
   updatedAt: S.String,
 })
 
@@ -83,6 +85,7 @@ export function createClaudeSessionStore(
       const updated: ClaudeDesktopSessionEntry = {
         sessionId: entry.sessionId,
         ...(entry.lastTurnId === undefined ? {} : { lastTurnId: entry.lastTurnId }),
+        origin: CLAUDE_SESSION_ORIGIN,
         updatedAt: now().toISOString(),
       }
       await writeStore(path, {

--- a/clients/khala-code-desktop/src/bun/codex-app-server-chat-runtime.ts
+++ b/clients/khala-code-desktop/src/bun/codex-app-server-chat-runtime.ts
@@ -47,6 +47,7 @@ import { projectKhalaCodeDesktopCodexThreadList } from "../shared/codex-threads.
 import type { KhalaCodeModelRoleEntry } from "../shared/model-roles.js"
 
 const CODEX_SESSION_STATE_SCHEMA = "khala-code-desktop.codex-sessions.v1"
+const CODEX_SESSION_ORIGIN = "khala-code-desktop"
 const DEFAULT_TURN_TIMEOUT_MS = 30 * 60 * 1_000
 const LOADED_THREAD_CACHE_TTL_MS = 45_000
 
@@ -54,6 +55,7 @@ type JsonObject = Readonly<Record<string, unknown>>
 
 type StoredCodexSession = {
   readonly lastCodexTurnId?: string
+  readonly origin?: typeof CODEX_SESSION_ORIGIN
   readonly threadId: string
   readonly updatedAt: string
 }
@@ -383,6 +385,7 @@ const parseState = (value: unknown): StoredCodexSessionState => {
     sessions[sessionId] = {
       threadId,
       updatedAt,
+      origin: CODEX_SESSION_ORIGIN,
       ...(lastCodexTurnId === null ? {} : { lastCodexTurnId }),
     }
   }
@@ -423,6 +426,7 @@ const persistSession = async (
   const state = await readState(statePath)
   state.sessions[desktopSessionId] = {
     ...session,
+    origin: CODEX_SESSION_ORIGIN,
     updatedAt: isoNow(),
   }
   await writeState(statePath, state)

--- a/clients/khala-code-desktop/src/bun/session-catalog.ts
+++ b/clients/khala-code-desktop/src/bun/session-catalog.ts
@@ -11,6 +11,7 @@ import {
 import type {
   KhalaCodeDesktopSessionCatalogEntry,
   KhalaCodeDesktopSessionCatalogResult,
+  KhalaCodeDesktopSessionCatalogScope,
   KhalaCodeDesktopSessionExactTotals,
   KhalaCodeDesktopSessionHarnessKind,
 } from "../shared/session-catalog.js"
@@ -18,6 +19,7 @@ import type {
 type JsonRecord = Readonly<Record<string, unknown>>
 
 export type KhalaCodeDesktopSessionCatalogRequest = {
+  readonly scope?: KhalaCodeDesktopSessionCatalogScope | undefined
   readonly limit?: number | undefined
   readonly searchTerm?: string | undefined
 }
@@ -222,6 +224,32 @@ const entryFromStoredSession = (
   }
 }
 
+const appOwnedThreadRefs = (
+  storedSessions: Readonly<Record<string, JsonRecord>>,
+): ReadonlySet<string> => {
+  const refs = new Set<string>()
+  for (const [desktopSessionRef, stored] of Object.entries(storedSessions)) {
+    refs.add(desktopSessionRef)
+    const sessionRef = sessionIdFrom(stored)
+    const threadRef = threadIdFrom(stored)
+    if (sessionRef !== null) refs.add(sessionRef)
+    if (threadRef !== null) refs.add(threadRef)
+  }
+  return refs
+}
+
+const threadBelongsToApp = (
+  thread: JsonRecord,
+  appRefs: ReadonlySet<string>,
+): boolean => {
+  const sessionRef = sessionIdFrom(thread)
+  const threadRef = threadIdFrom(thread)
+  return (
+    (sessionRef !== null && appRefs.has(sessionRef)) ||
+    (threadRef !== null && appRefs.has(threadRef))
+  )
+}
+
 const storedSessionHarnessKind = (
   fallback: KhalaCodeDesktopSessionHarnessKind,
   stored: JsonRecord,
@@ -283,6 +311,7 @@ export const readKhalaCodeDesktopSessionCatalog = async (
   const diagnostics: string[] = []
   const entries = new Map<string, KhalaCodeDesktopSessionCatalogEntry>()
   const env = options.env ?? Bun.env
+  const scope = request.scope ?? "app"
 
   const [
     codexStoredSessions,
@@ -309,6 +338,9 @@ export const readKhalaCodeDesktopSessionCatalog = async (
         .catch(error => ({ ok: false as const, error })),
   ])
 
+  const codexAppRefs = appOwnedThreadRefs(codexStoredSessions)
+  const claudeAppRefs = appOwnedThreadRefs(claudeStoredSessions)
+
   for (const [desktopSessionRef, stored] of Object.entries(codexStoredSessions)) {
     const entry = entryFromStoredSession(
       storedSessionHarnessKind("codex", stored),
@@ -331,10 +363,12 @@ export const readKhalaCodeDesktopSessionCatalog = async (
       const result = codexThreadList.result
       for (const value of result.data) {
         if (!isRecord(value)) continue
+        if (scope === "app" && !threadBelongsToApp(value, codexAppRefs)) continue
         const entry = entryFromThread("codex", value, "codex_app_server_thread_list")
         if (entry !== null) mergeEntry(entries, entry)
       }
       for (const thread of result.threads ?? []) {
+        if (scope === "app" && !threadBelongsToApp(thread, codexAppRefs)) continue
         const entry = entryFromThread("codex", thread, "codex_app_server_thread_projection")
         if (entry !== null) mergeEntry(entries, entry)
       }
@@ -349,10 +383,12 @@ export const readKhalaCodeDesktopSessionCatalog = async (
       const result = claudeThreadList.result
       for (const value of result.data) {
         if (!isRecord(value)) continue
+        if (scope === "app" && !threadBelongsToApp(value, claudeAppRefs)) continue
         const entry = entryFromThread("claude", value, "claude_sdk_list_sessions")
         if (entry !== null) mergeEntry(entries, entry)
       }
       for (const thread of result.threads ?? []) {
+        if (scope === "app" && !threadBelongsToApp(thread, claudeAppRefs)) continue
         const entry = entryFromThread("claude", thread, "claude_thread_projection")
         if (entry !== null) mergeEntry(entries, entry)
       }
@@ -370,6 +406,7 @@ export const readKhalaCodeDesktopSessionCatalog = async (
   return {
     ok: true,
     schemaVersion: "khala-code-desktop.session-catalog.v1",
+    scope,
     diagnostics,
     entries: limit === undefined ? sorted : sorted.slice(0, limit),
   }

--- a/clients/khala-code-desktop/src/contracts/ux-contracts.ts
+++ b/clients/khala-code-desktop/src/contracts/ux-contracts.ts
@@ -198,6 +198,50 @@ export const khalaCodeUxContractRegistry: BehaviorContractRegistryDocument = {
     },
     {
       authorityBoundary:
+        "This contract binds the History/session-catalog default and its explicit opt-in only. It does not prevent app-owned sessions from being enriched with runtime metadata, and it does not promise that externally created home sessions can always be opened successfully.",
+      blockerRefs: [],
+      contractId: "khala_code.history.app_sessions_default.v1",
+      enforcementTier: "test-sweep",
+      evidenceRefs: [
+        "clients/khala-code-desktop/src/bun/session-catalog.ts",
+        "clients/khala-code-desktop/src/ui/codex-thread-sidebar.ts",
+        "clients/khala-code-desktop/tests/session-catalog.test.ts",
+        "clients/khala-code-desktop/tests/codex-thread-sidebar.test.ts",
+        "docs/khala-code/khala-code-ux-contract.md",
+      ],
+      oracles: [
+        {
+          description:
+            "Builds a mixed app-owned plus headless-runtime catalog and proves the default sessionCatalog scope includes only the app-owned desktop thread while omitting unrelated home/headless prompts.",
+          id: "session_catalog_app_scope.unit",
+          kind: "bun-test",
+          mode: "unit",
+          ref: "clients/khala-code-desktop/tests/session-catalog.test.ts",
+        },
+        {
+          description:
+            "Mounts the real History sidebar in a DOM and proves the header toggle is off by default, requests app-only history first, and sends includeHomeSessions only after explicit user activation.",
+          id: "history_scope_toggle.dom",
+          kind: "bun-test",
+          mode: "dom",
+          ref: "clients/khala-code-desktop/tests/codex-thread-sidebar.test.ts",
+        },
+      ],
+      productArea: "History sidebar",
+      source: {
+        channel: "github-issue",
+        statedBy: "customer",
+        statedOn: "2026-07-03",
+      },
+      state: "enforced",
+      statement:
+        "History defaults to chats created in Khala Code Desktop, not every Codex or Claude session from the user's home stores. Showing all home sessions is an explicit opt-in, and stale missing-rollout rows must not permanently bury desktop chats as undismissable red errors.",
+      surface: "khala-code-desktop",
+      verification:
+        "bun test tests/session-catalog.test.ts tests/codex-thread-sidebar.test.ts inside clients/khala-code-desktop; both run in the package test glob, the package verify chain, and the repo test:khala-code-desktop sweep before pushes to main.",
+    },
+    {
+      authorityBoundary:
         "This binds control liveness only, not the exact reasoning-mode UI; that design is free to iterate as long as no control ships inert.",
       blockerRefs: ["blocker.khala_code_ux_mining.oracle_not_implemented_20260703"],
       contractId: "khala_code.composer.no_dead_controls.v1",
@@ -762,5 +806,5 @@ export const khalaCodeUxContractRegistry: BehaviorContractRegistryDocument = {
     },
   ],
   schemaVersion: BehaviorContractSchemaVersion,
-  version: "2026-07-03.5",
+  version: "2026-07-03.6",
 }

--- a/clients/khala-code-desktop/src/shared/rpc.ts
+++ b/clients/khala-code-desktop/src/shared/rpc.ts
@@ -374,6 +374,7 @@ const RpcSessionCatalogEntry = S.Struct({
 })
 
 const RpcSessionCatalogRequest = S.Struct({
+  scope: S.optional(S.Literals(["app", "all_home"])),
   limit: S.optional(S.Number),
   searchTerm: S.optional(S.String),
 })
@@ -381,6 +382,7 @@ const RpcSessionCatalogRequest = S.Struct({
 const RpcSessionCatalogResult = S.Struct({
   ok: S.Literal(true),
   schemaVersion: S.Literal("khala-code-desktop.session-catalog.v1"),
+  scope: S.Literals(["app", "all_home"]),
   entries: S.Array(RpcSessionCatalogEntry),
   diagnostics: S.Array(S.String),
 })

--- a/clients/khala-code-desktop/src/shared/session-catalog.ts
+++ b/clients/khala-code-desktop/src/shared/session-catalog.ts
@@ -1,6 +1,7 @@
 import type { KhalaCodeDesktopCodexThreadSummary } from "./codex-threads"
 
 export type KhalaCodeDesktopSessionHarnessKind = "claude" | "codex"
+export type KhalaCodeDesktopSessionCatalogScope = "app" | "all_home"
 
 export type KhalaCodeDesktopSessionExactTotals = {
   readonly cachedInputTokens?: number | undefined
@@ -34,6 +35,7 @@ export type KhalaCodeDesktopSessionCatalogEntry = {
 export type KhalaCodeDesktopSessionCatalogResult = {
   readonly ok: true
   readonly schemaVersion: "khala-code-desktop.session-catalog.v1"
+  readonly scope: KhalaCodeDesktopSessionCatalogScope
   readonly entries: readonly KhalaCodeDesktopSessionCatalogEntry[]
   readonly diagnostics: readonly string[]
 }

--- a/clients/khala-code-desktop/src/ui/codex-thread-sidebar.ts
+++ b/clients/khala-code-desktop/src/ui/codex-thread-sidebar.ts
@@ -46,6 +46,7 @@ export type CodexThreadSidebarOptions = {
   readonly isThreadStreaming?: (threadId: string) => boolean
   readonly listThreads: (input: {
     readonly archived: boolean
+    readonly includeHomeSessions: boolean
     readonly searchTerm: string
   }) => Promise<KhalaCodeDesktopCodexThreadListResult>
   readonly renameThread: (threadId: string, name: string) => Promise<KhalaCodeDesktopCodexThreadMutationResult>
@@ -230,6 +231,7 @@ export const mountCodexThreadSidebar = (
   let searchOpen = false
   let searchShouldFocus = false
   let searchTerm = ""
+  let includeHomeSessions = false
   let state: ViewState = { phase: "idle" }
   let visible = false
   let hotkeyHintsVisible = false
@@ -423,7 +425,7 @@ export const mountCodexThreadSidebar = (
   const loadRecentThreadData = async (): Promise<KhalaCodeDesktopCodexThreadListResult> => {
     const requestSequence = ++refreshSequence
     const data = applyOptimisticThreads(
-      await options.listThreads({ archived: false, searchTerm: "" }),
+      await options.listThreads({ archived: false, includeHomeSessions, searchTerm: "" }),
     )
     if (requestSequence !== refreshSequence) return data
     state = { phase: "ready", data }
@@ -606,6 +608,11 @@ export const mountCodexThreadSidebar = (
     render()
   }
 
+  const toggleHomeSessions = (): void => {
+    includeHomeSessions = !includeHomeSessions
+    void refresh()
+  }
+
   const threadButton = (
     thread: KhalaCodeDesktopCodexThreadSummary,
   ): HTMLElement => {
@@ -675,13 +682,27 @@ export const mountCodexThreadSidebar = (
     searchToggle.replaceChildren(sidebarIcon("Search", "Search threads"), srOnly("Search threads"))
     searchToggle.addEventListener("click", toggleSearch)
 
+    const homeSessionsToggle = el("button", "khala-thread-sidebar-home-toggle")
+    homeSessionsToggle.type = "button"
+    homeSessionsToggle.title = includeHomeSessions
+      ? "Showing all home sessions"
+      : "Show all home sessions"
+    homeSessionsToggle.setAttribute(
+      "aria-label",
+      includeHomeSessions ? "Showing all home sessions" : "Show all home sessions",
+    )
+    homeSessionsToggle.setAttribute("aria-pressed", includeHomeSessions ? "true" : "false")
+    if (includeHomeSessions) homeSessionsToggle.dataset.active = "true"
+    homeSessionsToggle.replaceChildren(sidebarIcon("History", "Home sessions"), srOnly("Home sessions"))
+    homeSessionsToggle.addEventListener("click", toggleHomeSessions)
+
     const newThread = el("button", "khala-thread-sidebar-new")
     newThread.type = "button"
     newThread.title = "New thread"
     newThread.setAttribute("aria-label", "New thread")
     newThread.replaceChildren(sidebarIcon("Plus", "New thread"), srOnly("New thread"))
     newThread.addEventListener("click", startNewChat)
-    headerActions.append(searchToggle, newThread)
+    headerActions.append(searchToggle, homeSessionsToggle, newThread)
     header.append(headerActions)
     container.append(header)
 
@@ -769,7 +790,7 @@ export const mountCodexThreadSidebar = (
     render()
     try {
       const data = applyOptimisticThreads(
-        await options.listThreads({ archived: false, searchTerm }),
+        await options.listThreads({ archived: false, includeHomeSessions, searchTerm }),
       )
       if (requestSequence !== refreshSequence) return
       state = { phase: "ready", data }

--- a/clients/khala-code-desktop/src/ui/main.ts
+++ b/clients/khala-code-desktop/src/ui/main.ts
@@ -879,6 +879,7 @@ const degradedSessionCatalog = (
   entries: [],
   ok: true,
   schemaVersion: "khala-code-desktop.session-catalog.v1",
+  scope: "app",
 })
 
 const degradedFleetStatus = (
@@ -4108,6 +4109,7 @@ const threadSidebar =
           try {
             catalog = await cachedSessionCatalog({
               limit: 50,
+              scope: request.includeHomeSessions ? "all_home" : "app",
               searchTerm: request.searchTerm,
             })
             clearBootRpcDegradedState("sessionCatalog")

--- a/clients/khala-code-desktop/src/ui/styles.css
+++ b/clients/khala-code-desktop/src/ui/styles.css
@@ -2098,6 +2098,7 @@ button {
 }
 .khala-thread-sidebar-new,
 .khala-thread-sidebar-refresh,
+.khala-thread-sidebar-home-toggle,
 .khala-thread-sidebar-search-toggle {
   font: inherit;
   color: var(--oa-color-component-text);
@@ -2105,6 +2106,7 @@ button {
 }
 .khala-thread-sidebar-new,
 .khala-thread-sidebar-refresh,
+.khala-thread-sidebar-home-toggle,
 .khala-thread-sidebar-search-toggle {
   display: inline-flex;
   align-items: center;
@@ -2125,8 +2127,15 @@ button {
   background: transparent;
   color: color-mix(in srgb, var(--oa-color-component-text) 68%, transparent);
 }
+.khala-thread-sidebar-home-toggle {
+  border: 0;
+  background: transparent;
+  color: color-mix(in srgb, var(--oa-color-component-text) 68%, transparent);
+}
 .khala-thread-sidebar-new:hover,
 .khala-thread-sidebar-refresh:hover,
+.khala-thread-sidebar-home-toggle:hover,
+.khala-thread-sidebar-home-toggle[data-active="true"],
 .khala-thread-sidebar-search-toggle:hover,
 .khala-thread-sidebar-search-toggle[aria-expanded="true"],
 .khala-thread-sidebar-search-toggle[data-active="true"] {

--- a/clients/khala-code-desktop/tests/codex-thread-sidebar.test.ts
+++ b/clients/khala-code-desktop/tests/codex-thread-sidebar.test.ts
@@ -403,4 +403,81 @@ describe("Khala Code thread sidebar", () => {
       window.close()
     }
   })
+
+  test("defaults history to app sessions and opts into all home sessions from the header toggle", async () => {
+    // Oracle for khala_code.history.app_sessions_default.v1
+    const window = new Window()
+    const previousDocument = globalThis.document
+    const previousNavigator = globalThis.navigator
+    Object.defineProperty(globalThis, "document", {
+      configurable: true,
+      value: window.document,
+    })
+    Object.defineProperty(globalThis, "navigator", {
+      configurable: true,
+      value: window.navigator,
+    })
+    try {
+      const container = document.createElement("aside")
+      document.body.append(container)
+      const requests: boolean[] = []
+      const sidebar = mountCodexThreadSidebar(container, {
+        activeThreadId: () => null,
+        archiveThread: async threadId => ({ action: "archive", ok: true, threadId }),
+        deleteThread: async threadId => ({ action: "delete", ok: true, threadId }),
+        forkThread: async threadId => ({ action: "fork", ok: true, threadId }),
+        listThreads: async request => {
+          requests.push(request.includeHomeSessions)
+          return {
+            ok: true,
+            data: [],
+            groups: [{ key: "all", label: "All sessions", threadIds: ["thread-a"] }],
+            threads: [thread("thread-a", "Desktop chat")],
+          }
+        },
+        renameThread: async threadId => ({ action: "rename", ok: true, threadId }),
+        resumeThread: async threadId => ({
+          ok: true,
+          thread: {},
+          threadId,
+          messages: [],
+        }),
+        sessionId: "desktop-session",
+        unarchiveThread: async threadId => ({ action: "unarchive", ok: true, threadId }),
+        onNewThreadRequested: () => undefined,
+        onThreadSelected: () => undefined,
+      })
+
+      sidebar.setVisible(true)
+      await sidebar.refresh()
+
+      expect(requests).toEqual([false, false])
+      const toggle = container.querySelector<HTMLButtonElement>(
+        ".khala-thread-sidebar-home-toggle",
+      )
+      expect(toggle).not.toBeNull()
+      expect(toggle?.getAttribute("aria-pressed")).toBe("false")
+
+      toggle?.click()
+      await Promise.resolve()
+      await Promise.resolve()
+
+      expect(requests.at(-1)).toBe(true)
+      expect(
+        container
+          .querySelector<HTMLButtonElement>(".khala-thread-sidebar-home-toggle")
+          ?.getAttribute("aria-pressed"),
+      ).toBe("true")
+    } finally {
+      Object.defineProperty(globalThis, "document", {
+        configurable: true,
+        value: previousDocument,
+      })
+      Object.defineProperty(globalThis, "navigator", {
+        configurable: true,
+        value: previousNavigator,
+      })
+      window.close()
+    }
+  })
 })

--- a/clients/khala-code-desktop/tests/rpc-schema.test.ts
+++ b/clients/khala-code-desktop/tests/rpc-schema.test.ts
@@ -150,12 +150,14 @@ describe("Khala Code desktop schema-first RPC contract", () => {
   test("decodes the schema-first cross-harness session catalog RPC", () => {
     expect(decodeKhalaCodeDesktopRpcParameters("sessionCatalog", [{
       limit: 20,
+      scope: "app",
       searchTerm: "plan",
-    }])).toEqual([{ limit: 20, searchTerm: "plan" }])
+    }])).toEqual([{ limit: 20, scope: "app", searchTerm: "plan" }])
 
     expect(decodeKhalaCodeDesktopRpcResult("sessionCatalog", {
       ok: true,
       schemaVersion: "khala-code-desktop.session-catalog.v1",
+      scope: "app",
       diagnostics: [],
       entries: [{
         catalogEntryId: "claude:session-1",

--- a/clients/khala-code-desktop/tests/session-catalog.test.ts
+++ b/clients/khala-code-desktop/tests/session-catalog.test.ts
@@ -91,6 +91,7 @@ describe("Khala Code cross-harness session catalog", () => {
     })
 
     expect(catalog.schemaVersion).toBe("khala-code-desktop.session-catalog.v1")
+    expect(catalog.scope).toBe("app")
     expect(catalog.diagnostics).toEqual([])
     expect(catalog.entries.map(entry => [entry.harnessKind, entry.threadRef, entry.desktopSessionRef])).toEqual([
       ["claude", "claude-session-1", "desktop-claude"],
@@ -166,6 +167,17 @@ describe("Khala Code cross-harness session catalog", () => {
   })
 
   test("uses Codex thread ids for sidebar resume even when session ids are UUIDs", async () => {
+    const root = await tempRoot()
+    const codexStatePath = join(root, "codex-sessions.json")
+    await writeFile(codexStatePath, JSON.stringify({
+      schema: "khala-code-desktop.codex-sessions.v1",
+      sessions: {
+        "desktop-codex": {
+          threadId: "id-recent-chat-row",
+          updatedAt: "2026-07-01T10:00:00.000Z",
+        },
+      },
+    }))
     const codexRuntime = {
       listThreads: async () => ({
         ok: true as const,
@@ -185,7 +197,7 @@ describe("Khala Code cross-harness session catalog", () => {
       codexRuntime,
       env: {
         KHALA_CODE_DESKTOP_CLAUDE_STATE_PATH: join(await tempRoot(), "missing-claude.json"),
-        KHALA_CODE_DESKTOP_CODEX_STATE_PATH: join(await tempRoot(), "missing-codex.json"),
+        KHALA_CODE_DESKTOP_CODEX_STATE_PATH: codexStatePath,
       },
     })
 
@@ -224,7 +236,7 @@ describe("Khala Code cross-harness session catalog", () => {
       }),
     } as Partial<CodexAppServerChatRuntime> as CodexAppServerChatRuntime
 
-    const catalog = await readKhalaCodeDesktopSessionCatalog({}, {
+    const catalog = await readKhalaCodeDesktopSessionCatalog({ scope: "all_home" }, {
       codexRuntime,
       env: {
         KHALA_CODE_DESKTOP_CLAUDE_STATE_PATH: join(await tempRoot(), "missing-claude.json"),
@@ -249,6 +261,94 @@ describe("Khala Code cross-harness session catalog", () => {
       .toEqual(["", ""])
     expect(JSON.stringify(catalog)).not.toContain("no rollout found")
     expect(JSON.stringify(catalog)).not.toContain("thread not found")
+  })
+
+  test("defaults to app-owned history and hides unrelated home runtime sessions", async () => {
+    // Oracle for khala_code.history.app_sessions_default.v1
+    const root = await tempRoot()
+    const codexStatePath = join(root, "codex-sessions.json")
+    await writeFile(codexStatePath, JSON.stringify({
+      schema: "khala-code-desktop.codex-sessions.v1",
+      sessions: {
+        "desktop-codex": {
+          threadId: "app-thread",
+          updatedAt: "2026-07-01T10:00:00.000Z",
+        },
+      },
+    }))
+    const codexRuntime = {
+      listThreads: async () => ({
+        ok: true as const,
+        data: [
+          {
+            id: "app-thread",
+            sessionId: "app-session",
+            title: "Desktop chat",
+            preview: "created here",
+            updatedAt: "2026-07-01T11:00:00.000Z",
+          },
+          {
+            id: "headless-thread",
+            sessionId: "headless-session",
+            title: "You are the Orrery memory-distiller",
+            preview: "headless automation",
+            updatedAt: "2026-07-01T12:00:00.000Z",
+          },
+        ],
+        threads: [],
+      }),
+    } as Partial<CodexAppServerChatRuntime> as CodexAppServerChatRuntime
+
+    const catalog = await readKhalaCodeDesktopSessionCatalog({}, {
+      codexRuntime,
+      env: {
+        KHALA_CODE_DESKTOP_CLAUDE_STATE_PATH: join(root, "missing-claude.json"),
+        KHALA_CODE_DESKTOP_CODEX_STATE_PATH: codexStatePath,
+      },
+    })
+
+    expect(catalog.scope).toBe("app")
+    expect(catalog.entries.map(entry => entry.threadRef)).toEqual(["app-thread"])
+    expect(JSON.stringify(catalog)).not.toContain("Orrery")
+    expect(JSON.stringify(catalog)).not.toContain("headless-thread")
+  })
+
+  test("can explicitly include all home runtime sessions", async () => {
+    const root = await tempRoot()
+    const codexStatePath = join(root, "codex-sessions.json")
+    await writeFile(codexStatePath, JSON.stringify({
+      schema: "khala-code-desktop.codex-sessions.v1",
+      sessions: {
+        "desktop-codex": {
+          threadId: "app-thread",
+          updatedAt: "2026-07-01T10:00:00.000Z",
+        },
+      },
+    }))
+    const codexRuntime = {
+      listThreads: async () => ({
+        ok: true as const,
+        data: [
+          { id: "app-thread", title: "Desktop chat", updatedAt: "2026-07-01T11:00:00.000Z" },
+          { id: "headless-thread", title: "Headless task", updatedAt: "2026-07-01T12:00:00.000Z" },
+        ],
+        threads: [],
+      }),
+    } as Partial<CodexAppServerChatRuntime> as CodexAppServerChatRuntime
+
+    const catalog = await readKhalaCodeDesktopSessionCatalog({ scope: "all_home" }, {
+      codexRuntime,
+      env: {
+        KHALA_CODE_DESKTOP_CLAUDE_STATE_PATH: join(root, "missing-claude.json"),
+        KHALA_CODE_DESKTOP_CODEX_STATE_PATH: codexStatePath,
+      },
+    })
+
+    expect(catalog.scope).toBe("all_home")
+    expect(catalog.entries.map(entry => entry.threadRef)).toEqual([
+      "headless-thread",
+      "app-thread",
+    ])
   })
 
   test("keeps legacy non-UUID Codex thread ids when no UUID session ref exists", async () => {

--- a/docs/khala-code/khala-code-ux-contract.md
+++ b/docs/khala-code/khala-code-ux-contract.md
@@ -52,7 +52,7 @@ sweep if this doc, the registry, or the oracle tests drift apart.
 
 ## Registry
 
-Registry version: `2026-07-03.5` (schema `openagents.behavior_contracts.v1`)
+Registry version: `2026-07-03.6` (schema `openagents.behavior_contracts.v1`)
 
 ### `khala_code.chat.sidebar_spinner_streaming_only.v1` — ENFORCED
 
@@ -104,6 +104,17 @@ Registry version: `2026-07-03.5` (schema `openagents.behavior_contracts.v1`)
 - **Oracle** `sidebar_hotkey_hints.dom` (bun-test, dom): Mounts the real thread sidebar in a DOM: enabling hotkey hints replaces the time slot of the nine most recent chats with their command-digit hints in place (no separate pane appears anywhere in the document), and disabling hints restores the timestamps. — `clients/khala-code-desktop/tests/ux-contracts.test.ts`
 - **Verification:** bun test tests/ux-contracts.test.ts inside clients/khala-code-desktop; runs in the package test glob, the package verify chain, and the repo test:khala-code-desktop sweep before pushes to main.
 - **Authority boundary:** Cmd+0 additionally maps to the tenth most recent chat and Cmd+ArrowUp/ArrowDown cycle through recency; those are compatible extensions, not part of this contract. The generalized overlay-menu component remains available for future dialog menus but is not mounted for this feature.
+
+### `khala_code.history.app_sessions_default.v1` — ENFORCED
+
+- **Surface:** khala-code-desktop (History sidebar)
+- **Stated by:** customer via github-issue on 2026-07-03
+- **Statement:** History defaults to chats created in Khala Code Desktop, not every Codex or Claude session from the user's home stores. Showing all home sessions is an explicit opt-in, and stale missing-rollout rows must not permanently bury desktop chats as undismissable red errors.
+- **Enforcement tier:** test-sweep
+- **Oracle** `session_catalog_app_scope.unit` (bun-test, unit): Builds a mixed app-owned plus headless-runtime catalog and proves the default sessionCatalog scope includes only the app-owned desktop thread while omitting unrelated home/headless prompts. — `clients/khala-code-desktop/tests/session-catalog.test.ts`
+- **Oracle** `history_scope_toggle.dom` (bun-test, dom): Mounts the real History sidebar in a DOM and proves the header toggle is off by default, requests app-only history first, and sends includeHomeSessions only after explicit user activation. — `clients/khala-code-desktop/tests/codex-thread-sidebar.test.ts`
+- **Verification:** bun test tests/session-catalog.test.ts tests/codex-thread-sidebar.test.ts inside clients/khala-code-desktop; both run in the package test glob, the package verify chain, and the repo test:khala-code-desktop sweep before pushes to main.
+- **Authority boundary:** This contract binds the History/session-catalog default and its explicit opt-in only. It does not prevent app-owned sessions from being enriched with runtime metadata, and it does not promise that externally created home sessions can always be opened successfully.
 
 ### `khala_code.composer.no_dead_controls.v1` — PENDING
 


### PR DESCRIPTION
## Summary
- Default Khala Code History/session catalog to app-owned desktop sessions while still enriching those rows from runtime metadata.
- Add an explicit icon-only History toggle for all home Codex/Claude sessions.
- Record and enforce the History behavior contract for issue #8233.

Fixes #8233.

## Verification
- `bun test tests/session-catalog.test.ts tests/codex-thread-sidebar.test.ts tests/rpc-schema.test.ts tests/ux-contracts.test.ts` from `clients/khala-code-desktop`
- `bun run typecheck` from `clients/khala-code-desktop`
- `bun run check:deploy` from repo root
