### PR TITLE
Improve forum last-post summary batching

### DIFF
--- a/apps/openagents.com/workers/api/src/forum/repository.ts
+++ b/apps/openagents.com/workers/api/src/forum/repository.ts
@@ -2369,6 +2369,7 @@ export const readForumBoardIndex = (
           latestTopicId: forum.latestTopicId,
         }),
       ),
+      { concurrency: 'unbounded' },
     )
     const forumsWithDisplay = forumSummaries.map((forum, index) =>
       forumWithDisplayProjection(
@@ -2681,6 +2682,7 @@ export const readForumTopicList = (
           latestTopicId: topic.topicId,
         }),
       ),
+      { concurrency: 'unbounded' },
     )
 
     return decodeForumTopicListResponse({


### PR DESCRIPTION
## Problem

#8256 reports that the public forum board index and topic list fetch each row's last-post summary sequentially. In the worst case, a 100-row topic list can turn into a long serial chain of D1 reads.

## Change

- Adds `{ concurrency: 'unbounded' }` to the `Effect.all` call in `readForumBoardIndex`.
- Adds `{ concurrency: 'unbounded' }` to the matching `Effect.all` call in `readForumTopicList`.
- Keeps response shape, ordering, queries, schemas, and route behavior unchanged.

## Validation

- `bun test apps/openagents.com/workers/api/src/forum/repository.test.ts`
- `bun run --cwd apps/openagents.com/workers/api typecheck`
- `git diff --check`

## Maintenance / Product Value

This removes avoidable serial D1 round trips from public forum list reads, which directly targets the slow forum loading reported by a community tester evaluating Khala Code Desktop.

## Not Changed

- No forum route or schema changes.
- No query semantic changes beyond concurrent execution of independent reads.
- No unrelated local dirty-checkout changes.

Closes #8256.
