### PR TITLE
Make enum-backed Codex settings editable

### DIFF
--- a/clients/khala-code-desktop/src/ui/codex-settings-panel.ts
+++ b/clients/khala-code-desktop/src/ui/codex-settings-panel.ts
@@ -94,6 +94,9 @@ const metric = (label: string, value: unknown): HTMLElement => {
   return item
 }
 
+const stringOrNull = (value: unknown): string | null =>
+  typeof value === "string" ? value : null
+
 const section = (title: string, children: readonly Node[]): HTMLElement => {
   const node = el("section", "khala-settings-section")
   node.append(el("h3", "khala-settings-section-title", title), ...children)
@@ -237,8 +240,28 @@ export const mountCodexSettingsPanel = (
         onChange: value => void write("service_tier", value === "" ? null : value),
       }),
       metric("Provider", current.config.modelProvider),
-      metric("Summary", current.config.reasoningSummary),
-      metric("Verbosity", current.config.verbosity),
+      renderSelect({
+        label: "Summary",
+        selected: current.config.reasoningSummary ?? "",
+        options: [
+          { label: "Default", value: "" },
+          { label: "Auto", value: "auto" },
+          { label: "Concise", value: "concise" },
+          { label: "Detailed", value: "detailed" },
+        ],
+        onChange: value => void write("model_reasoning_summary", value === "" ? null : value),
+      }),
+      renderSelect({
+        label: "Verbosity",
+        selected: current.config.verbosity ?? "",
+        options: [
+          { label: "Default", value: "" },
+          { label: "Low", value: "low" },
+          { label: "Medium", value: "medium" },
+          { label: "High", value: "high" },
+        ],
+        onChange: value => void write("model_verbosity", value === "" ? null : value),
+      }),
     ])
   }
 
@@ -330,9 +353,30 @@ export const mountCodexSettingsPanel = (
       })),
       onChange: value => void write("default_permissions", value),
     }),
-    metric("Approval", current.config.approvalPolicy),
+    renderSelect({
+      label: "Approval",
+      selected: stringOrNull(current.config.approvalPolicy) ?? "",
+      options: [
+        { label: "Default", value: "" },
+        { label: "Untrusted", value: "untrusted" },
+        { label: "On failure", value: "on-failure" },
+        { label: "On request", value: "on-request" },
+        { label: "Never", value: "never" },
+      ],
+      onChange: value => void write("approval_policy", value === "" ? null : value),
+    }),
     metric("Reviewer", current.config.approvalsReviewer),
-    metric("Sandbox", current.config.sandboxMode),
+    renderSelect({
+      label: "Sandbox",
+      selected: current.config.sandboxMode ?? "",
+      options: [
+        { label: "Default", value: "" },
+        { label: "Read only", value: "read-only" },
+        { label: "Workspace write", value: "workspace-write" },
+        { label: "Danger full access", value: "danger-full-access" },
+      ],
+      onChange: value => void write("sandbox_mode", value === "" ? null : value),
+    }),
   ])
 
   const renderProviderSection = (

--- a/clients/khala-code-desktop/tests/codex-settings-panel.test.ts
+++ b/clients/khala-code-desktop/tests/codex-settings-panel.test.ts
@@ -41,6 +41,32 @@ const installDom = (): {
   }
 }
 
+const selectForLabel = (
+  container: HTMLElement,
+  label: string,
+): HTMLSelectElement => {
+  const controls = Array.from(container.querySelectorAll(".khala-settings-control"))
+  const control = controls.find(node =>
+    node.querySelector(".khala-settings-control-label")?.textContent === label
+  )
+  const select = control?.querySelector("select")
+  if (select === null || select === undefined) {
+    throw new Error(`missing select for ${label}`)
+  }
+  return select as HTMLSelectElement
+}
+
+const changeSelect = async (
+  select: HTMLSelectElement,
+  value: string,
+  window: Window,
+): Promise<void> => {
+  select.value = value
+  select.dispatchEvent(new window.Event("change") as unknown as Event)
+  await Promise.resolve()
+  await Promise.resolve()
+}
+
 describe("Codex settings panel", () => {
   // Oracle for khala_code.settings.hidden_models_excluded_from_picker.v1
   test("does not expose hidden Codex models as selectable chat models", async () => {
@@ -140,6 +166,60 @@ describe("Codex settings panel", () => {
         .map(node => node.textContent)
       expect(metricValues).not.toContain("Unset")
       expect(metricValues).toContain("Default")
+    } finally {
+      cleanup()
+    }
+  })
+
+  // Oracle for the first #8254 slice: enum-backed Codex config metrics are
+  // editable through the existing config/value/write RPC surface.
+  test("writes enum-backed config selects through the Codex config-value RPC", async () => {
+    const { cleanup, container, window } = installDom()
+    const writes: unknown[] = []
+    const settings = projectKhalaCodeDesktopCodexSettings({
+      configRead: {
+        config: {
+          model: "gpt-5.5-codex",
+          model_reasoning_summary: null,
+          model_verbosity: null,
+          approval_policy: null,
+          sandbox_mode: null,
+        },
+      },
+      modelList: {
+        data: [{
+          id: "gpt-5.5-codex",
+          model: "gpt-5.5-codex",
+          displayName: "GPT-5.5",
+          hidden: false,
+        }],
+      },
+    })
+
+    try {
+      const panel = mountCodexSettingsPanel(container, {
+        fetch: async () => settings,
+        write: async request => {
+          writes.push(request)
+          return { ok: true, settings }
+        },
+      })
+
+      await panel.refresh()
+
+      await changeSelect(selectForLabel(container, "Summary"), "detailed", window)
+      await changeSelect(selectForLabel(container, "Verbosity"), "high", window)
+      await changeSelect(selectForLabel(container, "Approval"), "on-request", window)
+      await changeSelect(selectForLabel(container, "Sandbox"), "workspace-write", window)
+      await changeSelect(selectForLabel(container, "Summary"), "", window)
+
+      expect(writes).toEqual([
+        { keyPath: "model_reasoning_summary", value: "detailed" },
+        { keyPath: "model_verbosity", value: "high" },
+        { keyPath: "approval_policy", value: "on-request" },
+        { keyPath: "sandbox_mode", value: "workspace-write" },
+        { keyPath: "model_reasoning_summary", value: null },
+      ])
     } finally {
       cleanup()
     }


### PR DESCRIPTION
## Problem

Issue #8254 reports that several Codex settings shown in the Khala Code Desktop settings panel are read-only even though existing config-value write plumbing can persist scalar config updates.

## Change

- Convert enum-backed read-only fields into dropdowns:
  - Reasoning summary: `model_reasoning_summary`
  - Verbosity: `model_verbosity`
  - Approval policy: `approval_policy`
  - Sandbox mode: `sandbox_mode`
- Keep blank/default selections writing `null` through the existing `codexConfigValueWrite` path.
- Add a DOM-level panel test proving the new selects call the existing config-value write RPC with the expected key paths and values.

## Validation

- `bun test clients/khala-code-desktop/tests/codex-settings-panel.test.ts`
- `bun test clients/khala-code-desktop/tests/codex-settings.test.ts`
- `bun run --cwd clients/khala-code-desktop typecheck`
- `git diff --check`

## Maintenance / Product Value

This clears the first narrow #8254 slice without adding a parallel persistence path. The settings panel now exposes safe enum-backed controls while keeping all writes on the existing Codex app-server config writer.

## Intentionally Not Changed

- Model provider remains read-only in this PR. It should be sourced from the active provider list rather than exposed as a free-typed field.
- Reviewer remains read-only.

Refs #8254
