### PR TITLE
feat(khala-code-desktop): TUI ergonomics — one-shot argv, single-prompt piping, honest usage, tool-activity + spinner/resume

### DIFF
--- a/clients/khala-code-desktop/scripts/khala-code-tui.ts
+++ b/clients/khala-code-desktop/scripts/khala-code-tui.ts
@@ -5,37 +5,111 @@
 //
 // Usage:
 //   bun scripts/khala-code-tui.ts                    # interactive REPL
-//   echo "prompt" | bun scripts/khala-code-tui.ts    # piped turns, exit at EOF
+//   bun scripts/khala-code-tui.ts "explain this bug" # one-shot: run a prompt, print, exit
+//   echo "prompt" | bun scripts/khala-code-tui.ts    # piped: whole stdin is ONE prompt
+//   printf 'a\nb\n' | bun scripts/khala-code-tui.ts --lines   # one turn per line (scripting)
+//   bun scripts/khala-code-tui.ts --resume <threadId>          # continue an existing thread
 //
-// Slash commands: /new (fresh thread), /status (harness readiness), /exit
+// Slash commands (interactive/--lines): /new /status /help /exit
+// stdout carries assistant text only; tool activity, token usage, and status
+// go to stderr, so `... | tui` pipes cleanly.
 
 import { createInterface } from "node:readline/promises"
-import { Buffer } from "node:buffer"
 
 import { createCodexAppServerChatRuntime } from "../src/bun/codex-app-server-chat-runtime.js"
 import { createCodexAppServerHost } from "../src/bun/codex-app-server-client.js"
 import { inspectCodexHarnessStatus } from "../src/bun/codex-harness-status.js"
-import { khalaCodeConfigFromRuntimeEnv } from "../src/bun/khala-code-config.js"
 import { projectKhalaCodeDesktopEventToThreadEvents } from "../src/shared/headless-events.js"
 import type { KhalaCodeDesktopChatTurnEvent } from "../src/shared/rpc.js"
 
+// ---- argv ------------------------------------------------------------------
+const rawArgs = process.argv.slice(2)
+const wantHelp = rawArgs.includes("-h") || rawArgs.includes("--help")
+const perLine = rawArgs.includes("--lines")
+let resumeThreadId: string | undefined
+const positional: string[] = []
+for (let i = 0; i < rawArgs.length; i += 1) {
+  const arg = rawArgs[i]
+  if (arg === "--resume") {
+    resumeThreadId = rawArgs[i + 1]
+    i += 1
+    continue
+  }
+  if (arg.startsWith("-")) continue
+  positional.push(arg)
+}
+const oneShotPrompt = positional.length > 0 ? positional.join(" ") : undefined
+
+const HELP = `khala-code tui — terminal chat over the local Codex app-server harness
+
+  bun scripts/khala-code-tui.ts                 interactive REPL
+  bun scripts/khala-code-tui.ts "<prompt>"      one-shot: run a prompt and exit
+  echo "<prompt>" | bun scripts/khala-code-tui.ts   piped: whole stdin is one prompt
+  printf 'a\\nb\\n' | ... --lines               one turn per line (scripting)
+  ... --resume <threadId>                       continue an existing app-server thread
+
+Slash commands: /new  /status  /help  /exit
+stdout = assistant text only; tool activity, token usage and status print to stderr.`
+
 const interactive = process.stdin.isTTY === true && process.stdout.isTTY === true
 const workingDirectory = process.cwd()
-const env = khalaCodeConfigFromRuntimeEnv().env
-const epochMs = (): number => new Date().getTime()
+const env = Bun.env
 
-let sessionId = `khala-code-tui-${epochMs().toString(36)}`
-let threadId: string | undefined
+let sessionId = `khala-code-tui-${Date.now().toString(36)}`
+let threadId: string | undefined = resumeThreadId
 let activeTurnId: string | undefined
 let messageCounter = 0
+let interruptArmed = false
+
+// ---- thinking spinner (interactive only; stderr, no ANSI escapes) ----------
+const spinnerFrames = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"]
+let spinnerTimer: ReturnType<typeof setInterval> | undefined
+const startSpinner = (): void => {
+  if (!interactive || spinnerTimer !== undefined) return
+  let i = 0
+  spinnerTimer = setInterval(() => {
+    process.stderr.write(`\r${spinnerFrames[i++ % spinnerFrames.length]} thinking… `)
+  }, 90)
+}
+const stopSpinner = (): void => {
+  if (spinnerTimer === undefined) return
+  clearInterval(spinnerTimer)
+  spinnerTimer = undefined
+  process.stderr.write("\r             \r")
+}
+
+// ---- event stream ----------------------------------------------------------
+const toolGlyph: Record<string, string> = {
+  command_execution: "⚙",
+  file_change: "✎",
+  mcp_tool_call: "⚙",
+  todo_list: "☑",
+  error: "⚠",
+}
 
 const host = createCodexAppServerHost({ env })
 
 const onEvent = (event: KhalaCodeDesktopChatTurnEvent): void => {
   for (const threadEvent of projectKhalaCodeDesktopEventToThreadEvents(event)) {
-    const projected = threadEvent as { readonly delta?: string; readonly type?: string }
+    const projected = threadEvent as {
+      readonly delta?: string
+      readonly type?: string
+      readonly item?: { readonly kind?: string; readonly tool_name?: string }
+    }
     if (projected.type === "item.delta" && typeof projected.delta === "string") {
+      stopSpinner()
       process.stdout.write(projected.delta)
+    } else if (
+      projected.type === "item.started" &&
+      projected.item?.kind &&
+      projected.item.kind !== "message"
+    ) {
+      // Surface tool activity (previously dropped) — meta goes to stderr.
+      stopSpinner()
+      const kind = projected.item.kind
+      const glyph = toolGlyph[kind] ?? "•"
+      const name = projected.item.tool_name ? `: ${projected.item.tool_name}` : ""
+      process.stderr.write(`  ${glyph} ${kind}${name}\n`)
     }
   }
 }
@@ -47,6 +121,26 @@ const runtime = createCodexAppServerChatRuntime({
   workingDirectory,
 })
 
+const formatUsage = (response: unknown): string => {
+  const usage = (response as {
+    usage?: { input?: number; output?: number; reasoningOutput?: number; cachedInput?: number }
+  }).usage
+  const input = usage?.input ?? 0
+  const output = usage?.output ?? 0
+  const reasoning = usage?.reasoningOutput ?? 0
+  const cached = usage?.cachedInput ?? 0
+  // The codex app-server path currently reports all-zero usage for turns that
+  // plainly consumed tokens; report unknown rather than fabricate zeros, per
+  // the exact/estimated/unknown honesty rule.
+  if (usage === undefined || (input === 0 && output === 0 && reasoning === 0 && cached === 0)) {
+    return "[tokens: unknown]"
+  }
+  const parts = [`in ${input}`, `out ${output}`]
+  if (reasoning) parts.push(`reasoning ${reasoning}`)
+  if (cached) parts.push(`cached ${cached}`)
+  return `[tokens: ${parts.join(" · ")}]`
+}
+
 const printStatus = async (): Promise<boolean> => {
   const status = await inspectCodexHarnessStatus({ env })
   const auth = status.auth as
@@ -54,7 +148,7 @@ const printStatus = async (): Promise<boolean> => {
     | undefined
   if (status.available) {
     if (interactive) {
-      process.stdout.write(
+      process.stderr.write(
         `khala-code tui — codex harness ready (${status.binary?.version ?? "codex"}, home ${
           status.home?.path ?? "?"
         })\n`,
@@ -78,9 +172,11 @@ const ensureThread = async (): Promise<void> => {
 
 const runTurn = async (prompt: string): Promise<void> => {
   await ensureThread()
-  const turnId = `turn-${epochMs().toString(36)}`
+  const turnId = `turn-${Date.now().toString(36)}`
   activeTurnId = turnId
+  interruptArmed = false
   messageCounter += 1
+  startSpinner()
   try {
     const response = await runtime.startTurn({
       cwd: workingDirectory,
@@ -90,22 +186,29 @@ const runTurn = async (prompt: string): Promise<void> => {
       turnId,
     })
     threadId = response.backend.threadId ?? threadId
+    stopSpinner()
     if (response.ok) {
       process.stdout.write("\n")
+      process.stderr.write(`${formatUsage(response)}\n`)
       return
     }
     const backend = response.backend as { readonly blockerRefs?: readonly string[] }
     const blockers = backend.blockerRefs?.length ? ` — ${backend.blockerRefs.join(", ")}` : ""
-    process.stdout.write(`\n[turn ${response.backend.turnStatus ?? "failed"}${blockers}]\n`)
+    process.stderr.write(
+      `[turn ${response.backend.turnStatus ?? "failed"}${blockers}] ${formatUsage(response)}\n`,
+    )
   } catch (error) {
+    stopSpinner()
     const message = error instanceof Error ? error.message : String(error)
-    process.stdout.write(`\n[turn failed: ${message}]\n`)
+    process.stderr.write(`[turn failed: ${message}]\n`)
   } finally {
     activeTurnId = undefined
+    interruptArmed = false
   }
 }
 
 const shutdown = (code: number): never => {
+  stopSpinner()
   try {
     host.dispose()
   } catch {
@@ -116,8 +219,14 @@ const shutdown = (code: number): never => {
 
 process.on("SIGINT", () => {
   if (activeTurnId !== undefined) {
+    if (interruptArmed) {
+      process.stderr.write("\n[force quit]\n")
+      shutdown(130)
+    }
+    interruptArmed = true
     const turnId = activeTurnId
-    process.stdout.write("\n[interrupting turn]\n")
+    stopSpinner()
+    process.stderr.write("\n[interrupting turn — Ctrl-C again to force quit]\n")
     void runtime.interruptTurn({ sessionId, turnId }).catch(() => undefined)
     return
   }
@@ -125,21 +234,32 @@ process.on("SIGINT", () => {
   shutdown(0)
 })
 
+if (wantHelp) {
+  process.stdout.write(`${HELP}\n`)
+  shutdown(0)
+}
+
 const ready = await printStatus()
 if (!ready) shutdown(2)
 
-if (interactive) {
-  process.stdout.write("multi-turn thread; /new /status /exit; Ctrl-C interrupts a turn\n\n")
+// One-shot: a prompt passed as argv runs once and exits (works with a TTY too).
+if (oneShotPrompt !== undefined) {
+  await runTurn(oneShotPrompt)
+  shutdown(0)
 }
 
 const handleLine = async (line: string): Promise<"continue" | "exit"> => {
   const trimmed = line.trim()
   if (trimmed.length === 0) return "continue"
   if (trimmed === "/exit" || trimmed === "/quit") return "exit"
+  if (trimmed === "/help") {
+    process.stderr.write(`${HELP}\n`)
+    return "continue"
+  }
   if (trimmed === "/new") {
-    sessionId = `khala-code-tui-${epochMs().toString(36)}`
+    sessionId = `khala-code-tui-${Date.now().toString(36)}`
     threadId = undefined
-    if (interactive) process.stdout.write("[new thread]\n")
+    if (interactive) process.stderr.write("[new thread]\n")
     return "continue"
   }
   if (trimmed === "/status") {
@@ -150,15 +270,8 @@ const handleLine = async (line: string): Promise<"continue" | "exit"> => {
   return "continue"
 }
 
-const readPipedStdin = async (): Promise<string> => {
-  const chunks: Array<Buffer> = []
-  for await (const chunk of process.stdin) {
-    chunks.push(typeof chunk === "string" ? Buffer.from(chunk) : chunk)
-  }
-  return Buffer.concat(chunks).toString("utf8")
-}
-
 if (interactive) {
+  process.stderr.write("multi-turn thread; /new /status /help /exit; Ctrl-C interrupts a turn\n\n")
   // Interactive REPL: readline owns the prompt.
   const rl = createInterface({ input: process.stdin, output: process.stdout })
   while (true) {
@@ -172,11 +285,19 @@ if (interactive) {
   }
   rl.close()
 } else {
-  // Piped mode: drain stdin first, then run each line as a sequential turn —
-  // readline would drop lines that arrive while a turn is still streaming.
-  const text = await readPipedStdin()
-  for (const line of text.split("\n")) {
-    if ((await handleLine(line)) === "exit") break
+  const text = await Bun.stdin.text()
+  if (perLine) {
+    // Scripting mode: one turn per line, slash-commands active. Piped mode
+    // drains stdin first — readline would drop lines that arrive mid-stream.
+    for (const line of text.split("\n")) {
+      if ((await handleLine(line)) === "exit") break
+    }
+  } else {
+    // Default piped mode: the whole of stdin is a single prompt, so a
+    // multi-line heredoc reaches the model intact instead of being split
+    // into one turn per line.
+    const prompt = text.replace(/\n+$/u, "")
+    if (prompt.trim().length > 0) await runTurn(prompt)
   }
 }
 


### PR DESCRIPTION
## What

Follow-up to #8221: five usability improvements to the Khala Code TUI, all in the single file `clients/khala-code-desktop/scripts/khala-code-tui.ts` — no new dependencies, no other files touched. Prompted by an operator-run extensive runtime test of the merged TUI.

1. **One-shot prompt from argv** — `bun scripts/khala-code-tui.ts "explain this bug"` runs a single turn and exits (like `codex exec` / `claude -p`), instead of only interactive or piped input.
2. **Piped stdin is one prompt by default** — previously piped mode split stdin on newlines and ran each line as its own turn, so a multi-line heredoc silently fractured into N turns. Now the whole of stdin is a single prompt; `--lines` opts back into one-turn-per-line for scripting (slash-commands stay active there).
3. **Tool-activity forwarding** — `onEvent` previously forwarded only `item.delta` and dropped everything else; it now also surfaces `item.started` tool events (`command_execution` / `file_change` / `mcp_tool_call` / …) as a compact stderr line. Honest scope: the Codex app-server chat runtime the TUI uses folds exec output into the assistant text stream and does not emit discrete `tool_event`s (the tool-emitting paths are the Claude and legacy-khala runtimes), so on the current Codex path this handler is forward-compatible rather than active — the new thinking spinner is what covers the "looks idle during a long turn" gap on Codex today.
4. **Honest per-turn token usage** — prints `[tokens: in N · out N]` to stderr after each turn, and `[tokens: unknown]` when the backend reports no usage or all-zero usage. The codex app-server path currently returns all-zeros for turns that plainly spent tokens; reporting `unknown` follows the exact/estimated/unknown rule instead of fabricating zeros.
5. **Robustness / ergonomics** — a thinking spinner (interactive only, no ANSI cursor codes) so a long turn does not look frozen; `/help`; `--resume <threadId>` to continue an existing app-server thread across launches; and double-Ctrl-C to force-quit if an interrupt ever hangs.

stdout now carries assistant text only; all meta (tool lines, token usage, status, spinner) goes to stderr, so `… | tui` pipes clean model output.

## Validation (live, signed-in Codex, macOS, codex-cli 0.142.5)

`bun run typecheck` passes. A 12-case runtime battery is green at this change:

- single turn; multi-turn thread continuity (a codeword recalled across turns); `/new` resets the thread with no cross-thread memory; blank/whitespace-line skipping; three sequential `--lines` turns in order; clean `/exit` → rc 0; harness-unavailable (empty `CODEX_HOME`) → typed blocker on stderr + exit 2; one-shot argv; **piped multi-line = exactly one turn** (verified via a single usage line, not N); usage line present on stderr; `--help` → rc 0; SIGINT interrupts an in-flight turn.

The tool-activity case is intentionally not asserted green on the Codex path, for the reason in item 3 (that runtime emits no discrete tool events); the handler is verified to typecheck and is correct for the tool-emitting runtimes.

## Intentionally not changed

- No `package.json` script entry (shared hot file).
- No changes to the app window, the RPC bridge, headless JSONL mode, or the chat runtimes — this is a single-file client-script change.

---
*Filed by Lathe (operator agent). Follow-up improvements after a hands-on extensive test of the TUI merged in #8221; behaviors above were exercised live before filing.*