### PR TITLE
fix: column-scope the artanis_responder_ticks Postgres mirror upsert to stop scan/compose clobber

### DIFF
--- a/apps/openagents.com/workers/api/src/artanis-domain-store.test.ts
+++ b/apps/openagents.com/workers/api/src/artanis-domain-store.test.ts
@@ -1,23 +1,28 @@
 // KS-8.6 (#8317): artanis domain seam — flags, fail-soft dual-write, and
 // flag-routed reads (unit level; the cross-engine convergence proof lives in
 // artanis-domain-repository.contract.test.ts).
-
 import { describe, expect, test } from 'vitest'
 
 import {
   ARTANIS_DOMAIN_TABLES,
+  type ArtanisDomainDiagnostic,
+  type ArtanisDomainDiagnosticEvent,
+  type ArtanisDomainRow,
+  type PostgresArtanisDomainStore,
   artanisAuthorityDb,
   artanisDomainFlagsFromEnv,
   artanisRead,
   isArtanisDomainHandle,
   makeArtanisDatabaseForEnv,
   makeArtanisDomainHandle,
+  makePostgresArtanisDomainStore,
   mirrorArtanisRows,
-  type ArtanisDomainDiagnostic,
-  type ArtanisDomainDiagnosticEvent,
-  type ArtanisDomainRow,
-  type PostgresArtanisDomainStore,
 } from './artanis-domain-store'
+import {
+  recordArtanisResponderComposeTick,
+  recordArtanisResponderScanTick,
+} from './artanis-responder-ticks'
+import type { KhalaSyncPushSqlClient } from './khala-sync-push-routes'
 import { makeSqliteD1 } from './test/sqlite-d1'
 
 type Logged = readonly [ArtanisDomainDiagnosticEvent, ArtanisDomainDiagnostic]
@@ -25,21 +30,152 @@ type Logged = readonly [ArtanisDomainDiagnosticEvent, ArtanisDomainDiagnostic]
 const fakePostgres = (
   overrides: Partial<PostgresArtanisDomainStore> = {},
 ): PostgresArtanisDomainStore & {
-  upserts: Array<{ table: string; rows: ReadonlyArray<ArtanisDomainRow> }>
+  upserts: Array<{
+    table: string
+    rows: ReadonlyArray<ArtanisDomainRow>
+    updateColumns: ReadonlyArray<string> | undefined
+  }>
 } => {
   const upserts: Array<{
     table: string
     rows: ReadonlyArray<ArtanisDomainRow>
+    updateColumns: ReadonlyArray<string> | undefined
   }> = []
   return {
     selectLatestRows: () => Promise.resolve([]),
     selectRowsByKey: () => Promise.resolve([]),
-    upsertRows: (table, rows) => {
-      upserts.push({ rows, table })
+    upsertRows: (table, rows, updateColumns) => {
+      upserts.push({ rows, table, updateColumns })
       return Promise.resolve()
     },
     upserts,
     ...overrides,
+  }
+}
+
+const capturePostgresStatements = () => {
+  const statements: Array<{
+    params: Array<unknown>
+    text: string
+  }> = []
+  const client: KhalaSyncPushSqlClient = {
+    end: () => Promise.resolve(),
+    sql: {
+      unsafe: (text: string, params: Array<unknown>) => {
+        statements.push({ params, text })
+        return Promise.resolve([])
+      },
+    } as unknown as KhalaSyncPushSqlClient['sql'],
+  }
+  return {
+    statements,
+    store: makePostgresArtanisDomainStore({
+      acquireSql: () => Promise.resolve(client),
+    }),
+  }
+}
+
+const responderTickRow = (
+  overrides: ArtanisDomainRow = {},
+): ArtanisDomainRow => ({
+  compose_blocked: 0,
+  compose_considered: 3,
+  compose_responded: 2,
+  compose_skipped_reason: null,
+  compose_state: 'ran',
+  compose_tipped: 1,
+  created_at: '2026-07-05T00:00:00.000Z',
+  scan_blocked: 0,
+  scan_proposed: 2,
+  scan_scanned: 4,
+  scan_skipped: 0,
+  scan_skipped_reason: null,
+  scan_state: 'ran',
+  scheduled_at: '2026-07-05T00:00:00.000Z',
+  tick_ref: 'receipt.artanis_responder.tick.20260705000000000Z',
+  updated_at: '2026-07-05T00:00:00.000Z',
+  ...overrides,
+})
+
+const createResponderTicksSqlite = () => {
+  const sqlite = makeSqliteD1()
+  sqlite.exec(`
+    CREATE TABLE artanis_responder_ticks (
+      tick_ref TEXT PRIMARY KEY,
+      scheduled_at TEXT NOT NULL UNIQUE,
+      scan_state TEXT NOT NULL DEFAULT 'pending',
+      scan_scanned INTEGER NOT NULL DEFAULT 0,
+      scan_proposed INTEGER NOT NULL DEFAULT 0,
+      scan_blocked INTEGER NOT NULL DEFAULT 0,
+      scan_skipped INTEGER NOT NULL DEFAULT 0,
+      scan_skipped_reason TEXT,
+      compose_state TEXT NOT NULL DEFAULT 'pending',
+      compose_considered INTEGER NOT NULL DEFAULT 0,
+      compose_responded INTEGER NOT NULL DEFAULT 0,
+      compose_blocked INTEGER NOT NULL DEFAULT 0,
+      compose_tipped INTEGER NOT NULL DEFAULT 0,
+      compose_skipped_reason TEXT,
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL
+    );
+  `)
+  return sqlite
+}
+
+const selectResponderTickRow = async (
+  db: D1Database,
+  scheduledAt: string,
+): Promise<ArtanisDomainRow> => {
+  const row = await db
+    .prepare(
+      `SELECT ${ARTANIS_DOMAIN_TABLES.artanis_responder_ticks.columns.join(', ')}
+         FROM artanis_responder_ticks
+        WHERE scheduled_at = ?`,
+    )
+    .bind(scheduledAt)
+    .first<ArtanisDomainRow>()
+  if (row === null) {
+    throw new Error(`expected artanis_responder_ticks row ${scheduledAt}`)
+  }
+  return row
+}
+
+const statefulResponderTickPostgres = (): PostgresArtanisDomainStore & {
+  row: (scheduledAt: string) => ArtanisDomainRow | undefined
+} => {
+  const rows = new Map<string, ArtanisDomainRow>()
+  const spec = ARTANIS_DOMAIN_TABLES.artanis_responder_ticks
+  const completeRow = (row: ArtanisDomainRow): ArtanisDomainRow =>
+    Object.fromEntries(
+      spec.columns.map(column => [column, row[column] ?? null]),
+    )
+
+  return {
+    row: scheduledAt => rows.get(scheduledAt),
+    selectLatestRows: () => Promise.resolve([]),
+    selectRowsByKey: () => Promise.resolve([]),
+    upsertRows: (table, upsertRows, updateColumns) => {
+      if (table !== 'artanis_responder_ticks') {
+        return Promise.reject(new Error(`unexpected table ${table}`))
+      }
+      const updateColumnList =
+        updateColumns ??
+        spec.columns.filter(column => column !== spec.conflictKey)
+      for (const row of upsertRows) {
+        const key = String(row[spec.conflictKey] ?? '')
+        const current = rows.get(key)
+        if (current === undefined) {
+          rows.set(key, completeRow(row))
+          continue
+        }
+        const next = { ...current }
+        for (const column of updateColumnList) {
+          next[column] = row[column] ?? null
+        }
+        rows.set(key, next)
+      }
+      return Promise.resolve()
+    },
   }
 }
 
@@ -73,8 +209,7 @@ describe('artanisDomainFlagsFromEnv', () => {
         .reads,
     ).toBe('compare')
     expect(
-      artanisDomainFlagsFromEnv({ KHALA_SYNC_ARTANIS_READS: 'postgrse' })
-        .reads,
+      artanisDomainFlagsFromEnv({ KHALA_SYNC_ARTANIS_READS: 'postgrse' }).reads,
     ).toBe('d1')
   })
 })
@@ -155,6 +290,7 @@ describe('mirrorArtanisRows (fail-soft dual-write)', () => {
     expect(postgres.upserts[0]?.rows.map(row => row['memory_ref'])).toEqual([
       'mem-1',
     ])
+    expect(postgres.upserts[0]?.updateColumns).toBeUndefined()
     expect(logged).toEqual([])
     sqlite.close()
   })
@@ -213,6 +349,161 @@ describe('mirrorArtanisRows (fail-soft dual-write)', () => {
       mirrorArtanisRows(handle, 'artanis_owner_memory', 'body', ['x']),
     ).resolves.toBeUndefined()
     expect(logged[0]?.[0]).toBe('khala_sync_artanis_dual_write_failed')
+    sqlite.close()
+  })
+
+  test('an unregistered scoped update column is refused through the fail-soft mirror', async () => {
+    const sqlite = seededSqlite()
+    const logged: Array<Logged> = []
+    const postgres = fakePostgres()
+    const handle = makeArtanisDomainHandle({
+      d1: sqlite.db,
+      flags: { dualWrite: true, reads: 'd1' },
+      log: (event, fields) => logged.push([event, fields]),
+      postgres,
+    })
+    await expect(
+      mirrorArtanisRows(
+        handle,
+        'artanis_owner_memory',
+        'memory_ref',
+        ['mem-1'],
+        ['owner_id', 'not_a_column'],
+      ),
+    ).resolves.toBeUndefined()
+    expect(logged[0]?.[0]).toBe('khala_sync_artanis_dual_write_failed')
+    expect(postgres.upserts).toEqual([])
+    sqlite.close()
+  })
+
+  test('scoped Postgres upserts insert all registry columns but only update the requested subset', async () => {
+    const { statements, store } = capturePostgresStatements()
+    await store.upsertRows(
+      'artanis_responder_ticks',
+      [responderTickRow()],
+      ['scan_state', 'scan_scanned', 'updated_at'],
+    )
+
+    const statement = statements[0]
+    expect(statement).toBeDefined()
+    expect(statement?.params).toHaveLength(
+      ARTANIS_DOMAIN_TABLES.artanis_responder_ticks.columns.length,
+    )
+    expect(statement?.text).toContain(
+      `INSERT INTO artanis_responder_ticks (${ARTANIS_DOMAIN_TABLES.artanis_responder_ticks.columns.join(', ')})`,
+    )
+    expect(statement?.text).toContain(
+      'ON CONFLICT (scheduled_at) DO UPDATE SET scan_state = EXCLUDED.scan_state, scan_scanned = EXCLUDED.scan_scanned, updated_at = EXCLUDED.updated_at',
+    )
+    expect(statement?.text).not.toContain(
+      'compose_state = EXCLUDED.compose_state',
+    )
+  })
+
+  test('scoped Postgres upserts reject unknown update columns before SQL text is emitted', async () => {
+    const { statements, store } = capturePostgresStatements()
+    await expect(
+      store.upsertRows(
+        'artanis_responder_ticks',
+        [responderTickRow()],
+        ['scan_state', 'scan_state; DROP TABLE artanis_responder_ticks'],
+      ),
+    ).rejects.toThrow(TypeError)
+    expect(statements).toEqual([])
+  })
+
+  test('Postgres upserts without scoped columns still update all non-key columns', async () => {
+    const { statements, store } = capturePostgresStatements()
+    await store.upsertRows('artanis_owner_memory', [
+      {
+        body: 'body v2',
+        created_at: '2026-07-04T00:00:00.000Z',
+        kind: 'note',
+        memory_ref: 'mem-1',
+        note_category: 'fact',
+        owner_id: 'owner-1',
+        role: null,
+      },
+    ])
+
+    const expectedUpdates = ARTANIS_DOMAIN_TABLES.artanis_owner_memory.columns
+      .filter(
+        column =>
+          column !== ARTANIS_DOMAIN_TABLES.artanis_owner_memory.conflictKey,
+      )
+      .map(column => `${column} = EXCLUDED.${column}`)
+      .join(', ')
+    expect(statements[0]?.text).toContain(`DO UPDATE SET ${expectedUpdates}`)
+  })
+
+  test('responder tick scoped mirrors keep scan and compose columns through a delayed stale snapshot replay', async () => {
+    const sqlite = createResponderTicksSqlite()
+    const postgres = statefulResponderTickPostgres()
+    const handle = makeArtanisDomainHandle({
+      d1: sqlite.db,
+      flags: { dualWrite: true, reads: 'd1' },
+      postgres,
+    })
+    const nowIso = '2026-07-05T00:01:00.000Z'
+    const composeUpdateColumns = [
+      'compose_state',
+      'compose_considered',
+      'compose_responded',
+      'compose_blocked',
+      'compose_tipped',
+      'compose_skipped_reason',
+      'updated_at',
+    ] as const
+
+    await recordArtanisResponderComposeTick(handle, {
+      nowIso,
+      outcome: {
+        blocked: 0,
+        considered: 3,
+        responded: 2,
+        skippedReason: null,
+        tipped: 1,
+      },
+    })
+    const staleComposeSnapshot = await selectResponderTickRow(sqlite.db, nowIso)
+    const afterComposeInsert = postgres.row(nowIso)
+    if (afterComposeInsert === undefined) {
+      throw new Error('expected responder tick Postgres row after compose')
+    }
+    for (const column of ARTANIS_DOMAIN_TABLES.artanis_responder_ticks
+      .columns) {
+      expect(Object.hasOwn(afterComposeInsert, column)).toBe(true)
+    }
+    expect(afterComposeInsert['scan_state']).toBe('pending')
+    expect(afterComposeInsert['compose_state']).toBe('ran')
+
+    await postgres.upsertRows(
+      'artanis_responder_ticks',
+      [staleComposeSnapshot],
+      composeUpdateColumns,
+    )
+    expect(postgres.row(nowIso)).toEqual(afterComposeInsert)
+
+    await recordArtanisResponderScanTick(handle, {
+      nowIso,
+      outcome: {
+        blocked: 0,
+        proposed: 2,
+        scanned: 4,
+        skipped: 0,
+        skippedReason: null,
+      },
+    })
+    expect(postgres.row(nowIso)?.['scan_state']).toBe('ran')
+    expect(postgres.row(nowIso)?.['compose_state']).toBe('ran')
+
+    await postgres.upsertRows(
+      'artanis_responder_ticks',
+      [staleComposeSnapshot],
+      composeUpdateColumns,
+    )
+    expect(postgres.row(nowIso)?.['scan_state']).toBe('ran')
+    expect(postgres.row(nowIso)?.['compose_state']).toBe('ran')
     sqlite.close()
   })
 })
@@ -362,14 +653,13 @@ describe('registry', () => {
   })
 
   test('stays in lock-step with the khala-sync-server backfill registry', async () => {
-    const backfill = (await import(
-      '../../../../../packages/khala-sync-server/src/artanis-backfill.js'
-    )) as {
-      ARTANIS_TABLE_SPECS: Record<
-        string,
-        { columns: ReadonlyArray<string>; conflictKey: string }
-      >
-    }
+    const backfill =
+      (await import('../../../../../packages/khala-sync-server/src/artanis-backfill.js')) as {
+        ARTANIS_TABLE_SPECS: Record<
+          string,
+          { columns: ReadonlyArray<string>; conflictKey: string }
+        >
+      }
     expect(Object.keys(backfill.ARTANIS_TABLE_SPECS).sort()).toEqual(
       Object.keys(ARTANIS_DOMAIN_TABLES).sort(),
     )

--- a/apps/openagents.com/workers/api/src/artanis-domain-store.ts
+++ b/apps/openagents.com/workers/api/src/artanis-domain-store.ts
@@ -15,13 +15,15 @@
 //     way. `makeArtanisDatabaseForEnv(env)` is the index.ts drop-in that
 //     upgrades the six cron ticks and the artanis routes to the seam.
 //
-//  2. `mirrorArtanisRows(db, table, keyColumn, keys)` — the dual-write.
+//  2. `mirrorArtanisRows(db, table, keyColumn, keys, updateColumns?)` — the
+//     dual-write.
 //     After the authoritative D1 write, the RESOLVED row(s) are read back
-//     from D1 by key and converged into Postgres as full-row upserts
-//     (`ON CONFLICT (natural key) DO UPDATE`), so a row touched by
-//     dual-write self-heals even before the backfill reaches it, and
-//     re-mirroring is idempotent by construction. A Postgres failure NEVER
-//     fails the request — it logs the typed
+//     from D1 by key and converged into Postgres as full-row upserts by
+//     default (`ON CONFLICT (natural key) DO UPDATE`), or as column-scoped
+//     conflict updates when a concurrent-writer caller supplies
+//     `updateColumns`. A row touched by dual-write self-heals even before
+//     the backfill reaches it, and re-mirroring is idempotent by
+//     construction. A Postgres failure NEVER fails the request — it logs the typed
 //     `khala_sync_artanis_dual_write_failed` diagnostic (the drift metric)
 //     and moves on. This deliberately preserves the Artanis operator-chat
 //     fail-soft precedent (2d46d808): persistence degradation must never
@@ -43,14 +45,13 @@
 // dual-write on → backfill (khala-sync-server scripts/backfill-artanis.ts)
 // → second sweep → --verify → compare reads → postgres reads → re-home the
 // six cron ticks → drop the D1 tables in the follow-up decommission issue.
-
 import type { SyncSql } from '@openagentsinc/khala-sync-server'
 
 import {
-  defaultMakeKhalaSyncSqlClient,
   type KhalaSyncHyperdriveBinding,
   type KhalaSyncPushSqlClient,
   type MakeKhalaSyncPushSqlClient,
+  defaultMakeKhalaSyncSqlClient,
 } from './khala-sync-push-routes'
 import { logWorkerRouteWarning } from './observability'
 import { openAgentsDatabase } from './runtime'
@@ -87,10 +88,8 @@ export const artanisDomainFlagsFromEnv = (
   const readsRaw = env.KHALA_SYNC_ARTANIS_READS?.trim().toLowerCase()
 
   return {
-    dualWrite:
-      dualWriteRaw === undefined || !FLAG_OFF_VALUES.has(dualWriteRaw),
-    reads:
-      readsRaw === 'postgres' || readsRaw === 'compare' ? readsRaw : 'd1',
+    dualWrite: dualWriteRaw === undefined || !FLAG_OFF_VALUES.has(dualWriteRaw),
+    reads: readsRaw === 'postgres' || readsRaw === 'compare' ? readsRaw : 'd1',
   }
 }
 
@@ -390,6 +389,8 @@ class ArtanisDomainKeyColumnError extends TypeError {}
 
 class ArtanisDomainSqlCapabilityError extends TypeError {}
 
+class ArtanisDomainUpdateColumnError extends TypeError {}
+
 const requireKeyColumn = (
   table: ArtanisDomainTable,
   keyColumn: string,
@@ -400,6 +401,45 @@ const requireKeyColumn = (
     )
   }
   return keyColumn
+}
+
+const resolveUpsertUpdateColumns = (
+  table: ArtanisDomainTable,
+  updateColumns: ReadonlyArray<string> | undefined,
+): ReadonlyArray<string> => {
+  const spec = ARTANIS_DOMAIN_TABLES[table]
+  const requested =
+    updateColumns ?? spec.columns.filter(column => column !== spec.conflictKey)
+
+  if (requested.length === 0) {
+    throw new ArtanisDomainUpdateColumnError(
+      `artanis domain store: at least one update column is required for ${table}`,
+    )
+  }
+
+  const seen = new Set<string>()
+  return requested.map(column => {
+    const registeredColumn = spec.columns.find(
+      candidate => candidate === column,
+    )
+    if (registeredColumn === undefined) {
+      throw new ArtanisDomainUpdateColumnError(
+        `artanis domain store: ${column} is not a registered column of ${table}`,
+      )
+    }
+    if (registeredColumn === spec.conflictKey) {
+      throw new ArtanisDomainUpdateColumnError(
+        `artanis domain store: ${column} is the conflict key of ${table} and cannot be an update column`,
+      )
+    }
+    if (seen.has(registeredColumn)) {
+      throw new ArtanisDomainUpdateColumnError(
+        `artanis domain store: ${column} is duplicated in the update columns for ${table}`,
+      )
+    }
+    seen.add(registeredColumn)
+    return registeredColumn
+  })
 }
 
 // ---------------------------------------------------------------------------
@@ -440,13 +480,14 @@ const normalizeValue = (value: unknown): string | number | null => {
 export type PostgresArtanisDomainStore = Readonly<{
   /**
    * Converge Postgres to the RESOLVED rows the authoritative D1 write
-   * produced — full-row `ON CONFLICT (natural key) DO UPDATE` upserts, so
-   * a row touched by dual-write self-heals even before the backfill
-   * reaches it, and re-mirroring the same row is a no-op.
+   * produced. The INSERT always carries all registry columns; the conflict
+   * UPDATE touches either all non-key columns or the caller-provided,
+   * registry-validated subset for concurrent-writer tables.
    */
   upsertRows: (
     table: ArtanisDomainTable,
     rows: ReadonlyArray<ArtanisDomainRow>,
+    updateColumns?: ReadonlyArray<string>,
   ) => Promise<void>
   /** Registry-validated key lookup (read cutover + compare mode). */
   selectRowsByKey: (
@@ -513,29 +554,29 @@ export const makePostgresArtanisDomainStore = (
             )
           }),
 
-    upsertRows: (table, rows) =>
-      rows.length === 0
-        ? Promise.resolve()
-        : withSql(async unsafe => {
-            const spec = ARTANIS_DOMAIN_TABLES[table]
-            const columnsSql = spec.columns.join(', ')
-            const updates = spec.columns
-              .filter(column => column !== spec.conflictKey)
-              .map(column => `${column} = EXCLUDED.${column}`)
-              .join(', ')
-            for (const row of rows) {
-              const values = spec.columns.map(column =>
-                normalizeValue(row[column]),
-              )
-              const placeholders = values
-                .map((_, index) => `$${index + 1}`)
-                .join(', ')
-              await unsafe(
-                `INSERT INTO ${table} (${columnsSql}) VALUES (${placeholders}) ON CONFLICT (${spec.conflictKey}) DO UPDATE SET ${updates}`,
-                values as Array<unknown>,
-              )
-            }
-          }),
+    upsertRows: async (table, rows, updateColumns) => {
+      const spec = ARTANIS_DOMAIN_TABLES[table]
+      const updateColumnList = resolveUpsertUpdateColumns(table, updateColumns)
+      if (rows.length === 0) return
+
+      const columnsSql = spec.columns.join(', ')
+      const updates = updateColumnList
+        .map(column => `${column} = EXCLUDED.${column}`)
+        .join(', ')
+
+      await withSql(async unsafe => {
+        for (const row of rows) {
+          const values = spec.columns.map(column => normalizeValue(row[column]))
+          const placeholders = values
+            .map((_, index) => `$${index + 1}`)
+            .join(', ')
+          await unsafe(
+            `INSERT INTO ${table} (${columnsSql}) VALUES (${placeholders}) ON CONFLICT (${spec.conflictKey}) DO UPDATE SET ${updates}`,
+            values as Array<unknown>,
+          )
+        }
+      })
+    },
   }
 }
 
@@ -614,6 +655,7 @@ export const mirrorArtanisRows = async (
   table: ArtanisDomainTable,
   keyColumn: string,
   keys: ReadonlyArray<string | number>,
+  updateColumns?: ReadonlyArray<string>,
 ): Promise<void> => {
   if (!isArtanisDomainHandle(db)) return
   const { d1, flags, log, postgres } = db
@@ -623,6 +665,9 @@ export const mirrorArtanisRows = async (
   try {
     const spec = ARTANIS_DOMAIN_TABLES[table]
     const column = requireKeyColumn(table, keyColumn)
+    if (updateColumns !== undefined) {
+      resolveUpsertUpdateColumns(table, updateColumns)
+    }
     const placeholders = keys.map(() => '?').join(', ')
     const result = await d1
       .prepare(
@@ -632,7 +677,7 @@ export const mirrorArtanisRows = async (
       .all<ArtanisDomainRow>()
     const rows = result.results ?? []
     if (rows.length === 0) return
-    await postgres.upsertRows(table, rows)
+    await postgres.upsertRows(table, rows, updateColumns)
   } catch (error) {
     log('khala_sync_artanis_dual_write_failed', {
       messageSafe: safeMessage(error),

--- a/apps/openagents.com/workers/api/src/artanis-responder-ticks.ts
+++ b/apps/openagents.com/workers/api/src/artanis-responder-ticks.ts
@@ -1,7 +1,7 @@
 import {
+  type ArtanisDatabase,
   artanisAuthorityDb,
   mirrorArtanisRows,
-  type ArtanisDatabase,
 } from './artanis-domain-store'
 import {
   type PublicProjectionStalenessContract,
@@ -117,6 +117,26 @@ const outcomeState = (
   return skippedReason.includes('error') ? 'error' : 'skipped'
 }
 
+const ARTANIS_RESPONDER_SCAN_TICK_MIRROR_COLUMNS = [
+  'scan_state',
+  'scan_scanned',
+  'scan_proposed',
+  'scan_blocked',
+  'scan_skipped',
+  'scan_skipped_reason',
+  'updated_at',
+] as const
+
+const ARTANIS_RESPONDER_COMPOSE_TICK_MIRROR_COLUMNS = [
+  'compose_state',
+  'compose_considered',
+  'compose_responded',
+  'compose_blocked',
+  'compose_tipped',
+  'compose_skipped_reason',
+  'updated_at',
+] as const
+
 export const recordArtanisResponderScanTick = async (
   db: ArtanisDatabase,
   input: Readonly<{ nowIso: string; outcome: ArtanisResponderScanTickOutcome }>,
@@ -151,9 +171,13 @@ export const recordArtanisResponderScanTick = async (
     )
     .run()
   // KS-8.6 dual-write: converge the tick receipt into Postgres (fail-soft).
-  await mirrorArtanisRows(db, 'artanis_responder_ticks', 'scheduled_at', [
-    input.nowIso,
-  ])
+  await mirrorArtanisRows(
+    db,
+    'artanis_responder_ticks',
+    'scheduled_at',
+    [input.nowIso],
+    ARTANIS_RESPONDER_SCAN_TICK_MIRROR_COLUMNS,
+  )
 }
 
 export const recordArtanisResponderComposeTick = async (
@@ -194,9 +218,13 @@ export const recordArtanisResponderComposeTick = async (
     )
     .run()
   // KS-8.6 dual-write: converge the tick receipt into Postgres (fail-soft).
-  await mirrorArtanisRows(db, 'artanis_responder_ticks', 'scheduled_at', [
-    input.nowIso,
-  ])
+  await mirrorArtanisRows(
+    db,
+    'artanis_responder_ticks',
+    'scheduled_at',
+    [input.nowIso],
+    ARTANIS_RESPONDER_COMPOSE_TICK_MIRROR_COLUMNS,
+  )
 }
 
 export const projectArtanisResponderTickReadiness = (
@@ -350,7 +378,9 @@ export const readArtanisResponderTickReadiness = async (
     .all()
 
   return projectArtanisResponderTickReadiness(
-    (tickResult.results ?? []) as unknown as ReadonlyArray<ArtanisResponderTickRow>,
-    (actionResult.results ?? []) as unknown as ReadonlyArray<ArtanisResponderTickActionRow>,
+    (tickResult.results ??
+      []) as unknown as ReadonlyArray<ArtanisResponderTickRow>,
+    (actionResult.results ??
+      []) as unknown as ReadonlyArray<ArtanisResponderTickActionRow>,
   )
 }


### PR DESCRIPTION
## Summary

Concurrent responder ticks no longer clobber each other's half of the Postgres mirror row. The dual-write mirror now scopes its `ON CONFLICT DO UPDATE` to each writer's own columns, exactly like the authoritative D1 write already does, so the scan and compose ticks converge into the same row instead of overwriting one another from a stale snapshot.

`mirrorArtanisRows(db, table, keyColumn, keys, updateColumns?)` threads an optional `updateColumns` subset down into `PostgresArtanisDomainStore.upsertRows(table, rows, updateColumns?)`. When provided, the generated statement still `INSERT`s every registry column (so a fresh row is complete from the D1 snapshot) but restricts the update list to the validated subset; when absent, behavior is unchanged (all non-key columns), so the other 19 tables and existing callers are untouched. The subset is validated against `ARTANIS_DOMAIN_TABLES[table].columns` (conflict key excluded, unknown/duplicate columns rejected), keeping the statement registry-only-dynamic-text and Hyperdrive transaction-mode safe. The two responder-tick write sites now pass their own `scan_*` / `compose_*` column sets, matching each tick's existing D1 `DO UPDATE SET` scope.

## Why this matters

`artanis_responder_ticks` is the one mirrored table written by two independent every-minute cron ticks (`ArtanisResponder.scan` and `.compose`) that share one row keyed by `scheduled_at`. In D1 each tick uses a column-scoped `ON CONFLICT(scheduled_at) DO UPDATE SET <only its own columns>`, so D1 never drifts. But the mirror read the full resolved D1 row back and did a full-row `ON CONFLICT DO UPDATE SET <every non-key column>`. When the two ticks' read-then-upsert round trips interleave, the last full-row upsert to land overwrites the other writer's columns from a stale snapshot. A production `--verify` (issue #8409) found rows where Postgres held `scan_state=pending` while D1 had `scan_state=ran`, which blocks read-routing or retiring D1 for this table. Scoping the mirror update to each writer's columns makes the two stores converge identically, so a stale snapshot can no longer overwrite the other writer's half. The mirror stays fail-soft (never throws; a rejected column logs `khala_sync_artanis_dual_write_failed`).

## Testing

Added a deterministic race-replay regression test in `artanis-domain-store.test.ts` using the existing `makeSqliteD1` real-SQLite D1 stand-in plus a Postgres fake that applies column-scoped `ON CONFLICT` semantics: it seeds the row via compose then scan, replays compose's stale-snapshot mirror after scan's mirror, and asserts the converged row keeps both `scan_state=ran` and `compose_state=ran` (the pre-fix full-row upsert left `scan_state=pending`). Further tests assert the scoped upsert `INSERT`s all registry columns but only updates the passed subset, that an unknown/injection column is rejected before any SQL text is emitted, and that the no-`updateColumns` path still updates all non-key columns for single-writer tables. Ran the full `artanis-domain-store.test.ts` suite (26 passing) and `tsc -p tsconfig.json --noEmit` for the api worker (clean).

Fixes #8409
