### PR TITLE
Harden registry note version guard

### DIFF
--- a/apps/openagents.com/workers/api/src/product-promises.test.ts
+++ b/apps/openagents.com/workers/api/src/product-promises.test.ts
@@ -111,16 +111,47 @@ describe('public product promises document', () => {
     const decoded = S.decodeUnknownSync(ProductPromisesDocument)(
       publicProductPromisesDocument(),
     )
-    const newestRegistryNote = decoded.notes.find(note =>
-      note.startsWith('Registry '),
+    const registryVersions = decoded.notes.flatMap(note => {
+      const match = /^Registry (\d{4}-\d{2}-\d{2})\.(\d+)/.exec(note)
+      const date = match?.[1]
+      const sequenceText = match?.[2]
+
+      if (date === undefined || sequenceText === undefined) {
+        return []
+      }
+
+      return [
+        {
+          date,
+          sequence: Number.parseInt(sequenceText, 10),
+          version: `${date}.${sequenceText}`,
+        },
+      ]
+    })
+    const [firstRegistryVersion, ...remainingRegistryVersions] =
+      registryVersions
+
+    expect(firstRegistryVersion).toBeDefined()
+
+    const newestRegistryVersion = remainingRegistryVersions.reduce(
+      (latest, candidate) => {
+        if (candidate.date > latest.date) {
+          return candidate
+        }
+        if (
+          candidate.date === latest.date &&
+          candidate.sequence > latest.sequence
+        ) {
+          return candidate
+        }
+        return latest
+      },
+      firstRegistryVersion!,
     )
-    const newestRegistryVersion = /^Registry (?<version>\d{4}-\d{2}-\d{2}\.\d+)/.exec(
-      newestRegistryNote ?? '',
-    )?.groups?.version
 
     expect(decoded.registryVersion).toBe(PublicProductPromisesVersion)
     expect(decoded.version).toBe(PublicProductPromisesVersion)
-    expect(newestRegistryVersion).toBe(PublicProductPromisesVersion)
+    expect(newestRegistryVersion.version).toBe(PublicProductPromisesVersion)
   })
 
   test('keeps business quick-win paid receipt blockers exact for issue 7025', () => {


### PR DESCRIPTION
Problem
- Audit post #89 found that the product-promises registry alignment regression trusted the first `Registry ` note in `notes[]`, assuming newest-first ordering.
- Current main can still miss a later maximum registry label if note order changes.

Change
- Scan every decoded Registry note matching `Registry YYYY-MM-DD.N`.
- Compute the maximum by ISO date and numeric sequence.
- Assert `registryVersion`, `version`, and `PublicProductPromisesVersion` all match that maximum.

Files touched
- `apps/openagents.com/workers/api/src/product-promises.test.ts`

Validation
- `bun install --frozen-lockfile`
- `bun run --cwd apps/openagents.com/workers/api test -- src/product-promises.test.ts`
- `git diff --check`
- `rg -n "<<<<<<<|=======|>>>>>>>" apps/openagents.com/workers/api/src/product-promises.test.ts`
- `bun run check:deploy`

Maintenance / revenue value
- Keeps the Product Promises public registry guard from accepting source-history ordering drift.
- Reduces risk of stale or misordered registry copy supporting an invalid public promise/version claim.

Intentionally not changed
- No promise state, registry narrative, product copy, docs, routes, or runtime behavior.
- The duplicated `.2` narrative and missing `.3` breadcrumb remain outside this PR.
