### PR TITLE
Persist Apollo subject refs on OB-2 pipeline rows

### DIFF
--- a/apps/openagents.com/workers/api/migrations/0314_business_pipeline_subject_ref.sql
+++ b/apps/openagents.com/workers/api/migrations/0314_business_pipeline_subject_ref.sql
@@ -1,0 +1,12 @@
+-- OB-2 Apollo sourcing subject identity gate (#8559).
+--
+-- Stores only the public-safe opaque prospect subject ref that Apollo ingest
+-- already uses for suppressions. No names, domains, emails, raw Apollo payloads,
+-- or private contact data belong in this column.
+
+ALTER TABLE business_pipeline_rows
+  ADD COLUMN subject_ref TEXT;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_business_pipeline_rows_subject_ref
+  ON business_pipeline_rows(subject_ref)
+  WHERE subject_ref IS NOT NULL;

--- a/apps/openagents.com/workers/api/src/agent-readiness-public-report-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/agent-readiness-public-report-routes.test.ts
@@ -69,6 +69,7 @@ const makeDb = (): D1Database => {
   db.exec(migration('0294_business_pipeline_queue.sql'))
   db.exec(migration('0296_business_outreach_sequences.sql'))
   db.exec(migration('0299_business_pipeline_partner_routing.sql'))
+  db.exec(migration('0314_business_pipeline_subject_ref.sql'))
   db.exec(migration('0297_business_source_attribution.sql'))
   db.exec(migration('0310_agent_readiness_public_reports.sql'))
   return new SqliteD1(db) as unknown as D1Database

--- a/apps/openagents.com/workers/api/src/business-affiliate-attribution.test.ts
+++ b/apps/openagents.com/workers/api/src/business-affiliate-attribution.test.ts
@@ -149,6 +149,7 @@ const SCHEMA = [
   '0278_business_commitment_ledger.sql',
   '0294_business_pipeline_queue.sql',
   '0299_business_pipeline_partner_routing.sql',
+  '0314_business_pipeline_subject_ref.sql',
   '0297_business_source_attribution.sql',
   '0298_business_affiliate_attribution.sql',
 ].map(migration)

--- a/apps/openagents.com/workers/api/src/business-checkout-kickoff.test.ts
+++ b/apps/openagents.com/workers/api/src/business-checkout-kickoff.test.ts
@@ -101,6 +101,7 @@ const makeDb = (): D1Database => {
     '0278_business_commitment_ledger.sql',
     '0294_business_pipeline_queue.sql',
     '0299_business_pipeline_partner_routing.sql',
+    '0314_business_pipeline_subject_ref.sql',
     '0297_business_source_attribution.sql',
   ]) {
     db.exec(migration(name))

--- a/apps/openagents.com/workers/api/src/business-domain-repository.contract.test.ts
+++ b/apps/openagents.com/workers/api/src/business-domain-repository.contract.test.ts
@@ -86,6 +86,10 @@ const MIGRATION_0022 = path.resolve(
   import.meta.dirname,
   '../../../../../packages/khala-sync-server/migrations/0023_business_funnel.sql',
 )
+const MIGRATION_0051 = path.resolve(
+  import.meta.dirname,
+  '../../../../../packages/khala-sync-server/migrations/0051_business_pipeline_subject_ref.sql',
+)
 
 type PgClient = {
   end: (options?: { timeout?: number }) => Promise<void>
@@ -861,8 +865,10 @@ describe.skipIf(!hasLocalPostgres())(
       await admin.unsafe('CREATE DATABASE business_contract')
       pgUrl = pg.urlFor('business_contract')
       const migration = readFileSync(MIGRATION_0022, 'utf8')
+      const pipelineSubjectMigration = readFileSync(MIGRATION_0051, 'utf8')
       const target = postgres(pgUrl, { max: 1, prepare: false })
       await target.unsafe(migration)
+      await target.unsafe(pipelineSubjectMigration)
       await target.end({ timeout: 5 })
     }, 120_000)
 
@@ -960,6 +966,7 @@ describe.skipIf(!hasLocalPostgres())(
         source_ref: 'direct',
         stage: 'intake_received',
         stage_updated_at: '2026-07-04T00:00:00.000Z',
+        subject_ref: null,
         updated_at: '2026-07-04T00:00:00.000Z',
         vertical: 'vertical.test',
       }

--- a/apps/openagents.com/workers/api/src/business-outreach-daily-ledger-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/business-outreach-daily-ledger-routes.test.ts
@@ -58,6 +58,7 @@ const makeDb = (): D1Database => {
   db.exec(migration('0294_business_pipeline_queue.sql'))
   db.exec('ALTER TABLE business_pipeline_rows ADD COLUMN business_signup_request_id TEXT;')
   db.exec(migration('0299_business_pipeline_partner_routing.sql'))
+  db.exec(migration('0314_business_pipeline_subject_ref.sql'))
   db.exec(migration('0296_business_outreach_sequences.sql'))
   db.exec(migration('0026_email_ledger.sql'))
   db.exec(migration('0063_email_campaign_records.sql'))

--- a/apps/openagents.com/workers/api/src/business-outreach-daily-ledger.test.ts
+++ b/apps/openagents.com/workers/api/src/business-outreach-daily-ledger.test.ts
@@ -59,6 +59,7 @@ const makeDb = (): D1Database => {
   db.exec(migration('0294_business_pipeline_queue.sql'))
   db.exec('ALTER TABLE business_pipeline_rows ADD COLUMN business_signup_request_id TEXT;')
   db.exec(migration('0299_business_pipeline_partner_routing.sql'))
+  db.exec(migration('0314_business_pipeline_subject_ref.sql'))
   db.exec(migration('0296_business_outreach_sequences.sql'))
   db.exec(migration('0026_email_ledger.sql'))
   db.exec(migration('0063_email_campaign_records.sql'))

--- a/apps/openagents.com/workers/api/src/business-outreach-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/business-outreach-routes.test.ts
@@ -64,6 +64,7 @@ const makeDb = (): D1Database => {
   db.exec(migration('0294_business_pipeline_queue.sql'))
   db.exec('ALTER TABLE business_pipeline_rows ADD COLUMN business_signup_request_id TEXT;')
   db.exec(migration('0299_business_pipeline_partner_routing.sql'))
+  db.exec(migration('0314_business_pipeline_subject_ref.sql'))
   db.exec(migration('0296_business_outreach_sequences.sql'))
   return new SqliteD1(db) as unknown as D1Database
 }

--- a/apps/openagents.com/workers/api/src/business-pipeline-queue.ts
+++ b/apps/openagents.com/workers/api/src/business-pipeline-queue.ts
@@ -105,6 +105,7 @@ export const BusinessPipelineRow = S.Struct({
   sourceRef: S.String,
   stage: BusinessPipelineStage,
   stageUpdatedAt: S.String,
+  subjectRef: S.NullOr(S.String),
   updatedAt: S.String,
   vertical: S.String,
 })
@@ -257,6 +258,7 @@ export type BusinessPipelineCreateInput = Readonly<{
   receiptRefs?: ReadonlyArray<string>
   sourceRef: string
   stage?: BusinessPipelineStage
+  subjectRef?: string | null
   vertical: string
 }>
 
@@ -336,6 +338,7 @@ type BusinessPipelineD1Row = Readonly<{
   source_ref: string
   stage: BusinessPipelineStage
   stage_updated_at: string
+  subject_ref: string | null
   updated_at: string
   vertical: string
 }>
@@ -630,6 +633,7 @@ const businessPipelineRowFromD1 = (row: BusinessPipelineD1Row): BusinessPipeline
     sourceRef: row.source_ref,
     stage: S.decodeUnknownSync(BusinessPipelineStage)(row.stage),
     stageUpdatedAt: row.stage_updated_at,
+    subjectRef: row.subject_ref,
     updatedAt: row.updated_at,
     vertical: row.vertical,
   }
@@ -637,6 +641,9 @@ const businessPipelineRowFromD1 = (row: BusinessPipelineD1Row): BusinessPipeline
   assertPublicSafeRef('pipelineRef', record.pipelineRef)
   assertPublicSafeDescriptor('vertical', record.vertical)
   assertPublicSafeRef('sourceRef', record.sourceRef)
+  if (record.subjectRef !== null) {
+    assertPublicSafeRef('subjectRef', record.subjectRef)
+  }
   assertPublicSafeDescriptor('ownerRole', record.ownerRole)
   if (record.nextActionDueAt !== null) {
     assertPublicSafeDescriptor('nextActionDueAt', record.nextActionDueAt)
@@ -783,6 +790,7 @@ const pipelineRowSelect = `SELECT
   source_ref,
   stage,
   stage_updated_at,
+  subject_ref,
   updated_at,
   vertical
  FROM business_pipeline_rows`
@@ -929,6 +937,18 @@ export const makeD1BusinessPipelineStore = (db: D1Database): BusinessPipelineSto
     return row === null ? null : businessPipelineRowFromD1(row)
   }
 
+  const readPipelineRowBySubjectRef = async (
+    subjectRef: string,
+  ): Promise<BusinessPipelineRow | null> => {
+    assertPublicSafeRef('subjectRef', subjectRef)
+    const row = await db
+      .prepare(`${pipelineRowSelect} WHERE subject_ref = ?`)
+      .bind(subjectRef)
+      .first<BusinessPipelineD1Row>()
+
+    return row === null ? null : businessPipelineRowFromD1(row)
+  }
+
   const listPipelineRows = async (): Promise<ReadonlyArray<BusinessPipelineRow>> => {
     const rows = await db
       .prepare(`${pipelineRowSelect} ORDER BY updated_at DESC, pipeline_ref ASC`)
@@ -1062,6 +1082,7 @@ export const makeD1BusinessPipelineStore = (db: D1Database): BusinessPipelineSto
       const quotedBand = normalizeQuotedBand(input.quotedBand)
       const nextActionDueAt = input.nextActionDueAt?.trim() || null
       const blockerRef = normalizeNullableRef('blockerRef', input.blockerRef)
+      const subjectRef = normalizeNullableRef('subjectRef', input.subjectRef)
       const businessSignupRequestId = normalizeNullableRef(
         'businessSignupRequestId',
         input.businessSignupRequestId,
@@ -1104,6 +1125,7 @@ export const makeD1BusinessPipelineStore = (db: D1Database): BusinessPipelineSto
             business_signup_request_id,
             vertical,
             source_ref,
+            subject_ref,
             stage,
             quoted_min_usd_cents,
             quoted_max_usd_cents,
@@ -1125,13 +1147,14 @@ export const makeD1BusinessPipelineStore = (db: D1Database): BusinessPipelineSto
             created_at,
             updated_at,
             stage_updated_at
-          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
         )
         .bind(
           pipelineRef,
           businessSignupRequestId,
           vertical,
           sourceRef,
+          subjectRef,
           stage,
           quotedBand.minUsdCents,
           quotedBand.maxUsdCents,
@@ -1157,6 +1180,23 @@ export const makeD1BusinessPipelineStore = (db: D1Database): BusinessPipelineSto
         .run()
 
       if (Number(result.meta?.changes ?? 0) === 0) {
+        const existingPipelineRow = await readPipelineRow(pipelineRef)
+        if (existingPipelineRow !== null) {
+          throw new BusinessPipelineStoreError({
+            kind: 'conflict',
+            reason: `pipeline row already exists: ${pipelineRef}`,
+          })
+        }
+        const existingSubjectRow =
+          subjectRef === null
+            ? null
+            : await readPipelineRowBySubjectRef(subjectRef)
+        if (existingSubjectRow !== null) {
+          throw new BusinessPipelineStoreError({
+            kind: 'conflict',
+            reason: `subjectRef already linked: ${subjectRef}`,
+          })
+        }
         throw new BusinessPipelineStoreError({
           kind: 'conflict',
           reason: `pipeline row already exists: ${pipelineRef}`,
@@ -1276,8 +1316,33 @@ export const makeD1BusinessPipelineStore = (db: D1Database): BusinessPipelineSto
       const unsuppressed = normalizedProspects.filter(
         prospect => !suppressedSubjectRefs.has(prospect.subjectRef),
       )
+      const waveSubjectRefs = new Set<string>()
+      const waveSubjectDuplicatePipelineRefs: Array<string> = []
+      const subjectUniqueUnsuppressed = unsuppressed.filter(prospect => {
+        if (waveSubjectRefs.has(prospect.subjectRef)) {
+          waveSubjectDuplicatePipelineRefs.push(prospect.pipelineRef)
+          return false
+        }
+        waveSubjectRefs.add(prospect.subjectRef)
+        return true
+      })
+      const existingSubjectRows = await Promise.all(
+        subjectUniqueUnsuppressed.map(async prospect => ({
+          existing: await readPipelineRowBySubjectRef(prospect.subjectRef),
+          pipelineRef: prospect.pipelineRef,
+        })),
+      )
+      const existingSubjectDuplicatePipelineRefs = existingSubjectRows.flatMap(
+        entry => entry.existing === null ? [] : [entry.pipelineRef],
+      )
+      const existingSubjectDuplicateSet = new Set(
+        existingSubjectDuplicatePipelineRefs,
+      )
+      const insertable = subjectUniqueUnsuppressed.filter(
+        prospect => !existingSubjectDuplicateSet.has(prospect.pipelineRef),
+      )
       const outcomes = await Promise.all(
-        unsuppressed.map(async prospect => {
+        insertable.map(async prospect => {
           try {
             const row = await createPipelineRow(
               {
@@ -1291,6 +1356,7 @@ export const makeD1BusinessPipelineStore = (db: D1Database): BusinessPipelineSto
                   ...(prospect.receiptRefs ?? []),
                 ],
                 sourceRef: prospect.sourceRef,
+                subjectRef: prospect.subjectRef,
                 vertical: prospect.vertical,
               },
               runtime,
@@ -1312,6 +1378,15 @@ export const makeD1BusinessPipelineStore = (db: D1Database): BusinessPipelineSto
                   pipelineRef: prospect.pipelineRef,
                 }
               }
+              const existingSubject = await readPipelineRowBySubjectRef(
+                prospect.subjectRef,
+              )
+              if (existingSubject !== null) {
+                return {
+                  kind: 'duplicate' as const,
+                  pipelineRef: prospect.pipelineRef,
+                }
+              }
             }
             throw error
           }
@@ -1323,11 +1398,16 @@ export const makeD1BusinessPipelineStore = (db: D1Database): BusinessPipelineSto
       const duplicates = outcomes.flatMap(outcome =>
         outcome.kind === 'duplicate' ? [outcome.pipelineRef] : [],
       )
+      const allDuplicates = [
+        ...waveSubjectDuplicatePipelineRefs,
+        ...existingSubjectDuplicatePipelineRefs,
+        ...duplicates,
+      ]
 
       return S.decodeUnknownSync(BusinessPipelineApolloWaveIngest)({
         acceptedCount: inserted.length,
-        duplicateCount: duplicates.length,
-        duplicates,
+        duplicateCount: allDuplicates.length,
+        duplicates: allDuplicates,
         inserted,
         schemaVersion: 'openagents.business_pipeline_apollo_wave_ingest.v1',
         segmentRef,

--- a/apps/openagents.com/workers/api/src/business-pipeline-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/business-pipeline-routes.test.ts
@@ -61,6 +61,7 @@ const makeDb = (): D1Database => {
   db.exec(migration('0294_business_pipeline_queue.sql'))
   db.exec(migration('0296_business_outreach_sequences.sql'))
   db.exec(migration('0299_business_pipeline_partner_routing.sql'))
+  db.exec(migration('0314_business_pipeline_subject_ref.sql'))
   db.exec(migration('0297_business_source_attribution.sql'))
   return new SqliteD1(db) as unknown as D1Database
 }
@@ -183,7 +184,12 @@ describe('business pipeline queue routes', () => {
       wave: {
         acceptedCount: number
         duplicateCount: number
-        inserted: ReadonlyArray<{ sourceRef: string }>
+        duplicates: ReadonlyArray<string>
+        inserted: ReadonlyArray<{
+          pipelineRef: string
+          sourceRef: string
+          subjectRef: string | null
+        }>
         suppressed: ReadonlyArray<{ subjectRef: string }>
         suppressedCount: number
       }
@@ -200,6 +206,17 @@ describe('business pipeline queue routes', () => {
         row => row.sourceRef === 'apollo_agent_readiness_agency',
       ),
     ).toBe(true)
+    expect(agencyBody.wave.inserted).toContainEqual(
+      expect.objectContaining({
+        pipelineRef: 'biz-pipe-agency-001',
+        subjectRef: 'prospect.agency.001',
+      }),
+    )
+    expect(
+      agencyBody.wave.inserted.some(
+        row => row.subjectRef === 'prospect.agency.050',
+      ),
+    ).toBe(false)
 
     const legalWave = await runRoute(
       db,
@@ -236,13 +253,68 @@ describe('business pipeline queue routes', () => {
       }),
     )
     expect(replay.status).toBe(201)
-    expect(await replay.json()).toMatchObject({
+    const replayBody = await replay.json() as {
+      wave: {
+        acceptedCount: number
+        duplicateCount: number
+        duplicates: ReadonlyArray<string>
+        suppressedCount: number
+      }
+    }
+    expect(replayBody).toMatchObject({
       wave: {
         acceptedCount: 0,
         duplicateCount: 99,
         suppressedCount: 1,
       },
     })
+    expect(replayBody.wave.duplicates).toContain('biz-pipe-agency-001')
+    expect(replayBody.wave.duplicates).not.toContain('biz-pipe-agency-050')
+
+    const sameSubjectSecondWave = await runRoute(
+      db,
+      operatorRequest('/api/operator/business/pipeline/apollo-waves', {
+        body: JSON.stringify({
+          prospects: [{
+            pipelineRef: 'biz-pipe-agency-followup-001',
+            quotedBandLabel: 'audit first',
+            quotedMaxUsdCents: 500_000,
+            quotedMinUsdCents: 150_000,
+            subjectRef: 'prospect.agency.001',
+            vertical: 'agency',
+          }],
+          segmentRef: 'segment.apollo.agencies_seo',
+          sourceRef: 'apollo_agent_readiness_agency',
+          waveRef: 'apollo.wave.agencies_seo.20260708b',
+        }),
+        method: 'POST',
+      }),
+    )
+    expect(sameSubjectSecondWave.status).toBe(201)
+    expect(await sameSubjectSecondWave.json()).toMatchObject({
+      wave: {
+        acceptedCount: 0,
+        duplicateCount: 1,
+        duplicates: ['biz-pipe-agency-followup-001'],
+        suppressedCount: 0,
+      },
+    })
+
+    const list = await runRoute(
+      db,
+      operatorRequest('/api/operator/business/pipeline'),
+    )
+    const listBody = await list.json() as {
+      rows: ReadonlyArray<{ pipelineRef: string; subjectRef: string | null }>
+    }
+    expect(
+      listBody.rows.filter(row => row.subjectRef === 'prospect.agency.001'),
+    ).toEqual([
+      expect.objectContaining({
+        pipelineRef: 'biz-pipe-agency-001',
+        subjectRef: 'prospect.agency.001',
+      }),
+    ])
 
     const metrics = await runRoute(
       db,

--- a/apps/openagents.com/workers/api/src/business-pipeline-routes.ts
+++ b/apps/openagents.com/workers/api/src/business-pipeline-routes.ts
@@ -151,6 +151,7 @@ const createInputFromBody = (
     receiptRefs: stringArrayFromUnknown(body.receiptRefs),
     sourceRef: optionalString(body.sourceRef) ?? '',
     ...(stage === undefined ? {} : { stage }),
+    subjectRef: optionalString(body.subjectRef) ?? null,
     vertical: optionalString(body.vertical) ?? '',
   }
 }

--- a/apps/openagents.com/workers/api/src/business-signup-referral.test.ts
+++ b/apps/openagents.com/workers/api/src/business-signup-referral.test.ts
@@ -141,6 +141,7 @@ const SCHEMA = [
   '0278_business_commitment_ledger.sql',
   '0294_business_pipeline_queue.sql',
   '0299_business_pipeline_partner_routing.sql',
+  '0314_business_pipeline_subject_ref.sql',
   '0297_business_source_attribution.sql',
   '0298_business_affiliate_attribution.sql',
 ].map(migration)

--- a/apps/openagents.com/workers/api/src/business-signup-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/business-signup-routes.test.ts
@@ -77,6 +77,7 @@ const SCHEMA = [
   '0278_business_commitment_ledger.sql',
   '0294_business_pipeline_queue.sql',
   '0299_business_pipeline_partner_routing.sql',
+  '0314_business_pipeline_subject_ref.sql',
   '0297_business_source_attribution.sql',
 ].map(migration)
 

--- a/apps/openagents.com/workers/api/src/business-starter-credit-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/business-starter-credit-routes.test.ts
@@ -130,6 +130,7 @@ const makeDb = (): D1Database => {
   db.exec(migration('0294_business_pipeline_queue.sql'))
   db.exec('ALTER TABLE business_pipeline_rows ADD COLUMN business_signup_request_id TEXT;')
   db.exec(migration('0299_business_pipeline_partner_routing.sql'))
+  db.exec(migration('0314_business_pipeline_subject_ref.sql'))
   db.exec(migration('0295_business_starter_credit_grants.sql'))
   return new SqliteD1(db) as unknown as D1Database
 }

--- a/apps/openagents.com/workers/api/src/qa-swarm-first-engagement-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/qa-swarm-first-engagement-routes.test.ts
@@ -110,6 +110,7 @@ const makeDb = (): D1Database => {
     '0278_business_commitment_ledger.sql',
     '0294_business_pipeline_queue.sql',
     '0299_business_pipeline_partner_routing.sql',
+    '0314_business_pipeline_subject_ref.sql',
     '0297_business_source_attribution.sql',
     '0292_qa_swarm_first_engagements.sql',
     '0293_revenue_event_provenance.sql',

--- a/apps/openagents.com/workers/api/src/test/sqlite-d1.ts
+++ b/apps/openagents.com/workers/api/src/test/sqlite-d1.ts
@@ -2331,8 +2331,13 @@ CREATE TABLE IF NOT EXISTS business_pipeline_rows (
   partner_due_window_ref       TEXT,
   partner_budget_range_ref     TEXT,
   partner_privacy_tier_ref     TEXT,
-  partner_route_updated_at     TEXT
+  partner_route_updated_at     TEXT,
+  subject_ref                  TEXT
 );
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_business_pipeline_rows_subject_ref
+  ON business_pipeline_rows(subject_ref)
+  WHERE subject_ref IS NOT NULL;
 
 CREATE TABLE IF NOT EXISTS business_starter_credit_grants (
   grant_ref                    TEXT NOT NULL PRIMARY KEY,

--- a/apps/openagents.com/workers/api/src/vertical-funnel-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/vertical-funnel-routes.test.ts
@@ -59,6 +59,7 @@ const SCHEMA = [
   '0278_business_commitment_ledger.sql',
   '0294_business_pipeline_queue.sql',
   '0299_business_pipeline_partner_routing.sql',
+  '0314_business_pipeline_subject_ref.sql',
   '0297_business_source_attribution.sql',
 ].map(migration)
 

--- a/packages/khala-sync-server/migrations/0051_business_pipeline_subject_ref.sql
+++ b/packages/khala-sync-server/migrations/0051_business_pipeline_subject_ref.sql
@@ -1,0 +1,12 @@
+-- OB-2 Apollo sourcing mirror parity (#8559).
+--
+-- Mirrors the D1 business_pipeline_rows.subject_ref column as an opaque,
+-- public-safe prospect subject identifier. D1 remains write-authority and
+-- makes the uniqueness/dedupe decision; Postgres only converges accepted rows.
+
+ALTER TABLE business_pipeline_rows
+  ADD COLUMN IF NOT EXISTS subject_ref text;
+
+CREATE UNIQUE INDEX IF NOT EXISTS business_pipeline_rows_subject_ref_idx
+  ON business_pipeline_rows(subject_ref)
+  WHERE subject_ref IS NOT NULL;

--- a/packages/khala-sync-server/src/business-backfill.test.ts
+++ b/packages/khala-sync-server/src/business-backfill.test.ts
@@ -127,6 +127,7 @@ const pipelineRow = (
   source_ref: "direct",
   stage: "intake_received",
   stage_updated_at: `2026-07-01T0${n}:00:00.000Z`,
+  subject_ref: null,
   updated_at: `2026-07-01T0${n}:00:00.000Z`,
   vertical: "vertical.test",
   ...overrides,

--- a/packages/khala-sync-server/src/business-domain-tables.ts
+++ b/packages/khala-sync-server/src/business-domain-tables.ts
@@ -315,6 +315,7 @@ export const BUSINESS_DOMAIN_TABLE_SPECS: Readonly<
       "partner_budget_range_ref",
       "partner_privacy_tier_ref",
       "partner_route_updated_at",
+      "subject_ref",
     ],
     keyColumns: ["pipeline_ref"],
     lookupColumns: [],


### PR DESCRIPTION
Refs #8559

## Problem

OB-2 Apollo ingest already received a public-safe `subjectRef` and used it for suppression, but pipeline rows did not persist or surface that identity. That left the route able to double-count the same Apollo subject when a later wave reused the subject with a fresh `pipelineRef`, which kept #8559's public acceptance blocker open.

## Behavior

- Adds nullable public-safe `subject_ref` persistence for business pipeline rows in D1 and the Khala Sync Postgres mirror, with partial unique indexes for non-null subject refs.
- Surfaces `subjectRef` on pipeline rows and accepts it through the operator create route.
- De-dupes Apollo prospects by `subjectRef` within a wave, across replayed waves, and across later waves that use a new `pipelineRef` for the same subject.
- Keeps subject suppressions first-class: suppressed subjects are still not inserted or reported as duplicates.

## Files Touched

- Worker business pipeline store/routes/tests and D1 test helper.
- D1 migration `0314_business_pipeline_subject_ref.sql`.
- Khala Sync mirror migration/table schema/backfill fixture/contract setup.
- Adjacent route tests that bootstrap the business pipeline migrations.

## Validation

- `bun run test -- src/business-pipeline-routes.test.ts`
- `bun run test:pending-migrations-guard` from `apps/openagents.com`
- `bun run test:pending-migrations-guard` from `packages/khala-sync-server`
- `bun test src/business-backfill.test.ts` from `packages/khala-sync-server` (rerun with local bind permission after sandbox `EPERM`)
- `bun run test -- src/business-domain-repository.contract.test.ts` from `apps/openagents.com/workers/api` (rerun with local bind permission after sandbox `EPERM`)
- `git diff --check`

Attempted broader typechecks in the Worker API and Khala Sync package, but both still hit the existing workspace/dependency/type baseline outside this patch's files (for example missing workspace `effect`/`postgres` resolution in the typecheck graph and existing schema shape errors).

## Maintenance / Revenue Value

This clears the narrow OB-2 public promise gate AtlantisPleb identified: Apollo-sourced pipeline rows now carry an auditable public-safe subject identity, and repeated prospects cannot inflate proof or revenue-path counts just because a later wave emits a different pipeline ref.

## Intentionally Not Changed

- No live Apollo wave receipts or outbound sends.
- No OB-1 cap changes, OB-3 public report work, or Sarah/KHS/Gemma behavior.
- No private prospect names, domains, emails, raw Apollo data, tokens, keys, or payment material.
