### PR TITLE
Add Sarah blueprint delta SSE events

### DIFF
--- a/apps/sarah/src/services/account-link.test.ts
+++ b/apps/sarah/src/services/account-link.test.ts
@@ -12,6 +12,7 @@ import { afterEach, describe, expect, test } from "bun:test"
 import {
   accountPromptLine,
   buildAccountLinkContactRow,
+  linkSarahProspectAccount,
   resolveOpenAgentsSession,
   SARAH_ACCOUNT_CONTACT_ID_PREFIX,
   SARAH_ACCOUNT_LINK_MODE,
@@ -75,6 +76,44 @@ describe("KHS-7 account linking (#8606)", () => {
     })
     expect(line).toContain("buyer@example.com")
     expect(line).toContain("never ask them to create an account")
+  })
+
+  test("account link publishes a typed account_linked blueprint delta", async () => {
+    const { sarahAvatarEventStream } = await import("./avatar-event-bus.ts")
+    const stream = sarahAvatarEventStream("prospect-abc")
+    const reader = stream.body!.getReader()
+    const decoder = new TextDecoder()
+    await reader.read()
+
+    await linkSarahProspectAccount("prospect-abc", {
+      userId: "user_123",
+      email: "buyer@example.com",
+      name: "Buyer",
+    })
+
+    const event = JSON.parse(
+      decoder.decode((await reader.read()).value).replace(/^data:\s*/, ""),
+    ) as {
+      type: string
+      at: string
+      delta: {
+        kind: string
+        contactId: string
+        email: string
+        userRef: string
+      }
+    }
+    expect(event).toEqual({
+      type: "blueprint_delta",
+      at: expect.any(String),
+      delta: {
+        kind: "account_linked",
+        contactId: "oa_user:user_123",
+        email: "buyer@example.com",
+        userRef: "user_123",
+      },
+    })
+    await reader.cancel()
   })
 
   test("test-mode session resolution accepts only a valid userId payload", async () => {

--- a/apps/sarah/src/services/account-link.ts
+++ b/apps/sarah/src/services/account-link.ts
@@ -20,6 +20,7 @@ import {
   sarahTurnStoreStatus,
 } from "./turn-store.ts"
 import { prospectRefAliases } from "./prospect-memory.ts"
+import { publishSarahBlueprintDelta } from "./avatar-event-bus.ts"
 
 export type OpenAgentsSessionUser = {
   userId: string
@@ -168,6 +169,12 @@ export async function linkSarahProspectAccount(
 ): Promise<{ contactId: string; email: string | null }> {
   const row = buildAccountLinkContactRow(prospectRef, user)
   await persistSarahProspectContact(row)
+  publishSarahBlueprintDelta(prospectRefAliases(prospectRef), {
+    kind: "account_linked",
+    contactId: row.contactId,
+    email: row.contactEmail,
+    userRef: user.userId,
+  })
   return { contactId: row.contactId, email: row.contactEmail }
 }
 

--- a/apps/sarah/src/services/avatar-event-bus.ts
+++ b/apps/sarah/src/services/avatar-event-bus.ts
@@ -8,20 +8,53 @@
  * ephemeral UI signals — the session index remains the durable record.
  */
 
-export type SarahAvatarEvent = {
-  type:
-    | "transcript"
-    | "card"
-    | "guard_refusal"
-    | "session"
-  role?: "user" | "assistant"
-  text?: string
-  title?: string
-  body?: string
-  href?: string
-  state?: string
-  at: string
-}
+export type SarahBlueprintFactLabel =
+  | "company"
+  | "role"
+  | "need"
+  | "stack"
+  | "contact"
+  | "other"
+
+export type SarahBlueprintDelta =
+  | {
+      kind: "fact_added"
+      label: SarahBlueprintFactLabel
+      text: string
+      sourceTurnId: string
+    }
+  | {
+      kind: "draft_revision"
+      revision: number
+      needsCount: number
+      matchedModules: Array<{
+        ref: string
+        name: string
+        matchBasis: string
+        matchedNeedTurnIds: string[]
+      }>
+    }
+  | {
+      kind: "contact_linked"
+      contactId: string | null
+      email: string | null
+      mode: string | null
+    }
+  | {
+      kind: "account_linked"
+      contactId: string
+      email: string | null
+      userRef: string
+    }
+
+export type SarahAvatarEventInput =
+  | { type: "transcript"; role: "user" | "assistant"; text: string }
+  | { type: "card"; title: string; body: string; href?: string }
+  | { type: "guard_refusal"; title: string; body: string }
+  | { type: "session"; state: string; title?: string; body?: string }
+  | { type: "blueprint_delta"; delta: SarahBlueprintDelta }
+
+export type SarahAvatarEvent = SarahAvatarEventInput & { at: string }
 
 type Subscriber = (event: SarahAvatarEvent) => void
 
@@ -29,7 +62,7 @@ const subscribers = new Map<string, Set<Subscriber>>()
 
 export function publishSarahAvatarEvent(
   conversationRef: string,
-  event: Omit<SarahAvatarEvent, "at">,
+  event: SarahAvatarEventInput,
 ): void {
   const full: SarahAvatarEvent = { ...event, at: new Date().toISOString() }
   for (const notify of subscribers.get(conversationRef) ?? []) {
@@ -38,6 +71,15 @@ export function publishSarahAvatarEvent(
     } catch {
       // A broken subscriber never blocks the turn.
     }
+  }
+}
+
+export function publishSarahBlueprintDelta(
+  conversationRefs: Iterable<string>,
+  delta: SarahBlueprintDelta,
+): void {
+  for (const ref of conversationRefs) {
+    publishSarahAvatarEvent(ref, { type: "blueprint_delta", delta })
   }
 }
 

--- a/apps/sarah/src/services/customer-blueprint.test.ts
+++ b/apps/sarah/src/services/customer-blueprint.test.ts
@@ -306,6 +306,60 @@ describe("buildCustomerBlueprintDraft scoping (KHS-3 single-ref seam)", () => {
     expect(storedDrafts[0]!.prospectRef).toBe("prospect-a")
   })
 
+  test("draft revisions publish typed blueprint deltas to this prospect's aliases", async () => {
+    const { sarahAvatarEventStream } = await import("./avatar-event-bus.ts")
+    const raw = sarahAvatarEventStream("prospect-a")
+    const alias = sarahAvatarEventStream("prospect:prospect-a")
+    const rawReader = raw.body!.getReader()
+    const aliasReader = alias.body!.getReader()
+    const decoder = new TextDecoder()
+    await rawReader.read()
+    await aliasReader.read()
+
+    const result = await buildCustomerBlueprintDraft("prospect-a")
+    expect(result.ok).toBe(true)
+
+    await rawReader.read() // existing "Your Blueprint draft" card
+    await aliasReader.read()
+    const rawDelta = JSON.parse(
+      decoder.decode((await rawReader.read()).value).replace(/^data:\s*/, ""),
+    ) as {
+      type: string
+      delta: {
+        kind: string
+        revision: number
+        needsCount: number
+        matchedModules: Array<{
+          ref: string
+          name: string
+          matchBasis: string
+          matchedNeedTurnIds: string[]
+        }>
+      }
+    }
+    const aliasDelta = JSON.parse(
+      decoder.decode((await aliasReader.read()).value).replace(/^data:\s*/, ""),
+    ) as typeof rawDelta
+
+    expect(rawDelta).toEqual(aliasDelta)
+    expect(rawDelta.type).toBe("blueprint_delta")
+    expect(rawDelta.delta.kind).toBe("draft_revision")
+    expect(rawDelta.delta.revision).toBe(1)
+    expect(rawDelta.delta.needsCount).toBe(1)
+    expect(rawDelta.delta.matchedModules.length).toBeGreaterThan(0)
+    expect(rawDelta.delta.matchedModules[0]).toEqual(
+      expect.objectContaining({
+        ref: expect.any(String),
+        name: expect.any(String),
+        matchBasis: expect.any(String),
+        matchedNeedTurnIds: expect.any(Array),
+      }),
+    )
+
+    await rawReader.cancel()
+    await aliasReader.cancel()
+  })
+
   test("an empty ref refuses instead of reading unscoped", async () => {
     const result = await buildCustomerBlueprintDraft("")
     expect(result.ok).toBe(false)

--- a/apps/sarah/src/services/customer-blueprint.ts
+++ b/apps/sarah/src/services/customer-blueprint.ts
@@ -44,7 +44,10 @@ import {
   type SarahMemoryTurnRow,
   type SarahProspectFact,
 } from "./prospect-memory.ts"
-import { publishSarahAvatarEvent } from "./avatar-event-bus.ts"
+import {
+  publishSarahAvatarEvent,
+  publishSarahBlueprintDelta,
+} from "./avatar-event-bus.ts"
 import { cosineSimilarity, sarahEmbedText } from "./semantic-answer-cache.ts"
 import { readSarahStore } from "./turn-store.ts"
 
@@ -497,6 +500,17 @@ export async function buildCustomerBlueprintDraft(
       body: summary,
     })
   }
+  publishSarahBlueprintDelta(aliases, {
+    kind: "draft_revision",
+    revision,
+    needsCount: draft.needs.length,
+    matchedModules: draft.suggestedModules.map((module) => ({
+      ref: module.ref,
+      name: module.name,
+      matchBasis: module.matchBasis,
+      matchedNeedTurnIds: module.matchedNeedTurnIds,
+    })),
+  })
 
   return { ok: true, draft, stored, revision }
 }

--- a/apps/sarah/src/services/prospect-memory.test.ts
+++ b/apps/sarah/src/services/prospect-memory.test.ts
@@ -13,6 +13,7 @@ import {
   getProspectMemoryContext,
   isCrossProspectMemoryProbe,
   PROSPECT_MEMORY_MAX_CHARS,
+  publishProspectFactBlueprintDeltas,
   prospectRefAliases,
   redactProspectFactForCrossScope,
 } from "./prospect-memory.ts"
@@ -146,6 +147,55 @@ describe("distillProspectFacts (deterministic v1)", () => {
     const [fact] = distillProspectFacts([turn("7", "user", long)])
     expect(fact!.fact.length).toBeLessThanOrEqual(160)
     expect(fact!.fact).toContain('"we need')
+  })
+
+  test("publishes one fact_added blueprint delta to this prospect's aliases only", async () => {
+    const { sarahAvatarEventStream } = await import("./avatar-event-bus.ts")
+    const raw = sarahAvatarEventStream("abc123")
+    const alias = sarahAvatarEventStream("prospect:abc123")
+    const other = sarahAvatarEventStream("prospect:other")
+    const rawReader = raw.body!.getReader()
+    const aliasReader = alias.body!.getReader()
+    const otherReader = other.body!.getReader()
+    const decoder = new TextDecoder()
+    await rawReader.read()
+    await aliasReader.read()
+    await otherReader.read()
+
+    const [fact] = distillProspectFacts([
+      turn("turn-need", "user", "We need an AI sales agent for our site"),
+    ])
+    publishProspectFactBlueprintDeltas("abc123", [fact!])
+
+    const rawFrame = decoder.decode((await rawReader.read()).value)
+    const aliasFrame = decoder.decode((await aliasReader.read()).value)
+    for (const frame of [rawFrame, aliasFrame]) {
+      const event = JSON.parse(frame.replace(/^data:\s*/, "")) as {
+        type: string
+        delta: { kind: string; label: string; text: string; sourceTurnId: string }
+      }
+      expect(event.type).toBe("blueprint_delta")
+      expect(event.delta).toEqual({
+        kind: "fact_added",
+        label: "need",
+        text: "We need an AI sales agent for our site",
+        sourceTurnId: "turn-need",
+      })
+    }
+
+    const noOtherFrame = await Promise.race([
+      otherReader.read().then(() => false),
+      Bun.sleep(25).then(() => true),
+    ])
+    const noDuplicateFrame = await Promise.race([
+      rawReader.read().then(() => false),
+      Bun.sleep(25).then(() => true),
+    ])
+    expect(noOtherFrame).toBe(true)
+    expect(noDuplicateFrame).toBe(true)
+    await rawReader.cancel()
+    await aliasReader.cancel()
+    await otherReader.cancel()
   })
 })
 

--- a/apps/sarah/src/services/prospect-memory.ts
+++ b/apps/sarah/src/services/prospect-memory.ts
@@ -28,6 +28,10 @@
  */
 
 import { readSarahStore } from "./turn-store.ts"
+import {
+  publishSarahBlueprintDelta,
+  type SarahBlueprintFactLabel,
+} from "./avatar-event-bus.ts"
 
 export type SarahMemoryTurnRow = {
   /** sarah_transcript_turns.id — provenance for distilled facts. */
@@ -238,6 +242,43 @@ export function formatMemoryContext(input: {
 
 type ProfileFactJson = { fact: string; source_turn_id: string; at: string }
 
+const FACT_DELTA_LABELS = new Set([
+  "company",
+  "role",
+  "need",
+  "stack",
+  "contact",
+])
+
+function factDeltaLabel(fact: string): SarahBlueprintFactLabel {
+  const raw = fact.split(":", 1)[0]?.trim() ?? ""
+  return FACT_DELTA_LABELS.has(raw)
+    ? (raw as SarahBlueprintFactLabel)
+    : "other"
+}
+
+function factDeltaText(fact: string): string {
+  const withoutLabel = fact.replace(/^[a-z_]+:\s*/i, "").trim()
+  const quoted = withoutLabel.match(/^"([\s\S]*)"$/)
+  return quoted ? quoted[1]!.trim() : withoutLabel
+}
+
+export function publishProspectFactBlueprintDeltas(
+  prospectRef: string,
+  facts: SarahProspectFact[],
+): void {
+  const aliases = prospectRefAliases(prospectRef)
+  if (aliases.length === 0) return
+  for (const fact of facts) {
+    publishSarahBlueprintDelta(aliases, {
+      kind: "fact_added",
+      label: factDeltaLabel(fact.fact),
+      text: factDeltaText(fact.fact),
+      sourceTurnId: fact.sourceTurnId,
+    })
+  }
+}
+
 let profileSchemaReady: Promise<boolean> | null = null
 
 async function ensureProfileSchema(): Promise<boolean> {
@@ -272,17 +313,19 @@ async function upsertProspectProfile(
     source_turn_id: fact.sourceTurnId,
     at: fact.at,
   }))
-  await readSarahStore(
+  const stored = await readSarahStore(async (sql) => {
     // Bun SQL: bind the JS array directly — a stringified param lands as a
     // jsonb *string*, not an array (verified against Postgres 16).
-    (sql) => sql`
+    await sql`
       INSERT INTO sarah_prospect_profile (prospect_ref, facts, updated_at)
       VALUES (${prospectRef}, ${payload}, now())
       ON CONFLICT (prospect_ref) DO UPDATE SET
         facts = EXCLUDED.facts,
         updated_at = now()
-    `,
-  )
+    `
+    return true
+  })
+  if (stored) publishProspectFactBlueprintDeltas(prospectRef, facts)
 }
 
 function asMemoryTurnRow(row: Record<string, unknown>): SarahMemoryTurnRow {

--- a/apps/sarah/src/services/session-index.ts
+++ b/apps/sarah/src/services/session-index.ts
@@ -4,6 +4,8 @@ import {
   persistSarahProspectContact,
   persistSarahTurn,
 } from "./turn-store.ts";
+import { publishSarahBlueprintDelta } from "./avatar-event-bus.ts";
+import { prospectRefAliases } from "./prospect-memory.ts";
 import { dirname, join } from "node:path";
 
 export type SarahTranscriptRecord = {
@@ -276,6 +278,12 @@ export async function recordSarahCrmContact({
     prospectRef,
     contactId: contactId ?? null,
     contactEmail: contactEmail ?? null,
+    mode: mode ?? null,
+  });
+  publishSarahBlueprintDelta(prospectRefAliases(prospectRef), {
+    kind: "contact_linked",
+    contactId: contactId ?? null,
+    email: contactEmail ?? null,
     mode: mode ?? null,
   });
 }


### PR DESCRIPTION
Closes #8627.

## Problem
BM-2 needs a typed SSE feed before the /sarah Blueprint Map can render live prospect facts, draft revisions, and link state. The current avatar bus only has transcript/card/session/refusal shapes, so the UI would otherwise have to infer state from flat cards.

## What Changed
- Added a typed `blueprint_delta` Sarah avatar event union:
  - `fact_added`
  - `draft_revision`
  - `contact_linked`
  - `account_linked`
- Added a small bus helper that publishes deltas to the exact refs supplied by the caller.
- Published BM-1 deltas from the existing knowledge landing points:
  - prospect profile upsert emits `fact_added` deltas from distilled facts
  - customer Blueprint draft emits `draft_revision` alongside the existing card
  - CRM contact capture emits `contact_linked`
  - account linking emits `account_linked`
- Kept all prospect routing on `prospectRefAliases(prospectRef)`, matching the existing per-alias card behavior and KHS isolation posture.

## Tests / Validation
- `cd apps/sarah && bun test` -> 246 pass, 0 fail
- `cd apps/sarah && bun test src/services/prospect-memory.test.ts src/services/customer-blueprint.test.ts src/services/account-link.test.ts src/server.test.ts` -> 62 pass, 0 fail
- `cd apps/sarah && bun run typecheck` currently fails on untouched `src/contracts/avatar-ux-contracts.ts` enum literal mismatches:
  - `"script"` not assignable to `BehaviorContractOracleKind`
  - `"e2e"` not assignable to `BehaviorContractOracleMode`
  - `"smoke"` not assignable to `BehaviorContractEnforcementTier`

## Maintenance / Revenue Value
This unblocks BM-2's Blueprint Map graph with a typed, provenance-carrying feed instead of scraping cards. It makes Sarah's "what she knows / what she is still learning / what modules match" promise inspectable in real time without widening any cross-prospect read path.

## Intentionally Not Changed
- No BM-2 graph UI
- No BM-3 split layout or declutter work
- No BM-4 Actions/code/receipts panel
- No BM-5 playback/QA gate
- No new public claim that the map is visible yet
