### PR TITLE
Add Desktop service topology oracle

### DIFF
--- a/apps/openagents-desktop/src/service-topology.ts
+++ b/apps/openagents-desktop/src/service-topology.ts
@@ -1,0 +1,446 @@
+export type DesktopServiceScope =
+  | "process"
+  | "work_context"
+  | "conversation_or_run"
+  | "request_or_command"
+  | "foreign_host_or_view"
+  | "renderer_view"
+
+export type DesktopServiceOwner =
+  | "electron-main"
+  | "preload"
+  | "renderer"
+  | "shared-contract"
+  | "test-fixture"
+
+export type DesktopAuthority =
+  | "runtime"
+  | "filesystem"
+  | "transport"
+  | "identity"
+  | "policy"
+  | "provider"
+  | "database"
+  | "clock"
+  | "foreign_host"
+  | "view_projection"
+
+export type DesktopPublicSchemaIdentity = Readonly<{
+  name: string
+  module: string
+  legacy?: true
+}>
+
+export type DesktopOwnedResource = Readonly<{
+  kind: "fiber" | "subscription" | "native_handle" | "database" | "file" | "http_listener"
+  disposesWith: DesktopServiceScope | "external"
+}>
+
+export type DesktopServiceTopologyEntry = Readonly<{
+  id: string
+  label: string
+  owner: DesktopServiceOwner
+  scope: DesktopServiceScope
+  modules: ReadonlyArray<string>
+  dependsOn: ReadonlyArray<string>
+  authority: ReadonlyArray<DesktopAuthority>
+  publicSchemas?: ReadonlyArray<DesktopPublicSchemaIdentity>
+  ownedResources?: ReadonlyArray<DesktopOwnedResource>
+  perimeter?: true
+  internalRunPromise?: true
+  ambientAuthority?: ReadonlyArray<"cwd" | "async_local_storage" | "renderer_path" | "module_singleton">
+  failureTaxonomy?: "recoverable_domain_refusal" | "dependency_outage" | "interruption" | "invariant_defect" | "telemetry_degradation"
+}>
+
+export type DesktopServiceTopologyViolation = Readonly<{
+  code:
+    | "duplicate_service_id"
+    | "unknown_dependency"
+    | "cycle"
+    | "wrong_scope_dependency"
+    | "renderer_runtime_authority"
+    | "duplicate_public_schema_identity"
+    | "ambient_authority"
+    | "unowned_resource"
+    | "internal_run_promise_escape"
+  serviceId: string
+  detail: string
+}>
+
+const scopeRank: Record<DesktopServiceScope, number> = {
+  process: 0,
+  work_context: 1,
+  conversation_or_run: 2,
+  request_or_command: 3,
+  foreign_host_or_view: 3,
+  renderer_view: 4,
+}
+
+const runtimeGatewaySchemas = [
+  "DesktopRuntimeGatewayRequest",
+  "DesktopRuntimeGatewayResponse",
+  "DesktopRuntimeGatewayEvent",
+]
+
+const chatSchemas = [
+  "DesktopThread",
+  "DesktopTurnRequest",
+]
+
+const workspaceSchemas = [
+  "DesktopWorkspaceFileRequest",
+  "DesktopWorkspaceSaveRequest",
+  "DesktopWorkspaceGitDiffRequest",
+]
+
+export const desktopServiceTopology = [
+  {
+    id: "electron-main-composition",
+    label: "Electron main composition root and IPC perimeter",
+    owner: "electron-main",
+    scope: "process",
+    modules: ["apps/openagents-desktop/src/main.ts"],
+    dependsOn: [
+      "desktop-runtime-gateway",
+      "desktop-session-custody",
+      "desktop-sync-host",
+      "workspace-root",
+      "legacy-thread-store",
+      "codex-history-reader",
+      "fleet-stage-control",
+      "codex-connect-host",
+      "preload-bridge",
+    ],
+    authority: ["runtime", "policy", "clock"],
+    perimeter: true,
+    ownedResources: [{ kind: "native_handle", disposesWith: "process" }],
+    failureTaxonomy: "invariant_defect",
+  },
+  {
+    id: "desktop-runtime-gateway",
+    label: "Host-owned Desktop Runtime Gateway",
+    owner: "electron-main",
+    scope: "process",
+    modules: [
+      "apps/openagents-desktop/src/runtime-gateway.ts",
+      "apps/openagents-desktop/src/runtime-gateway-contract.ts",
+    ],
+    dependsOn: [
+      "desktop-sync-host",
+      "desktop-session-custody",
+      "codex-history-reader",
+    ],
+    authority: ["runtime", "policy"],
+    publicSchemas: runtimeGatewaySchemas.map(name => ({
+      name,
+      module: "apps/openagents-desktop/src/runtime-gateway-contract.ts",
+    })),
+    failureTaxonomy: "recoverable_domain_refusal",
+  },
+  {
+    id: "desktop-session-custody",
+    label: "OpenAgents account session vault, PKCE, recovery, and sign-out host",
+    owner: "electron-main",
+    scope: "process",
+    modules: [
+      "apps/openagents-desktop/src/desktop-session-vault.ts",
+      "apps/openagents-desktop/src/desktop-session-pkce.ts",
+      "apps/openagents-desktop/src/desktop-session-recovery.ts",
+    ],
+    dependsOn: [],
+    authority: ["identity", "transport", "clock"],
+    ownedResources: [
+      { kind: "file", disposesWith: "process" },
+      { kind: "http_listener", disposesWith: "request_or_command" },
+    ],
+    perimeter: true,
+    failureTaxonomy: "dependency_outage",
+  },
+  {
+    id: "desktop-sync-host",
+    label: "Host-owned Khala Sync local store and authenticated session adapter",
+    owner: "electron-main",
+    scope: "process",
+    modules: [
+      "apps/openagents-desktop/src/desktop-sync-host.ts",
+      "apps/openagents-desktop/src/desktop-sync-store.ts",
+    ],
+    dependsOn: ["desktop-session-custody"],
+    authority: ["database", "identity", "transport"],
+    publicSchemas: [
+      {
+        name: "KhalaSyncSchema",
+        module: "packages/khala-sync/src/index.ts",
+      },
+    ],
+    ownedResources: [
+      { kind: "database", disposesWith: "process" },
+      { kind: "subscription", disposesWith: "process" },
+    ],
+    failureTaxonomy: "dependency_outage",
+  },
+  {
+    id: "workspace-root",
+    label: "Selected workspace filesystem and Git review surface",
+    owner: "electron-main",
+    scope: "work_context",
+    modules: [
+      "apps/openagents-desktop/src/workspace-service.ts",
+      "apps/openagents-desktop/src/workspace-contract.ts",
+    ],
+    dependsOn: [],
+    authority: ["filesystem", "policy"],
+    publicSchemas: workspaceSchemas.map(name => ({
+      name,
+      module: "apps/openagents-desktop/src/workspace-contract.ts",
+    })),
+    failureTaxonomy: "recoverable_domain_refusal",
+  },
+  {
+    id: "codex-history-reader",
+    label: "Read-only Codex history catalog and page projector",
+    owner: "electron-main",
+    scope: "process",
+    modules: [
+      "apps/openagents-desktop/src/codex-history.ts",
+      "apps/openagents-desktop/src/codex-history-contract.ts",
+    ],
+    dependsOn: [],
+    authority: ["filesystem"],
+    publicSchemas: [
+      {
+        name: "CodexHistoryCatalog",
+        module: "apps/openagents-desktop/src/codex-history-contract.ts",
+      },
+      {
+        name: "CodexHistoryPage",
+        module: "apps/openagents-desktop/src/codex-history-contract.ts",
+      },
+    ],
+    failureTaxonomy: "recoverable_domain_refusal",
+  },
+  {
+    id: "legacy-thread-store",
+    label: "Local development thread JSON store and fallback chat turn",
+    owner: "electron-main",
+    scope: "conversation_or_run",
+    modules: [
+      "apps/openagents-desktop/src/thread-store.ts",
+      "apps/openagents-desktop/src/chat-service.ts",
+      "apps/openagents-desktop/src/chat-contract.ts",
+    ],
+    dependsOn: ["workspace-root"],
+    authority: ["filesystem", "transport"],
+    publicSchemas: chatSchemas.map(name => ({
+      name,
+      module: "apps/openagents-desktop/src/chat-contract.ts",
+      legacy: true,
+    })),
+    ownedResources: [{ kind: "file", disposesWith: "conversation_or_run" }],
+    failureTaxonomy: "dependency_outage",
+  },
+  {
+    id: "fleet-stage-control",
+    label: "Pylon Fleet stage request perimeter",
+    owner: "electron-main",
+    scope: "request_or_command",
+    modules: [
+      "apps/openagents-desktop/src/fleet-control.ts",
+      "apps/openagents-desktop/src/fleet-contract.ts",
+    ],
+    dependsOn: ["workspace-root"],
+    authority: ["provider", "policy", "transport"],
+    publicSchemas: [
+      {
+        name: "FleetStageRequest",
+        module: "apps/openagents-desktop/src/fleet-contract.ts",
+      },
+    ],
+    perimeter: true,
+    failureTaxonomy: "recoverable_domain_refusal",
+  },
+  {
+    id: "codex-connect-host",
+    label: "Local Pylon Codex account reconnect host",
+    owner: "electron-main",
+    scope: "request_or_command",
+    modules: [
+      "apps/openagents-desktop/src/codex-connect.ts",
+      "apps/openagents-desktop/src/codex-connect-contract.ts",
+    ],
+    dependsOn: [],
+    authority: ["provider", "transport", "identity"],
+    publicSchemas: [
+      {
+        name: "CodexAccountsResult",
+        module: "apps/openagents-desktop/src/codex-connect-contract.ts",
+      },
+      {
+        name: "CodexConnectStatus",
+        module: "apps/openagents-desktop/src/codex-connect-contract.ts",
+      },
+    ],
+    perimeter: true,
+    ownedResources: [{ kind: "native_handle", disposesWith: "request_or_command" }],
+    failureTaxonomy: "interruption",
+  },
+  {
+    id: "preload-bridge",
+    label: "Sandboxed preload bridge with schema-checked IPC calls",
+    owner: "preload",
+    scope: "foreign_host_or_view",
+    modules: ["apps/openagents-desktop/src/preload.cts"],
+    dependsOn: [
+      "desktop-runtime-gateway",
+      "workspace-root",
+      "legacy-thread-store",
+      "fleet-stage-control",
+      "codex-connect-host",
+    ],
+    authority: ["foreign_host"],
+    perimeter: true,
+    failureTaxonomy: "recoverable_domain_refusal",
+  },
+  {
+    id: "effect-native-renderer",
+    label: "Effect Native renderer state, command registry, and projections",
+    owner: "renderer",
+    scope: "renderer_view",
+    modules: [
+      "apps/openagents-desktop/src/renderer/boot.ts",
+      "apps/openagents-desktop/src/renderer/shell.ts",
+      "apps/openagents-desktop/src/renderer/runtime-conversation.ts",
+      "apps/openagents-desktop/src/renderer/history-workspace.ts",
+      "apps/openagents-desktop/src/renderer/command-registry.ts",
+      "apps/openagents-desktop/src/renderer/settings.ts",
+    ],
+    dependsOn: ["preload-bridge"],
+    authority: ["view_projection"],
+    failureTaxonomy: "telemetry_degradation",
+  },
+] as const satisfies ReadonlyArray<DesktopServiceTopologyEntry>
+
+const violation = (
+  code: DesktopServiceTopologyViolation["code"],
+  serviceId: string,
+  detail: string,
+): DesktopServiceTopologyViolation => ({ code, serviceId, detail })
+
+const findCycle = (
+  entries: ReadonlyArray<DesktopServiceTopologyEntry>,
+): ReadonlyArray<string> | null => {
+  const byId = new Map(entries.map(entry => [entry.id, entry]))
+  const visiting = new Set<string>()
+  const visited = new Set<string>()
+  const path: string[] = []
+
+  const walk = (serviceId: string): ReadonlyArray<string> | null => {
+    if (visiting.has(serviceId)) {
+      return [...path.slice(path.indexOf(serviceId)), serviceId]
+    }
+    if (visited.has(serviceId)) return null
+    const entry = byId.get(serviceId)
+    if (entry === undefined) return null
+    visiting.add(serviceId)
+    path.push(serviceId)
+    for (const dependencyId of entry.dependsOn) {
+      const cycle = walk(dependencyId)
+      if (cycle !== null) return cycle
+    }
+    path.pop()
+    visiting.delete(serviceId)
+    visited.add(serviceId)
+    return null
+  }
+
+  for (const entry of entries) {
+    const cycle = walk(entry.id)
+    if (cycle !== null) return cycle
+  }
+  return null
+}
+
+export const validateDesktopServiceTopology = (
+  entries: ReadonlyArray<DesktopServiceTopologyEntry> = desktopServiceTopology,
+): ReadonlyArray<DesktopServiceTopologyViolation> => {
+  const violations: DesktopServiceTopologyViolation[] = []
+  const byId = new Map<string, DesktopServiceTopologyEntry>()
+
+  for (const entry of entries) {
+    if (byId.has(entry.id)) {
+      violations.push(violation("duplicate_service_id", entry.id, "Service ids must be unique."))
+    }
+    byId.set(entry.id, entry)
+  }
+
+  for (const entry of entries) {
+    for (const dependencyId of entry.dependsOn) {
+      const dependency = byId.get(dependencyId)
+      if (dependency === undefined) {
+        violations.push(violation("unknown_dependency", entry.id, `Unknown dependency ${dependencyId}.`))
+        continue
+      }
+      if (entry.perimeter !== true && scopeRank[dependency.scope] > scopeRank[entry.scope]) {
+        violations.push(violation(
+          "wrong_scope_dependency",
+          entry.id,
+          `${entry.scope} service may not capture narrower ${dependency.scope} dependency ${dependencyId}.`,
+        ))
+      }
+    }
+
+    if (entry.scope === "renderer_view" && entry.authority.some(authority => authority !== "view_projection")) {
+      violations.push(violation("renderer_runtime_authority", entry.id, "Renderer/view state may only own view projections."))
+    }
+    if ((entry.ambientAuthority?.length ?? 0) > 0) {
+      violations.push(violation("ambient_authority", entry.id, `Ambient authority: ${entry.ambientAuthority?.join(", ")}.`))
+    }
+    for (const resource of entry.ownedResources ?? []) {
+      if (resource.disposesWith !== "external" && scopeRank[resource.disposesWith] < scopeRank[entry.scope]) {
+        violations.push(violation(
+          "unowned_resource",
+          entry.id,
+          `${resource.kind} disposes with wider ${resource.disposesWith} scope instead of owning ${entry.scope} scope.`,
+        ))
+      }
+    }
+    if (entry.internalRunPromise === true && entry.perimeter !== true) {
+      violations.push(violation("internal_run_promise_escape", entry.id, "Internal runPromise/runPromise-like exits must stay at named perimeter modules."))
+    }
+  }
+
+  const cycle = findCycle(entries)
+  if (cycle !== null) {
+    violations.push(violation("cycle", cycle[0] ?? "unknown", `Cycle: ${cycle.join(" -> ")}.`))
+  }
+
+  const schemaModules = new Map<string, Set<string>>()
+  for (const entry of entries) {
+    for (const schema of entry.publicSchemas ?? []) {
+      if (schema.legacy === true) continue
+      const modules = schemaModules.get(schema.name) ?? new Set<string>()
+      modules.add(schema.module)
+      schemaModules.set(schema.name, modules)
+    }
+  }
+  for (const [schemaName, modules] of schemaModules) {
+    if (modules.size > 1) {
+      violations.push(violation(
+        "duplicate_public_schema_identity",
+        schemaName,
+        `Public schema ${schemaName} is declared by ${[...modules].join(", ")}.`,
+      ))
+    }
+  }
+
+  return violations
+}
+
+export const assertValidDesktopServiceTopology = (
+  entries: ReadonlyArray<DesktopServiceTopologyEntry> = desktopServiceTopology,
+): void => {
+  const violations = validateDesktopServiceTopology(entries)
+  if (violations.length > 0) {
+    throw new Error(violations.map(item => `${item.code}:${item.serviceId}:${item.detail}`).join("\n"))
+  }
+}

--- a/apps/openagents-desktop/tests/service-topology.test.ts
+++ b/apps/openagents-desktop/tests/service-topology.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, test } from "bun:test"
+
+import {
+  assertValidDesktopServiceTopology,
+  desktopServiceTopology,
+  validateDesktopServiceTopology,
+  type DesktopServiceTopologyEntry,
+} from "../src/service-topology.ts"
+
+const service = (
+  override: Partial<DesktopServiceTopologyEntry> & Pick<DesktopServiceTopologyEntry, "id" | "scope">,
+): DesktopServiceTopologyEntry => ({
+  label: override.id,
+  owner: "electron-main",
+  modules: [`${override.id}.ts`],
+  dependsOn: [],
+  authority: [],
+  ...override,
+})
+
+const codes = (entries: ReadonlyArray<DesktopServiceTopologyEntry>) =>
+  validateDesktopServiceTopology(entries).map(violation => violation.code)
+
+describe("Desktop service topology oracle (#8678)", () => {
+  test("current Desktop services satisfy the checked topology manifest", () => {
+    expect(() => assertValidDesktopServiceTopology()).not.toThrow()
+
+    const ids: ReadonlySet<string> = new Set(desktopServiceTopology.map(entry => entry.id))
+    for (const id of [
+      "electron-main-composition",
+      "desktop-runtime-gateway",
+      "desktop-session-custody",
+      "desktop-sync-host",
+      "workspace-root",
+      "codex-history-reader",
+      "legacy-thread-store",
+      "fleet-stage-control",
+      "codex-connect-host",
+      "preload-bridge",
+      "effect-native-renderer",
+    ]) {
+      expect(ids.has(id)).toBe(true)
+    }
+  })
+
+  test("fails an ordinary process service that captures WorkContext authority", () => {
+    expect(codes([
+      service({ id: "workspace", scope: "work_context" }),
+      service({ id: "process-capture", scope: "process", dependsOn: ["workspace"] }),
+    ])).toContain("wrong_scope_dependency")
+  })
+
+  test("allows a named perimeter composition root to wire narrower services", () => {
+    expect(codes([
+      service({ id: "workspace", scope: "work_context" }),
+      service({ id: "composition-root", scope: "process", dependsOn: ["workspace"], perimeter: true }),
+    ])).not.toContain("wrong_scope_dependency")
+  })
+
+  test("fails WorkContext services that capture view or run scopes", () => {
+    expect(codes([
+      service({ id: "view", scope: "foreign_host_or_view" }),
+      service({ id: "workspace", scope: "work_context", dependsOn: ["view"] }),
+    ])).toContain("wrong_scope_dependency")
+  })
+
+  test("fails renderer-owned runtime authority", () => {
+    expect(codes([
+      service({ id: "renderer", scope: "renderer_view", owner: "renderer", authority: ["runtime"] }),
+    ])).toContain("renderer_runtime_authority")
+  })
+
+  test("fails duplicate public Schema identities unless explicitly legacy", () => {
+    const duplicate: DesktopServiceTopologyEntry[] = [
+      service({
+        id: "gateway-a",
+        scope: "process",
+        publicSchemas: [{ name: "Command", module: "a.ts" }],
+      }),
+      service({
+        id: "gateway-b",
+        scope: "process",
+        publicSchemas: [{ name: "Command", module: "b.ts" }],
+      }),
+    ]
+    expect(codes(duplicate)).toContain("duplicate_public_schema_identity")
+
+    const legacy: DesktopServiceTopologyEntry[] = [
+      service({
+        id: "gateway-a",
+        scope: "process",
+        publicSchemas: [{ name: "Command", module: "a.ts" }],
+      }),
+      service({
+        id: "legacy-chat",
+        scope: "conversation_or_run",
+        publicSchemas: [{ name: "Command", module: "legacy.ts", legacy: true }],
+      }),
+    ]
+    expect(codes(legacy)).not.toContain("duplicate_public_schema_identity")
+  })
+
+  test("fails ambient path or AsyncLocalStorage authority", () => {
+    expect(codes([
+      service({ id: "ambient", scope: "work_context", ambientAuthority: ["cwd", "async_local_storage"] }),
+    ])).toContain("ambient_authority")
+  })
+
+  test("fails resources that are owned by a wider scope than their service", () => {
+    expect(codes([
+      service({
+        id: "request-listener",
+        scope: "request_or_command",
+        ownedResources: [{ kind: "subscription", disposesWith: "process" }],
+      }),
+    ])).toContain("unowned_resource")
+  })
+
+  test("fails internal runPromise escapes outside named perimeter modules", () => {
+    expect(codes([
+      service({ id: "internal-runtime", scope: "conversation_or_run", internalRunPromise: true }),
+    ])).toContain("internal_run_promise_escape")
+    expect(codes([
+      service({ id: "runtime-perimeter", scope: "process", internalRunPromise: true, perimeter: true }),
+    ])).not.toContain("internal_run_promise_escape")
+  })
+
+  test("fails cycles and unknown dependencies", () => {
+    expect(codes([
+      service({ id: "a", scope: "process", dependsOn: ["b"] }),
+      service({ id: "b", scope: "process", dependsOn: ["a"] }),
+    ])).toContain("cycle")
+    expect(codes([
+      service({ id: "a", scope: "process", dependsOn: ["missing"] }),
+    ])).toContain("unknown_dependency")
+  })
+})


### PR DESCRIPTION
## Scope

Adds the first checked Desktop service-topology manifest/oracle slice for #8678.

- Inventories the current Runtime Gateway, session custody, Sync, workspace, history, local chat, fleet, Codex Connect, preload, and renderer services.
- Validates duplicate ids, unknown dependencies, cycles, forbidden scope capture, renderer runtime authority, duplicate public Schema identities, declared ambient authority, wider-lived resources, and declared internal runtime exits.
- Adds focused Bun regression tests.

## Validation

- Desktop typecheck: PASS
- Service-topology and Electron-boundary tests on current main: PASS, 30 tests
- Diff check: PASS

## Review disposition

This is a useful additive foundation and is approved for merge. It does **not** close #8678. Remaining acceptance work includes cache/freshness declarations, source-coupled detection rather than declaration-only flags, replaceability proofs, lifecycle/remount/shutdown disposal oracles, and structured trace correlation.

Tracks #8678.