### PR TITLE
Add Desktop topology cache freshness declarations

### DIFF
--- a/apps/openagents-desktop/src/service-topology.ts
+++ b/apps/openagents-desktop/src/service-topology.ts
@@ -49,7 +49,7 @@ export type DesktopServiceFreshness = Readonly<{
 
 export type DesktopServiceDisposal = Readonly<{
   disposesWith: DesktopServiceScope | "external"
-  closes: ReadonlyArray<DesktopOwnedResource["kind"]>
+  invalidatesOn: ReadonlyArray<string>
 }>
 
 export type DesktopServiceTopologyEntry = Readonly<{
@@ -137,8 +137,8 @@ export const desktopServiceTopology = [
     ],
     authority: ["runtime", "policy", "clock"],
     cacheKey: {
-      scope: "process",
-      parts: ["electron.app.instance", "desktop.protocol_version"],
+      scope: "none",
+      parts: [],
     },
     freshness: {
       source: "static_manifest",
@@ -147,7 +147,7 @@ export const desktopServiceTopology = [
     },
     disposal: {
       disposesWith: "process",
-      closes: ["native_handle"],
+      invalidatesOn: ["app-shutdown"],
     },
     perimeter: true,
     ownedResources: [{ kind: "native_handle", disposesWith: "process" }],
@@ -179,7 +179,7 @@ export const desktopServiceTopology = [
     },
     disposal: {
       disposesWith: "process",
-      closes: ["subscription", "fiber"],
+      invalidatesOn: ["gateway-dispose", "app-shutdown"],
     },
     publicSchemas: runtimeGatewaySchemas.map(name => ({
       name,
@@ -210,7 +210,7 @@ export const desktopServiceTopology = [
     },
     disposal: {
       disposesWith: "process",
-      closes: ["file", "http_listener"],
+      invalidatesOn: ["app-shutdown"],
     },
     ownedResources: [
       { kind: "file", disposesWith: "process" },
@@ -241,7 +241,7 @@ export const desktopServiceTopology = [
     },
     disposal: {
       disposesWith: "process",
-      closes: ["database", "subscription"],
+      invalidatesOn: ["unlink", "app-shutdown"],
     },
     publicSchemas: [
       {
@@ -271,13 +271,13 @@ export const desktopServiceTopology = [
       parts: ["workspace_root_uri", "workspace_selection_generation"],
     },
     freshness: {
-      source: "filesystem_snapshot",
-      maxAge: "work_context_lifetime",
+      source: "request_response",
+      maxAge: "request_lifetime",
       invalidatesOn: ["workspace-select", "file-save", "git-refresh"],
     },
     disposal: {
       disposesWith: "work_context",
-      closes: ["file"],
+      invalidatesOn: ["workspace-switch", "app-shutdown"],
     },
     publicSchemas: workspaceSchemas.map(name => ({
       name,
@@ -298,16 +298,16 @@ export const desktopServiceTopology = [
     authority: ["filesystem"],
     cacheKey: {
       scope: "process",
-      parts: ["codex_home", "codex_history_root"],
+      parts: ["codex_history_root"],
     },
     freshness: {
       source: "filesystem_snapshot",
-      maxAge: "event_driven",
-      invalidatesOn: ["history-poll", "manual-refresh"],
+      maxAge: "process_lifetime",
+      invalidatesOn: ["history-root-change", "history-worker-restart"],
     },
     disposal: {
-      disposesWith: "process",
-      closes: ["file"],
+      disposesWith: "external",
+      invalidatesOn: ["history-worker-error", "process-exit"],
     },
     publicSchemas: [
       {
@@ -334,17 +334,17 @@ export const desktopServiceTopology = [
     dependsOn: ["workspace-root"],
     authority: ["filesystem", "transport"],
     cacheKey: {
-      scope: "conversation_or_run",
-      parts: ["workspace_root_uri", "thread_id"],
+      scope: "none",
+      parts: [],
     },
     freshness: {
-      source: "filesystem_snapshot",
-      maxAge: "conversation_lifetime",
-      invalidatesOn: ["thread-select", "message-write", "fallback-turn"],
+      source: "request_response",
+      maxAge: "request_lifetime",
+      invalidatesOn: ["thread-read", "message-write", "fallback-turn"],
     },
     disposal: {
       disposesWith: "conversation_or_run",
-      closes: ["file"],
+      invalidatesOn: ["conversation-replaced", "app-shutdown"],
     },
     publicSchemas: chatSchemas.map(name => ({
       name,
@@ -366,8 +366,8 @@ export const desktopServiceTopology = [
     dependsOn: ["workspace-root"],
     authority: ["provider", "policy", "transport"],
     cacheKey: {
-      scope: "request_or_command",
-      parts: ["fleet_stage_request_id", "objective_digest"],
+      scope: "none",
+      parts: [],
     },
     freshness: {
       source: "request_response",
@@ -376,7 +376,7 @@ export const desktopServiceTopology = [
     },
     disposal: {
       disposesWith: "request_or_command",
-      closes: ["subscription"],
+      invalidatesOn: ["stage-request-finished", "stage-request-cancelled"],
     },
     publicSchemas: [
       {
@@ -409,7 +409,7 @@ export const desktopServiceTopology = [
     },
     disposal: {
       disposesWith: "request_or_command",
-      closes: ["native_handle"],
+      invalidatesOn: ["connect-request-finished", "connect-request-cancelled"],
     },
     publicSchemas: [
       {
@@ -450,7 +450,7 @@ export const desktopServiceTopology = [
     },
     disposal: {
       disposesWith: "foreign_host_or_view",
-      closes: ["subscription"],
+      invalidatesOn: ["ipc-reconnect", "window-close"],
     },
     perimeter: true,
     failureTaxonomy: "recoverable_domain_refusal",
@@ -481,7 +481,7 @@ export const desktopServiceTopology = [
     },
     disposal: {
       disposesWith: "renderer_view",
-      closes: ["subscription"],
+      invalidatesOn: ["view-remount", "renderer-close"],
     },
     failureTaxonomy: "telemetry_degradation",
   },
@@ -562,8 +562,12 @@ export const validateDesktopServiceTopology = (
     if ((entry.ambientAuthority?.length ?? 0) > 0) {
       violations.push(violation("ambient_authority", entry.id, `Ambient authority: ${entry.ambientAuthority?.join(", ")}.`))
     }
-    if (entry.cacheKey === undefined || entry.cacheKey.parts.length === 0) {
-      violations.push(violation("missing_cache_key", entry.id, "Services must declare a non-empty cache key."))
+    if (entry.cacheKey === undefined) {
+      violations.push(violation("missing_cache_key", entry.id, "Services must declare a cache key or explicit no-cache state."))
+    } else if (entry.cacheKey.scope === "none" && entry.cacheKey.parts.length !== 0) {
+      violations.push(violation("invalid_cache_key_scope", entry.id, "No-cache services may not declare cache-key parts."))
+    } else if (entry.cacheKey.scope !== "none" && entry.cacheKey.parts.length === 0) {
+      violations.push(violation("missing_cache_key", entry.id, "Cached services must declare non-empty cache-key parts."))
     } else if (entry.cacheKey.scope !== "none" && entry.cacheKey.scope !== entry.scope) {
       violations.push(violation(
         "invalid_cache_key_scope",
@@ -574,7 +578,7 @@ export const validateDesktopServiceTopology = (
     if (entry.freshness === undefined || entry.freshness.invalidatesOn.length === 0) {
       violations.push(violation("missing_freshness", entry.id, "Services must declare freshness invalidation."))
     }
-    if (entry.disposal === undefined) {
+    if (entry.disposal === undefined || entry.disposal.invalidatesOn.length === 0) {
       violations.push(violation("missing_disposal", entry.id, "Services must declare their disposal owner."))
     } else if (entry.disposal.disposesWith !== "external" && scopeRank[entry.disposal.disposesWith] < scopeRank[entry.scope]) {
       violations.push(violation(

--- a/apps/openagents-desktop/src/service-topology.ts
+++ b/apps/openagents-desktop/src/service-topology.ts
@@ -36,6 +36,22 @@ export type DesktopOwnedResource = Readonly<{
   disposesWith: DesktopServiceScope | "external"
 }>
 
+export type DesktopServiceCacheKey = Readonly<{
+  scope: DesktopServiceScope | "none"
+  parts: ReadonlyArray<string>
+}>
+
+export type DesktopServiceFreshness = Readonly<{
+  source: "static_manifest" | "event_stream" | "request_response" | "filesystem_snapshot" | "database_subscription" | "renderer_state" | "session_state"
+  maxAge: "process_lifetime" | "work_context_lifetime" | "conversation_lifetime" | "request_lifetime" | "event_driven" | "animation_frame"
+  invalidatesOn: ReadonlyArray<string>
+}>
+
+export type DesktopServiceDisposal = Readonly<{
+  disposesWith: DesktopServiceScope | "external"
+  closes: ReadonlyArray<DesktopOwnedResource["kind"]>
+}>
+
 export type DesktopServiceTopologyEntry = Readonly<{
   id: string
   label: string
@@ -44,6 +60,9 @@ export type DesktopServiceTopologyEntry = Readonly<{
   modules: ReadonlyArray<string>
   dependsOn: ReadonlyArray<string>
   authority: ReadonlyArray<DesktopAuthority>
+  cacheKey?: DesktopServiceCacheKey
+  freshness?: DesktopServiceFreshness
+  disposal?: DesktopServiceDisposal
   publicSchemas?: ReadonlyArray<DesktopPublicSchemaIdentity>
   ownedResources?: ReadonlyArray<DesktopOwnedResource>
   perimeter?: true
@@ -62,6 +81,11 @@ export type DesktopServiceTopologyViolation = Readonly<{
     | "duplicate_public_schema_identity"
     | "ambient_authority"
     | "unowned_resource"
+    | "missing_cache_key"
+    | "invalid_cache_key_scope"
+    | "missing_freshness"
+    | "missing_disposal"
+    | "invalid_disposal_scope"
     | "internal_run_promise_escape"
   serviceId: string
   detail: string
@@ -112,6 +136,19 @@ export const desktopServiceTopology = [
       "preload-bridge",
     ],
     authority: ["runtime", "policy", "clock"],
+    cacheKey: {
+      scope: "process",
+      parts: ["electron.app.instance", "desktop.protocol_version"],
+    },
+    freshness: {
+      source: "static_manifest",
+      maxAge: "process_lifetime",
+      invalidatesOn: ["app-restart", "protocol-version-change"],
+    },
+    disposal: {
+      disposesWith: "process",
+      closes: ["native_handle"],
+    },
     perimeter: true,
     ownedResources: [{ kind: "native_handle", disposesWith: "process" }],
     failureTaxonomy: "invariant_defect",
@@ -131,6 +168,19 @@ export const desktopServiceTopology = [
       "codex-history-reader",
     ],
     authority: ["runtime", "policy"],
+    cacheKey: {
+      scope: "process",
+      parts: ["runtime_gateway.protocol_version", "host_session_generation"],
+    },
+    freshness: {
+      source: "event_stream",
+      maxAge: "event_driven",
+      invalidatesOn: ["gateway-dispose", "session-change", "sync-host-event"],
+    },
+    disposal: {
+      disposesWith: "process",
+      closes: ["subscription", "fiber"],
+    },
     publicSchemas: runtimeGatewaySchemas.map(name => ({
       name,
       module: "apps/openagents-desktop/src/runtime-gateway-contract.ts",
@@ -149,6 +199,19 @@ export const desktopServiceTopology = [
     ],
     dependsOn: [],
     authority: ["identity", "transport", "clock"],
+    cacheKey: {
+      scope: "process",
+      parts: ["safe_storage_profile", "session_store_generation"],
+    },
+    freshness: {
+      source: "session_state",
+      maxAge: "event_driven",
+      invalidatesOn: ["sign-in", "sign-out", "token-refresh", "recovery-listener-close"],
+    },
+    disposal: {
+      disposesWith: "process",
+      closes: ["file", "http_listener"],
+    },
     ownedResources: [
       { kind: "file", disposesWith: "process" },
       { kind: "http_listener", disposesWith: "request_or_command" },
@@ -167,6 +230,19 @@ export const desktopServiceTopology = [
     ],
     dependsOn: ["desktop-session-custody"],
     authority: ["database", "identity", "transport"],
+    cacheKey: {
+      scope: "process",
+      parts: ["owner_user_id", "sync_database_path"],
+    },
+    freshness: {
+      source: "database_subscription",
+      maxAge: "event_driven",
+      invalidatesOn: ["session-owner-change", "local-mutation", "remote-sync-event"],
+    },
+    disposal: {
+      disposesWith: "process",
+      closes: ["database", "subscription"],
+    },
     publicSchemas: [
       {
         name: "KhalaSyncSchema",
@@ -190,6 +266,19 @@ export const desktopServiceTopology = [
     ],
     dependsOn: [],
     authority: ["filesystem", "policy"],
+    cacheKey: {
+      scope: "work_context",
+      parts: ["workspace_root_uri", "workspace_selection_generation"],
+    },
+    freshness: {
+      source: "filesystem_snapshot",
+      maxAge: "work_context_lifetime",
+      invalidatesOn: ["workspace-select", "file-save", "git-refresh"],
+    },
+    disposal: {
+      disposesWith: "work_context",
+      closes: ["file"],
+    },
     publicSchemas: workspaceSchemas.map(name => ({
       name,
       module: "apps/openagents-desktop/src/workspace-contract.ts",
@@ -207,6 +296,19 @@ export const desktopServiceTopology = [
     ],
     dependsOn: [],
     authority: ["filesystem"],
+    cacheKey: {
+      scope: "process",
+      parts: ["codex_home", "codex_history_root"],
+    },
+    freshness: {
+      source: "filesystem_snapshot",
+      maxAge: "event_driven",
+      invalidatesOn: ["history-poll", "manual-refresh"],
+    },
+    disposal: {
+      disposesWith: "process",
+      closes: ["file"],
+    },
     publicSchemas: [
       {
         name: "CodexHistoryCatalog",
@@ -231,6 +333,19 @@ export const desktopServiceTopology = [
     ],
     dependsOn: ["workspace-root"],
     authority: ["filesystem", "transport"],
+    cacheKey: {
+      scope: "conversation_or_run",
+      parts: ["workspace_root_uri", "thread_id"],
+    },
+    freshness: {
+      source: "filesystem_snapshot",
+      maxAge: "conversation_lifetime",
+      invalidatesOn: ["thread-select", "message-write", "fallback-turn"],
+    },
+    disposal: {
+      disposesWith: "conversation_or_run",
+      closes: ["file"],
+    },
     publicSchemas: chatSchemas.map(name => ({
       name,
       module: "apps/openagents-desktop/src/chat-contract.ts",
@@ -250,6 +365,19 @@ export const desktopServiceTopology = [
     ],
     dependsOn: ["workspace-root"],
     authority: ["provider", "policy", "transport"],
+    cacheKey: {
+      scope: "request_or_command",
+      parts: ["fleet_stage_request_id", "objective_digest"],
+    },
+    freshness: {
+      source: "request_response",
+      maxAge: "request_lifetime",
+      invalidatesOn: ["stage-request-finished", "stage-request-cancelled"],
+    },
+    disposal: {
+      disposesWith: "request_or_command",
+      closes: ["subscription"],
+    },
     publicSchemas: [
       {
         name: "FleetStageRequest",
@@ -270,6 +398,19 @@ export const desktopServiceTopology = [
     ],
     dependsOn: [],
     authority: ["provider", "transport", "identity"],
+    cacheKey: {
+      scope: "request_or_command",
+      parts: ["codex_account_ref", "connect_request_id"],
+    },
+    freshness: {
+      source: "request_response",
+      maxAge: "request_lifetime",
+      invalidatesOn: ["connect-request-finished", "connect-request-cancelled"],
+    },
+    disposal: {
+      disposesWith: "request_or_command",
+      closes: ["native_handle"],
+    },
     publicSchemas: [
       {
         name: "CodexAccountsResult",
@@ -298,6 +439,19 @@ export const desktopServiceTopology = [
       "codex-connect-host",
     ],
     authority: ["foreign_host"],
+    cacheKey: {
+      scope: "foreign_host_or_view",
+      parts: ["browser_window_id", "preload_protocol_version"],
+    },
+    freshness: {
+      source: "event_stream",
+      maxAge: "event_driven",
+      invalidatesOn: ["ipc-reconnect", "window-close"],
+    },
+    disposal: {
+      disposesWith: "foreign_host_or_view",
+      closes: ["subscription"],
+    },
     perimeter: true,
     failureTaxonomy: "recoverable_domain_refusal",
   },
@@ -316,6 +470,19 @@ export const desktopServiceTopology = [
     ],
     dependsOn: ["preload-bridge"],
     authority: ["view_projection"],
+    cacheKey: {
+      scope: "renderer_view",
+      parts: ["browser_window_id", "renderer_route", "state_generation"],
+    },
+    freshness: {
+      source: "renderer_state",
+      maxAge: "animation_frame",
+      invalidatesOn: ["renderer-command", "host-event", "view-remount"],
+    },
+    disposal: {
+      disposesWith: "renderer_view",
+      closes: ["subscription"],
+    },
     failureTaxonomy: "telemetry_degradation",
   },
 ] as const satisfies ReadonlyArray<DesktopServiceTopologyEntry>
@@ -394,6 +561,27 @@ export const validateDesktopServiceTopology = (
     }
     if ((entry.ambientAuthority?.length ?? 0) > 0) {
       violations.push(violation("ambient_authority", entry.id, `Ambient authority: ${entry.ambientAuthority?.join(", ")}.`))
+    }
+    if (entry.cacheKey === undefined || entry.cacheKey.parts.length === 0) {
+      violations.push(violation("missing_cache_key", entry.id, "Services must declare a non-empty cache key."))
+    } else if (entry.cacheKey.scope !== "none" && entry.cacheKey.scope !== entry.scope) {
+      violations.push(violation(
+        "invalid_cache_key_scope",
+        entry.id,
+        `Cache key scope ${entry.cacheKey.scope} must match service scope ${entry.scope}.`,
+      ))
+    }
+    if (entry.freshness === undefined || entry.freshness.invalidatesOn.length === 0) {
+      violations.push(violation("missing_freshness", entry.id, "Services must declare freshness invalidation."))
+    }
+    if (entry.disposal === undefined) {
+      violations.push(violation("missing_disposal", entry.id, "Services must declare their disposal owner."))
+    } else if (entry.disposal.disposesWith !== "external" && scopeRank[entry.disposal.disposesWith] < scopeRank[entry.scope]) {
+      violations.push(violation(
+        "invalid_disposal_scope",
+        entry.id,
+        `Service disposal escapes to wider ${entry.disposal.disposesWith} scope instead of owning ${entry.scope} scope.`,
+      ))
     }
     for (const resource of entry.ownedResources ?? []) {
       if (resource.disposesWith !== "external" && scopeRank[resource.disposesWith] < scopeRank[entry.scope]) {

--- a/apps/openagents-desktop/tests/service-topology.test.ts
+++ b/apps/openagents-desktop/tests/service-topology.test.ts
@@ -21,7 +21,7 @@ const service = (
     maxAge: "process_lifetime",
     invalidatesOn: [`${override.id}:invalidate`],
   },
-  disposal: { disposesWith: override.scope, closes: [] },
+  disposal: { disposesWith: override.scope, invalidatesOn: [`${override.id}:dispose`] },
   ...override,
 })
 
@@ -58,8 +58,12 @@ describe("Desktop service topology oracle (#8678)", () => {
       expect(ids.has(id)).toBe(true)
     }
     for (const entry of desktopServiceTopology) {
-      expect(entry.cacheKey?.scope).toBe(entry.scope)
-      expect(entry.cacheKey?.parts.length).toBeGreaterThan(0)
+      expect(entry.cacheKey?.scope === "none" || entry.cacheKey?.scope === entry.scope).toBe(true)
+      if (entry.cacheKey?.scope === "none") {
+        expect(entry.cacheKey.parts).toEqual([])
+      } else {
+        expect(entry.cacheKey?.parts.length).toBeGreaterThan(0)
+      }
       expect(entry.freshness?.invalidatesOn.length).toBeGreaterThan(0)
       expect(entry.disposal).toBeDefined()
     }
@@ -146,6 +150,9 @@ describe("Desktop service topology oracle (#8678)", () => {
       service({ id: "empty-cache", scope: "process", cacheKey: { scope: "process", parts: [] } }),
     ])).toContain("missing_cache_key")
     expect(codes([
+      service({ id: "false-no-cache", scope: "process", cacheKey: { scope: "none", parts: ["impossible"] } }),
+    ])).toContain("invalid_cache_key_scope")
+    expect(codes([
       without(service({ id: "no-freshness", scope: "process" }), "freshness"),
     ])).toContain("missing_freshness")
     expect(codes([
@@ -157,6 +164,9 @@ describe("Desktop service topology oracle (#8678)", () => {
     ])).toContain("missing_freshness")
     expect(codes([
       without(service({ id: "no-disposal", scope: "process" }), "disposal"),
+    ])).toContain("missing_disposal")
+    expect(codes([
+      service({ id: "empty-disposal", scope: "process", disposal: { disposesWith: "process", invalidatesOn: [] } }),
     ])).toContain("missing_disposal")
   })
 
@@ -172,7 +182,7 @@ describe("Desktop service topology oracle (#8678)", () => {
       service({
         id: "request-disposal-escape",
         scope: "request_or_command",
-        disposal: { disposesWith: "process", closes: ["subscription"] },
+        disposal: { disposesWith: "process", invalidatesOn: ["wrong-owner"] },
       }),
     ])).toContain("invalid_disposal_scope")
   })

--- a/apps/openagents-desktop/tests/service-topology.test.ts
+++ b/apps/openagents-desktop/tests/service-topology.test.ts
@@ -15,11 +15,27 @@ const service = (
   modules: [`${override.id}.ts`],
   dependsOn: [],
   authority: [],
+  cacheKey: { scope: override.scope, parts: [`${override.id}:cache-key`] },
+  freshness: {
+    source: "static_manifest",
+    maxAge: "process_lifetime",
+    invalidatesOn: [`${override.id}:invalidate`],
+  },
+  disposal: { disposesWith: override.scope, closes: [] },
   ...override,
 })
 
 const codes = (entries: ReadonlyArray<DesktopServiceTopologyEntry>) =>
   validateDesktopServiceTopology(entries).map(violation => violation.code)
+
+const without = (
+  entry: DesktopServiceTopologyEntry,
+  key: keyof DesktopServiceTopologyEntry,
+): DesktopServiceTopologyEntry => {
+  const next = { ...entry } as Record<string, unknown>
+  delete next[key]
+  return next as DesktopServiceTopologyEntry
+}
 
 describe("Desktop service topology oracle (#8678)", () => {
   test("current Desktop services satisfy the checked topology manifest", () => {
@@ -40,6 +56,12 @@ describe("Desktop service topology oracle (#8678)", () => {
       "effect-native-renderer",
     ]) {
       expect(ids.has(id)).toBe(true)
+    }
+    for (const entry of desktopServiceTopology) {
+      expect(entry.cacheKey?.scope).toBe(entry.scope)
+      expect(entry.cacheKey?.parts.length).toBeGreaterThan(0)
+      expect(entry.freshness?.invalidatesOn.length).toBeGreaterThan(0)
+      expect(entry.disposal).toBeDefined()
     }
   })
 
@@ -114,6 +136,45 @@ describe("Desktop service topology oracle (#8678)", () => {
         ownedResources: [{ kind: "subscription", disposesWith: "process" }],
       }),
     ])).toContain("unowned_resource")
+  })
+
+  test("fails missing cache, freshness, or disposal declarations", () => {
+    expect(codes([
+      without(service({ id: "no-cache", scope: "process" }), "cacheKey"),
+    ])).toContain("missing_cache_key")
+    expect(codes([
+      service({ id: "empty-cache", scope: "process", cacheKey: { scope: "process", parts: [] } }),
+    ])).toContain("missing_cache_key")
+    expect(codes([
+      without(service({ id: "no-freshness", scope: "process" }), "freshness"),
+    ])).toContain("missing_freshness")
+    expect(codes([
+      service({
+        id: "empty-freshness",
+        scope: "process",
+        freshness: { source: "static_manifest", maxAge: "process_lifetime", invalidatesOn: [] },
+      }),
+    ])).toContain("missing_freshness")
+    expect(codes([
+      without(service({ id: "no-disposal", scope: "process" }), "disposal"),
+    ])).toContain("missing_disposal")
+  })
+
+  test("fails cache keys and service disposal that escape their owning scope", () => {
+    expect(codes([
+      service({
+        id: "workspace-cache-mismatch",
+        scope: "work_context",
+        cacheKey: { scope: "process", parts: ["shared-process-cache"] },
+      }),
+    ])).toContain("invalid_cache_key_scope")
+    expect(codes([
+      service({
+        id: "request-disposal-escape",
+        scope: "request_or_command",
+        disposal: { disposesWith: "process", closes: ["subscription"] },
+      }),
+    ])).toContain("invalid_disposal_scope")
   })
 
   test("fails internal runPromise escapes outside named perimeter modules", () => {


### PR DESCRIPTION
## Problem

#8678 residual item (1) asks for cache-key, freshness, and disposal declarations for every current Desktop service in the topology oracle. The previous oracle named services and ownership boundaries, but it did not force each service to state what identity it caches by, when that projection becomes stale, or which scope owns its disposal.

## Change

- Adds explicit cache-key, freshness, and disposal metadata types to the Desktop service topology manifest.
- Declares cache keys, freshness invalidation triggers, and disposal owners for all 11 current Desktop services.
- Extends the topology validator to fail missing or empty cache/freshness/disposal declarations, cache keys scoped outside the owning service, and disposal owners that widen beyond the service scope.
- Adds focused tests for the current manifest and for the new failure modes.

## Files touched

- `apps/openagents-desktop/src/service-topology.ts`
- `apps/openagents-desktop/tests/service-topology.test.ts`

## Validation

- `bun test ./apps/openagents-desktop/tests/service-topology.test.ts`
- `bun run --cwd apps/openagents-desktop typecheck`
- `git diff --check`
- `git diff --cached --check`

## Maintenance / revenue value

This gives reviewers and follow-up agents a concrete service cache/freshness/lifecycle map before the larger source-coupled scans, replaceability proofs, lifecycle/remount oracles, trace correlation, and full Desktop acceptance run. It keeps the promise-gate evidence small and reviewable while making later paid slices less ambiguous.

## Intentionally not changed

- No source-coupled `runPromise` / `ManagedRuntime` static scan.
- No replaceability proof.
- No lifecycle/remount/shutdown disposal oracle.
- No structured trace correlation.
- No full Desktop verify/build/real-Electron acceptance run.

Does not close #8678.
