### PR TITLE
fix(desktop): fail closed for local Fable sends

### DIFF
--- a/apps/openagents-desktop/src/renderer/runtime-conversation.test.ts
+++ b/apps/openagents-desktop/src/renderer/runtime-conversation.test.ts
@@ -20,11 +20,15 @@ describe("authoritative Runtime Gateway chat adapter", () => {
   })
 
   test("selects one mode at boot and retains local chat when Sync is unavailable", async () => {
+    const sent: Array<{ id: string; message: string; harness?: string }> = []
     const local: ChatHost = {
-      listThreads: async () => [],
+      listThreads: async () => [{ id: "thread.local.1", title: "Local", updatedAt: now, notes: [] }],
       newThread: async () => null,
       openThread: async () => null,
-      sendMessage: async () => ({ ok: false }),
+      sendMessage: async input => {
+        sent.push({ id: input.id, message: input.message, harness: input.harness })
+        return { ok: true }
+      },
     }
     const selected = await selectDesktopChatHost({
       local,
@@ -34,7 +38,14 @@ describe("authoritative Runtime Gateway chat adapter", () => {
         reason: "not_live",
       }),
     })
-    expect(selected).toBe(local)
+    expect(await selected.listThreads()).toEqual([{ id: "thread.local.1", title: "Local", updatedAt: now, notes: [] }])
+    await expect(selected.sendMessage({ id: "thread.local.1", message: "no substitute", harness: "fable" })).resolves.toEqual({
+      ok: false,
+      error: "Fable requires a live Runtime Gateway conversation. Select Codex or sign in to OpenAgents Sync before targeting Fable.",
+    })
+    expect(sent).toEqual([])
+    await expect(selected.sendMessage({ id: "thread.local.1", message: "legacy ok", harness: "codex" })).resolves.toEqual({ ok: true })
+    expect(sent).toEqual([{ id: "thread.local.1", message: "legacy ok", harness: "codex" }])
 
     const catchingUp = await selectDesktopChatHost({
       local,
@@ -45,7 +56,7 @@ describe("authoritative Runtime Gateway chat adapter", () => {
         threads: [],
       }),
     })
-    expect(catchingUp).toBe(local)
+    await expect(catchingUp.sendMessage({ id: "thread.local.1", message: "still closed", harness: "fable" })).resolves.toMatchObject({ ok: false })
   })
 
   test("maps confirmed threads/messages and waits for exact mutation refs", async () => {

--- a/apps/openagents-desktop/src/renderer/runtime-conversation.ts
+++ b/apps/openagents-desktop/src/renderer/runtime-conversation.ts
@@ -15,6 +15,9 @@ export type RuntimeConversationOptions = Readonly<{
 
 let requestSequence = 0
 
+const unavailableLocalHarnessMessage =
+  "Fable requires a live Runtime Gateway conversation. Select Codex or sign in to OpenAgents Sync before targeting Fable."
+
 const timestamp = (value: string): string => {
   const date = new Date(value)
   return Number.isFinite(date.getTime())
@@ -266,12 +269,20 @@ export const makeRuntimeConversationChatHost = (
   }
 }
 
+const failClosedLocalHarnessHost = (local: ChatHost): ChatHost => ({
+  ...local,
+  sendMessage: async input => input.harness === "fable"
+    ? { ok: false, error: unavailableLocalHarnessMessage }
+    : local.sendMessage(input),
+})
+
 export const selectDesktopChatHost = async (input: Readonly<{
   request: RuntimeConversationRequest | undefined
   local: ChatHost
   options?: Omit<RuntimeConversationOptions, "request">
 }>): Promise<ChatHost> => {
-  if (input.request === undefined) return input.local
+  const local = failClosedLocalHarnessHost(input.local)
+  if (input.request === undefined) return local
   const result = await input.request({
     kind: "query",
     requestId: `renderer-conversation-mode-${++requestSequence}`,
@@ -279,5 +290,5 @@ export const selectDesktopChatHost = async (input: Readonly<{
   })
   return result.kind === "conversation_catalog" && result.status.phase === "live"
     ? makeRuntimeConversationChatHost({ request: input.request, ...input.options })
-    : input.local
+    : local
 }


### PR DESCRIPTION
## Problem

Part III of the #8712 after-action identified an inert affordance: when Desktop falls back to local chat mode, selecting Fable can still press Send, but the route ignores the selector and falls through to the legacy local gateway path.

## Change

- Wrap the local chat host selected by `selectDesktopChatHost` with a fail-closed Fable guard.
- Return a clear local-mode error for `harness: "fable"` before the legacy local send host is called.
- Keep runtime Sync-mode lane routing unchanged: live `conversation.start` still maps Fable to `claude_pylon` and Codex to `codex_app_server`.
- Extend the runtime-conversation test to cover local unavailable/catching-up modes, proving Fable does not silently substitute while Codex/local sends still reach the existing host.

## Files

- `apps/openagents-desktop/src/renderer/runtime-conversation.ts`
- `apps/openagents-desktop/src/renderer/runtime-conversation.test.ts`

## Validation

- `bun test apps/openagents-desktop/src/renderer/runtime-conversation.test.ts` — 8 pass / 0 fail
- `bun run --cwd apps/openagents-desktop typecheck` — pass
- `bun run --cwd apps/openagents-desktop test` — 239 pass / 0 fail / 1281 expects (run outside sandbox because the PKCE tests bind a loopback listener)

## Value

This closes one mode x lane x action cell from the Part III failure: local mode x Fable selected x Send now fails with an explicit unavailable-lane message instead of hitting the dead legacy gateway and returning a model 400.

## Not Changed

- No local Claude streaming lane.
- No chip-disable UI.
- No legacy gateway model slug or endpoint repair.
- No CUT-10 runtime-live integration.
- No owner live-proof claim.

Refs #8712.
