### PR TITLE
feat(mobile): prove CUT-24 accessibility core flows

### DIFF
--- a/apps/openagents-mobile/src/contracts/ux-contracts.ts
+++ b/apps/openagents-mobile/src/contracts/ux-contracts.ts
@@ -5,7 +5,7 @@ import {
 export const openAgentsMobileUxContractRegistry: BehaviorContractRegistryDocument =
   {
     schemaVersion: BehaviorContractSchemaVersion,
-    version: "2026-07-11.3",
+    version: "2026-07-12.2",
     contracts: [
       {
         contractId: "openagents_mobile.seam.identity.local_first_account_link.v1",
@@ -140,6 +140,46 @@ export const openAgentsMobileUxContractRegistry: BehaviorContractRegistryDocumen
         ],
         verification:
           "Mobile coding, conversation, Home, sync-host, full app, and typecheck suites; physical iOS/Android receipts remain open on #8694.",
+      },
+      {
+        contractId: "openagents_mobile.seam.accessibility_core_flows.v1",
+        state: "enforced",
+        surface: "openagents-mobile",
+        productArea: "mobile accessibility",
+        enforcementTier: "test-sweep",
+        blockerRefs: [],
+        source: {
+          channel: "sol-roadmap",
+          statedBy: "owner",
+          statedOn: "2026-07-12",
+        },
+        statement:
+          "Mobile Home and Khala coding flows carry platform font-scale and reduced-motion state into the Effect Native view program, keep primary touch targets at least 44pt and larger under Dynamic Type, expose non-empty labels/roles for chrome, transcript, composer, runtime questions, approvals, and drawer navigation, and avoid app-owned animation in these core flows.",
+        authorityBoundary:
+          "React Native reads OS accessibility signals only through AccessibilityInfo and useWindowDimensions, then projects bounded booleans/numbers into serializable Effect Native state. No prompt, credential, provider payload, file path, or private Sync row is included in accessibility metadata; physical device screen-reader proof is not claimed by this deterministic oracle.",
+        seam: {
+          client: "apps/openagents-mobile/src/screens/home-core.ts",
+          server: "apps/openagents-mobile/src/screens/home-screen.tsx",
+        },
+        evidenceRefs: [
+          "apps/openagents-mobile/src/screens/home-screen.tsx",
+          "apps/openagents-mobile/src/screens/home-core.ts",
+          "apps/openagents-mobile/src/screens/khala-core.ts",
+          "apps/openagents-mobile/tests/mobile-accessibility.test.ts",
+          "github:OpenAgentsInc/openagents#8704",
+        ],
+        oracles: [
+          {
+            id: "mobile_accessibility_core_flows",
+            kind: "bun-test",
+            mode: "unit",
+            ref: "apps/openagents-mobile/tests/mobile-accessibility.test.ts",
+            description:
+              "Proves bounded font-scale/reduced-motion projection, enlarged touch targets, transcript/composer/runtime-control accessibility metadata, and absence of app-owned animation in mobile core coding flows.",
+          },
+        ],
+        verification:
+          "Mobile accessibility oracle, Home/Khala focused suites, mobile typecheck, and app test sweep. Manual VoiceOver/TalkBack and physical device receipts remain intentionally unclaimed.",
       },
     ],
   };

--- a/apps/openagents-mobile/src/screens/home-core.ts
+++ b/apps/openagents-mobile/src/screens/home-core.ts
@@ -40,9 +40,19 @@ import {
   initialKhalaState,
   khalaHandlers,
   khalaIntentDefinitions,
+  defaultMobileAccessibilityProfile,
+  mobileInteractiveStyle,
+  normalizeMobileAccessibilityProfile,
   renderKhalaSurface,
   type KhalaState,
   type KhalaTurnClient,
+  type MobileAccessibilityProfile,
+} from "./khala-core"
+
+export {
+  defaultMobileAccessibilityProfile,
+  normalizeMobileAccessibilityProfile,
+  type MobileAccessibilityProfile,
 } from "./khala-core"
 
 /**
@@ -79,6 +89,7 @@ export interface HomeState {
     kind: "ready" | "failed"
     message: string
   }> | null
+  readonly accessibility: MobileAccessibilityProfile
   readonly khala: KhalaState
 }
 
@@ -166,6 +177,7 @@ export const initialHomeState: HomeState = {
   codingComposer: null,
   codingAttachmentPicking: false,
   codingAttachmentStatus: null,
+  accessibility: defaultMobileAccessibilityProfile,
   khala: initialKhalaState,
 }
 
@@ -276,6 +288,7 @@ export const renderContentView = (state: HomeState): View =>
           state.codingComposer,
           state.codingAttachmentPicking,
           state.codingAttachmentStatus,
+          state.accessibility,
         )]
       : [
           Spacer({ key: "openagents-top-space", size: "16" }),
@@ -294,11 +307,12 @@ export const renderContentView = (state: HomeState): View =>
           }),
           ...(state.syncPhase === "session_ready"
             ? [Button({
-                key: "openagents-sign-out",
-                label: "Sign out",
-                variant: "secondary",
-                onPress: IntentRef("OpenAgentsSignOutPressed", StaticPayload({})),
-              })]
+              key: "openagents-sign-out",
+              label: "Sign out",
+              variant: "secondary",
+              onPress: IntentRef("OpenAgentsSignOutPressed", StaticPayload({})),
+              style: mobileInteractiveStyle(state.accessibility),
+            })]
             : state.syncPhase === "authenticating"
               ? []
               : [Button({
@@ -306,6 +320,7 @@ export const renderContentView = (state: HomeState): View =>
                   label: "Link OpenAgents account",
                   variant: "primary",
                   onPress: IntentRef("OpenAgentsSignInPressed", StaticPayload({})),
+                  style: mobileInteractiveStyle(state.accessibility),
                 })]),
         ],
   )
@@ -322,6 +337,10 @@ export const renderHomeView = (state: HomeState): View =>
       direction: "column",
       gap: "2",
       padding: "2",
+      a11y: {
+        role: "region",
+        label: `OpenAgents mobile home, ${state.accessibility.textScale} text scale, reduced motion ${state.accessibility.reduceMotion ? "on" : "off"}`,
+      },
       style: { width: "full", height: "full", backgroundColor: "background" },
     },
     [
@@ -330,7 +349,7 @@ export const renderHomeView = (state: HomeState): View =>
           key: "home-toolbar",
           placement: "top",
           surface: "glass",
-          style: { width: "full", minHeight: 44 },
+          style: { width: "full", minHeight: state.accessibility.minTouchTarget },
         },
         [
           IconButton({
@@ -338,6 +357,7 @@ export const renderHomeView = (state: HomeState): View =>
             icon: "Menu",
             accessibilityLabel: state.drawerOpen ? "Close navigation" : "Open navigation",
             onPress: IntentRef("DrawerToggled", StaticPayload({})),
+            style: mobileInteractiveStyle(state.accessibility),
           }),
           Button({
             key: "home-surface-mode",
@@ -347,6 +367,7 @@ export const renderHomeView = (state: HomeState): View =>
               "SurfaceModeSelected",
               StaticPayload({ mode: state.surfaceMode === "khala" ? "openagents" : "khala" }),
             ),
+            style: mobileInteractiveStyle(state.accessibility),
           }),
           Spacer({ key: "home-toolbar-space", size: "1", style: { flex: 1 } }),
           IconButton({
@@ -354,6 +375,7 @@ export const renderHomeView = (state: HomeState): View =>
             icon: "Compose",
             accessibilityLabel: "New chat",
             onPress: IntentRef("NewChatPressed", StaticPayload({})),
+            style: mobileInteractiveStyle(state.accessibility),
           }),
         ],
       ),
@@ -361,13 +383,25 @@ export const renderHomeView = (state: HomeState): View =>
     ],
   )
 
-const drawerRow = (input: { readonly key: string; readonly label: string; readonly onPress: ReturnType<typeof IntentRef>; readonly selected?: boolean }): View =>
+const drawerRow = (
+  input: {
+    readonly key: string
+    readonly label: string
+    readonly onPress: ReturnType<typeof IntentRef>
+    readonly selected?: boolean
+  },
+  accessibility: MobileAccessibilityProfile,
+): View =>
   Button({
     key: input.key,
     label: input.label,
     variant: input.selected === true ? "secondary" : "ghost",
     onPress: input.onPress,
-    style: { width: "full", ...(input.selected === true ? { backgroundColor: "surfaceRaised" } : {}) },
+    style: {
+      width: "full",
+      ...mobileInteractiveStyle(accessibility),
+      ...(input.selected === true ? { backgroundColor: "surfaceRaised" } : {}),
+    },
   })
 
 const codingSessionStateLabel = (state: MobileCodingDirectory["sessions"][number]["state"]): string => {
@@ -384,14 +418,14 @@ export const renderDrawerView = (state: HomeState): View =>
     { key: "drawer-root", direction: "column", gap: "2", padding: "4", style: { width: "full", height: "full", backgroundColor: "surface" } },
     [
       Spacer({ key: "drawer-top-space", size: "10" }),
-      drawerRow({ key: "drawer-new-chat", label: "New chat", onPress: IntentRef("NewChatPressed", StaticPayload({})), selected: state.surfaceMode === "khala" && state.khala.entries.length === 0 }),
-      drawerRow({ key: "drawer-khala", label: state.conversationAuthority === "sync" ? "OpenAgents" : "Khala", onPress: IntentRef("SurfaceModeSelected", StaticPayload({ mode: "khala" })), selected: state.surfaceMode === "khala" }),
+      drawerRow({ key: "drawer-new-chat", label: "New chat", onPress: IntentRef("NewChatPressed", StaticPayload({})), selected: state.surfaceMode === "khala" && state.khala.entries.length === 0 }, state.accessibility),
+      drawerRow({ key: "drawer-khala", label: state.conversationAuthority === "sync" ? "OpenAgents" : "Khala", onPress: IntentRef("SurfaceModeSelected", StaticPayload({ mode: "khala" })), selected: state.surfaceMode === "khala" }, state.accessibility),
       ...state.conversationThreads.map(thread => drawerRow({
         key: `drawer-thread-${thread.threadRef}`,
         label: thread.title,
         onPress: IntentRef("ConversationThreadSelected", StaticPayload({ threadRef: thread.threadRef })),
         selected: state.activeThreadRef === thread.threadRef,
-      })),
+      }, state.accessibility)),
       ...(state.codingDirectory?.authority === "confirmed" && state.codingDirectory.sessions.length > 0
         ? [
             Text({
@@ -418,12 +452,12 @@ export const renderDrawerView = (state: HomeState): View =>
                     threadRef: session.threadRef,
                   })),
                   selected: state.activeThreadRef === session.threadRef,
-                })),
+                }, state.accessibility)),
             ]),
           ]
         : []),
       Spacer({ key: "drawer-flex-space", size: "8" }),
-      drawerRow({ key: "drawer-settings", label: "Settings", onPress: IntentRef("SettingsPressed", StaticPayload({})) }),
+      drawerRow({ key: "drawer-settings", label: "Settings", onPress: IntentRef("SettingsPressed", StaticPayload({})) }, state.accessibility),
       Text({ key: "drawer-bundle", content: `Bundle ${BUNDLE_TAG}`, variant: "caption", color: "textMuted" }),
     ],
   )
@@ -435,6 +469,7 @@ export interface HomeProgramOptions {
     signOut: () => Promise<void>
   }>
   readonly conversation?: Extract<MobileConversationSelection, { readonly mode: "sync" }>
+  readonly accessibility?: MobileAccessibilityProfile
   readonly coding?: Readonly<{
     directory: MobileCodingDirectory
     activeComposer: () => MobileCodingComposerSession | null
@@ -597,22 +632,27 @@ const failedConversationState = (
 
 export const initialHomeStateForConversation = (
   selection: HomeProgramOptions["conversation"],
-): HomeState => selection === undefined
-  ? initialHomeState
-  : {
-      ...initialHomeState,
-      syncPhase: "live",
-      conversationAuthority: "sync",
-      conversationThreads: selection.threads,
-      activeThreadRef: selection.activeThread?.threadRef ?? null,
-      codingDirectory: null,
-      khala: confirmedKhalaState(
-        selection.activeThread,
-        0,
-        selection.host.decideInteraction !== undefined,
-        selection.host.controlTurn !== undefined,
-      ),
-    }
+  accessibility: MobileAccessibilityProfile = defaultMobileAccessibilityProfile,
+): HomeState => {
+  const profile = normalizeMobileAccessibilityProfile(accessibility)
+  return selection === undefined
+    ? { ...initialHomeState, accessibility: profile }
+    : {
+        ...initialHomeState,
+        accessibility: profile,
+        syncPhase: "live",
+        conversationAuthority: "sync",
+        conversationThreads: selection.threads,
+        activeThreadRef: selection.activeThread?.threadRef ?? null,
+        codingDirectory: null,
+        khala: confirmedKhalaState(
+          selection.activeThread,
+          0,
+          selection.host.decideInteraction !== undefined,
+          selection.host.controlTurn !== undefined,
+        ),
+      }
+}
 
 const makeSyncedConversationHandlers = (
   state: SubscriptionRef.SubscriptionRef<HomeState>,
@@ -1075,6 +1115,9 @@ export interface HomeProgramHandle {
   readonly sync: {
     readonly setPhase: (phase: MobileSyncPhase) => void
   }
+  readonly accessibility: {
+    readonly setProfile: (profile: MobileAccessibilityProfile) => void
+  }
   readonly coding: {
     readonly selectSession: (target: MobileCodingTarget) => void
     readonly pickAttachments: () => void
@@ -1088,7 +1131,10 @@ export interface HomeProgramHandle {
 export const buildHomeProgram = (options: HomeProgramOptions = {}): HomeProgramHandle =>
   Effect.runSync(
     Effect.gen(function* () {
-      const baseInitialState = initialHomeStateForConversation(options.conversation)
+      const baseInitialState = initialHomeStateForConversation(
+        options.conversation,
+        options.accessibility,
+      )
       const activeComposer = options.coding?.activeComposer() ?? null
       const programInitialState: HomeState = {
         ...baseInitialState,
@@ -1155,6 +1201,14 @@ export const buildHomeProgram = (options: HomeProgramOptions = {}): HomeProgramH
                     khala: initialKhalaState,
                   }
                 : { ...current, syncPhase: phase }))
+          },
+        },
+        accessibility: {
+          setProfile: profile => {
+            Effect.runFork(SubscriptionRef.update(state, current => ({
+              ...current,
+              accessibility: normalizeMobileAccessibilityProfile(profile),
+            })))
           },
         },
         coding: {

--- a/apps/openagents-mobile/src/screens/home-screen.tsx
+++ b/apps/openagents-mobile/src/screens/home-screen.tsx
@@ -1,8 +1,10 @@
-import { useEffect, useMemo } from "react"
+import { useEffect, useMemo, useState } from "react"
 import {
+  AccessibilityInfo,
   KeyboardAvoidingView,
   Platform,
   View as RNView,
+  useWindowDimensions,
 } from "react-native"
 import { SafeAreaView } from "react-native-safe-area-context"
 
@@ -19,6 +21,7 @@ import { EffectNativeHost } from "../effect-native/effect-native-host"
 import { sendKhalaTurn } from "../khala/khala-client"
 import {
   buildHomeProgram,
+  normalizeMobileAccessibilityProfile,
   renderHomeView,
   type MobileSyncPhase,
 } from "./home-core"
@@ -57,10 +60,39 @@ export const HomeScreen = ({ syncPhase, sessionActions, conversation, coding }: 
     ) => Promise<MobileCodingAttachmentUpdateResult>
   }>
 }) => {
+  const { fontScale } = useWindowDimensions()
+  const [reduceMotion, setReduceMotion] = useState(false)
+  const accessibility = useMemo(
+    () => normalizeMobileAccessibilityProfile({ fontScale, reduceMotion }),
+    [fontScale, reduceMotion],
+  )
   const program = useMemo(
-    () => buildHomeProgram({ khalaTurn: { sendTurn: sendKhalaTurn }, sessionActions, conversation, coding }),
+    () => buildHomeProgram({
+      khalaTurn: { sendTurn: sendKhalaTurn },
+      sessionActions,
+      conversation,
+      accessibility,
+      coding,
+    }),
     [sessionActions, conversation, coding],
   )
+  useEffect(() => {
+    let active = true
+    void AccessibilityInfo.isReduceMotionEnabled().then(enabled => {
+      if (active) setReduceMotion(enabled)
+    })
+    const subscription = AccessibilityInfo.addEventListener(
+      "reduceMotionChanged",
+      setReduceMotion,
+    )
+    return () => {
+      active = false
+      subscription.remove()
+    }
+  }, [])
+  useEffect(() => {
+    program.accessibility.setProfile(accessibility)
+  }, [program, accessibility])
   useEffect(() => {
     program.sync.setPhase(syncPhase)
   }, [program, syncPhase])
@@ -77,7 +109,7 @@ export const HomeScreen = ({ syncPhase, sessionActions, conversation, coding }: 
             report={program.report}
             theme={khalaTheme}
             platform={enPlatform}
-            initialView={renderHomeView(program.initialState)}
+            initialView={renderHomeView({ ...program.initialState, accessibility })}
           />
         </SafeAreaView>
       </KeyboardAvoidingView>

--- a/apps/openagents-mobile/src/screens/khala-core.ts
+++ b/apps/openagents-mobile/src/screens/khala-core.ts
@@ -16,6 +16,41 @@ import {
 import type { MobileRuntimeControlAction } from "../conversation/mobile-conversation"
 import type { MobileCodingComposerSession } from "../coding/mobile-coding-composer"
 
+export type MobileTextScale = "normal" | "large" | "extra_large"
+
+export interface MobileAccessibilityProfile {
+  readonly reduceMotion: boolean
+  readonly fontScale: number
+  readonly textScale: MobileTextScale
+  readonly minTouchTarget: number
+}
+
+export const defaultMobileAccessibilityProfile: MobileAccessibilityProfile = {
+  reduceMotion: false,
+  fontScale: 1,
+  textScale: "normal",
+  minTouchTarget: 44,
+}
+
+export const normalizeMobileAccessibilityProfile = (input: Partial<Pick<MobileAccessibilityProfile, "reduceMotion" | "fontScale">> = {}): MobileAccessibilityProfile => {
+  const rawFontScale = Number.isFinite(input.fontScale) ? Number(input.fontScale) : 1
+  const fontScale = Math.min(2, Math.max(0.85, Math.round(rawFontScale * 100) / 100))
+  const textScale: MobileTextScale = fontScale >= 1.55
+    ? "extra_large"
+    : fontScale >= 1.25 ? "large" : "normal"
+  return {
+    reduceMotion: input.reduceMotion === true,
+    fontScale,
+    textScale,
+    minTouchTarget: textScale === "extra_large" ? 56 : textScale === "large" ? 52 : 44,
+  }
+}
+
+export const mobileInteractiveStyle = (accessibility: MobileAccessibilityProfile) => ({
+  minHeight: accessibility.minTouchTarget,
+  minWidth: accessibility.minTouchTarget,
+})
+
 /**
  * The public Khala mode: one conversation over the public orchestration
  * endpoint. It deliberately has no named-persona relationship, FleetRun, account, or
@@ -105,7 +140,11 @@ const interactionStatusLabel = (status: KhalaInteractionStatus): string => {
   }
 }
 
-const interactionBody = (state: KhalaState, entry: KhalaEntry): ReadonlyArray<View> => {
+const interactionBody = (
+  state: KhalaState,
+  entry: KhalaEntry,
+  accessibility: MobileAccessibilityProfile,
+): ReadonlyArray<View> => {
   const interaction = entry.interaction
   if (interaction === undefined) {
     return [Text({
@@ -140,7 +179,7 @@ const interactionBody = (state: KhalaState, entry: KhalaEntry): ReadonlyArray<Vi
           optionRef: option.optionRef,
           multiSelect: question.multiSelect,
         })),
-        style: { width: "full" },
+        style: { width: "full", ...mobileInteractiveStyle(accessibility) },
       }),
       ...(option.description === undefined ? [] : [Text({
         key: `${entry.key}-${question.questionRef}-${option.optionRef}-description`,
@@ -164,6 +203,7 @@ const interactionBody = (state: KhalaState, entry: KhalaEntry): ReadonlyArray<Vi
             turnRef: interaction.turnRef,
             kind: interaction.kind,
           })),
+          style: mobileInteractiveStyle(accessibility),
         })]
       : interaction.kind === "tool_approval"
         ? [
@@ -171,16 +211,18 @@ const interactionBody = (state: KhalaState, entry: KhalaEntry): ReadonlyArray<Vi
               key: `${entry.key}-approve`, label: submitting ? "Submitting…" : "Approve",
               variant: "primary", disabled: !actionable,
               onPress: IntentRef("RuntimeInteractionDecisionSubmitted", StaticPayload({ interactionRef: interaction.interactionRef, turnRef: interaction.turnRef, kind: interaction.kind, outcome: "approve" })),
+              style: mobileInteractiveStyle(accessibility),
             }),
             Button({
               key: `${entry.key}-deny`, label: "Deny", variant: "secondary", disabled: !actionable,
               onPress: IntentRef("RuntimeInteractionDecisionSubmitted", StaticPayload({ interactionRef: interaction.interactionRef, turnRef: interaction.turnRef, kind: interaction.kind, outcome: "deny" })),
+              style: mobileInteractiveStyle(accessibility),
             }),
           ]
         : [
-            Button({ key: `${entry.key}-accept`, label: submitting ? "Submitting…" : "Accept plan", variant: "primary", disabled: !actionable, onPress: IntentRef("RuntimeInteractionDecisionSubmitted", StaticPayload({ interactionRef: interaction.interactionRef, turnRef: interaction.turnRef, kind: interaction.kind, outcome: "accept" })) }),
-            Button({ key: `${entry.key}-changes`, label: "Request changes", variant: "secondary", disabled: !actionable, onPress: IntentRef("RuntimeInteractionDecisionSubmitted", StaticPayload({ interactionRef: interaction.interactionRef, turnRef: interaction.turnRef, kind: interaction.kind, outcome: "request_changes" })) }),
-            Button({ key: `${entry.key}-replan`, label: "Replan", variant: "ghost", disabled: !actionable, onPress: IntentRef("RuntimeInteractionDecisionSubmitted", StaticPayload({ interactionRef: interaction.interactionRef, turnRef: interaction.turnRef, kind: interaction.kind, outcome: "replan" })) }),
+            Button({ key: `${entry.key}-accept`, label: submitting ? "Submitting…" : "Accept plan", variant: "primary", disabled: !actionable, onPress: IntentRef("RuntimeInteractionDecisionSubmitted", StaticPayload({ interactionRef: interaction.interactionRef, turnRef: interaction.turnRef, kind: interaction.kind, outcome: "accept" })), style: mobileInteractiveStyle(accessibility) }),
+            Button({ key: `${entry.key}-changes`, label: "Request changes", variant: "secondary", disabled: !actionable, onPress: IntentRef("RuntimeInteractionDecisionSubmitted", StaticPayload({ interactionRef: interaction.interactionRef, turnRef: interaction.turnRef, kind: interaction.kind, outcome: "request_changes" })), style: mobileInteractiveStyle(accessibility) }),
+            Button({ key: `${entry.key}-replan`, label: "Replan", variant: "ghost", disabled: !actionable, onPress: IntentRef("RuntimeInteractionDecisionSubmitted", StaticPayload({ interactionRef: interaction.interactionRef, turnRef: interaction.turnRef, kind: interaction.kind, outcome: "replan" })), style: mobileInteractiveStyle(accessibility) }),
           ]
   return [
     Text({ key: `${entry.key}-title`, content: interaction.title, variant: "heading", color: "textPrimary" }),
@@ -223,7 +265,10 @@ const runtimeControlActions = (
   return []
 }
 
-const runtimeControlViews = (state: KhalaState): ReadonlyArray<View> => {
+const runtimeControlViews = (
+  state: KhalaState,
+  accessibility: MobileAccessibilityProfile,
+): ReadonlyArray<View> => {
   const turn = state.runtimeTurn
   if (turn === null) return []
   const actions = runtimeControlActions(state)
@@ -252,6 +297,7 @@ const runtimeControlViews = (state: KhalaState): ReadonlyArray<View> => {
           action,
           runRef: turn.runRef,
         })),
+        style: mobileInteractiveStyle(accessibility),
       })
     }),
   )]
@@ -383,6 +429,7 @@ export const renderKhalaSurface = (
     kind: "ready" | "failed"
     message: string
   }> | null = null,
+  accessibility: MobileAccessibilityProfile = defaultMobileAccessibilityProfile,
 ): View =>
   Stack(
     {
@@ -390,6 +437,10 @@ export const renderKhalaSurface = (
       direction: "column",
       gap: "3",
       padding: "4",
+      a11y: {
+        role: "region",
+        label: `Conversation surface, ${accessibility.textScale} text scale, reduced motion ${accessibility.reduceMotion ? "on" : "off"}`,
+      },
       style: { width: "full", height: "full" },
     },
     [
@@ -418,12 +469,16 @@ export const renderKhalaSurface = (
             ? entry.status === "pending" ? "YOU · PENDING" : "YOU"
             : entry.role === "assistant" ? "ASSISTANT" : "SYSTEM",
           ...(entry.createdAt === undefined ? {} : { timestamp: entry.createdAt.slice(11, 16) }),
-          body: interactionBody(state, entry),
+          body: interactionBody(state, entry, accessibility),
         })),
+        a11y: {
+          role: "list",
+          label: `Conversation transcript, reduced motion ${accessibility.reduceMotion ? "on" : "off"}`,
+        },
         pinToEnd: true,
         style: { width: "full", flex: 1 },
       }),
-      ...runtimeControlViews(state),
+      ...runtimeControlViews(state, accessibility),
       ...codingComposerContextViews(
         codingComposer,
         codingAttachmentStatus,
@@ -438,7 +493,7 @@ export const renderKhalaSurface = (
           padding: "2",
           style: {
             width: "full",
-            minHeight: 54,
+            minHeight: Math.max(54, accessibility.minTouchTarget),
             borderRadius: "full",
             surface: "glass",
           },
@@ -460,6 +515,7 @@ export const renderKhalaSurface = (
               StaticPayload({}),
             ),
             surface: "glass",
+            style: mobileInteractiveStyle(accessibility),
           }),
           Composer({
             key: "khala-composer",
@@ -489,7 +545,7 @@ export const renderKhalaSurface = (
                 }),
             style: {
               flex: 1,
-              minHeight: 44,
+              minHeight: accessibility.minTouchTarget,
               borderWidth: 0,
               surface: "glass",
             },

--- a/apps/openagents-mobile/tests/mobile-accessibility.test.ts
+++ b/apps/openagents-mobile/tests/mobile-accessibility.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, test } from "bun:test"
+import { readFileSync } from "node:fs"
+import { join } from "node:path"
+import { Effect, Stream } from "@effect-native/core/effect"
+
+import {
+  buildHomeProgram,
+  initialHomeState,
+  normalizeMobileAccessibilityProfile,
+  renderContentView,
+  renderDrawerView,
+  renderHomeView,
+} from "../src/screens/home-core"
+
+const appRoot = join(import.meta.dir, "..")
+
+const settle = Effect.gen(function* () {
+  yield* Effect.promise<void>(() => new Promise(resolve => setTimeout(resolve, 0)))
+  yield* Effect.yieldNow
+})
+
+const lastState = (program: ReturnType<typeof buildHomeProgram>) =>
+  Effect.map(Stream.runHead(program.stateChanges), option => {
+    if (option._tag !== "Some") throw new Error("expected state")
+    return option.value
+  })
+
+const collectNodes = (value: unknown): ReadonlyArray<Record<string, any>> => {
+  if (value === null || typeof value !== "object") return []
+  const current = value as Record<string, any>
+  return [
+    ...(typeof current._tag === "string" ? [current] : []),
+    ...Object.values(current).flatMap(collectNodes),
+  ]
+}
+
+describe("contract openagents_mobile.seam.accessibility_core_flows.v1", () => {
+  test("normalizes platform font scale and reduced-motion into bounded view state", () => {
+    expect(normalizeMobileAccessibilityProfile({
+      fontScale: 1.58,
+      reduceMotion: true,
+    })).toEqual({
+      reduceMotion: true,
+      fontScale: 1.58,
+      textScale: "extra_large",
+      minTouchTarget: 56,
+    })
+    expect(normalizeMobileAccessibilityProfile({ fontScale: 0.1 })).toMatchObject({
+      fontScale: 0.85,
+      textScale: "normal",
+      minTouchTarget: 44,
+    })
+    expect(normalizeMobileAccessibilityProfile({ fontScale: 1.3 })).toMatchObject({
+      textScale: "large",
+      minTouchTarget: 52,
+    })
+  })
+
+  test("mobile chrome and drawer controls keep minimum touch targets under large dynamic type", () => {
+    const accessibility = normalizeMobileAccessibilityProfile({ fontScale: 1.3 })
+    const state = { ...initialHomeState, accessibility, drawerOpen: true }
+    const homeNodes = collectNodes(renderHomeView(state))
+    const drawerNodes = collectNodes(renderDrawerView(state))
+    const toolbar = homeNodes.find(node => node.key === "home-toolbar")
+    const controls = [...homeNodes, ...drawerNodes].filter(node =>
+      node.key === "home-navigation" ||
+      node.key === "home-surface-mode" ||
+      node.key === "home-new-chat" ||
+      node.key === "drawer-new-chat" ||
+      node.key === "drawer-khala" ||
+      node.key === "drawer-settings")
+
+    expect(toolbar?.style?.minHeight).toBe(52)
+    expect(controls.length).toBeGreaterThanOrEqual(6)
+    for (const control of controls) {
+      expect(control.style?.minHeight).toBeGreaterThanOrEqual(52)
+      expect(control.style?.minWidth).toBeGreaterThanOrEqual(52)
+    }
+  })
+
+  test("conversation, transcript, composer, and runtime actions project reduced motion without visible copy", () => {
+    const accessibility = normalizeMobileAccessibilityProfile({
+      reduceMotion: true,
+      fontScale: 1.7,
+    })
+    const state = {
+      ...initialHomeState,
+      accessibility,
+      khala: {
+        ...initialHomeState.khala,
+        interactionActionsAvailable: true,
+        entries: [{
+          key: "question-1",
+          role: "system" as const,
+          text: "Choose a branch",
+          status: "done" as const,
+          interaction: {
+            kind: "provider_question" as const,
+            interactionRef: "interaction.mobile.a11y",
+            turnRef: "turn.mobile.a11y",
+            status: "pending" as const,
+            title: "Choose branch",
+            prompt: "Pick the branch to continue.",
+            questions: [{
+              questionRef: "question.branch",
+              displayText: "Branch",
+              multiSelect: false,
+              options: [{ optionRef: "main", label: "main" }],
+            }],
+          },
+        }],
+      },
+    }
+    const nodes = collectNodes(renderContentView(state))
+    const surface = nodes.find(node => node.key === "khala-surface")
+    const transcript = nodes.find(node => node.key === "khala-transcript")
+    const composer = nodes.find(node => node.key === "khala-composer")
+    const option = nodes.find(node => node.key === "question-1-question.branch-main")
+
+    expect(surface?.a11y?.label).toContain("reduced motion on")
+    expect(transcript?.a11y).toEqual({
+      role: "list",
+      label: "Conversation transcript, reduced motion on",
+    })
+    expect(composer?.style?.minHeight).toBe(56)
+    expect(option?.style?.minHeight).toBe(56)
+    expect(JSON.stringify(renderContentView(state))).not.toContain("Reduced motion is enabled")
+  })
+
+  test("the live Home program accepts host accessibility updates without rebuilding auth or Sync state", async () => {
+    const program = buildHomeProgram()
+    const accessibility = normalizeMobileAccessibilityProfile({
+      reduceMotion: true,
+      fontScale: 1.31,
+    })
+    program.accessibility.setProfile(accessibility)
+    await Effect.runPromise(settle)
+    const state = await Effect.runPromise(lastState(program))
+
+    expect(state.accessibility).toEqual(accessibility)
+    expect(JSON.stringify(renderHomeView(state))).toContain("large text scale")
+    expect(state.conversationAuthority).toBe("local")
+    expect(state.syncPhase).toBe("unconfigured")
+  })
+
+  test("the React Native host reads OS font scale and reduced-motion, while app code avoids bespoke animation", () => {
+    const host = readFileSync(join(appRoot, "src/screens/home-screen.tsx"), "utf8")
+    const khala = readFileSync(join(appRoot, "src/screens/khala-core.ts"), "utf8")
+
+    expect(host).toContain("useWindowDimensions")
+    expect(host).toContain("AccessibilityInfo.isReduceMotionEnabled")
+    expect(host).toContain('"reduceMotionChanged"')
+    expect(host).toContain("program.accessibility.setProfile")
+    expect(host).not.toContain("Animated")
+    expect(khala).not.toContain("Animated")
+  })
+})


### PR DESCRIPTION
## Problem

CUT-24 desktop landed, but #8704 stayed open because the mobile half still lacked deterministic accessibility evidence for core Home/Khala coding flows.

## What Changed

- Added a bounded mobile accessibility profile for `fontScale`, `textScale`, `reduceMotion`, and minimum touch target size.
- Projected React Native `useWindowDimensions()` and `AccessibilityInfo` reduced-motion state into the Effect Native Home program without rebuilding auth or Sync ownership.
- Threaded the profile through Home and Khala chrome, drawer, transcript, composer, runtime questions, approvals, and runtime controls.
- Registered `openagents_mobile.seam.accessibility_core_flows.v1` with public-safe oracle evidence.
- Added a focused mobile accessibility oracle for Dynamic Type target sizing, reduced-motion metadata, and app-owned animation absence.

## Validation

- `bun test tests/mobile-accessibility.test.ts`
- `bun test tests/home-shell-core.test.ts tests/khala-surface.test.ts tests/authoritative-home.test.ts tests/component-sharing.test.ts`
- `bun run --cwd apps/openagents-mobile typecheck`
- `bun run --cwd apps/openagents-mobile test`
- `git diff --check`

## Not Changed

No desktop/provider/runtime/Codex/Claude/Fable/Sync/auth/OTA/package/lock changes. This PR does not claim physical VoiceOver/TalkBack or live-device proof.
