### PR TITLE
fix(khala): split Pylon heartbeat diagnostics

### DIFF
--- a/apps/openagents.com/workers/api/src/inference/chat-completions-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/chat-completions-routes.test.ts
@@ -479,6 +479,9 @@ describe('coding delegation default-on guard', () => {
     expect(response.headers.get('openagents-selected-pylon-ref')).toBe(
       'pylon.owner.codex',
     )
+    const text = await response.text()
+    expect(text).toContain('"pylonRef":"pylon.owner.codex"')
+    expect(text).toContain('"workflowClass":"codex_agent_task"')
   })
 
   test('direct agent-owned Pylon dispatch survives a transient OpenAuth link read failure', async () => {

--- a/apps/openagents.com/workers/api/src/inference/coding-workflow-delegation.test.ts
+++ b/apps/openagents.com/workers/api/src/inference/coding-workflow-delegation.test.ts
@@ -958,11 +958,54 @@ describe('coding workflow delegation', () => {
     expect(result).toMatchObject({
       error: 'target_pylon_unavailable',
       evidenceRefs: expect.arrayContaining([
-        'evidence.khala_coding.target_pylon_ref.unavailable.stale_or_missing_heartbeat',
+        'evidence.khala_coding.target_pylon_ref.unavailable.heartbeat_stale',
       ]),
       kind: 'rejected',
       statusCode: 409,
     })
+    if (result?.kind !== 'rejected') {
+      throw new Error('expected a rejection')
+    }
+    expect(result.reason).toContain('last heartbeated 3600s ago')
+    expect(result.reason).toContain('omit --pylon-ref')
+  })
+
+  test('diagnoses a never-heartbeated target separately from a stale target (#8716)', async () => {
+    const result = await delegateCodingWorkflow({
+      classification,
+      linkedAgents: [linkedOwner],
+      makeId: () => 'id1',
+      nowIso,
+      pylonStore: makeStore({
+        registrations: [
+          registration({
+            latestHeartbeatAt: null,
+            latestHeartbeatStatus: null,
+          }),
+        ],
+      }),
+      rawBody: {
+        openagents: { coding: { targetPylonRef: 'pylon.owner.codex' } },
+      },
+      requestId: 'chatcmpl_coding_missing_heartbeat',
+    })
+
+    expect(result).toMatchObject({
+      error: 'target_pylon_unavailable',
+      evidenceRefs: expect.arrayContaining([
+        'evidence.khala_coding.target_pylon_ref.unavailable.heartbeat_missing',
+      ]),
+      kind: 'rejected',
+      statusCode: 409,
+    })
+    if (result?.kind !== 'rejected') {
+      throw new Error('expected a rejection')
+    }
+    expect(result.evidenceRefs).not.toContain(
+      'evidence.khala_coding.target_pylon_ref.unavailable.heartbeat_stale',
+    )
+    expect(result.reason).toContain('no recorded online heartbeat yet')
+    expect(result.reason).toContain('omit --pylon-ref')
   })
 
   test('does not reject a heartbeat written after the request timestamp as stale clock skew', async () => {

--- a/apps/openagents.com/workers/api/src/inference/coding-workflow-delegation.ts
+++ b/apps/openagents.com/workers/api/src/inference/coding-workflow-delegation.ts
@@ -635,28 +635,62 @@ const assignmentRequestFromInput = (
   ],
 })
 
-const hasFreshOnlineHeartbeat = (
+const onlineHeartbeatStatuses = ['available', 'healthy', 'idle', 'online', 'ready']
+
+type HeartbeatAdmissionSubCondition =
+  | 'heartbeat_missing'
+  | 'heartbeat_stale'
+  | 'heartbeat_status_unavailable'
+
+const heartbeatAgeSeconds = (
   registration: PylonApiRegistrationRecord,
   nowIso: string,
-): boolean => {
+): number | null => {
   if (registration.latestHeartbeatAt === null) {
-    return false
+    return null
+  }
+  const now = Date.parse(nowIso)
+  const heartbeat = Date.parse(registration.latestHeartbeatAt)
+  if (!Number.isFinite(now) || !Number.isFinite(heartbeat)) {
+    return null
+  }
+  return Math.max(0, Math.floor((now - heartbeat) / 1000))
+}
+
+const heartbeatAdmissionFailure = (
+  registration: PylonApiRegistrationRecord,
+  nowIso: string,
+): HeartbeatAdmissionSubCondition | null => {
+  if (registration.latestHeartbeatAt === null) {
+    return 'heartbeat_missing'
   }
 
   const now = Date.parse(nowIso)
   const heartbeat = Date.parse(registration.latestHeartbeatAt)
   const status = (registration.latestHeartbeatStatus ?? '').trim().toLowerCase()
 
+  if (!Number.isFinite(now) || !Number.isFinite(heartbeat)) {
+    return 'heartbeat_missing'
+  }
+  if (now - heartbeat > 5 * 60 * 1000) {
+    return 'heartbeat_stale'
+  }
+  if (!onlineHeartbeatStatuses.includes(status)) {
+    return 'heartbeat_status_unavailable'
+  }
+
+  return null
+}
+
+const hasFreshOnlineHeartbeat = (
+  registration: PylonApiRegistrationRecord,
+  nowIso: string,
+): boolean => {
   // The request timestamp is captured before the registration read. A Pylon
   // may write a newer heartbeat while that request is in flight, so a
   // future delta is freshness evidence rather than staleness. This matches the
   // canonical Pylon admission policy: only age beyond the TTL is stale.
-  return (
-    Number.isFinite(now) &&
-    Number.isFinite(heartbeat) &&
-    now - heartbeat <= 5 * 60 * 1000 &&
-    ['available', 'healthy', 'idle', 'online', 'ready'].includes(status)
-  )
+  return heartbeatAdmissionFailure(registration, nowIso) === null
 }
 
 const hasAgentCapability = (
@@ -747,7 +781,7 @@ const accountRefHashSelectionCandidates = (
 // the same diagnosis covers both the Codex and Claude lanes.
 type AgentAdmissionSubCondition =
   | 'not_active'
-  | 'stale_or_missing_heartbeat'
+  | HeartbeatAdmissionSubCondition
   | 'not_agent_capable'
   | 'no_available_agent_capacity'
 
@@ -761,8 +795,9 @@ const agentAdmissionFailures = (
   if (registration.status !== 'active') {
     failures.push('not_active')
   }
-  if (!hasFreshOnlineHeartbeat(registration, nowIso)) {
-    failures.push('stale_or_missing_heartbeat')
+  const heartbeatFailure = heartbeatAdmissionFailure(registration, nowIso)
+  if (heartbeatFailure !== null) {
+    failures.push(heartbeatFailure)
   }
   if (!hasAgentCapability(registration, profile)) {
     failures.push('not_agent_capable')
@@ -794,11 +829,36 @@ const diagnoseAgentUnavailability = (
   evidenceRefs: ReadonlyArray<string>
   reason: string
 }> => {
-  const reasonText: Record<AgentAdmissionSubCondition, string> = {
-    no_available_agent_capacity: `it is not advertising any available ${profile.label} capacity (heartbeat ${profile.capacityService} available=0)`,
-    not_active: 'it is not active',
-    not_agent_capable: `it is not ${profile.label}-capable (the heartbeat is not publishing the local ${profile.label} capability)`,
-    stale_or_missing_heartbeat: 'its online heartbeat is stale or missing',
+  const reasonText = (
+    failure: AgentAdmissionSubCondition,
+    registration: PylonApiRegistrationRecord | null,
+  ): string => {
+    switch (failure) {
+      case 'heartbeat_missing':
+        return 'this specific pinned Pylon has no recorded online heartbeat yet; another linked Pylon may be available, so omit --pylon-ref to use caller-scoped selection'
+      case 'heartbeat_stale': {
+        const ageSeconds =
+          registration === null ? null : heartbeatAgeSeconds(registration, nowIso)
+        return ageSeconds === null
+          ? 'this specific pinned Pylon heartbeat is stale; another linked Pylon may be available, so omit --pylon-ref to use caller-scoped selection'
+          : `this specific pinned Pylon last heartbeated ${ageSeconds}s ago, past the 300s freshness TTL; another linked Pylon may be available, so omit --pylon-ref to use caller-scoped selection`
+      }
+      case 'heartbeat_status_unavailable': {
+        const status =
+          registration?.latestHeartbeatStatus === null ||
+          registration?.latestHeartbeatStatus === undefined ||
+          registration.latestHeartbeatStatus.trim() === ''
+            ? 'unknown'
+            : registration.latestHeartbeatStatus.trim()
+        return `its latest heartbeat status is ${status}, not one of ${onlineHeartbeatStatuses.join(', ')}`
+      }
+      case 'no_available_agent_capacity':
+        return `it is not advertising any available ${profile.label} capacity (heartbeat ${profile.capacityService} available=0)`
+      case 'not_active':
+        return 'it is not active'
+      case 'not_agent_capable':
+        return `it is not ${profile.label}-capable (the heartbeat is not publishing the local ${profile.label} capability)`
+    }
   }
   const best =
     registrations.length === 0
@@ -811,6 +871,7 @@ const diagnoseAgentUnavailability = (
               profile,
               accountKey,
             ),
+            registration,
           }))
           .sort((left, right) => left.failures.length - right.failures.length)[0]
   const failures =
@@ -841,7 +902,7 @@ const diagnoseAgentUnavailability = (
     ],
     reason:
       `The requested linked Pylon cannot take a ${profile.label} coding assignment because ` +
-      `${failures.map(failure => reasonText[failure]).join('; ')}.`,
+      `${failures.map(failure => reasonText(failure, best?.registration ?? null)).join('; ')}.`,
   }
 }
 

--- a/apps/openagents.com/workers/api/src/khala-delegation-gepa-feedback.test.ts
+++ b/apps/openagents.com/workers/api/src/khala-delegation-gepa-feedback.test.ts
@@ -177,7 +177,7 @@ describe('Khala delegation GEPA feedback', () => {
         blockerRefs: [
           'blocker.public.pylon_dispatch.no_available_codex_capacity',
           'blocker.public.pylon_dispatch.duplicate_active_assignment',
-          'evidence.khala_coding.target_pylon_ref.unavailable.stale_or_missing_heartbeat',
+          'evidence.khala_coding.target_pylon_ref.unavailable.heartbeat_stale',
           'blocker.public.khala_delegation.pr_conflicted',
           'blocker.public.khala_delegation.objective_too_vague',
         ],
@@ -207,7 +207,7 @@ describe('Khala delegation GEPA feedback', () => {
       [
         traceFor(
           'pylon_assignment_bad',
-          'verify_failed after stale_or_missing_heartbeat; pr_conflicted and objective_too_vague.',
+          'verify_failed after heartbeat_stale; pr_conflicted and objective_too_vague.',
         ),
       ],
     )

--- a/apps/openagents.com/workers/api/src/khala-delegation-gepa-feedback.ts
+++ b/apps/openagents.com/workers/api/src/khala-delegation-gepa-feedback.ts
@@ -258,6 +258,8 @@ const deriveFailureRefs = (
   }
   if (
     text.includes('stale_or_missing_heartbeat') ||
+    text.includes('heartbeat_stale') ||
+    text.includes('heartbeat_missing') ||
     text.includes('stale_heartbeat') ||
     text.includes('pylon_stale')
   ) {


### PR DESCRIPTION
## Problem

Fixes #8716.

The Khala coding delegation gate returned the same `stale_or_missing_heartbeat` diagnosis for two different explicit target-Pylon states: a Pylon that never heartbeated and a Pylon whose heartbeat aged past the freshness TTL. That made a correct multi-Pylon admission path look like a freshness bug. The issue also asked that admitted responses make the selected Pylon clear for resolver-selected capacity.

Claim: https://github.com/OpenAgentsInc/openagents/issues/8716#issuecomment-4950615855

## Change

- Splits targeted-Pylon heartbeat diagnosis into explicit subconditions:
  - `heartbeat_missing`
  - `heartbeat_stale`
  - `heartbeat_status_unavailable`
- Makes stale-heartbeat refusal text name the pinned-Pylon age and the 300s TTL, and directs operators to omit `--pylon-ref` for caller-scoped selection when another linked Pylon may be available.
- Adds regression coverage that the chat-completions delegation response includes selected `pylonRef` metadata in the SSE payload, alongside the existing selected-Pylon header.
- Keeps GEPA feedback parsing compatible with historical `stale_or_missing_heartbeat` text while recognizing the new refs.

## Validation

- `bun run --cwd apps/openagents.com/workers/api vitest run src/inference/coding-workflow-delegation.test.ts src/inference/chat-completions-routes.test.ts src/khala-delegation-gepa-feedback.test.ts`
  - 3 files passed, 220 tests passed.
- `NODE_OPTIONS=--max-old-space-size=8192 bun run --cwd apps/openagents.com/workers/api typecheck`
  - Passed.

## Not Changed

No dispatch authority widening, no Pylon registration schema/migration, no product-promise/OpenAPI versioning, no spend, no account-pool depletion fix, and no workspace dependency/install failure handling.
