### PR TITLE
fix(fast-follow-spec): return diagnostics instead of throwing on non-array path fields (#8958)

### DIFF
--- a/packages/fast-follow-spec/fixtures/conformance/0.1/invalid/schema-error-non-array-paths.json
+++ b/packages/fast-follow-spec/fixtures/conformance/0.1/invalid/schema-error-non-array-paths.json
@@ -1,0 +1,1 @@
+{"replace":"\"agent_instructions\":[\"AGENTS.md\"]","with":"\"agent_instructions\":\"AGENTS.md\"","code":"schema_error"}

--- a/packages/fast-follow-spec/src/index.ts
+++ b/packages/fast-follow-spec/src/index.ts
@@ -140,7 +140,10 @@ const pathEntries = (blocks: Record<string, unknown>): Array<[string, unknown]> 
     "assurance_specs",
     "roadmap_authorities",
   ]) {
-    for (const [i, value] of (Array.isArray(target?.[key]) ? (target[key] as unknown[]) : []).entries())
+    for (const [i, value] of (Array.isArray(target?.[key])
+      ? (target[key] as unknown[])
+      : []
+    ).entries())
       add(`target.${key}[${i}]`, value);
   }
   for (const [key, value] of Object.entries(
@@ -148,14 +151,23 @@ const pathEntries = (blocks: Record<string, unknown>): Array<[string, unknown]> 
   ))
     add(`target.artifact_paths.${key}`, value);
   for (const [i, source] of (Array.isArray(sources) ? sources : []).entries())
-    for (const [j, value] of (Array.isArray(source.teardown_refs) ? (source.teardown_refs as unknown[]) : []).entries())
+    for (const [j, value] of (Array.isArray(source.teardown_refs)
+      ? (source.teardown_refs as unknown[])
+      : []
+    ).entries())
       add(`sources[${i}].teardown_refs[${j}]`, value);
   for (const [i, directive] of (Array.isArray(directives) ? directives : []).entries())
-    for (const [j, value] of (Array.isArray(directive.target_scopes) ? (directive.target_scopes as unknown[]) : []).entries())
+    for (const [j, value] of (Array.isArray(directive.target_scopes)
+      ? (directive.target_scopes as unknown[])
+      : []
+    ).entries())
       add(`directives[${i}].target_scopes[${j}]`, value);
   const initial = work?.initial_program as Record<string, unknown> | undefined;
   if (initial) add("work_generation.initial_program.strategy_ref", initial.strategy_ref);
-  for (const [i, value] of (Array.isArray(authority?.research_write_paths) ? (authority.research_write_paths as unknown[]) : []).entries())
+  for (const [i, value] of (Array.isArray(authority?.research_write_paths)
+    ? (authority.research_write_paths as unknown[])
+    : []
+  ).entries())
     add(`authority.research_write_paths[${i}]`, value);
   return entries;
 };

--- a/packages/fast-follow-spec/src/index.ts
+++ b/packages/fast-follow-spec/src/index.ts
@@ -140,22 +140,22 @@ const pathEntries = (blocks: Record<string, unknown>): Array<[string, unknown]> 
     "assurance_specs",
     "roadmap_authorities",
   ]) {
-    for (const [i, value] of ((target?.[key] as unknown[]) ?? []).entries())
+    for (const [i, value] of (Array.isArray(target?.[key]) ? (target[key] as unknown[]) : []).entries())
       add(`target.${key}[${i}]`, value);
   }
   for (const [key, value] of Object.entries(
     (target?.artifact_paths as Record<string, unknown>) ?? {},
   ))
     add(`target.artifact_paths.${key}`, value);
-  for (const [i, source] of (sources ?? []).entries())
-    for (const [j, value] of ((source.teardown_refs as unknown[]) ?? []).entries())
+  for (const [i, source] of (Array.isArray(sources) ? sources : []).entries())
+    for (const [j, value] of (Array.isArray(source.teardown_refs) ? (source.teardown_refs as unknown[]) : []).entries())
       add(`sources[${i}].teardown_refs[${j}]`, value);
-  for (const [i, directive] of (directives ?? []).entries())
-    for (const [j, value] of ((directive.target_scopes as unknown[]) ?? []).entries())
+  for (const [i, directive] of (Array.isArray(directives) ? directives : []).entries())
+    for (const [j, value] of (Array.isArray(directive.target_scopes) ? (directive.target_scopes as unknown[]) : []).entries())
       add(`directives[${i}].target_scopes[${j}]`, value);
   const initial = work?.initial_program as Record<string, unknown> | undefined;
   if (initial) add("work_generation.initial_program.strategy_ref", initial.strategy_ref);
-  for (const [i, value] of ((authority?.research_write_paths as unknown[]) ?? []).entries())
+  for (const [i, value] of (Array.isArray(authority?.research_write_paths) ? (authority.research_write_paths as unknown[]) : []).entries())
     add(`authority.research_write_paths[${i}]`, value);
   return entries;
 };


### PR DESCRIPTION
Fixes #8958: `parseFastFollow` crashed with an uncaught `TypeError` instead of returning a diagnostic when a path-list field in a typed block was authored as a non-array.

## Change

- `pathEntries` (`src/index.ts`): each of the six cast-then-iterate sites (`(x as unknown[]) ?? []`) becomes `Array.isArray(x) ? x : []`, so a non-array value no longer reaches `.entries()`. The already-recorded `schema_error` diagnostic carries the failure; no new diagnostic code, no control-flow restructuring (per the issue's pre-decided rabbit holes).
- One frozen conformance fixture (`fixtures/conformance/0.1/invalid/schema-error-non-array-paths.json`): mutates `agent_instructions` from `["AGENTS.md"]` to `"AGENTS.md"` and asserts `schema_error` — before this change that mutation crashed the conformance loop itself.

## Verification (node 24.13.1 / pnpm 11.10.0 / vp 0.2.4)

- Issue repro before: uncaught `TypeError: ((intermediate value) ?? []).entries is not a function or its return value is not iterable` at `pathEntries`. After: `{ valid: false, diagnostics: [{ code: "schema_error", message: "SchemaError(Expected array, got \"AGENTS.md\" at [\"agent_instructions\"])", path: "target" }] }`.
- `vp test --run packages/fast-follow-spec` → 13 passed (2 files), including the new fixture through the existing conformance loop.
- `tsc -p tsconfig.json --noEmit` → 0 errors; `vp fmt --check` and `vp lint --quiet` clean on the touched file.

Package-local: exactly these 2 files, zero shared-wiring changes.

Closes #8958.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
