### PR TITLE
Fix Sarah arbitration typecheck

### DIFF
--- a/packages/sarah/src/community-arbitration/verification.ts
+++ b/packages/sarah/src/community-arbitration/verification.ts
@@ -54,7 +54,6 @@ import {
   ARBITRATION_REASON_CLASSES,
   ArbitrationReasonClassSchema,
   COMMUNITY_ARBITRATION_FEEDBACK_KIND,
-  SARAH_CW_05_PACKET,
   type ArbitrationReasonClass,
 } from "./types.ts";
 


### PR DESCRIPTION
## Problem

FORGE-01 is landed, but its literal full-check rerun stops in the API
typecheck because `SARAH_CW_05_PACKET` is imported and never used in the Sarah
community-arbitration verifier.

## Change

Remove that unused import. This is behavior-preserving and changes no
arbitration schema, authority, route, Forge contract, or generated inventory.

## Files

- `packages/sarah/src/community-arbitration/verification.ts`

## Validation

- `pnpm --dir apps/openagents.com/workers/api run typecheck`
- `pnpm --dir packages/sarah exec vp test --run src/community-arbitration/community-arbitration.test.ts src/community-arbitration/verification.test.ts`
  - 2 files, 34 tests passed
- `git diff --check origin/main...HEAD`

## Value

Clears the deterministic TypeScript blocker recorded on openagents#9243 so
the Forge completion gate can proceed to its remaining acceptance failures.

## Intentionally unchanged

- no Forge behavior or ProductSpec changes
- no promise-state or acceptance claim
- no generated files

Dependency setup note: normal `pnpm install --frozen-lockfile` currently stops
on an unrelated `nostr-effect` archive missing from `allowBuilds`; dependencies
for these type-only checks were linked with `--ignore-scripts`.

Refs openagents#9243.
