### PR TITLE
Fix fresh installs for the public Nostr chat package

### DIFF
--- a/packages/public-nostr-chat/package.json
+++ b/packages/public-nostr-chat/package.json
@@ -19,7 +19,7 @@
   },
   "dependencies": {
     "effect": "catalog:",
-    "nostr-effect": "github:OpenAgentsInc/nostr-effect#1314ed6ee6cc508ba9a54d03372fe1c71a984815"
+    "nostr-effect": "https://github.com/OpenAgentsInc/nostr-effect/archive/1314ed6ee6cc508ba9a54d03372fe1c71a984815.tar.gz"
   },
   "devDependencies": {
     "typescript": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2534,8 +2534,8 @@ importers:
         specifier: 4.0.0-beta.94
         version: 4.0.0-beta.94
       nostr-effect:
-        specifier: github:OpenAgentsInc/nostr-effect#1314ed6ee6cc508ba9a54d03372fe1c71a984815
-        version: https://codeload.github.com/OpenAgentsInc/nostr-effect/tar.gz/1314ed6ee6cc508ba9a54d03372fe1c71a984815
+        specifier: https://github.com/OpenAgentsInc/nostr-effect/archive/1314ed6ee6cc508ba9a54d03372fe1c71a984815.tar.gz
+        version: https://github.com/OpenAgentsInc/nostr-effect/archive/1314ed6ee6cc508ba9a54d03372fe1c71a984815.tar.gz
     devDependencies:
       typescript:
         specifier: 'catalog:'
@@ -10463,11 +10463,6 @@ packages:
   normalize-url@6.1.0:
     resolution: {integrity: sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==}
     engines: {node: '>=10'}
-
-  nostr-effect@https://codeload.github.com/OpenAgentsInc/nostr-effect/tar.gz/1314ed6ee6cc508ba9a54d03372fe1c71a984815:
-    resolution: {gitHosted: true, tarball: https://codeload.github.com/OpenAgentsInc/nostr-effect/tar.gz/1314ed6ee6cc508ba9a54d03372fe1c71a984815}
-    version: 0.0.13
-    engines: {node: '>=24'}
 
   nostr-effect@https://github.com/OpenAgentsInc/nostr-effect/archive/1314ed6ee6cc508ba9a54d03372fe1c71a984815.tar.gz:
     resolution: {integrity: sha512-WW12/cS9II6SIjcgzewOd8DYoqEJKrw7+Fl//+PXvALkZQ0yVNhzlDOvHS/S38Aw68IJE4NWioJdJ+S1waY88Q==, tarball: https://github.com/OpenAgentsInc/nostr-effect/archive/1314ed6ee6cc508ba9a54d03372fe1c71a984815.tar.gz}
@@ -21915,22 +21910,6 @@ snapshots:
       validate-npm-package-license: 3.0.4
 
   normalize-url@6.1.0: {}
-
-  nostr-effect@https://codeload.github.com/OpenAgentsInc/nostr-effect/tar.gz/1314ed6ee6cc508ba9a54d03372fe1c71a984815:
-    dependencies:
-      '@noble/ciphers': 1.2.1
-      '@noble/curves': 1.8.1
-      '@noble/hashes': 1.7.1
-      '@scure/base': 1.2.4
-      '@scure/bip32': 1.6.2
-      '@scure/bip39': 1.5.4
-      effect: 4.0.0-beta.94
-      pako: 2.1.0
-      postgres: 3.4.9
-      ws: 8.21.1
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
 
   nostr-effect@https://github.com/OpenAgentsInc/nostr-effect/archive/1314ed6ee6cc508ba9a54d03372fe1c71a984815.tar.gz:
     dependencies:


### PR DESCRIPTION
Closes #9270.

## Problem

`@openagentsinc/public-nostr-chat` was the only workspace consumer expressing the pinned `nostr-effect@1314ed6...` revision with GitHub shorthand. Pnpm treated that form as a git-hosted package requiring an unapproved prepare script, so a fresh worktree stopped before the shared parity tests.

## Claim

Behavior-preserving dependency metadata fix. The dependency revision and package bytes are unchanged; the manifest now uses the same integrity-pinned archive URL as every other workspace consumer.

## Files

- `packages/public-nostr-chat/package.json`: align the dependency form.
- `pnpm-lock.yaml`: point the importer at the existing archive snapshot and remove the now-unused codeload snapshot.

## Validation

- fresh bootstrap proceeds past `nostr-effect` and links all 2,114 packages;
- `vp test --run src/*.test.ts`: 7 files, 39 tests passed;
- `tsc -p tsconfig.json --noEmit`: passed;
- `pnpm install --lockfile-only --frozen-lockfile`: passed and reported the lockfile passes supply-chain policy;
- `git diff --check`: passed.

## Reviewer / Maintenance Value

Independent reviewers can reproduce the Agent Chat parity and channel-registry suite without weakening lifecycle-script policy or relying on a warmed dependency tree.

## Intentionally Not Changed

No runtime code, dependency revision, `allowBuilds` policy, or unrelated lockfile entry changed. A full fresh bootstrap subsequently exposes a separate repository-wide `@google/genai@1.52.0` ignored-build approval failure; this PR does not make that policy decision and does not claim the whole-repository install is green.