### PR TITLE
fix(mobile): route Sarah beta and decode linked accounts

### DIFF
--- a/apps/openagents-mobile/src/mobile-update.ts
+++ b/apps/openagents-mobile/src/mobile-update.ts
@@ -1,0 +1,72 @@
+export type MobileUpdatePhase = "checking" | "downloaded" | "current" | "error";
+
+export type MobileUpdateProjection = Readonly<{
+  appLabel: string;
+  copyText: string;
+  phase: MobileUpdatePhase;
+  releaseFingerprint: string;
+  runtimeFingerprint: string;
+  statusLabel: string;
+  voiceEnvironment: string;
+  voiceHost: string;
+}>;
+
+const short = (value: string | null | undefined, length: number): string => {
+  const normalized = value?.trim();
+  return normalized === undefined || normalized === "" ? "unavailable" : normalized.slice(0, length);
+};
+
+export const projectMobileUpdate = (input: Readonly<{
+  appVersion: string;
+  buildNumber: string;
+  updateId: string | null;
+  runtimeVersion: string | null;
+  isEmbeddedLaunch: boolean;
+  isChecking: boolean;
+  isDownloading: boolean;
+  isUpdatePending: boolean;
+  hasError: boolean;
+  voiceEnvironment: string;
+  voiceHost: string;
+}>): MobileUpdateProjection => {
+  const runtimeFingerprint = short(input.runtimeVersion, 10);
+  const releaseFingerprint =
+    input.updateId === null
+      ? `embedded-${runtimeFingerprint}`
+      : short(input.updateId, 8);
+  const phase: MobileUpdatePhase =
+    input.isChecking || input.isDownloading
+      ? "checking"
+      : input.isUpdatePending
+        ? "downloaded"
+        : input.hasError
+          ? "error"
+          : "current";
+  const statusLabel =
+    phase === "checking"
+      ? "Checking for update"
+      : phase === "downloaded"
+        ? "Update downloaded—restart to apply"
+        : phase === "error"
+          ? "Update check failed—try again"
+          : input.isEmbeddedLaunch
+            ? "Embedded update running"
+            : "Current update applied";
+  const appLabel = `${input.appVersion} (${input.buildNumber})`;
+  return {
+    appLabel,
+    phase,
+    releaseFingerprint,
+    runtimeFingerprint,
+    statusLabel,
+    voiceEnvironment: input.voiceEnvironment,
+    voiceHost: input.voiceHost,
+    copyText: [
+      `OpenAgents ${appLabel}`,
+      `Update ${releaseFingerprint}`,
+      `Runtime ${runtimeFingerprint}`,
+      `State ${statusLabel}`,
+      `Sarah voice ${input.voiceEnvironment} ${input.voiceHost}`,
+    ].join("\n"),
+  };
+};

--- a/apps/openagents-mobile/src/sarah-voice/client.ts
+++ b/apps/openagents-mobile/src/sarah-voice/client.ts
@@ -34,7 +34,7 @@ const OmegaNostrSessionResponseSchema = S.Struct({
   expiresIn: S.Number.check(S.isInt(), S.isGreaterThan(0)),
   user: S.Struct({
     userId: S.String.check(S.isMinLength(1), S.isMaxLength(256)),
-    provider: S.Literal("nostr"),
+    provider: S.Literals(["nostr", "github", "email"]),
   }),
 });
 
@@ -472,7 +472,7 @@ export class SarahVoiceClient {
         typeof error === "object" && error !== null && "message" in error && "retryable" in error
           ? (error as Readonly<{ message: string; retryable: boolean }>)
           : {
-              message: error instanceof Error ? error.message : "Sarah voice is unavailable.",
+              message: "Sarah voice could not verify the OpenAgents session. Try again.",
               retryable: true,
             };
       this.shouldRun = false;
@@ -627,9 +627,21 @@ export class SarahVoiceClient {
         failure: statusMessage(response.status, error),
       };
     }
-    const session = S.decodeUnknownSync(OmegaNostrSessionResponseSchema)(await response.json(), {
-      onExcessProperty: "preserve",
-    });
+    let session: typeof OmegaNostrSessionResponseSchema.Type;
+    try {
+      session = S.decodeUnknownSync(OmegaNostrSessionResponseSchema)(await response.json(), {
+        onExcessProperty: "preserve",
+      });
+    } catch {
+      return {
+        _tag: "Failure",
+        status: 502,
+        failure: {
+          message: "Sarah voice could not verify the OpenAgents session. Try again.",
+          retryable: true,
+        },
+      };
+    }
     return {
       _tag: "Success",
       value: {

--- a/apps/openagents-mobile/src/sarah-voice/environment.ts
+++ b/apps/openagents-mobile/src/sarah-voice/environment.ts
@@ -1,0 +1,6 @@
+export const SARAH_BETA_VOICE_BASE_URL =
+  "https://openagents-monolith-staging-ezxz4mgdsq-uc.a.run.app" as const;
+
+export const SARAH_BETA_VOICE_ENVIRONMENT = "Staging beta" as const;
+
+export const sarahVoiceApiHost = (): string => new URL(SARAH_BETA_VOICE_BASE_URL).hostname;

--- a/apps/openagents-mobile/src/screens/omega-home-screen.tsx
+++ b/apps/openagents-mobile/src/screens/omega-home-screen.tsx
@@ -1,8 +1,17 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { Linking } from "react-native";
 import { Camera, CameraView } from "expo-camera";
+import * as Clipboard from "expo-clipboard";
 import { randomUUID } from "expo-crypto";
+import * as Updates from "expo-updates";
 import { Effect } from "effect";
+
+import appConfig from "../../app.json";
+import { projectMobileUpdate } from "../mobile-update";
+import {
+  SARAH_BETA_VOICE_ENVIRONMENT,
+  sarahVoiceApiHost,
+} from "../sarah-voice/environment";
 
 import {
   createOmegaDeviceBridgeClient,
@@ -169,6 +178,64 @@ export const OmegaHomeScreen = ({
   const [draft, setDraft] = useState("");
   const [notice, setNotice] = useState<string | null>(null);
   const [observedAt, setObservedAt] = useState(Date.now());
+  const [manualUpdateBusy, setManualUpdateBusy] = useState(false);
+  const [manualUpdateError, setManualUpdateError] = useState(false);
+  const updates = Updates.useUpdates();
+
+  const update = useMemo(
+    () =>
+      projectMobileUpdate({
+        appVersion: appConfig.expo.version,
+        buildNumber: appConfig.expo.ios.buildNumber,
+        updateId: updates.currentlyRunning.updateId ?? Updates.updateId,
+        runtimeVersion: updates.currentlyRunning.runtimeVersion ?? Updates.runtimeVersion,
+        isEmbeddedLaunch: updates.currentlyRunning.isEmbeddedLaunch,
+        isChecking: manualUpdateBusy || updates.isChecking,
+        isDownloading: updates.isDownloading,
+        isUpdatePending: updates.isUpdatePending,
+        hasError:
+          manualUpdateError ||
+          updates.checkError !== undefined ||
+          updates.downloadError !== undefined,
+        voiceEnvironment: SARAH_BETA_VOICE_ENVIRONMENT,
+        voiceHost: sarahVoiceApiHost(),
+      }),
+    [
+      manualUpdateBusy,
+      manualUpdateError,
+      updates.checkError,
+      updates.currentlyRunning.isEmbeddedLaunch,
+      updates.currentlyRunning.runtimeVersion,
+      updates.currentlyRunning.updateId,
+      updates.downloadError,
+      updates.isChecking,
+      updates.isDownloading,
+      updates.isUpdatePending,
+    ],
+  );
+
+  const onUpdatePressed = useCallback((): void => {
+    setManualUpdateError(false);
+    if (updates.isUpdatePending) {
+      void Updates.reloadAsync().catch(() => setManualUpdateError(true));
+      return;
+    }
+    if (!Updates.isEnabled) {
+      setManualUpdateError(true);
+      return;
+    }
+    setManualUpdateBusy(true);
+    void (async () => {
+      const result = await Updates.checkForUpdateAsync();
+      if (result.isAvailable) await Updates.fetchUpdateAsync();
+    })()
+      .catch(() => setManualUpdateError(true))
+      .finally(() => setManualUpdateBusy(false));
+  }, [updates.isUpdatePending]);
+
+  const onUpdateCopied = useCallback((): void => {
+    void Clipboard.setStringAsync(update.copyText);
+  }, [update.copyText]);
 
   // Relative stamps have to age on their own. Without a tick, a row that says
   // "2m" keeps saying "2m" until the desktop happens to send something.
@@ -253,6 +320,7 @@ export const OmegaHomeScreen = ({
     // not open yet, so it says so rather than offering a control that cannot work.
     commandLaneAvailable: false,
     commandNotice: null,
+    update,
     now: observedAt,
   };
 
@@ -267,6 +335,8 @@ export const OmegaHomeScreen = ({
         onEnqueuePressed: () => undefined,
         onSteerPressed: () => undefined,
         onSarahVoicePressed,
+        onUpdatePressed,
+        onUpdateCopied,
       }}
     />
   );

--- a/apps/openagents-mobile/src/screens/omega-home-view.tsx
+++ b/apps/openagents-mobile/src/screens/omega-home-view.tsx
@@ -22,6 +22,7 @@ import {
 } from "../ui/surfaces";
 import { Text } from "../ui/text";
 import { colors, radius, spacing } from "../ui/theme";
+import type { MobileUpdateProjection } from "../mobile-update";
 import type {
   OmegaDeviceBridgeState,
   OmegaMirrorRun,
@@ -44,6 +45,7 @@ export type OmegaHomeViewModel = Readonly<{
   threadDraft: string;
   commandLaneAvailable: boolean;
   commandNotice: string | null;
+  update: MobileUpdateProjection;
   /** The clock the relative stamps are read against, so rows agree. */
   now: number;
 }>;
@@ -56,6 +58,8 @@ export type OmegaHomeActions = Readonly<{
   onEnqueuePressed: () => void;
   onSteerPressed: () => void;
   onSarahVoicePressed: () => void;
+  onUpdatePressed: () => void;
+  onUpdateCopied: () => void;
 }>;
 
 export const connectionToneOf = (state: OmegaDeviceBridgeState): BadgeTone => {
@@ -297,6 +301,52 @@ const TranscriptTurn = ({
   );
 };
 
+const UpdateCard = ({
+  update,
+  actions,
+}: {
+  readonly update: MobileUpdateProjection;
+  readonly actions: OmegaHomeActions;
+}) => (
+  <Card
+    accessibilityLabel={`Update. ${update.statusLabel}. OpenAgents ${update.appLabel}. Sarah voice ${update.voiceEnvironment}.`}
+    style={$updateCard}
+  >
+    <View style={$rowHead}>
+      <Text preset="subheading">Update</Text>
+      <Badge
+        label={update.statusLabel}
+        tone={update.phase === "error" ? "danger" : update.phase === "current" ? "success" : "info"}
+      />
+    </View>
+    <Text preset="caption" color={colors.textDim}>
+      {`OpenAgents ${update.appLabel} · Update ${update.releaseFingerprint} · Runtime ${update.runtimeFingerprint}`}
+    </Text>
+    <Text preset="caption" color={colors.textDim} numberOfLines={1}>
+      {`Sarah voice · ${update.voiceEnvironment} · ${update.voiceHost}`}
+    </Text>
+    {update.phase === "downloaded" ? (
+      <Text preset="caption" color={colors.warn}>
+        Apply now, or fully close and open the app again.
+      </Text>
+    ) : null}
+    <View style={$updateActions}>
+      <Button
+        label={update.phase === "downloaded" ? "Apply update" : "Check update"}
+        preset="secondary"
+        onPress={actions.onUpdatePressed}
+        style={$compactButton}
+      />
+      <Button
+        label="Copy details"
+        preset="ghost"
+        onPress={actions.onUpdateCopied}
+        style={$compactButton}
+      />
+    </View>
+  </Card>
+);
+
 export const OmegaHomeView = ({
   model,
   actions,
@@ -345,6 +395,7 @@ export const OmegaHomeView = ({
             />
           }
         />
+        <UpdateCard update={model.update} actions={actions} />
         <View style={$pairing}>
           <Text preset="display">Mirror your desktop</Text>
           <Text preset="body" color={colors.textDim} style={$pairingBody}>
@@ -465,6 +516,7 @@ export const OmegaHomeView = ({
           </View>
         }
       />
+      <UpdateCard update={model.update} actions={actions} />
       <FlatList
         ref={listRef}
         data={model.activity}
@@ -521,6 +573,25 @@ const $pairing: ViewStyle = {
 };
 
 const $pairingBody: TextStyle = { maxWidth: 340 };
+
+const $updateCard: ViewStyle = {
+  marginHorizontal: spacing.medium,
+  marginTop: spacing.extraSmall,
+  gap: spacing.tiny,
+  paddingVertical: spacing.small,
+};
+
+const $updateActions: ViewStyle = {
+  flexDirection: "row",
+  alignItems: "center",
+  gap: spacing.extraSmall,
+};
+
+const $compactButton: ViewStyle = {
+  minHeight: 36,
+  paddingVertical: spacing.extraSmall,
+  paddingHorizontal: spacing.small,
+};
 
 const $feed: ViewStyle = {
   paddingHorizontal: spacing.medium,

--- a/apps/openagents-mobile/src/screens/sarah-voice-screen.tsx
+++ b/apps/openagents-mobile/src/screens/sarah-voice-screen.tsx
@@ -21,6 +21,7 @@ import {
 } from "../sarah-voice/client";
 import { sarahVoiceAppStateAction } from "../sarah-voice/app-state";
 import { makeSarahVoiceDeviceLinkRecovery } from "../sarah-voice/device-link";
+import { SARAH_BETA_VOICE_BASE_URL } from "../sarah-voice/environment";
 import { bytesToBase64 } from "../sarah-voice/protocol";
 import { makeSarahVoiceSessionVault } from "../sarah-voice/session-vault";
 import {
@@ -36,10 +37,7 @@ import { Badge, Card, Divider, EmptyState } from "../ui/surfaces";
 import { Text } from "../ui/text";
 import { colors, radius, spacing } from "../ui/theme";
 
-const OPENAGENTS_BASE_URL =
-  process.env.EXPO_PUBLIC_OPENAGENTS_BASE_URL?.trim() || "https://openagents.com";
-const SARAH_DEVICE_KEY_STORE =
-  OPENAGENTS_BASE_URL === "https://openagents.com" ? undefined : SARAH_STAGING_DEVICE_KEY_STORE_KEY;
+const SARAH_DEVICE_KEY_STORE = SARAH_STAGING_DEVICE_KEY_STORE_KEY;
 const PLAYBACK_DRAIN_POLL_MS = 40;
 const unsupportedMicrophoneFormat = "unsupported_microphone_format";
 
@@ -198,7 +196,7 @@ export const SarahVoiceScreen = ({ onClose }: { readonly onClose: () => void }) 
         }
         identityRef.current = identity;
         const client = new SarahVoiceClient({
-          baseUrl: OPENAGENTS_BASE_URL,
+          baseUrl: SARAH_BETA_VOICE_BASE_URL,
           publicKeyHex: identity.publicKeyHex,
           signer: identity.signer,
           vault: makeSarahVoiceSessionVault(

--- a/apps/openagents-mobile/tests/mobile-update.test.ts
+++ b/apps/openagents-mobile/tests/mobile-update.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from "vite-plus/test";
+
+import { projectMobileUpdate } from "../src/mobile-update";
+import {
+  SARAH_BETA_VOICE_BASE_URL,
+  SARAH_BETA_VOICE_ENVIRONMENT,
+  sarahVoiceApiHost,
+} from "../src/sarah-voice/environment";
+
+const input = {
+  appVersion: "0.5.2",
+  buildNumber: "127",
+  updateId: "36c6c979-28d1-40ed-b17d-f66d96f085af",
+  runtimeVersion: "4d325a423edf99c9fcdadf67ed6b8b0bcb743dfc",
+  isEmbeddedLaunch: false,
+  isChecking: false,
+  isDownloading: false,
+  isUpdatePending: false,
+  hasError: false,
+  voiceEnvironment: SARAH_BETA_VOICE_ENVIRONMENT,
+  voiceHost: sarahVoiceApiHost(),
+} as const;
+
+describe("mobile update diagnostic", () => {
+  test("shows the applied OTA and the scoped staging voice environment", () => {
+    expect(projectMobileUpdate(input)).toEqual({
+      appLabel: "0.5.2 (127)",
+      copyText: [
+        "OpenAgents 0.5.2 (127)",
+        "Update 36c6c979",
+        "Runtime 4d325a423e",
+        "State Current update applied",
+        "Sarah voice Staging beta openagents-monolith-staging-ezxz4mgdsq-uc.a.run.app",
+      ].join("\n"),
+      phase: "current",
+      releaseFingerprint: "36c6c979",
+      runtimeFingerprint: "4d325a423e",
+      statusLabel: "Current update applied",
+      voiceEnvironment: "Staging beta",
+      voiceHost: "openagents-monolith-staging-ezxz4mgdsq-uc.a.run.app",
+    });
+    expect(SARAH_BETA_VOICE_BASE_URL).toBe(
+      "https://openagents-monolith-staging-ezxz4mgdsq-uc.a.run.app",
+    );
+  });
+
+  test("shows checking and downloaded restart states from Expo Updates", () => {
+    expect(projectMobileUpdate({ ...input, isChecking: true }).statusLabel).toBe(
+      "Checking for update",
+    );
+    expect(projectMobileUpdate({ ...input, isUpdatePending: true })).toMatchObject({
+      phase: "downloaded",
+      statusLabel: "Update downloaded—restart to apply",
+    });
+  });
+
+  test("uses a stable embedded fingerprint when no OTA identifier exists", () => {
+    expect(
+      projectMobileUpdate({ ...input, updateId: null, isEmbeddedLaunch: true }),
+    ).toMatchObject({
+      releaseFingerprint: "embedded-4d325a423e",
+      statusLabel: "Embedded update running",
+    });
+  });
+});

--- a/apps/openagents-mobile/tests/sarah-voice-client.test.ts
+++ b/apps/openagents-mobile/tests/sarah-voice-client.test.ts
@@ -174,12 +174,14 @@ const sessionResponse = (
     : {}),
 });
 
-const normalSessionResponse = (): Record<string, unknown> => ({
+const normalSessionResponse = (
+  provider: "nostr" | "github" | "email" = "nostr",
+): Record<string, unknown> => ({
   accessToken,
   expiresIn: 900,
   user: {
     userId: ownerRef,
-    provider: "nostr",
+    provider,
   },
 });
 
@@ -415,7 +417,7 @@ describe("managed Sarah mobile voice client", () => {
     expect(vault.read()).toMatchObject({ publicKeyHex, ownerRef, accessToken });
   });
 
-  test("links a signed-in fresh device and retries the scoped Sarah session", async () => {
+  test("accepts a linked canonical GitHub account after fresh device link", async () => {
     const vault = makeVault();
     const nativeSession = makeNativeSessionStore(canonicalSessionRecord());
     const requests: Array<Readonly<{ url: string; init?: RequestInit }>> = [];
@@ -435,7 +437,7 @@ describe("managed Sarah mobile voice client", () => {
           omegaAttempts += 1;
           return omegaAttempts === 1
             ? Response.json({ error: "mobile_session_required" }, { status: 401 })
-            : Response.json(normalSessionResponse());
+            : Response.json(normalSessionResponse("github"));
         }
         if (url.endsWith("/api/mobile/auth/session")) {
           return Response.json({
@@ -581,6 +583,70 @@ describe("managed Sarah mobile voice client", () => {
       "https://openagents.com/api/omega/auth/session",
       "https://openagents.com/api/omega/sarah/voice/session",
     ]);
+  });
+
+  test("accepts an already linked canonical email account", async () => {
+    const vault = makeVault();
+    const client = new SarahVoiceClient({
+      baseUrl: "https://openagents.com",
+      publicKeyHex,
+      signer,
+      vault: vault.vault,
+      fetch: (async (input, init) => {
+        const url = String(input);
+        if (url.endsWith("/api/omega/auth/session")) {
+          return Response.json(normalSessionResponse("email"));
+        }
+        const body = JSON.parse(String(init?.body)) as Readonly<{ identity: VoiceIdentity }>;
+        return Response.json(sessionResponse(body.identity, "t".repeat(43), false), {
+          status: 201,
+        });
+      }) as typeof globalThis.fetch,
+      createSocket: (url, headers) => new FixtureSocket(url, headers),
+      sha256,
+      randomUuid: () => "voice-linked-email",
+      now: () => 10_000,
+      setTimeout,
+      clearTimeout,
+    });
+
+    await client.start();
+
+    expect(client.snapshot()).toMatchObject({ phase: "connecting", message: null });
+    expect(vault.read()).toMatchObject({ ownerRef, accessToken });
+  });
+
+  test("does not expose a canonical session decoder error", async () => {
+    const vault = makeVault();
+    const client = new SarahVoiceClient({
+      baseUrl: "https://openagents.com",
+      publicKeyHex,
+      signer,
+      vault: vault.vault,
+      fetch: (async () =>
+        Response.json({
+          accessToken,
+          expiresIn: 900,
+          user: { userId: ownerRef, provider: "unsupported" },
+        })) as typeof globalThis.fetch,
+      createSocket: () => {
+        throw new Error("An invalid session must not open a socket.");
+      },
+      sha256,
+      randomUuid: () => "voice-invalid-session",
+      now: () => 10_000,
+      setTimeout,
+      clearTimeout,
+    });
+
+    await client.start();
+
+    expect(client.snapshot()).toMatchObject({
+      phase: "error",
+      message: "Sarah voice could not verify the OpenAgents session. Try again.",
+      retryable: true,
+    });
+    expect(client.snapshot().message).not.toContain("provider");
   });
 
   test("asks a signed-out user to sign in before Sarah voice", async () => {


### PR DESCRIPTION
Fixes the physical build-127 Sarah failures in #9273. Canonical GitHub and email session providers are accepted after strict NIP-98 device proof. Sarah voice alone is routed to the explicit staging beta endpoint. Raw schema errors are replaced with safe recovery text. The home view shows actual Expo Updates metadata, runtime, resolved Sarah environment, and safe check/apply/copy actions. Mobile tests: 68/68. Typecheck and exact build-127 runtime fingerprint passed. OTA publication remains held until the server account-rebind GO receipt.