### PR TITLE
fix(sarah): bind staging entitlement to canonical account

### DIFF
--- a/apps/openagents.com/workers/api/src/index.ts
+++ b/apps/openagents.com/workers/api/src/index.ts
@@ -13991,7 +13991,7 @@ const allExactRoutes: ReadonlyArray<ExactRoute<Env>> = [
                 close: client.end,
               }
             },
-            isStagingOwnerSession: async (session, workerEnv) => {
+            stagingOwnerEntitlementEnabled: workerEnv => {
               const enabled = ['1', 'true', 'on'].includes(
                 workerEnv.SARAH_STAGING_OWNER_VOICE_ENTITLEMENT_ENABLED?.trim().toLowerCase() ??
                   '',
@@ -14006,8 +14006,7 @@ const allExactRoutes: ReadonlyArray<ExactRoute<Env>> = [
               } catch {
                 return false
               }
-              const owner = await resolveOmegaNostrOwner(workerEnv)
-              return owner?.userId === session.user.userId
+              return true
             },
             requireUserBearerSession,
             userIdFromSession: session => session.user.userId,

--- a/apps/openagents.com/workers/api/src/sarah-realtime-voice-routes.test.ts
+++ b/apps/openagents.com/workers/api/src/sarah-realtime-voice-routes.test.ts
@@ -59,7 +59,7 @@ const makeDependencies = (
     sessionExpiresAt: input.sessionExpiresAt,
     settlementReceiptRef: null,
   })),
-  ensureStagingOwnerEntitlement: SarahRealtimeVoiceStore['ensureStagingOwnerEntitlement'] = vi.fn(
+  readActiveStagingOwnerEntitlement: SarahRealtimeVoiceStore['readActiveStagingOwnerEntitlement'] = vi.fn(
     async () => undefined,
   ),
 ) => {
@@ -68,7 +68,7 @@ const makeDependencies = (
     reserve,
     connect: vi.fn(),
     recordUsage: vi.fn(),
-    ensureStagingOwnerEntitlement,
+    readActiveStagingOwnerEntitlement,
     settle: vi.fn(),
     sweepExpired: vi.fn(),
   } as unknown as SarahRealtimeVoiceStore
@@ -89,7 +89,7 @@ const makeDependencies = (
       now: () => Date.UTC(2026, 6, 28, 12, 0, 0),
     },
     reserve,
-    ensureStagingOwnerEntitlement,
+    readActiveStagingOwnerEntitlement,
   }
 }
 
@@ -232,7 +232,7 @@ describe('managed Sarah Realtime voice session route', () => {
       {
         ...fixture.dependencies,
         audit,
-        isStagingOwnerSession: async () => true,
+        stagingOwnerEntitlementEnabled: () => true,
       },
       request({
         schema: SARAH_VOICE_PROTOCOL_VERSION,
@@ -270,7 +270,7 @@ describe('managed Sarah Realtime voice session route', () => {
     const response = await handleSarahRealtimeVoiceSessionRequest(
       {
         ...fixture.dependencies,
-        isStagingOwnerSession: async () => false,
+        stagingOwnerEntitlementEnabled: () => true,
       },
       request({
         schema: SARAH_VOICE_PROTOCOL_VERSION,
@@ -283,7 +283,38 @@ describe('managed Sarah Realtime voice session route', () => {
 
     expect(response.status).toBe(402)
     expect(await response.json()).toEqual({ error: 'insufficient_credit' })
-    expect(fixture.ensureStagingOwnerEntitlement).not.toHaveBeenCalled()
+    expect(fixture.readActiveStagingOwnerEntitlement).toHaveBeenCalledWith({
+      entitlementRef: 'sarah_voice_entitlement:staging_owner_v1',
+      nowIso: '2026-07-28T12:00:00.000Z',
+      ownerUserId: 'user-1',
+    })
+    expect(fixture.reserve).toHaveBeenCalledWith(
+      expect.objectContaining({
+        creditMode: 'metered',
+        entitlementRef: null,
+        reservedMsat: 25_000,
+      }),
+    )
+  })
+
+  test('does not read the staging entitlement when the server gate is off', async () => {
+    const fixture = makeDependencies()
+    const response = await handleSarahRealtimeVoiceSessionRequest(
+      {
+        ...fixture.dependencies,
+        stagingOwnerEntitlementEnabled: () => false,
+      },
+      request({
+        schema: SARAH_VOICE_PROTOCOL_VERSION,
+        identity,
+        disclosureRef: 'disclosure-1',
+      }),
+      {},
+      ctx,
+    )
+
+    expect(response.status).toBe(201)
+    expect(fixture.readActiveStagingOwnerEntitlement).not.toHaveBeenCalled()
     expect(fixture.reserve).toHaveBeenCalledWith(
       expect.objectContaining({
         creditMode: 'metered',

--- a/apps/openagents.com/workers/api/src/sarah-realtime-voice-routes.ts
+++ b/apps/openagents.com/workers/api/src/sarah-realtime-voice-routes.ts
@@ -102,10 +102,7 @@ export type SarahRealtimeVoiceRouteDependencies<User, Bindings> = Readonly<{
   ) => Promise<'Consumed' | 'Invalid' | 'Unavailable'>
   mintNostrSession?: NostrSessionMint<User, Bindings> | undefined
   requireUserBearerSession: UserBearerSessionBoundary<User, Bindings>
-  isStagingOwnerSession?: (
-    session: Readonly<{ user: User }>,
-    env: Bindings,
-  ) => Promise<boolean>
+  stagingOwnerEntitlementEnabled?: (env: Bindings) => boolean
   userIdFromSession: (session: Readonly<{ user: User }>) => string
   verifyNostrProof?: NostrProofVerify<Bindings> | undefined
   now?: (() => number) | undefined
@@ -321,17 +318,16 @@ export const handleSarahRealtimeVoiceSessionRequest = async <User, Bindings>(
     | undefined
   try {
     opened = await dependencies.openStore(env)
-    const isStagingOwner =
-      (await dependencies.isStagingOwnerSession?.(session, env)) === true
-    const entitlement = isStagingOwner
-      ? await opened.store.ensureStagingOwnerEntitlement({
+    const stagingEntitlementEnabled =
+      dependencies.stagingOwnerEntitlementEnabled?.(env) === true
+    const entitlement = stagingEntitlementEnabled
+      ? await opened.store.readActiveStagingOwnerEntitlement({
           entitlementRef: 'sarah_voice_entitlement:staging_owner_v1',
-          expiresAt: new Date(nowMs + 7 * 24 * 60 * 60 * 1_000).toISOString(),
           nowIso,
           ownerUserId: userId,
         })
       : undefined
-    if (isStagingOwner) {
+    if (stagingEntitlementEnabled) {
       dependencies.audit?.(
         entitlement === undefined
           ? 'staging_owner_entitlement_inactive'

--- a/docs/omega/2026-07-28-sarah-voice-unmetered-entitlement-plan.md
+++ b/docs/omega/2026-07-28-sarah-voice-unmetered-entitlement-plan.md
@@ -24,26 +24,28 @@ The exception has these server checks:
 1. `SARAH_STAGING_OWNER_VOICE_ENTITLEMENT_ENABLED` is on.
 2. `OPENAGENTS_APP_URL` identifies the staging Cloud Run service.
 3. The request has a valid OpenAgents session.
-4. The session user is the canonical primary owner user.
+4. The fixed database record belongs to the authenticated canonical user.
 5. The user is active.
 6. The database entitlement is active and not expired.
 
-The service derives the owner user from the configured primary admin email.
+An authorized operator creates the record for one approved canonical account.
+The request cannot create the record or change its owner.
 The client does not send an owner allowlist value.
 The client does not send a GitHub header or an entitlement flag.
 A linked Nostr device and a GitHub or email session resolve to the same
 canonical user before this check.
 
-The first eligible request creates this exact server record:
+The operator creates this exact server record before a test:
 
 - entitlement reference: `sarah_voice_entitlement:staging_owner_v1`
 - environment: `staging`
-- duration: seven days from the first eligible request
+- duration: a bounded operator-selected test period
 - activation actor: `operator:staging_owner_voice_entitlement`
-- activation source: `cloudrun:staging_owner_account_match`
+- activation source: `operator:cloud_sql`
 
 The unique user constraint prevents a second record.
-An expired or revoked record does not become active again automatically.
+The route does not create or reactivate a record.
+An expired or revoked record does not become active automatically.
 The audit table records the activation.
 The route log contains only the entitlement reference and a user digest.
 

--- a/packages/khala-sync-server/src/sarah-realtime-voice-store.test.ts
+++ b/packages/khala-sync-server/src/sarah-realtime-voice-store.test.ts
@@ -159,6 +159,13 @@ describe.skipIf(!hasLocalPostgres())("Sarah Realtime voice credit authority", ()
       entitlementRef: "sarah_voice_entitlement:staging_owner_v1",
       ownerUserId: "user-sarah-staging-owner",
     });
+    expect(
+      await store.readActiveStagingOwnerEntitlement({
+        ownerUserId: "user-sarah-staging-owner",
+        entitlementRef: "sarah_voice_entitlement:staging_owner_v1",
+        nowIso: "2026-07-28T12:00:00.000Z",
+      }),
+    ).toEqual(entitlement);
 
     await store.reserve({
       sessionRef: "voice-entitled-session-1",
@@ -228,11 +235,10 @@ describe.skipIf(!hasLocalPostgres())("Sarah Realtime voice credit authority", ()
       WHERE entitlement_ref = 'sarah_voice_entitlement:staging_owner_v1'
     `;
     expect(
-      await store.ensureStagingOwnerEntitlement({
+      await store.readActiveStagingOwnerEntitlement({
         ownerUserId: "user-sarah-staging-owner",
         entitlementRef: "sarah_voice_entitlement:staging_owner_v1",
         nowIso: "2026-07-28T12:04:00.000Z",
-        expiresAt: "2026-08-04T12:04:00.000Z",
       }),
     ).toBeUndefined();
 

--- a/packages/khala-sync-server/src/sarah-realtime-voice-store.ts
+++ b/packages/khala-sync-server/src/sarah-realtime-voice-store.ts
@@ -119,6 +119,41 @@ const isUniqueViolation = (error: unknown): boolean =>
 export type SarahRealtimeVoiceStore = ReturnType<typeof makeSarahRealtimeVoiceStore>;
 
 export const makeSarahRealtimeVoiceStore = (sql: SyncSql) => {
+  const readActiveStagingOwnerEntitlement = async (
+    input: Readonly<{
+      ownerUserId: string;
+      entitlementRef: string;
+      nowIso: string;
+    }>,
+  ): Promise<SarahVoiceCreditEntitlement | undefined> => {
+    try {
+      const rows = (await sql`
+        SELECT entitlement_ref, owner_user_id, expires_at
+        FROM sarah_voice_credit_entitlements
+        WHERE owner_user_id = ${input.ownerUserId}
+          AND entitlement_ref = ${input.entitlementRef}
+          AND environment = 'staging'
+          AND state = 'active'
+          AND activated_at <= ${input.nowIso}
+          AND expires_at > ${input.nowIso}
+      `) as ReadonlyArray<{
+        entitlement_ref: string;
+        owner_user_id: string;
+        expires_at: string;
+      }>;
+      const row = first(rows);
+      return row === undefined
+        ? undefined
+        : {
+            entitlementRef: row.entitlement_ref,
+            ownerUserId: row.owner_user_id,
+            expiresAt: row.expires_at,
+          };
+    } catch (error) {
+      throw new SarahVoiceStorageError("Sarah voice entitlement lookup failed", error);
+    }
+  };
+
   const ensureStagingOwnerEntitlement = async (
     input: Readonly<{
       ownerUserId: string;
@@ -568,6 +603,7 @@ export const makeSarahRealtimeVoiceStore = (sql: SyncSql) => {
   return {
     connect,
     ensureStagingOwnerEntitlement,
+    readActiveStagingOwnerEntitlement,
     recordUsage,
     reserve,
     settle,


### PR DESCRIPTION
Fixes the staging Sarah owner entitlement regression from #9272. The voice route now reads the one explicit active staging entitlement for the authenticated canonical account. Requests cannot create, select, or reactivate an entitlement. The exact staging host and server flag remain required; unknown accounts continue through the normal credit gate. Verification: 12 focused route/store tests passed; API and khala-sync-server typechecks passed; the changed STE document passed its direct check.