### PR TITLE
Add product-scoped download resolver

### DIFF
--- a/apps/openagents.com/apps/start/src/product-download-resolver.server.test.ts
+++ b/apps/openagents.com/apps/start/src/product-download-resolver.server.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, test } from "vite-plus/test";
+
+import {
+  PRODUCT_DOWNLOAD_RESOLUTION_PATH,
+  PRODUCT_DOWNLOAD_RESOLUTION_SCHEMA_ID,
+  createProductDownloadResolver,
+} from "./product-download-resolver.server";
+
+const desktopResolution = {
+  schema: "openagents.desktop.download_resolution.v1",
+  source: "release_set_v2",
+  channel: "rc",
+  version: "0.1.0-rc.25",
+  releasedAt: "2026-07-29T22:00:00.000Z",
+  releaseNotes: "OpenAgents Desktop release.",
+  sourceRevision: "a".repeat(40),
+  detection: {
+    platform: "darwin",
+    architecture: "arm64",
+    method: "override",
+  },
+  availability: "available",
+  selected: {
+    target: "darwin-arm64",
+    format: "dmg",
+    version: "0.1.0-rc.25",
+    channel: "rc",
+    url: "https://updates.openagents.com/desktop/openagents/rc/openagents.dmg",
+    sha256: "b".repeat(64),
+    byteLength: 42,
+    minimumOs: "macOS 13",
+    preferred: true,
+  },
+  alternatives: [],
+} as const;
+
+describe("product-scoped signed download resolver", () => {
+  test("keeps OpenAgents Desktop on the existing signed resolver", async () => {
+    const delegated: string[] = [];
+    const resolver = createProductDownloadResolver(async (request) => {
+      delegated.push(request.url);
+      return Response.json(desktopResolution);
+    });
+    const response = await resolver.handle(
+      new Request(
+        `https://openagents.com${PRODUCT_DOWNLOAD_RESOLUTION_PATH}` +
+          "?product=openagents-desktop&target=darwin-arm64&format=dmg&channel=rc",
+      ),
+    );
+
+    expect(response?.status).toBe(200);
+    expect(delegated).toEqual([
+      "https://openagents.com/api/public/desktop-download" +
+        "?target=darwin-arm64&format=dmg&channel=rc",
+    ]);
+    expect(await response?.json()).toEqual({
+      schema: PRODUCT_DOWNLOAD_RESOLUTION_SCHEMA_ID,
+      product: "openagents-desktop",
+      resolution: desktopResolution,
+    });
+  });
+
+  test("fails Omega closed without consulting or relabeling the Desktop feed", async () => {
+    let delegated = false;
+    const resolver = createProductDownloadResolver(async () => {
+      delegated = true;
+      return Response.json(desktopResolution);
+    });
+    const response = await resolver.handle(
+      new Request(`https://openagents.com${PRODUCT_DOWNLOAD_RESOLUTION_PATH}?product=omega`),
+    );
+    const body = await response?.json();
+
+    expect(response?.status).toBe(200);
+    expect(delegated).toBe(false);
+    expect(body).toEqual({
+      schema: PRODUCT_DOWNLOAD_RESOLUTION_SCHEMA_ID,
+      product: "omega",
+      availability: "unavailable",
+      reason: "signed_release_not_published",
+    });
+    expect(body).not.toHaveProperty("url");
+    expect(body).not.toHaveProperty("version");
+    expect(JSON.stringify(body)).not.toContain("desktop");
+  });
+
+  test("rejects product ambiguity and Omega artifact selectors", async () => {
+    const resolver = createProductDownloadResolver();
+    const responses = await Promise.all(
+      [
+        "",
+        "?product=unknown",
+        "?product=omega&target=darwin-arm64",
+        "?product=omega&format=dmg",
+        "?product=omega&product=openagents-desktop",
+        "?product=openagents-desktop&unexpected=true",
+      ].map((query) =>
+        resolver.handle(
+          new Request(`https://openagents.com${PRODUCT_DOWNLOAD_RESOLUTION_PATH}${query}`),
+        ),
+      ),
+    );
+    for (const response of responses) {
+      expect(response?.status).toBe(400);
+      expect(response?.headers.get("cache-control")).toBe("no-store");
+    }
+  });
+
+  test("does not claim unrelated paths or non-GET requests", async () => {
+    const resolver = createProductDownloadResolver();
+    await expect(
+      resolver.handle(new Request("https://openagents.com/api/public/product-download/other")),
+    ).resolves.toBeUndefined();
+    const response = await resolver.handle(
+      new Request(`https://openagents.com${PRODUCT_DOWNLOAD_RESOLUTION_PATH}?product=omega`, {
+        method: "POST",
+      }),
+    );
+    expect(response?.status).toBe(405);
+    expect(response?.headers.get("allow")).toBe("GET");
+  });
+});

--- a/apps/openagents.com/apps/start/src/product-download-resolver.server.ts
+++ b/apps/openagents.com/apps/start/src/product-download-resolver.server.ts
@@ -1,0 +1,128 @@
+import { Exit, Schema } from "effect";
+
+import {
+  DESKTOP_DOWNLOAD_RESOLUTION_PATH,
+  DesktopDownloadResolutionSchema,
+  routeDesktopDownloadRequest,
+} from "./desktop-download-resolver.server";
+
+export const PRODUCT_DOWNLOAD_RESOLUTION_PATH = "/api/public/product-download";
+export const PRODUCT_DOWNLOAD_RESOLUTION_SCHEMA_ID =
+  "openagents.product.download_resolution.v1" as const;
+
+export const productDownloadIds = ["openagents-desktop", "omega"] as const;
+export type ProductDownloadId = (typeof productDownloadIds)[number];
+
+const DesktopProductDownloadResolutionSchema = Schema.Struct({
+  schema: Schema.Literal(PRODUCT_DOWNLOAD_RESOLUTION_SCHEMA_ID),
+  product: Schema.Literal("openagents-desktop"),
+  resolution: DesktopDownloadResolutionSchema,
+});
+
+const OmegaProductDownloadUnavailableSchema = Schema.Struct({
+  schema: Schema.Literal(PRODUCT_DOWNLOAD_RESOLUTION_SCHEMA_ID),
+  product: Schema.Literal("omega"),
+  availability: Schema.Literal("unavailable"),
+  reason: Schema.Literal("signed_release_not_published"),
+});
+
+export const ProductDownloadResolutionSchema = Schema.Union([
+  DesktopProductDownloadResolutionSchema,
+  OmegaProductDownloadUnavailableSchema,
+]);
+export type ProductDownloadResolution = typeof ProductDownloadResolutionSchema.Type;
+
+const decodeProductDownloadResolution = Schema.decodeUnknownExit(ProductDownloadResolutionSchema);
+
+type DesktopDownloadRoute = (request: Request) => Promise<Response | undefined>;
+
+const noStoreHeaders = { "cache-control": "no-store" } as const;
+const desktopQueryKeys = new Set(["product", "channel", "target", "format"]);
+
+const invalidQuery = (): Response =>
+  Response.json(
+    {
+      error: "invalid_query",
+      required: ["product"],
+      products: productDownloadIds,
+    },
+    { status: 400, headers: noStoreHeaders },
+  );
+
+export const createProductDownloadResolver = (
+  routeDesktop: DesktopDownloadRoute = routeDesktopDownloadRequest,
+) => {
+  const handle = async (request: Request): Promise<Response | undefined> => {
+    const url = new URL(request.url);
+    if (url.pathname !== PRODUCT_DOWNLOAD_RESOLUTION_PATH) return undefined;
+    if (request.method !== "GET") {
+      return Response.json(
+        { error: "method_not_allowed" },
+        { status: 405, headers: { allow: "GET", ...noStoreHeaders } },
+      );
+    }
+
+    const product = url.searchParams.get("product");
+    const hasOneProduct = url.searchParams.getAll("product").length === 1;
+    if (product === "omega") {
+      if (!hasOneProduct || [...url.searchParams.keys()].some((key) => key !== "product")) {
+        return invalidQuery();
+      }
+      const resolution: ProductDownloadResolution = {
+        schema: PRODUCT_DOWNLOAD_RESOLUTION_SCHEMA_ID,
+        product,
+        availability: "unavailable",
+        reason: "signed_release_not_published",
+      };
+      return Response.json(resolution, { headers: noStoreHeaders });
+    }
+    if (
+      !hasOneProduct ||
+      product !== "openagents-desktop" ||
+      [...url.searchParams.keys()].some((key) => !desktopQueryKeys.has(key))
+    ) {
+      return invalidQuery();
+    }
+
+    url.pathname = DESKTOP_DOWNLOAD_RESOLUTION_PATH;
+    url.searchParams.delete("product");
+    const desktopResponse = await routeDesktop(new Request(url, request));
+    if (desktopResponse === undefined) {
+      return Response.json(
+        { error: "desktop_resolver_unavailable" },
+        { status: 503, headers: noStoreHeaders },
+      );
+    }
+    if (!desktopResponse.ok) {
+      return Response.json(
+        { error: "desktop_resolution_rejected", product },
+        { status: desktopResponse.status, headers: noStoreHeaders },
+      );
+    }
+    const candidate = {
+      schema: PRODUCT_DOWNLOAD_RESOLUTION_SCHEMA_ID,
+      product,
+      resolution: await desktopResponse.json(),
+    };
+    const decoded = decodeProductDownloadResolution(candidate);
+    if (!Exit.isSuccess(decoded)) {
+      return Response.json(
+        { error: "desktop_resolution_invalid" },
+        { status: 503, headers: noStoreHeaders },
+      );
+    }
+    return Response.json(decoded.value, {
+      status: desktopResponse.status,
+      headers: noStoreHeaders,
+    });
+  };
+
+  return { handle };
+};
+
+let defaultResolver: ReturnType<typeof createProductDownloadResolver> | undefined;
+
+export const routeProductDownloadRequest = (request: Request): Promise<Response | undefined> => {
+  defaultResolver ??= createProductDownloadResolver();
+  return defaultResolver.handle(request);
+};

--- a/apps/openagents.com/apps/start/src/server.ts
+++ b/apps/openagents.com/apps/start/src/server.ts
@@ -12,6 +12,7 @@ import { routeDesktopDownloadRequest } from './desktop-download-resolver.server'
 import { routeForgeRepositoryAssetRequest } from './forge-repository-asset-proxy'
 import { routeKhalaSyncProxyRequest } from './khala-sync-proxy'
 import { routeManagedSandboxProxyRequest } from './managed-sandbox-proxy'
+import { routeProductDownloadRequest } from './product-download-resolver.server'
 import { routeQaBoardRequest } from './qa-board-projection.server'
 
 type StartWorkerEnv = Record<string, unknown>
@@ -72,6 +73,10 @@ export async function routeSharedAgentSurface(
   // from the promoted signed release set (fail-closed, no handwritten URLs).
   const desktopDownloadResponse = await routeDesktopDownloadRequest(request)
   if (desktopDownloadResponse !== undefined) return desktopDownloadResponse
+
+  // EP263-07 (#9280): keep product identity explicit before release selection.
+  const productDownloadResponse = await routeProductDownloadRequest(request)
+  if (productDownloadResponse !== undefined) return productDownloadResponse
 
   return undefined
 }

--- a/apps/openagents.com/workers/api/src/cloudrun/public-site-host.test.ts
+++ b/apps/openagents.com/workers/api/src/cloudrun/public-site-host.test.ts
@@ -35,8 +35,10 @@ describe('public Start homepage host boundary', () => {
     // are Start-served and must cross the Cloud Run adapter (QA-4 lesson).
     expect(isStartServerRequestPath('/api/public/desktop-download')).toBe(true)
     expect(isStartServerRequestPath('/api/public/desktop-download/artifact')).toBe(true)
+    expect(isStartServerRequestPath('/api/public/product-download')).toBe(true)
     expect(isStartServerRequestPath('/api/public/desktop-download/')).toBe(false)
     expect(isStartServerRequestPath('/api/public/desktop-download/other')).toBe(false)
+    expect(isStartServerRequestPath('/api/public/product-download/')).toBe(false)
     expect(
       isStartServerRequestPath(
         '/internal/v1/repositories/tenant.openagents/omega/web-read-asset/crates/zed/icon.png',

--- a/apps/openagents.com/workers/api/src/cloudrun/start-ui.ts
+++ b/apps/openagents.com/workers/api/src/cloudrun/start-ui.ts
@@ -31,6 +31,7 @@ const START_SERVER_REQUEST_PATHS = new Set([
   // DIST-10 (#8923): Desktop download resolver + verified artifact redirect.
   '/api/public/desktop-download',
   '/api/public/desktop-download/artifact',
+  '/api/public/product-download',
 ])
 const FORGE_REPOSITORY_ASSET_REQUEST_PATH =
   /^\/internal\/v1\/repositories\/[^/]+\/[^/]+\/web-read-asset\/.+$/u


### PR DESCRIPTION
## Problem

`openagents.com` has one signed download resolver, and it is explicitly the
OpenAgents Desktop ReleaseSet v2 resolver. EP263-07 needs an Omega identity
without allowing the Desktop feed to be inferred or relabeled as Omega.

## Change

- add `/api/public/product-download` with explicit `openagents-desktop` and
  `omega` product identities;
- delegate Desktop requests to the existing signed resolver without changing
  its paths or response contract;
- return `signed_release_not_published` for Omega with no URL or version;
- reject ambiguous product parameters and Omega target/format selectors;
- route the exact endpoint through the existing Start/Cloud Run adapter.

## Validation

- `node_modules/.bin/vp test --run apps/openagents.com/apps/start/src/product-download-resolver.server.test.ts apps/openagents.com/workers/api/src/cloudrun/public-site-host.test.ts`
- `node_modules/.bin/tsc -p apps/openagents.com/apps/start/tsconfig.json --noEmit`
- `node_modules/.bin/tsc -p apps/openagents.com/workers/api/tsconfig.cloudrun.json --noEmit`
- `git diff --check`

Focused result: 2 files, 12 tests passed. Both typechecks exit 0.

## Product value

This establishes the distribution identity boundary needed by #9280 while
keeping public truth conservative: Omega cannot appear downloadable until its
own signed release source and installed evidence are supplied.

## Intentionally unchanged

No Omega candidate was cut, signed, promoted, or published. No homepage or
download-page copy changed. No platform cell was admitted. The Electron
Desktop feed, resolver, page, package identity, update path, and rollback path
remain unchanged. This is a narrow EP263-07 infrastructure slice, not closure
of #9280.

Public claim:
https://openagents.com/forum/t/1b143fd4-4d1a-45d0-af2a-63aa04413f8d
